### PR TITLE
#295 allow mat-muls on the denominator

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -405,16 +405,10 @@ def simplify_multiplication_division(myclass, left, right):
                 constant_numerator_expr
             )
             if nonconst_numerator_expr is None:
-                if new_denominator is None:
-                    result = constant_numerator_expr
-                else:
-                    result = constant_numerator_expr / new_denominator
+                result = constant_numerator_expr / new_denominator
             else:
-                if new_denominator is None:
-                    result = constant_numerator_expr * nonconst_numerator_expr
-                else:
-                    result = constant_numerator_expr * nonconst_numerator_expr \
-                        / new_denominator
+                result = constant_numerator_expr * nonconst_numerator_expr \
+                    / new_denominator
 
     else:
         # can reorder the numerator since no matrix multiplies

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -173,11 +173,10 @@ def simplify_multiplication_division(myclass, left, right):
     function would simplify (3*(1 + d)*2) to (6 * (1 + d))
 
     As well as Multiplication and Division, this function can handle
-    MatrixMultiplication in two different ways:
-    1. If any MatrixMultiplications are found on the denominator, an exception is raised
-    2. If any MatrixMultiplications are found on the numerator, no reordering of
-    children is done to find groups of constant children. In this case only neighbouring
-    constant children on the numerator are simplified
+    MatrixMultiplication. If any MatrixMultiplications are found on the
+    numerator/denominator, no reordering of children is done to find groups of constant
+    children. In this case only neighbouring constant children on the numerator are
+    simplified
 
     Parameters
     ----------
@@ -194,6 +193,7 @@ def simplify_multiplication_division(myclass, left, right):
     numerator = []
     denominator = []
     numerator_types = []
