### PR TITLE
#227 change evaluate to __call__

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,4 +30,4 @@ Contents
     source/discretisations/index
     source/spatial_methods/index
     source/solvers/index
-
+    source/processed_variable

--- a/docs/source/expression_tree/variable.rst
+++ b/docs/source/expression_tree/variable.rst
@@ -3,5 +3,3 @@ Variable
 
 .. autoclass:: pybamm.Variable
   :members:
-
-.

--- a/docs/source/expression_tree/vector.rst
+++ b/docs/source/expression_tree/vector.rst
@@ -6,5 +6,3 @@ Vector
 
 .. autoclass:: pybamm.StateVector
   :members:
-
-.

--- a/docs/source/processed_variable.rst
+++ b/docs/source/processed_variable.rst
@@ -1,0 +1,5 @@
+Processed Variable
+==================
+
+.. autoclass:: pybamm.ProcessedVariable
+  :members:

--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -68,7 +68,7 @@ class ProcessedVariable(object):
                 t_sol, x_sol, entries, kind=interp_kind
             )
 
-    def evaluate(self, t, x=None):
+    def __call__(self, t, x=None):
         "Evaluate the variable at arbitrary t (and x), using interpolation"
         if self.x_sol is None:
             return self._interpolation_function(t)

--- a/tests/test_processed_variable.py
+++ b/tests/test_processed_variable.py
@@ -58,14 +58,14 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.array([np.linspace(0, 5, 1000)])
         processed_var = pybamm.ProcessedVariable(var, t_sol, y_sol)
         # vector
-        np.testing.assert_array_equal(processed_var.evaluate(t_sol), y_sol)
+        np.testing.assert_array_equal(processed_var(t_sol), y_sol)
         # scalar
-        np.testing.assert_array_equal(processed_var.evaluate(0.5), 2.5)
-        np.testing.assert_array_equal(processed_var.evaluate(0.7), 3.5)
+        np.testing.assert_array_equal(processed_var(0.5), 2.5)
+        np.testing.assert_array_equal(processed_var(0.7), 3.5)
 
         processed_eqn = pybamm.ProcessedVariable(eqn, t_sol, y_sol)
-        np.testing.assert_array_equal(processed_eqn.evaluate(t_sol), t_sol * y_sol)
-        np.testing.assert_array_almost_equal(processed_eqn.evaluate(0.5), 0.5 * 2.5)
+        np.testing.assert_array_equal(processed_eqn(t_sol), t_sol * y_sol)
+        np.testing.assert_array_almost_equal(processed_eqn(0.5), 0.5 * 2.5)
 
         # with spatial dependence
         var = pybamm.Variable("var", domain=["negative electrode", "separator"])
@@ -82,30 +82,28 @@ class TestProcessedVariable(unittest.TestCase):
 
         processed_var = pybamm.ProcessedVariable(var_sol, t_sol, y_sol, mesh=disc.mesh)
         # 2 vectors
-        np.testing.assert_array_almost_equal(
-            processed_var.evaluate(t_sol, x_sol), y_sol
-        )
+        np.testing.assert_array_almost_equal(processed_var(t_sol, x_sol), y_sol)
         # 1 vector, 1 scalar
         np.testing.assert_array_almost_equal(
-            processed_var.evaluate(0.5, x_sol)[:, 0], 2.5 * x_sol
+            processed_var(0.5, x_sol)[:, 0], 2.5 * x_sol
         )
         np.testing.assert_array_equal(
-            processed_var.evaluate(t_sol, x_sol[-1]), x_sol[-1] * np.linspace(0, 5)
+            processed_var(t_sol, x_sol[-1]), x_sol[-1] * np.linspace(0, 5)
         )
         # 2 scalars
         np.testing.assert_array_almost_equal(
-            processed_var.evaluate(0.5, x_sol[-1]), 2.5 * x_sol[-1]
+            processed_var(0.5, x_sol[-1]), 2.5 * x_sol[-1]
         )
         processed_eqn = pybamm.ProcessedVariable(eqn_sol, t_sol, y_sol, mesh=disc.mesh)
         # 2 vectors
         np.testing.assert_array_almost_equal(
-            processed_eqn.evaluate(t_sol, x_sol), t_sol * y_sol + x_sol[:, np.newaxis]
+            processed_eqn(t_sol, x_sol), t_sol * y_sol + x_sol[:, np.newaxis]
         )
         # 1 vector, 1 scalar
-        self.assertEqual(processed_eqn.evaluate(0.5, x_sol[10:30]).shape, (20, 1))
-        self.assertEqual(processed_eqn.evaluate(t_sol[4:9], x_sol[-1]).shape, (5,))
+        self.assertEqual(processed_eqn(0.5, x_sol[10:30]).shape, (20, 1))
+        self.assertEqual(processed_eqn(t_sol[4:9], x_sol[-1]).shape, (5,))
         # 2 scalars
-        self.assertEqual(processed_eqn.evaluate(0.5, x_sol[-1]).shape, (1,))
+        self.assertEqual(processed_eqn(0.5, x_sol[-1]).shape, (1,))
 
     def test_processed_variable_ode_pde_solution(self):
         # without space


### PR DESCRIPTION
# Description

Use `.__call__` instead of `.evaluate` to evaluate a processed variable
Fixes #227 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
