### PR TITLE
#244 remove unnecessary functions

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -155,7 +155,7 @@ from .meshes.submeshes import SubMesh1D, Uniform1DSubMesh
 # Spatial Methods
 #
 from .spatial_methods.spatial_method import SpatialMethod
-from .spatial_methods.finite_volume import FiniteVolume, NodeToEdge
+from .spatial_methods.finite_volume import FiniteVolume
 
 #
 # Simulation class

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -214,8 +214,6 @@ class ParameterValues(dict):
                 return pybamm.Function(symbol.func, new_child)
             elif isinstance(symbol, pybamm.Integral):
                 return pybamm.Integral(new_child, symbol.integration_variable)
-            elif isinstance(symbol, pybamm.NodeToEdge):
-                return pybamm.NodeToEdge(new_child, symbol.node_to_edge_function)
             elif isinstance(symbol, pybamm.BoundaryValue):
                 return pybamm.BoundaryValue(new_child, symbol.side)
             else:

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -497,7 +497,9 @@ class FiniteVolume(pybamm.SpatialMethod):
             elif side == "right":
                 return array[-1] + (array[-1] - array[-2]) / 2
 
-        return BoundaryValueEvaluated(discretised_symbol, linear_extrapolation)
+        boundary_value = pybamm.Function(linear_extrapolation, discretised_symbol)
+        boundary_value.domain = []
+        return boundary_value
 
     def mass_matrix(self, symbol, boundary_conditions):
         """
@@ -536,10 +538,6 @@ class FiniteVolume(pybamm.SpatialMethod):
         mass = kron(eye(sec_pts), prim_mass)
         return pybamm.Matrix(mass)
 
-    #######################################################
-    # Can probably be moved outside of the spatial method
-    ######################################################
-
     def compute_diffusivity(
         self, discretised_symbol, extrapolate_left=False, extrapolate_right=False
     ):
@@ -566,7 +564,7 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         Returns
         -------
-        :class:`pybamm.NodeToEdge`
+        :class:`pybamm.Function`
             Averaged symbol. When evaluated, this returns either a scalar or an array of
             shape (n-1,) as appropriate.
         """
@@ -582,73 +580,13 @@ class FiniteVolume(pybamm.SpatialMethod):
                 mean_array = np.concatenate([mean_array, np.array([right_node])])
             return mean_array
 
-        return pybamm.NodeToEdge(discretised_symbol, arithmetic_mean)
+        def node_to_edge(symbol):
+            # If the symbol is a numpy array of shape (n,), do the averaging
+            # NOTE: Doing this check every time might be slow?
+            if isinstance(symbol, np.ndarray) and len(symbol.shape) == 1:
+                return arithmetic_mean(symbol)
+            # If not, no need to average
+            else:
+                return symbol
 
-
-class BoundaryValueEvaluated(pybamm.SpatialOperator):
-    """A node in the expression tree representing a unary operator that evaluates the
-    value of its child at a boundary.
-
-    Parameters
-    ----------
-    child : :class:`Symbol`
-        child node
-    boundary_function : method
-        the function used to calculate the boundary value
-
-    **Extends:** :class:`pybamm.SpatialOperator`
-    """
-
-    def __init__(self, child, boundary_function):
-        """ See :meth:`pybamm.UnaryOperator.__init__()`. """
-        super().__init__(
-            "boundary value ({})".format(boundary_function.__name__), child
-        )
-        self._boundary_function = boundary_function
-        # Domain of BoundaryValue must be ([]) so that expressions can be formed
-        # of boundary values of variables in different domains
-        self.domain = []
-
-    def evaluate(self, t=None, y=None):
-        """ See :meth:`pybamm.Symbol.evaluate()`. """
-        evaluated_child = self.children[0].evaluate(t, y)
-        return self._boundary_function(evaluated_child)
-
-
-class NodeToEdge(pybamm.SpatialOperator):
-    """A node in the expression tree representing a unary operator that evaluates the
-    value of its child at cell edges by averaging the value at cell nodes.
-
-    Parameters
-    ----------
-
-    child : :class:`Symbol`
-        child node
-    node_to_edge_function : method
-        the function used to average; only acts if the child evaluates to a
-        one-dimensional numpy array
-
-    **Extends:** :class:`pybamm.SpatialOperator`
-    """
-
-    def __init__(self, child, node_to_edge_function):
-        """ See :meth:`pybamm.UnaryOperator.__init__()`. """
-        super().__init__(
-            "node to edge ({})".format(node_to_edge_function.__name__), child
-        )
-        self._node_to_edge_function = node_to_edge_function
-
-    @property
-    def node_to_edge_function(self):
-        return self._node_to_edge_function
-
-    def evaluate(self, t=None, y=None):
-        """ See :meth:`pybamm.Symbol.evaluate()`. """
-        evaluated_child = self.children[0].evaluate(t, y)
-        # If the evaluated child is a numpy array of shape (n,), do the averaging
-        # NOTE: Doing this check every time might be slow?
-        if isinstance(evaluated_child, np.ndarray) and len(evaluated_child.shape) == 1:
-            return self._node_to_edge_function(evaluated_child)
-        # If not, no need to average
-        else:
-            return evaluated_child
+        return pybamm.Function(node_to_edge, discretised_symbol)

