### PR TITLE
#203 more binary and unary simplifications, including concatentaions

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -50,7 +50,10 @@ from .util import load_function
 #
 # Classes for the Expression Tree
 #
-from .expression_tree.symbol import Symbol
+from .expression_tree.symbol import (
+    Symbol,
+    simplify_if_constant,
+)
 from .expression_tree.binary_operators import (
     BinaryOperator,
     Addition,
@@ -80,6 +83,7 @@ from .expression_tree.unary_operators import (
     grad,
     div,
     surf,
+    integrate,
 )
 from .expression_tree.parameter import Parameter, FunctionParameter
 from .expression_tree.broadcasts import Broadcast, NumpyBroadcast

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -131,9 +131,7 @@ class DomainConcatenation(Concatenation):
         self._size = self._slices[self.domain[-1]].stop
 
         # create disc of domain => slice for each child
-        self._children_slices = []
-        for child in self.children:
-            self._children_slices.append(self.create_slices(child))
+        self._children_slices = [self.create_slices(child) for child in self.children]
 
     @property
     def mesh(self):
@@ -171,3 +169,4 @@ class DomainConcatenation(Concatenation):
                 vector[self._slices[dom]] = child_vector[slices[dom]]
 
         return vector
+

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -8,8 +8,27 @@ import pybamm
 import anytree
 import numbers
 import copy
+import autograd.numpy as np
 
 from anytree.exporter import DotExporter
+
+
+def simplify_if_constant(new_node):
+    """
+    Utility function to simplify an expression tree if it evalutes to a constant
+    scalar, vector or matrix
+    """
+    if new_node.is_constant():
+        result = new_node.evaluate_ignoring_errors()
+        if result is not None:
+            if isinstance(result, numbers.Number):
+                return pybamm.Scalar(result, domain=new_node.domain)
+            elif isinstance(result, np.ndarray):
+                if result.ndim == 1:
+                    return pybamm.Vector(result, domain=new_node.domain)
+                else:
+                    return pybamm.Matrix(result, domain=new_node.domain)
+    return new_node
 
 
 class Symbol(anytree.NodeMixin):
@@ -361,28 +380,32 @@ class Symbol(anytree.NodeMixin):
         # do the search, return true if no relevent nodes are found
         return all([not (isinstance(n, search_types)) for n in self.pre_order()])
 
-    def evaluates_to_value(self, value):
+    def evaluate_ignoring_errors(self):
         """
-        Returns True if evaluating the expression returns a given constant value.
-        Returns False otherwise, including if NotImplementedError or TyperError
-        is raised.
-        !Not to be confused with isinstance(self, pybamm.Scalar)!
-
-        Parameters
-        ----------
-        value: Number
-            the value to compare against
+        Evaluates the expression. If a node exists in the tree that cannot be evaluated
+        as a scalar or vectr (e.g. Parameter, Variable, StateVector), then None is
+        returned. Otherwise the result of the evaluation is given
 
         See Also
         --------
         evaluate : evaluate the expression
 
         """
-        return (
-            self.is_constant()
-            and self.evaluates_to_number()
-            and self.evaluate() == value
-        )
+        try:
+            result = self.evaluate(t=0)
+        except NotImplementedError:
+            # return false if NotImplementedError is raised
+            # (there is a e.g. Parameter, Variable, ... in the tree)
+            return None
+        except TypeError as error:
+            # return false if specific TypeError is raised
+            # (there is a e.g. StateVector in the tree)
+            if error.args[0] == "StateVector cannot evaluate input 'y=None'":
+                return None
+            else:
+                raise error
+
+        return result
 
     def evaluates_to_number(self):
         """
@@ -396,20 +419,12 @@ class Symbol(anytree.NodeMixin):
         evaluate : evaluate the expression
 
         """
-        try:
-            # return true if node evaluates to a number
-            return isinstance(self.evaluate(t=0), numbers.Number)
-        except NotImplementedError:
-            # return false if NotImplementedError is raised
-            # (there is a e.g. Parameter, Variable, ... in the tree)
+        result = self.evaluate_ignoring_errors()
+
+        if isinstance(result, numbers.Number):
+            return True
+        else:
             return False
-        except TypeError as error:
-            # return false if specific TypeError is raised
-            # (there is a e.g. StateVector in the tree)
-            if error.args[0] == "StateVector cannot evaluate input 'y=None'":
-                return False
-            else:
-                raise error
 
     def has_spatial_derivatives(self):
         """Returns True if equation has spatial derivatives (grad or div)."""
@@ -440,4 +455,4 @@ class Symbol(anytree.NodeMixin):
 
         new_symbol = copy.deepcopy(self)
         new_symbol.parent = None
-        return new_symbol
+        return simplify_if_constant(new_symbol)

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -33,6 +33,20 @@ class UnaryOperator(pybamm.Symbol):
         """ See :meth:`pybamm.Symbol.__str__()`. """
         return "{}({!s})".format(self.name, self.children[0])
 
+    def simplify(self):
+        """ See :meth:`pybamm.Symbol.simplify()`. """
+        child = self.children[0].simplify()
+
+        # _binary_simplify defined in derived classes for specific rules
+        new_node = self._unary_simplify(child)
+
+        return pybamm.simplify_if_constant(new_node)
+
+    def _unary_simplify(self, child):
+        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
+
+        return self.__class__(child)
+
 
 class Negate(UnaryOperator):
     """A node in the expression tree representing a `-` negation operator
@@ -109,6 +123,15 @@ class Function(UnaryOperator):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         return self.func(self.children[0].evaluate(t, y))
 
+    # Function needs its own simplify as it has a different __init__ signature
+    def simplify(self):
+        """ See :meth:`pybamm.Symbol.simplify()`. """
+        child = self.children[0].simplify()
+
+        new_node = pybamm.Function(self.func, child)
+
+        return pybamm.simplify_if_constant(new_node)
+
 
 class SpatialOperator(UnaryOperator):
     """A node in the expression tree representing a unary spatial operator
@@ -138,6 +161,19 @@ class SpatialOperator(UnaryOperator):
         """ See :meth:`pybamm.Symbol.diff()`. """
         # We shouldn't need this
         raise NotImplementedError
+
+    def _unary_simplify(self, child):
+        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
+
+        # if there are none of these nodes in the child tree, then this expression
+        # does not depend on space, and therefore the spatial operator result is zero
+        search_types = (pybamm.Variable, pybamm.StateVector, pybamm.SpatialVariable)
+
+        # do the search, return a scalar zero node if no relevent nodes are found
+        if all([not (isinstance(n, search_types)) for n in self.pre_order()]):
+            return pybamm.Scalar(0)
+        else:
+            return self.__class__(child)
 
 
 class Gradient(SpatialOperator):
@@ -206,6 +242,11 @@ class Integral(SpatialOperator):
     def integration_variable(self):
         return self._integration_variable
 
+    def _unary_simplify(self, child):
+        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
+
+        return self.__class__(child, self.integration_variable)
+
 
 class BoundaryValue(SpatialOperator):
     """A node in the expression tree which gets the boundary value of a variable.
@@ -226,6 +267,11 @@ class BoundaryValue(SpatialOperator):
         # Domain of BoundaryValue must be ([]) so that expressions can be formed
         # of boundary values of variables in different domains
         self.domain = []
+
+    def _unary_simplify(self, child):
+        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
+
+        return self.__class__(child, self.side)
 
 
 #
@@ -293,3 +339,24 @@ def surf(variable):
     """
 
     return BoundaryValue(variable, "right")
+
+
+def integrate(expression, variable):
+    """convenience function for creating a :class:`Integral`
+
+    Parameters
+    ----------
+
+    expression : :class:`pybamm.Symbol`
+        The function to be integrated
+    integration_variable : :class:`pybamm.IndependentVariable`
+        The variable over which to integrate
+
+    Returns
+    -------
+
+    :class:`Integral`
+        the new integrated expression tree
+    """
+
+    return Integral(expression, variable)

--- a/tests/test_expression_tree/test_concatenations.py
+++ b/tests/test_expression_tree/test_concatenations.py
@@ -138,6 +138,27 @@ class TestConcatenations(unittest.TestCase):
             (mesh[b_dom[0]][0].npts + mesh[a_dom[0]][0].npts + mesh[b_dom[1]][0].npts,),
         )
 
