### PR TITLE
#270 simplify concat of state vectors

### DIFF
--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -210,6 +210,17 @@ class DomainConcatenation(Concatenation):
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
+        children = self.children
+        if all([isinstance(x, pybamm.StateVector) for x in children]):
+            if all(
+                [
+                    children[idx].y_slice.stop == children[idx + 1].y_slice.start
+                    for idx in range(len(children) - 1)
+                ]
+            ):
+                return pybamm.StateVector(
+                    slice(children[0].y_slice.start, children[-1].y_slice.stop)
+                )
         children = [child.simplify() for child in self.children]
 
         new_node = self.__class__(children, self.mesh, self)

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -211,17 +211,19 @@ class DomainConcatenation(Concatenation):
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
         children = self.children
-        if all([isinstance(x, pybamm.StateVector) for x in children]):
-            if all(
-                [
-                    children[idx].y_slice.stop == children[idx + 1].y_slice.start
-                    for idx in range(len(children) - 1)
-                ]
-            ):
-                return pybamm.StateVector(
-                    slice(children[0].y_slice.start, children[-1].y_slice.stop)
-                )
-        children = [child.simplify() for child in self.children]
+        # Simplify Concatenation of StateVectors to a single StateVector
+        if all([isinstance(x, pybamm.StateVector) for x in children]) and all(
+            [
+                children[idx].y_slice.stop == children[idx + 1].y_slice.start
+                for idx in range(len(children) - 1)
+            ]
+        ):
+            return pybamm.StateVector(
+                slice(children[0].y_slice.start, children[-1].y_slice.stop)
+            )
+
+        # Otherwise just simplify children and convert to array if constant
+        children = [child.simplify() for child in children]
 
         new_node = self.__class__(children, self.mesh, self)
 


### PR DESCRIPTION
# Description

Concatenation of StateVectors simplifies to a single StateVector
Fixes #270 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