--- a/tests/test_models/test_lead_acid/test_lead_acid_newman_tiedemann.py
+++ b/tests/test_models/test_lead_acid/test_lead_acid_newman_tiedemann.py
@@ -15,7 +15,7 @@ class TestLeadAcidNewmanTiedemann(unittest.TestCase):
         model = pybamm.lead_acid.NewmanTiedemann()
         # Make grid very coarse for quick test (note that r domain doesn't matter)
         var = pybamm.standard_spatial_vars
-        self.default_var_pts = {
+        model.default_var_pts = {
             var.x_n: 3,
             var.x_s: 3,
             var.x_p: 3,
@@ -29,7 +29,7 @@ class TestLeadAcidNewmanTiedemann(unittest.TestCase):
         model = pybamm.lead_acid.NewmanTiedemann()
         # Make grid very coarse for quick test (note that r domain doesn't matter)
         var = pybamm.standard_spatial_vars
-        self.default_var_pts = {
+        model.default_var_pts = {
             var.x_n: 3,
             var.x_s: 3,
             var.x_p: 3,

--- a/tests/test_models/test_lithium_ion/test_lithium_ion_dfn.py
+++ b/tests/test_models/test_lithium_ion/test_lithium_ion_dfn.py
@@ -12,12 +12,12 @@ class TestDFN(unittest.TestCase):
     def test_basic_processing(self):
         model = pybamm.lithium_ion.DFN()
         var = pybamm.standard_spatial_vars
-        self.default_var_pts = {
+        model.default_var_pts = {
             var.x_n: 3,
             var.x_s: 3,
             var.x_p: 3,
-            var.r_n: 1,
-            var.r_p: 1,
+            var.r_n: 3,
+            var.r_p: 3,
         }
 
         modeltest = tests.StandardModelTest(model)

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -16,21 +16,17 @@ class TestFiniteVolume(unittest.TestCase):
         def arithmetic_mean(array):
             return (array[1:] + array[:-1]) / 2
 
-        ava = pybamm.NodeToEdge(a, arithmetic_mean)
-        self.assertEqual(ava.name, "node to edge (arithmetic_mean)")
+        ava = pybamm.Function(arithmetic_mean, a)
+        self.assertEqual(ava.name, "function (arithmetic_mean)")
         self.assertEqual(ava.children[0].name, a.name)
 
-        b = pybamm.Scalar(-4)
-        avb = pybamm.NodeToEdge(b, arithmetic_mean)
-        self.assertEqual(avb.evaluate(), -4)
-
         c = pybamm.Vector(np.ones(10))
-        avc = pybamm.NodeToEdge(c, arithmetic_mean)
+        avc = pybamm.Function(arithmetic_mean, c)
         np.testing.assert_array_equal(avc.evaluate(), np.ones(9))
 
         d = pybamm.StateVector(slice(0, 10))
         y_test = np.ones(10)
-        avd = pybamm.NodeToEdge(d, arithmetic_mean)
+        avd = pybamm.Function(arithmetic_mean, d)
         np.testing.assert_array_equal(avd.evaluate(None, y_test), np.ones(9))
 
     def test_extrapolate_left_right(self):


### PR DESCRIPTION
# Description

Remove `NodeToEdge` and `BoundaryValueEvaluated` as they are overkill
Fixes #244 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