+    def test_domain_concatenation_simplify(self):
+        # create discretisation
+        disc = get_discretisation_for_testing()
+        mesh = disc.mesh
+
+        a_dom = ["negative electrode"]
+        b_dom = ["positive electrode"]
+        a = pybamm.NumpyBroadcast(pybamm.Scalar(2, a_dom), a_dom, mesh)
+        b = pybamm.Vector(np.ones_like(mesh[b_dom[0]][0].nodes), domain=b_dom)
+
+        conc = pybamm.DomainConcatenation([a, b], mesh)
+
+        # should be simplified to a vector
+        self.assertIsInstance(conc.simplify(), pybamm.Vector)
+        np.testing.assert_array_equal(
+            conc.simplify().evaluate(),
+            np.concatenate(
+                [np.full(mesh[a_dom[0]][0].npts, 2), np.full(mesh[b_dom[0]][0].npts, 1)]
+            ),
+        )
+
     def test_concatenation_orphans(self):
         a = pybamm.Variable("a")
         b = pybamm.Variable("b")


### PR DESCRIPTION
# Description

- expanded binary simplification
- added unary simplifications
- made sure DomainConcatenation simplification works
- for *all* nodes, if the expression evaluates to a constant scalar/vector/matrix, then it is simplified to an appropriate Scalar/Vector/Matrix node

Fixes #203 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
