### PR TITLE
Issue 242 output vars to spm

### DIFF
--- a/pybamm/models/lithium_ion/spm.py
+++ b/pybamm/models/lithium_ion/spm.py
@@ -57,11 +57,15 @@ class SPM(pybamm.LithiumIonBaseModel):
         ocp_p = param.U_p(c_s_p_surf)
         ocv = ocp_p - ocp_n
 
-        # reaction overpotentials
-        j0_n = (1 / param.C_r_n) * c_s_n_surf ** 0.5 * (1 - c_s_n_surf) ** 0.5
-        j0_p = (
-            (param.gamma_p / param.C_r_p) * c_s_p_surf ** 0.5 * (1 - c_s_p_surf) ** 0.5
+        # exhange current density
+        j0_n = pybamm.interface.exchange_current_density(
+            1, c_s_n_surf, ["negative electrode"]
         )
+        j0_p = pybamm.interface.exchange_current_density(
+            1, c_s_p_surf, ["positive electrode"]
+        )
+
+        # reaction overpotentials
         eta_r_n = -2 * pybamm.Function(np.arcsinh, i_cell / (j0_p * param.l_p))
         eta_r_p = -2 * pybamm.Function(np.arcsinh, i_cell / (j0_n * param.l_n))
         eta_r = eta_r_n + eta_r_p

--- a/pybamm/models/lithium_ion/spm.py
+++ b/pybamm/models/lithium_ion/spm.py
@@ -30,8 +30,6 @@ class SPM(pybamm.LithiumIonBaseModel):
 
         "Submodels"
         # Interfacial current density
-        # j_n = pybamm.interface.homogeneous_reaction(["negative electrode"])
-        # j_p = pybamm.interface.homogeneous_reaction(["positive electrode"])
         j_n = param.current_with_time / param.l_n
         j_p = -param.current_with_time / param.l_p
 

--- a/pybamm/models/submodels/interface.py
+++ b/pybamm/models/submodels/interface.py
@@ -102,9 +102,34 @@ def exchange_current_density(c_e, c_s_k_surf=None, domain=None):
             return sp.m_p * c_e ** 2 * c_w
 
 
+def inverse_butler_volmer(j, j0, ne):
+    """
+    Inverts the Butler-Volmer relation to solve for the reaction overpotential.
+
+    Parameters
+    ----------
+    param : parameter class
+        The parameters to use for this submodel
+    j : :class:`pybamm.Symbol`
+        The interfacial current density
+    j0 : :class:`pybamm.Symbol`
+        The exchange current density
+    ne : int
+        The number of electrons in the charge transfer reaction
+
+    Returns
+    -------
+    eta :class: `pybamm.Symbol`
+        The reaction overpotential
+    """
+    eta = (2 / ne) * pybamm.Function(np.arcsinh, j / j0)
+
+    return eta
+
+
 def butler_volmer(param, c_e, Delta_phi, c_s_k_surf=None, domain=None):
     """
-    Butler-Volmer reactions for lead-acid chemistry
+    Butler-Volmer reactions
 
     .. math::
         j = j_0(c) * \\sinh(\\phi - U(c)),


### PR DESCRIPTION
# Description
Cleaned up the SPM output variables a bit so that long expressions do not need to be implemented explicitly within the SPM model file. Other output variables are provided within submodels

Fixes #242

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