+    denominator_types = []
 
     # recursive function to flatten a term involving only multiplications or divisions
     def flatten(
@@ -260,10 +260,10 @@ def simplify_multiplication_division(myclass, left, right):
                         numerator_types.append(this_class)
                 else:
                     denominator.append(child)
-                    if this_class == pybamm.MatrixMultiplication:
-                        raise pybamm.ModelError(
-                            "matrix multiplication on the denominator"
-                        )
+                    if child == left_child:
+                        denominator_types.append(previous_class)
+                    else:
+                        denominator_types.append(this_class)
 
             if child == left_child and this_class == pybamm.Division:
                 in_numerator = not in_numerator
@@ -271,8 +271,12 @@ def simplify_multiplication_division(myclass, left, right):
     flatten(None, myclass, left, right, True, myclass == pybamm.MatrixMultiplication)
 
     # check if there is a matrix multiply in the numerator (if so we can't reorder it)
-    has_matrix_multiply = any(
+    numerator_has_mat_mul = any(
         [typ == pybamm.MatrixMultiplication for typ in numerator_types + [myclass]]
+    )
+
+    denominator_has_mat_mul = any(
+        [typ == pybamm.MatrixMultiplication for typ in denominator_types]
     )
 
     def partition_by_constant(source, types=None):
@@ -289,9 +293,6 @@ def simplify_multiplication_division(myclass, left, right):
             else:
                 nonconstant.append(child)
         return constant, nonconstant
-
-    # assume everything in denominator is a scalar so can reorder
-    denominator_constant, denominator_nonconstant = partition_by_constant(denominator)
 
     def fold_multiply(array, types=None):
         """
@@ -321,79 +322,100 @@ def simplify_multiplication_division(myclass, left, right):
                         ret = child * ret
         return ret
 
-    # compact denominator_constant to a constant scalar
-    constant_denominator_expr = fold_multiply(denominator_constant)
-
-    # see if there is a constant term in the numerator.
-    # if so combine with constant denominator term
-    found_a_constant = False
-    for i, child in enumerate(numerator):
-        if child.is_constant() and child.evaluate_ignoring_errors() is not None:
-            if constant_denominator_expr is not None:
-                numerator[i] = pybamm.simplify_if_constant(
-                    child / constant_denominator_expr
-                )
-            found_a_constant = True
-
-    if not found_a_constant:
-        # not possible to simplify numerator, just return as is
-        new_numerator = fold_multiply(numerator, numerator_types)
-
-        # there has to be at least one numerator
-        if constant_denominator_expr is not None:
-            # better to invert the constant denominator to get rid of the divide
-            invert_constant_denom = pybamm.simplify_if_constant(
-                1 / constant_denominator_expr
-            )
-            new_numerator = invert_constant_denom * new_numerator
-
-    # here we have determined that there is at least one constant in the numerator and
-    # we've combined all the constants in the denominator with it
-    elif has_matrix_multiply:
-        # only consider neighbouring children for numerator as we can't reorder mat muls
-        new_numerator = [numerator[0]]
-        new_numerator_types = [numerator_types[0]]
-        for child, typ in zip(numerator[1:], numerator_types[1:]):
+    def simplify_with_mat_mul(nodes, types):
+        new_nodes = [nodes[0]]
+        new_types = [types[0]]
+        for child, typ in zip(nodes[1:], types[1:]):
             if (
-                new_numerator[-1].is_constant()
+                new_nodes[-1].is_constant()
                 and child.is_constant()
-                and new_numerator[-1].evaluate_ignoring_errors() is not None
+                and new_nodes[-1].evaluate_ignoring_errors() is not None
                 and child.evaluate_ignoring_errors() is not None
             ):
                 if typ == pybamm.MatrixMultiplication:
-                    new_numerator[-1] = new_numerator[-1] @ child
+                    new_nodes[-1] = new_nodes[-1] @ child
                 else:
-                    new_numerator[-1] *= child
-                new_numerator[-1] = pybamm.simplify_if_constant(new_numerator[-1])
+                    new_nodes[-1] *= child
+                new_nodes[-1] = pybamm.simplify_if_constant(new_nodes[-1])
             else:
-                new_numerator.append(child)
-                new_numerator_types.append(typ)
-        new_numerator = fold_multiply(new_numerator, new_numerator_types)
+                new_nodes.append(child)
+                new_types.append(typ)
+        new_nodes = fold_multiply(new_nodes, new_types)
+        return new_nodes
+
+    if numerator_has_mat_mul and denominator_has_mat_mul:
+        new_numerator = simplify_with_mat_mul(numerator, numerator_types)
+        new_denominator = simplify_with_mat_mul(denominator, denominator_types)
+        result = new_numerator/new_denominator
+
+    elif numerator_has_mat_mul and not denominator_has_mat_mul:
+        new_numerator = simplify_with_mat_mul(numerator, numerator_types)
+
+        # can reorder the denominator since no matrix multiplies
+        denominator_constant, denominator_nonconst = partition_by_constant(denominator)
+
+        constant_denominator_expr = fold_multiply(denominator_constant)
+        nonconst_denominator_expr = fold_multiply(denominator_nonconst)
+
+        if constant_denominator_expr is None:
+            result = new_numerator/nonconst_denominator_expr
+        else:
+            # invert constant denominator terms for speed
+            constant_numerator_expr = pybamm.simplify_if_constant(
+                1/constant_denominator_expr
+            )
+            result = constant_numerator_expr*new_numerator/nonconst_denominator_expr
+
+    elif not numerator_has_mat_mul and denominator_has_mat_mul:
+        new_denominator = simplify_with_mat_mul(denominator, denominator_types)
+
+        # can reorder the numerator since no matrix multiplies
+        numerator_constant, numerator_nonconst = partition_by_constant(numerator)
+
+        constant_numerator_expr = pybamm.simplify_if_constant(
+            fold_multiply(numerator_constant)
+        )
+        nonconst_numerator_expr = fold_multiply(numerator_nonconst)
+
+        if constant_numerator_expr is None:
+            result = nonconst_numerator_expr/new_denominator
+        else:
+            constant_numerator_expr = pybamm.simplify_if_constant(
+                constant_numerator_expr
+            )
+            result = constant_numerator_expr*nonconst_numerator_expr/new_denominator
 
     else:
         # can reorder the numerator since no matrix multiplies
         numerator_constant, numerator_nonconstant = partition_by_constant(numerator)
 
         constant_numerator_expr = fold_multiply(numerator_constant)
-        nonconstant_numerator_expr = fold_multiply(numerator_nonconstant)
+        nonconst_numerator_expr = fold_multiply(numerator_nonconstant)
 
-        # there is at least one constant in the numerator
-        constant_numerator_expr = pybamm.simplify_if_constant(constant_numerator_expr)
+        # can reorder the denominator since no matrix multiplies
+        denominator_constant, denominator_nonconst = partition_by_constant(denominator)
 
-        # might be no nonconstant numerator terms
-        if nonconstant_numerator_expr is None:
-            new_numerator = constant_numerator_expr
+        constant_denominator_expr = fold_multiply(denominator_constant)
+        nonconst_denominator_expr = fold_multiply(denominator_nonconst)
+
+        if constant_numerator_expr is not None:
+            if constant_denominator_expr is not None:
+                constant_numerator_expr = pybamm.simplify_if_constant(
+                    constant_numerator_expr / constant_denominator_expr
+                )
+            else:
+                constant_numerator_expr = pybamm.simplify_if_constant(
+                    constant_numerator_expr
+                )
         else:
-            new_numerator = constant_numerator_expr * nonconstant_numerator_expr
+            if constant_denominator_expr is not None:
+                constant_numerator_expr = pybamm.simplify_if_constant(
+                    1/constant_denominator_expr
+                )
+        result = constant_numerator_expr * nonconst_numerator_expr \
+            / nonconst_denominator_expr
 
-    # combine new numerator with the nonconstant denominator terms (if they exist) and
-    # return the simplified expression
-    new_expression = new_numerator
-    new_denominator = fold_multiply(denominator_nonconstant)
-    if new_denominator is not None:
-        new_expression /= new_denominator
-
-    return new_expression
+    return result
 
 
 def is_zero(expr):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -346,7 +346,7 @@ def simplify_multiplication_division(myclass, left, right):
     if numerator_has_mat_mul and denominator_has_mat_mul:
         new_numerator = simplify_with_mat_mul(numerator, numerator_types)
         new_denominator = simplify_with_mat_mul(denominator, denominator_types)
-        result = new_numerator/new_denominator
+        result = new_numerator / new_denominator
 
     elif numerator_has_mat_mul and not denominator_has_mat_mul:
         new_numerator = simplify_with_mat_mul(numerator, numerator_types)
@@ -358,13 +358,13 @@ def simplify_multiplication_division(myclass, left, right):
         nonconst_denominator_expr = fold_multiply(denominator_nonconst)
 
         if constant_denominator_expr is None:
-            result = new_numerator/nonconst_denominator_expr
+            result = new_numerator / nonconst_denominator_expr
         else:
             # invert constant denominator terms for speed
             constant_numerator_expr = pybamm.simplify_if_constant(
-                1/constant_denominator_expr
+                1 / constant_denominator_expr
             )
-            result = constant_numerator_expr*new_numerator/nonconst_denominator_expr
+            result = constant_numerator_expr * new_numerator / nonconst_denominator_expr
 
     elif not numerator_has_mat_mul and denominator_has_mat_mul:
         new_denominator = simplify_with_mat_mul(denominator, denominator_types)
@@ -378,12 +378,12 @@ def simplify_multiplication_division(myclass, left, right):
         nonconst_numerator_expr = fold_multiply(numerator_nonconst)
 
         if constant_numerator_expr is None:
-            result = nonconst_numerator_expr/new_denominator
+            result = nonconst_numerator_expr / new_denominator
         else:
             constant_numerator_expr = pybamm.simplify_if_constant(
                 constant_numerator_expr
             )
-            result = constant_numerator_expr*nonconst_numerator_expr/new_denominator
+            result = constant_numerator_expr * nonconst_numerator_expr / new_denominator
 
     else:
         # can reorder the numerator since no matrix multiplies
@@ -410,7 +410,7 @@ def simplify_multiplication_division(myclass, left, right):
         else:
             if constant_denominator_expr is not None:
                 constant_numerator_expr = pybamm.simplify_if_constant(
-                    1/constant_denominator_expr
+                    1 / constant_denominator_expr
                 )
         result = constant_numerator_expr * nonconst_numerator_expr \
             / nonconst_denominator_expr

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -273,14 +273,18 @@ class Symbol(anytree.NodeMixin):
 
     def __mul__(self, other):
         """return a :class:`Multiplication` object"""
-        if isinstance(other, (Symbol, numbers.Number)):
+        if other is None:
+            return self
+        elif isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Multiplication(self, other)
         else:
             raise NotImplementedError
 
     def __rmul__(self, other):
         """return a :class:`Multiplication` object"""
-        if isinstance(other, (Symbol, numbers.Number)):
+        if other is None:
+            return self
+        elif isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Multiplication(other, self)
         else:
             raise NotImplementedError
@@ -301,6 +305,8 @@ class Symbol(anytree.NodeMixin):
 
     def __truediv__(self, other):
         """return a :class:`Division` object"""
+        if other is None:
+            return self
         if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Division(self, other)
         else:
@@ -308,6 +314,8 @@ class Symbol(anytree.NodeMixin):
 
     def __rtruediv__(self, other):
         """return a :class:`Division` object"""
+        if other is None:
+            return pybamm.Division(1.0, self)
         if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Division(other, self)
         else:

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -273,18 +273,14 @@ class Symbol(anytree.NodeMixin):
 
     def __mul__(self, other):
         """return a :class:`Multiplication` object"""
-        if other is None:
-            return self
-        elif isinstance(other, (Symbol, numbers.Number)):
+        if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Multiplication(self, other)
         else:
             raise NotImplementedError
 
     def __rmul__(self, other):
         """return a :class:`Multiplication` object"""
-        if other is None:
-            return self
-        elif isinstance(other, (Symbol, numbers.Number)):
+        if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Multiplication(other, self)
         else:
             raise NotImplementedError
@@ -305,8 +301,6 @@ class Symbol(anytree.NodeMixin):
 
     def __truediv__(self, other):
         """return a :class:`Division` object"""
-        if other is None:
-            return self
         if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Division(self, other)
         else:
@@ -314,8 +308,6 @@ class Symbol(anytree.NodeMixin):
 
     def __rtruediv__(self, other):
         """return a :class:`Division` object"""
-        if other is None:
-            return pybamm.Division(1.0, self)
         if isinstance(other, (Symbol, numbers.Number)):
             return pybamm.Division(other, self)
         else:

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -35,7 +35,6 @@ class TestMatrix(unittest.TestCase):
         a = pybamm.Scalar(0)
         b = pybamm.Scalar(1)
         c = pybamm.Parameter("c")
-        e = pybamm.Scalar(2)
 
         # matrix multiplication
         A = pybamm.Matrix(np.array([[1, 0], [0, 1]]))
@@ -101,19 +100,7 @@ class TestMatrix(unittest.TestCase):
         np.testing.assert_array_equal(
             expr2.evaluate(y=np.ones(300)), expr2simp.evaluate(y=np.ones(300))
         )
-
-        # we don't expect any speed up or slow down here
-        timer = pybamm.Timer()
-        start = timer.time()
-        for _ in range(40):
-            expr2.evaluate(y=np.ones(300))
-        end = timer.time()
-        start_simp = timer.time()
-        for _ in range(40):
-            expr2simp.evaluate(y=np.ones(300))
-        end_simp = timer.time()
-        self.assertLess(end_simp - start_simp, 1.2 * (end - start))
-        self.assertLess(end - start, 1.2 * (end_simp - start_simp))
+        self.assertEqual(expr2.id, expr2simp.id)
 
         # more complex expression, with simplification
         expr3 = m1 @ (v3 * (m2 @ v2))

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -66,6 +66,13 @@ class TestMatrix(unittest.TestCase):
                 expr.children[0].entries, np.array([[3, 0], [0, 3]])
             )
 
+        expr = (v @ v / 2).simplify()
+        self.assertIsInstance(expr, pybamm.Multiplication)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(),0.5)
+        self.assertIsInstance(expr.children[1], pybamm.MatrixMultiplication)
+
+
         # mat-mul on numerator and denominator
         expr = (m2 @ (m1 @ v) / (m2 @ (m1 @ v))).simplify()
         for child in expr.children:

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -69,9 +69,8 @@ class TestMatrix(unittest.TestCase):
         expr = (v @ v / 2).simplify()
         self.assertIsInstance(expr, pybamm.Multiplication)
         self.assertIsInstance(expr.children[0], pybamm.Scalar)
-        self.assertEqual(expr.children[0].evaluate(),0.5)
+        self.assertEqual(expr.children[0].evaluate(), 0.5)
         self.assertIsInstance(expr.children[1], pybamm.MatrixMultiplication)
-
 
         # mat-mul on numerator and denominator
         expr = (m2 @ (m1 @ v) / (m2 @ (m1 @ v))).simplify()

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -79,9 +79,6 @@ class TestMatrix(unittest.TestCase):
             self.assertIsInstance(expr, pybamm.Vector)
             np.testing.assert_array_equal(expr.entries, np.array([2, 2]))
 
-        with self.assertRaises(pybamm.ModelError):
-            (e / (m1 @ v)).simplify()
-
         # dont expant mult within mat-mult (issue #253)
         m1 = pybamm.Matrix(np.ones((300, 299)))
         m2 = pybamm.Matrix(np.ones((299, 300)))
@@ -108,11 +105,11 @@ class TestMatrix(unittest.TestCase):
         # we don't expect any speed up or slow down here
         timer = pybamm.Timer()
         start = timer.time()
-        for _ in range(20):
+        for _ in range(40):
             expr2.evaluate(y=np.ones(300))
         end = timer.time()
         start_simp = timer.time()
-        for _ in range(20):
+        for _ in range(40):
             expr2simp.evaluate(y=np.ones(300))
         end_simp = timer.time()
         self.assertLess(end_simp - start_simp, 1.2 * (end - start))

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -104,60 +104,60 @@ class TestMatrix(unittest.TestCase):
             )
 
         # matrix * vector
-        m1=pybamm.Matrix(np.array([[2, 0], [0, 2]]))
-        v1=pybamm.Vector(np.array([1, 1]))
+        m1 = pybamm.Matrix(np.array([[2, 0], [0, 2]]))
+        v1 = pybamm.Vector(np.array([1, 1]))
 
         for expr in [(m1 @ v1).simplify()]:
             self.assertIsInstance(expr, pybamm.Vector)
             np.testing.assert_array_equal(expr.entries, np.array([2, 2]))
 
         # dont expant mult within mat-mult (issue #253)
-        m1=pybamm.Matrix(np.ones((300, 299)))
-        m2=pybamm.Matrix(np.ones((299, 300)))
-        v1=pybamm.StateVector(slice(0, 299))
-        v2=pybamm.StateVector(slice(0, 300))
-        v3=pybamm.Vector(np.ones(299))
+        m1 = pybamm.Matrix(np.ones((300, 299)))
+        m2 = pybamm.Matrix(np.ones((299, 300)))
+        v1 = pybamm.StateVector(slice(0, 299))
+        v2 = pybamm.StateVector(slice(0, 300))
+        v3 = pybamm.Vector(np.ones(299))
 
-        expr=m1 @ (v1 * m2)
+        expr = m1 @ (v1 * m2)
         self.assertEqual(
-            expr.simplify().evaluate(y = np.ones((299, 1))).shape, (300, 300)
+            expr.simplify().evaluate(y=np.ones((299, 1))).shape, (300, 300)
         )
         np.testing.assert_array_equal(
-            expr.evaluate(y = np.ones((299, 1))),
-            expr.simplify().evaluate(y = np.ones((299, 1))),
+            expr.evaluate(y=np.ones((299, 1))),
+            expr.simplify().evaluate(y=np.ones((299, 1))),
         )
 
         # more complex expression
-        expr2=m1 @ (v1 * (m2 @ v2))
-        expr2simp=expr2.simplify()
+        expr2 = m1 @ (v1 * (m2 @ v2))
+        expr2simp = expr2.simplify()
         np.testing.assert_array_equal(
-            expr2.evaluate(y = np.ones(300)), expr2simp.evaluate(y = np.ones(300))
+            expr2.evaluate(y=np.ones(300)), expr2simp.evaluate(y=np.ones(300))
         )
         self.assertEqual(expr2.id, expr2simp.id)
 
         # more complex expression, with simplification
-        expr3=m1 @ (v3 * (m2 @ v2))
-        expr3simp=expr3.simplify()
+        expr3 = m1 @ (v3 * (m2 @ v2))
+        expr3simp = expr3.simplify()
         np.testing.assert_array_equal(
-            expr3.evaluate(y = np.ones(300)), expr3simp.evaluate(y = np.ones(300))
+            expr3.evaluate(y=np.ones(300)), expr3simp.evaluate(y=np.ones(300))
         )
 
         # we expect simplified solution to be much faster
-        timer=pybamm.Timer()
-        start=timer.time()
+        timer = pybamm.Timer()
+        start = timer.time()
         for _ in range(20):
             expr3.evaluate(y=np.ones(300))
-        end=timer.time()
-        start_simp=timer.time()
+        end = timer.time()
+        start_simp = timer.time()
         for _ in range(20):
             expr3simp.evaluate(y=np.ones(300))
-        end_simp=timer.time()
+        end_simp = timer.time()
         self.assertLess(end_simp - start_simp, 1.5 * (end - start))
         self.assertGreater(end - start, (end_simp - start_simp))
 
     def test_matrix_modification(self):
-        exp=self.mat @ self.mat + self.mat
-        self.A[0, 0]=-1
+        exp = self.mat @ self.mat + self.mat
+        self.A[0, 0] = -1
         self.assertTrue(exp.children[1]._entries[0, 0], -1)
         self.assertTrue(exp.children[0].children[0]._entries[0, 0], -1)
         self.assertTrue(exp.children[0].children[1]._entries[0, 0], -1)
@@ -168,5 +168,5 @@ if __name__ == "__main__":
     import sys
 
     if "-v" in sys.argv:
-        debug=True
+        debug = True
     unittest.main()

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -49,6 +49,7 @@ class TestMatrix(unittest.TestCase):
         m1 = pybamm.Matrix(np.array([[2, 0], [0, 2]]))
         m2 = pybamm.Matrix(np.array([[3, 0], [0, 3]]))
         v = pybamm.StateVector(slice(0, 2))
+        v2 = pybamm.StateVector(slice(2, 4))
 
         for expr in [((m2 @ m1) @ v).simplify(), (m2 @ (m1 @ v)).simplify()]:
             self.assertIsInstance(expr.children[0], pybamm.Matrix)
@@ -56,6 +57,38 @@ class TestMatrix(unittest.TestCase):
             np.testing.assert_array_equal(
                 expr.children[0].entries, np.array([[6, 0], [0, 6]])
             )
+
+        # div by a constant
+        for expr in [((m2 @ m1) @ v / 2).simplify(), (m2 @ (m1 @ v) / 2).simplify()]:
+            self.assertIsInstance(expr.children[0], pybamm.Matrix)
+            self.assertIsInstance(expr.children[1], pybamm.StateVector)
+            np.testing.assert_array_equal(
+                expr.children[0].entries, np.array([[3, 0], [0, 3]])
+            )
+
+        # mat-mul on numerator and denominator
+        expr = (m2 @ (m1 @ v) / (m2 @ (m1 @ v))).simplify()
+        for child in expr.children:
+            self.assertIsInstance(child.children[0], pybamm.Matrix)
+            self.assertIsInstance(child.children[1], pybamm.StateVector)
+            np.testing.assert_array_equal(
+                child.children[0].entries, np.array([[6, 0], [0, 6]])
+            )
+
+        # mat-mul just on denominator
+        expr = (1 / (m2 @ (m1 @ v))).simplify()
+        self.assertIsInstance(expr.children[1].children[0], pybamm.Matrix)
+        self.assertIsInstance(expr.children[1].children[1], pybamm.StateVector)
+        np.testing.assert_array_equal(
+            expr.children[1].children[0].entries, np.array([[6, 0], [0, 6]])
+        )
+        expr = (v2 / (m2 @ (m1 @ v))).simplify()
+        self.assertIsInstance(expr.children[0], pybamm.StateVector)
+        self.assertIsInstance(expr.children[1].children[0], pybamm.Matrix)
+        self.assertIsInstance(expr.children[1].children[1], pybamm.StateVector)
+        np.testing.assert_array_equal(
+            expr.children[1].children[0].entries, np.array([[6, 0], [0, 6]])
+        )
 
         # scalar * matrix
         for expr in [
@@ -71,60 +104,60 @@ class TestMatrix(unittest.TestCase):
             )
 
         # matrix * vector
-        m1 = pybamm.Matrix(np.array([[2, 0], [0, 2]]))
-        v1 = pybamm.Vector(np.array([1, 1]))
+        m1=pybamm.Matrix(np.array([[2, 0], [0, 2]]))
+        v1=pybamm.Vector(np.array([1, 1]))
 
         for expr in [(m1 @ v1).simplify()]:
             self.assertIsInstance(expr, pybamm.Vector)
             np.testing.assert_array_equal(expr.entries, np.array([2, 2]))
 
         # dont expant mult within mat-mult (issue #253)
-        m1 = pybamm.Matrix(np.ones((300, 299)))
-        m2 = pybamm.Matrix(np.ones((299, 300)))
-        v1 = pybamm.StateVector(slice(0, 299))
-        v2 = pybamm.StateVector(slice(0, 300))
-        v3 = pybamm.Vector(np.ones(299))
+        m1=pybamm.Matrix(np.ones((300, 299)))
+        m2=pybamm.Matrix(np.ones((299, 300)))
+        v1=pybamm.StateVector(slice(0, 299))
+        v2=pybamm.StateVector(slice(0, 300))
+        v3=pybamm.Vector(np.ones(299))
 
-        expr = m1 @ (v1 * m2)
+        expr=m1 @ (v1 * m2)
         self.assertEqual(
-            expr.simplify().evaluate(y=np.ones((299, 1))).shape, (300, 300)
+            expr.simplify().evaluate(y = np.ones((299, 1))).shape, (300, 300)
         )
         np.testing.assert_array_equal(
-            expr.evaluate(y=np.ones((299, 1))),
-            expr.simplify().evaluate(y=np.ones((299, 1))),
+            expr.evaluate(y = np.ones((299, 1))),
+            expr.simplify().evaluate(y = np.ones((299, 1))),
         )
 
         # more complex expression
-        expr2 = m1 @ (v1 * (m2 @ v2))
-        expr2simp = expr2.simplify()
+        expr2=m1 @ (v1 * (m2 @ v2))
+        expr2simp=expr2.simplify()
         np.testing.assert_array_equal(
-            expr2.evaluate(y=np.ones(300)), expr2simp.evaluate(y=np.ones(300))
+            expr2.evaluate(y = np.ones(300)), expr2simp.evaluate(y = np.ones(300))
         )
         self.assertEqual(expr2.id, expr2simp.id)
 
         # more complex expression, with simplification
-        expr3 = m1 @ (v3 * (m2 @ v2))
-        expr3simp = expr3.simplify()
+        expr3=m1 @ (v3 * (m2 @ v2))
+        expr3simp=expr3.simplify()
         np.testing.assert_array_equal(
-            expr3.evaluate(y=np.ones(300)), expr3simp.evaluate(y=np.ones(300))
+            expr3.evaluate(y = np.ones(300)), expr3simp.evaluate(y = np.ones(300))
         )
 
         # we expect simplified solution to be much faster
-        timer = pybamm.Timer()
-        start = timer.time()
+        timer=pybamm.Timer()
+        start=timer.time()
         for _ in range(20):
             expr3.evaluate(y=np.ones(300))
-        end = timer.time()
-        start_simp = timer.time()
+        end=timer.time()
+        start_simp=timer.time()
         for _ in range(20):
             expr3simp.evaluate(y=np.ones(300))
-        end_simp = timer.time()
+        end_simp=timer.time()
         self.assertLess(end_simp - start_simp, 1.5 * (end - start))
         self.assertGreater(end - start, (end_simp - start_simp))
 
     def test_matrix_modification(self):
-        exp = self.mat @ self.mat + self.mat
-        self.A[0, 0] = -1
+        exp=self.mat @ self.mat + self.mat
+        self.A[0, 0]=-1
         self.assertTrue(exp.children[1]._entries[0, 0], -1)
         self.assertTrue(exp.children[0].children[0]._entries[0, 0], -1)
         self.assertTrue(exp.children[0].children[1]._entries[0, 0], -1)
@@ -135,5 +168,5 @@ if __name__ == "__main__":
     import sys
 
     if "-v" in sys.argv:
-        debug = True
+        debug=True
     unittest.main()


### PR DESCRIPTION
# Description

Fixes #295 

removed timing test in test_matrix.py as was failing occasionally. changed to simply checking that the simplified expression was identical (according to the id)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
