### PR TITLE
Issue 175 indefinite integral

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -78,6 +78,7 @@ from .expression_tree.unary_operators import (
     Divergence,
     BoundaryValue,
     Integral,
+    IndefiniteIntegral,
     grad,
     div,
     surf,

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -285,6 +285,13 @@ class Discretisation(object):
                 child.domain, child, discretised_child
             )
 
+        elif isinstance(symbol, pybamm.IndefiniteIntegral):
+            child = symbol.children[0]
+            discretised_child = self.process_symbol(child)
+            return self._spatial_methods[child.domain[0]].indefinite_integral(
+                child.domain, child, discretised_child
+            )
+
         elif isinstance(symbol, pybamm.Broadcast):
             # Process child first
             new_child = self.process_symbol(symbol.children[0])

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -269,6 +269,57 @@ class Integral(SpatialOperator):
         return self.__class__(child, self.integration_variable)
 
 
+class IndefiniteIntegral(SpatialOperator):
+    """A node in the expression tree representing an indefinite integral operator
+
+    .. math::
+        I = \\int_{x_\text{min}}^{x}\\!f(u)\\,du
+
+    where :math:`u\\in\\text{domain}` which can represent either a
+    spatial or temporal variable.
+
+    Parameters
+    ----------
+    function : :class:`pybamm.Symbol`
+        The function to be integrated (will become self.children[0])
+    integration_variable : :class:`pybamm.IndependentVariable`
+        The variable over which to integrate
+
+    **Extends:** :class:`SpatialOperator`
+    """
+
+    def __init__(self, child, integration_variable):
+        if isinstance(integration_variable, pybamm.SpatialVariable):
+            # Check that child and integration_variable domains agree
+            if child.domain != integration_variable.domain:
+                raise pybamm.DomainError(
+                    """child and integration_variable must have the same domain"""
+                )
+        elif not isinstance(integration_variable, pybamm.IndependentVariable):
+            raise ValueError(
+                """integration_variable must be of type pybamm.IndependentVariable,
+                   not {}""".format(
+                    type(integration_variable)
+                )
+            )
+        name = "{} integrated w.r.t {}".format(child.name, integration_variable.name)
+        if isinstance(integration_variable, pybamm.SpatialVariable):
+            name += "on {}".format(integration_variable.domain)
+        super().__init__(name, child)
+        self._integration_variable = integration_variable
+        # the integrated variable has the same domain as the child
+        self.domain = child.domain
+
+    @property
+    def integration_variable(self):
+        return self._integration_variable
+
+    def _unary_simplify(self, child):
+        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
+
+        return self.__class__(child, self.integration_variable)
+
+
 class BoundaryValue(SpatialOperator):
     """A node in the expression tree which gets the boundary value of a variable.
 

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -389,15 +389,6 @@ class FiniteVolume(pybamm.SpatialMethod):
         n = submesh.npts
         sec_pts = len(submesh_list)
 
-        # # case input i, output phi
-        # # note we have added a row of zeros at top for F(0) = 0
-        # du_e = submesh.d_edges
-        # du_entries = [du_e] * n
-        # offset = -np.arange(1, n + 1, 1)
-        # sub_matrix = diags(du_entries, offset, shape=(n + 1, n))
-        # matrix = kron(eye(sec_pts), sub_matrix)
-
-        # case input i, output phi
         # note we have added a row of zeros at top for F(0) = 0
         du_n = submesh.d_nodes
         du_entries = [du_n] * (n - 1)

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -342,6 +342,71 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         return pybamm.Vector(vector)
 
+    def indefinite_integral(self, domain, symbol, discretised_symbol):
+        """Implementation of the indefinite integral operator. The
+        input discretised symbol must be defined on the internal mesh edges.
+        See :meth:`pybamm.BaseDiscretisation.indefinite_integral`
+        """
+
+        if not symbol.has_gradient_and_not_divergence():
+            raise pybamm.ModelError(
+                "Symbol to be integrated must be valid on the mesh edges"
+            )
+
+        # Calculate integration matrix
+        integration_matrix = self.indefinite_integral_matrix(domain)
+
+        # Don't need to check for spherical domains as spherical polars
+        # only change the diveregence (symbols here have grad and no div)
+        out = integration_matrix @ discretised_symbol
+
+        out.domain = domain
+
+        return out
+
+    def indefinite_integral_matrix(self, domain):
+        """
+        Matrix for finite-volume implementation of the indefinite integral
+
+        .. math::
+            F = \\int\\!f(u)\\,du
+
+
+        Parameters
+        ----------
+        domain : list
+            The domain(s) of integration
+
+        Returns
+        -------
+        :class:`pybamm.Vector`
+            The finite volume integral vector for the domain
+        """
+
+        # Create appropriate submesh by combining submeshes in domain
+        submesh_list = self.mesh.combine_submeshes(*domain)
+        submesh = submesh_list[0]
+        n = submesh.npts
+        sec_pts = len(submesh_list)
+
+        # # case input i, output phi
+        # # note we have added a row of zeros at top for F(0) = 0
+        # du_e = submesh.d_edges
+        # du_entries = [du_e] * n
+        # offset = -np.arange(1, n + 1, 1)
+        # sub_matrix = diags(du_entries, offset, shape=(n + 1, n))
+        # matrix = kron(eye(sec_pts), sub_matrix)
+
+        # case input i, output phi
+        # note we have added a row of zeros at top for F(0) = 0
+        du_n = submesh.d_nodes
+        du_entries = [du_n] * (n - 1)
+        offset = -np.arange(1, n, 1)
+        sub_matrix = diags(du_entries, offset, shape=(n, n - 1))
+        matrix = kron(eye(sec_pts), sub_matrix)
+
+        return pybamm.Matrix(matrix)
+
     def add_ghost_nodes(self, symbol, discretised_symbol, lbc=None, rbc=None):
         """
         Add Dirichlet boundary conditions via ghost nodes.

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -104,7 +104,7 @@ class SpatialMethod:
         """
         raise NotImplementedError
 
-    def integral(self, domain, discretised_symbol):
+    def integral(self, domain, symbol, discretised_symbol):
         """
         Implements the integral for a spatial method.
 
