### PR TITLE
Issue 233 add simplifications to solver

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -155,7 +155,7 @@ def simplify_multiplication_division(myclass, left, right):
     flatten(None, myclass, left, right, True)
 
     # check if there is a matrix multiply in the numerator (if so we can't reorder it)
-    has_matrix_multiply = False
+    has_matrix_multiply = myclass == pybamm.MatrixMultiplication
     for t in numerator_types:
         has_matrix_multiply |= t == pybamm.MatrixMultiplication
 

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -239,7 +239,7 @@ def simplify_multiplication_division(myclass, left, right):
 
     # check if there is a matrix multiply in the numerator (if so we can't reorder it)
     has_matrix_multiply = any(
-        [t == pybamm.MatrixMultiplication for t in numerator_types+[myclass]]
+        [t == pybamm.MatrixMultiplication for t in numerator_types + [myclass]]
     )
 
     def partition_by_constant(source, types=None):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -12,10 +12,19 @@ import copy
 
 def simplify_addition_subtraction(myclass, left, right):
     """
-    some common simplifications for addition and subtraction
+    if children are associative (addition, subtraction, etc) then try to find pairs of
+    constant children (that produce a value) and simplify them to a single term
 
-    if children are associative (addition, subtraction, etc) then try to find
-    pairs of constant children (that produce a value) and simplify them
+    Parameters
+    ----------
+
+    myclass: class
+        the binary operator class (pybamm.Addition or pybamm.Subtraction) operating on
+        children left and right
+    left: derived from pybamm.Symbol
+        the left child of the binary operator
+    right: derived from pybamm.Symbol
+        the right child of the binary operator
 
     """
     numerator = []
@@ -108,14 +117,24 @@ def simplify_addition_subtraction(myclass, left, right):
 
 def simplify_multiplication_division(myclass, left, right):
     """
-    some common simplifications for multiplication and division
-
     if children are associative (multiply, division, etc) then try to find
     pairs of constant children (that produce a value) and simplify them
 
     can handle matrix multiplication. If there are any on the numerator, it will only
     try to simplify pairs of neighbouring constant children. If there are any matrix
     multiplications on the denominator an exception is raised
+
+    Parameters
+    ----------
+
+    myclass: class
+        the binary operator class (pybamm.Addition or pybamm.Subtraction) operating on
+        children left and right
+    left: derived from pybamm.Symbol
+        the left child of the binary operator
+    right: derived from pybamm.Symbol
+        the right child of the binary operator
+
     """
     numerator = []
     denominator = []

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -238,9 +238,9 @@ def simplify_multiplication_division(myclass, left, right):
     flatten(None, myclass, left, right, True)
 
     # check if there is a matrix multiply in the numerator (if so we can't reorder it)
-    has_matrix_multiply = myclass == pybamm.MatrixMultiplication
-    for t in numerator_types:
-        has_matrix_multiply |= t == pybamm.MatrixMultiplication
+    has_matrix_multiply = any(
+        [t == pybamm.MatrixMultiplication for t in numerator_types+[myclass]]
+    )
 
     def partition_by_constant(source, types=None):
         """

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -34,11 +34,10 @@ class DaeSolver(pybamm.BaseSolver):
 
         """
 
-        # create simplified rhs and event expressions
+        # create simplified rhs algebraic and event expressions
         concatenated_rhs = model.concatenated_rhs.simplify()
         concatenated_algebraic = model.concatenated_algebraic.simplify()
         events = [event.simplify() for event in model.events]
-
 
         def residuals(t, y, ydot):
             rhs_eval = concatenated_rhs.evaluate(t, y)

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -32,8 +32,12 @@ class OdeSolver(pybamm.BaseSolver):
 
         """
 
+        # create simplified rhs and event expressions
+        concatenated_rhs = model.concatenated_rhs.simplify()
+        events = [event.simplify() for event in model.events]
+
         def dydt(t, y):
-            return model.concatenated_rhs.evaluate(t, y)
+            return concatenated_rhs.evaluate(t, y)
 
         # Create event-dependent function to evaluate events
         def event_fun(event):
@@ -42,7 +46,7 @@ class OdeSolver(pybamm.BaseSolver):
 
             return eval_event
 
-        events = [event_fun(event) for event in model.events]
+        events = [event_fun(event) for event in events]
 
         y0 = model.concatenated_initial_conditions
 

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -106,9 +106,30 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual((c * a).simplify().evaluate(), 0)
         self.assertIsInstance((b * c).simplify(), pybamm.Parameter)
         self.assertIsInstance((e * c).simplify(), pybamm.Multiplication)
+
         expr = (e * (e * c)).simplify()
+        self.assertIsInstance(expr, pybamm.Multiplication)
         self.assertIsInstance(expr.children[0], pybamm.Scalar)
         self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
+        expr = (e / (e * c)).simplify()
+        self.assertIsInstance(expr, pybamm.Division)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 1.0)
+        self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
+        expr = (e * (e / c)).simplify()
+        self.assertIsInstance(expr, pybamm.Division)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 4.0)
+        self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
+        expr = (e * (c / e)).simplify()
+        self.assertIsInstance(expr, pybamm.Multiplication)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 1.0)
+        self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
         self.assertIsInstance((c * e).simplify(), pybamm.Multiplication)
         self.assertIsInstance((e / c).simplify(), pybamm.Division)
         self.assertIsInstance((c / e).simplify(), pybamm.Division)

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -150,13 +150,18 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual(expr.children[0].evaluate(), 4.0)
         self.assertIsInstance(expr.children[1], pybamm.Parameter)
 
-        expr = ((e + c) + (c + e)).simplify()
+        expr = ((2 + c) + (c + 2)).simplify()
         self.assertIsInstance(expr, pybamm.Addition)
         self.assertIsInstance(expr.children[0], pybamm.Scalar)
         self.assertEqual(expr.children[0].evaluate(), 4.0)
         self.assertIsInstance(expr.children[1], pybamm.Addition)
         self.assertIsInstance(expr.children[1].children[0], pybamm.Parameter)
         self.assertIsInstance(expr.children[1].children[1], pybamm.Parameter)
+
+        expr = ((-1 + c) - (c + 1) + (c - 1)).simplify()
+        self.assertIsInstance(expr, pybamm.Addition)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), -3.0)
 
         # check these don't simplify
         self.assertIsInstance((c * e).simplify(), pybamm.Multiplication)

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -130,9 +130,40 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual(expr.children[0].evaluate(), 1.0)
         self.assertIsInstance(expr.children[1], pybamm.Parameter)
 
+        expr = ((e * c) * (c / e)).simplify()
+        self.assertIsInstance(expr, pybamm.Multiplication)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 1.0)
+        self.assertIsInstance(expr.children[1], pybamm.Multiplication)
+        self.assertIsInstance(expr.children[1].children[0], pybamm.Parameter)
+        self.assertIsInstance(expr.children[1].children[1], pybamm.Parameter)
+
+        expr = (e + (e + c)).simplify()
+        self.assertIsInstance(expr, pybamm.Addition)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 4.0)
+        self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
+        expr = (e + (e - c)).simplify()
+        self.assertIsInstance(expr, pybamm.Subtraction)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 4.0)
+        self.assertIsInstance(expr.children[1], pybamm.Parameter)
+
+        expr = ((e + c) + (c + e)).simplify()
+        self.assertIsInstance(expr, pybamm.Addition)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 4.0)
+        self.assertIsInstance(expr.children[1], pybamm.Addition)
+        self.assertIsInstance(expr.children[1].children[0], pybamm.Parameter)
+        self.assertIsInstance(expr.children[1].children[1], pybamm.Parameter)
+
         self.assertIsInstance((c * e).simplify(), pybamm.Multiplication)
         self.assertIsInstance((e / c).simplify(), pybamm.Division)
-        self.assertIsInstance((c / e).simplify(), pybamm.Division)
+
+        # should simplify division to multiply
+        self.assertIsInstance((c / e).simplify(), pybamm.Multiplication)
+
         self.assertIsInstance((c / b).simplify(), pybamm.Parameter)
         self.assertIsInstance((c * b).simplify(), pybamm.Parameter)
         self.assertIsInstance((A @ c).simplify(), pybamm.MatrixMultiplication)
@@ -200,6 +231,9 @@ class TestSymbol(unittest.TestCase):
                 expr.entries,
                 np.array([2, 2])
             )
+
+        with self.assertRaises(pybamm.ModelError):
+            (e / (m1@v)).simplify()
 
     def test_symbol_domains(self):
         a = pybamm.Symbol("a", domain=pybamm.KNOWN_DOMAINS[0])

--- a/tests/test_expression_tree/test_symbol.py
+++ b/tests/test_expression_tree/test_symbol.py
@@ -158,8 +158,12 @@ class TestSymbol(unittest.TestCase):
         self.assertIsInstance(expr.children[1].children[0], pybamm.Parameter)
         self.assertIsInstance(expr.children[1].children[1], pybamm.Parameter)
 
+        # check these don't simplify
         self.assertIsInstance((c * e).simplify(), pybamm.Multiplication)
         self.assertIsInstance((e / c).simplify(), pybamm.Division)
+        self.assertIsInstance((c).simplify(), pybamm.Parameter)
+        c1 = pybamm.Parameter("c1")
+        self.assertIsInstance((c1 * c).simplify(), pybamm.Multiplication)
 
         # should simplify division to multiply
         self.assertIsInstance((c / e).simplify(), pybamm.Multiplication)
@@ -183,6 +187,8 @@ class TestSymbol(unittest.TestCase):
         # power simplification
         self.assertIsInstance((c ** a).simplify(), pybamm.Scalar)
         self.assertEqual((c ** a).simplify().evaluate(), 1)
+        self.assertIsInstance((a ** c).simplify(), pybamm.Scalar)
+        self.assertEqual((a ** c).simplify().evaluate(), 0)
         d = pybamm.Scalar(2)
         self.assertIsInstance((c ** d).simplify(), pybamm.Power)
 


### PR DESCRIPTION
# Description

- add more simplifications to expression tree
   1. given a term in the expression tree consisting of multiplications/divisions, pybamm will attempt to simplify it by grouping together those sub-terms that are constant, and return a value, and those that are not. Those that are constant are reduced to a single sub-term
   2. given a term in the expression tree consisting of multiplications/divisions/matrix-multiplications, pybamm will attempt to simplify it by grouping together neighbouring sub-terms that are constant, and return a value. Note that this is different to 1, due to the presence of matrix-multiplications pybamm does not attempt to reorder the terms.
  3. given a term in the expression tree consisting of additions/subtractions, pybamm will attempt to simplify it by grouping together those sub-terms that are constant, and return a value, and those that are not. Those that are constant are reduced to a single sub-term

- adds simplifications to ode and dae solvers

Fixes #233 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