@@ -112,6 +112,8 @@ class SpatialMethod:
         ----------
         domain: iterable of strings
             The domain in which to integrate
+        symbol: class: pybamm.Symbol
+            The symbol to which is being integrated
         discretised_symbol: class: pybamm.Array
             The discretised symbol of the correct size
 
@@ -119,6 +121,27 @@ class SpatialMethod:
         -------
         :class: `pybamm.Array`
             Contains the result of acting the discretised integral on
+            the child discretised_symbol
+        """
+        raise NotImplementedError
+
+    def indefinite_integral(self, domain, symbol, discretised_symbol):
+        """
+        Implements the indefinite integral for a spatial method.
+
+        Parameters
+        ----------
+        domain: iterable of strings
+            The domain in which to integrate
+        symbol: class: pybamm.Symbol
+            The symbol to which is being integrated
+        discretised_symbol: class: pybamm.Array
+            The discretised symbol of the correct size
+
+        Returns
+        -------
+        :class: `pybamm.Array`
+            Contains the result of acting the discretised indefinite integral on
             the child discretised_symbol
         """
         raise NotImplementedError

--- a/tests/test_discretisations/test_discretisation.py
+++ b/tests/test_discretisations/test_discretisation.py
@@ -244,7 +244,9 @@ class TestDiscretise(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             spatial_method.divergence(None, None, {})
         with self.assertRaises(NotImplementedError):
-            spatial_method.integral(None, None)
+            spatial_method.integral(None, None, None)
+        with self.assertRaises(NotImplementedError):
+            spatial_method.indefinite_integral(None, None, None)
 
     def test_process_dict(self):
         # one equation

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -961,27 +961,6 @@ class TestFiniteVolume(unittest.TestCase):
         with self.assertRaisesRegex(pybamm.ModelError, "integrated"):
             disc.process_symbol(phi_integral)
 
-        # # microscale variable
-        # # microscale variable
-        # var = pybamm.Variable("var", domain=["negative particle"])
-        # r = pybamm.SpatialVariable("r", ["negative particle"])
-        # integral_eqn = pybamm.IndefiniteIntegral(var, r)
-        # disc.set_variable_slices([var])
-        # integral_eqn_disc = disc.process_symbol(integral_eqn)
-
-        # constant_y = np.ones_like(mesh["negative particle"][0].nodes)
-        # # np.testing.assert_array_equal(
-        #     integral_eqn_disc.evaluate(None, constant_y), np.pi
-        # )
-        # linear_y = mesh["negative particle"][0].nodes
-        # np.testing.assert_array_almost_equal(
-        #     integral_eqn_disc.evaluate(None, linear_y), 2 * np.pi / 3, places=4
-        # )
-        # one_over_y = 1 / mesh["negative particle"][0].nodes
-        # np.testing.assert_array_equal(
-        #     integral_eqn_disc.evaluate(None, one_over_y), 2 * np.pi
-        # )
-
     def test_grad_convergence_without_bcs(self):
         # Convergence
         whole_cell = ["negative electrode", "separator", "positive electrode"]

--- a/tests/test_spatial_methods/test_finite_volume.py
+++ b/tests/test_spatial_methods/test_finite_volume.py
@@ -856,32 +856,34 @@ class TestFiniteVolume(unittest.TestCase):
         disc = pybamm.Discretisation(mesh, spatial_methods)
 
         # input a phi, take grad, then integrate to recover phi approximation
+        # (need to test this way as check evaluated on edges using if has grad
+        # and no div)
         phi = pybamm.Variable("phi", domain=["negative electrode", "separator"])
         i = pybamm.grad(phi)  # create test current (variable on edges)
 
         x = pybamm.SpatialVariable("x", ["negative electrode", "separator"])
-        phi_integral = pybamm.IndefiniteIntegral(i, x)
+        int_grad_phi = pybamm.IndefiniteIntegral(i, x)
         disc.set_variable_slices([phi])  # i is not a fundamental variable
 
-        phi_integral_disc = disc.process_symbol(phi_integral)
+        int_grad_phi_disc = disc.process_symbol(int_grad_phi)
 
         combined_submesh = mesh.combine_submeshes("negative electrode", "separator")
 
         # constant case
         phi_exact = np.ones_like(combined_submesh[0].nodes)
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += 1  # add constant of integration
         np.testing.assert_array_equal(phi_exact, phi_approx)
 
         # linear case
         phi_exact = combined_submesh[0].nodes
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += phi_exact[0]  # add constant of integration
         np.testing.assert_array_almost_equal(phi_exact, phi_approx)
 
         # sine case
         phi_exact = np.sin(combined_submesh[0].nodes)
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += phi_exact[0]  # add constant of integration
         np.testing.assert_array_almost_equal(phi_exact, phi_approx)
 
@@ -890,27 +892,27 @@ class TestFiniteVolume(unittest.TestCase):
         phi = pybamm.Variable("phi", domain=["separator", "positive electrode"])
         i = pybamm.grad(phi)  # create test current (variable on edges)
         x = pybamm.SpatialVariable("x", ["separator", "positive electrode"])
-        phi_integral = pybamm.IndefiniteIntegral(i, x)
+        int_grad_phi = pybamm.IndefiniteIntegral(i, x)
         disc.set_variable_slices([phi])  # i is not a fundamental variable
 
-        phi_integral_disc = disc.process_symbol(phi_integral)
+        int_grad_phi_disc = disc.process_symbol(int_grad_phi)
         combined_submesh = mesh.combine_submeshes("separator", "positive electrode")
 
         # constant case
         phi_exact = np.ones_like(combined_submesh[0].nodes)
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += 1  # add constant of integration
         np.testing.assert_array_equal(phi_exact, phi_approx)
 
         # linear case
         phi_exact = combined_submesh[0].nodes
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += phi_exact[0]  # add constant of integration
         np.testing.assert_array_almost_equal(phi_exact, phi_approx)
 
         # sine case
         phi_exact = np.sin(combined_submesh[0].nodes)
-        phi_approx = phi_integral_disc.evaluate(None, phi_exact)
+        phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += phi_exact[0]  # add constant of integration
         np.testing.assert_array_almost_equal(phi_exact, phi_approx)
 
@@ -948,18 +950,18 @@ class TestFiniteVolume(unittest.TestCase):
         phi = pybamm.Variable("phi", domain=["separator", "positive electrode"])
         no_grad_or_div = phi
         x = pybamm.SpatialVariable("x", ["separator", "positive electrode"])
-        phi_integral = pybamm.IndefiniteIntegral(no_grad_or_div, x)
+        int_grad_phi = pybamm.IndefiniteIntegral(no_grad_or_div, x)
         disc.set_variable_slices([phi])
 
         with self.assertRaisesRegex(pybamm.ModelError, "integrated"):
-            disc.process_symbol(phi_integral)
+            disc.process_symbol(int_grad_phi)
 
         grad_and_div = pybamm.div(pybamm.grad(phi))
-        phi_integral = pybamm.IndefiniteIntegral(grad_and_div, x)
+        int_grad_phi = pybamm.IndefiniteIntegral(grad_and_div, x)
         disc.set_variable_slices([phi])
 
         with self.assertRaisesRegex(pybamm.ModelError, "integrated"):
-            disc.process_symbol(phi_integral)
+            disc.process_symbol(int_grad_phi)
 
     def test_grad_convergence_without_bcs(self):
         # Convergence


### PR DESCRIPTION
# Description
Implements the indefinite integral for the cases which we require (i.e. integrate current to get potential). 

Fixes #175

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)



# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
