### PR TITLE
#307 remove duplicate code in integrals

### DIFF
--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -319,17 +319,17 @@ class Discretisation(object):
                 child, discretised_child, self._bcs
             )
 
-        elif isinstance(symbol, pybamm.Integral):
-            child = symbol.children[0]
-            discretised_child = self.process_symbol(child)
-            return self._spatial_methods[child.domain[0]].integral(
-                child.domain, child, discretised_child
-            )
-
         elif isinstance(symbol, pybamm.IndefiniteIntegral):
             child = symbol.children[0]
             discretised_child = self.process_symbol(child)
             return self._spatial_methods[child.domain[0]].indefinite_integral(
+                child.domain, child, discretised_child
+            )
+
+        elif isinstance(symbol, pybamm.Integral):
+            child = symbol.children[0]
+            discretised_child = self.process_symbol(child)
+            return self._spatial_methods[child.domain[0]].integral(
                 child.domain, child, discretised_child
             )
 

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -50,7 +50,7 @@ class Symbol(anytree.NodeMixin):
 
     def __init__(self, name, children=[], domain=[]):
         super(Symbol, self).__init__()
-        self._name = name
+        self.name = name
 
         for child in children:
             # copy child before adding
@@ -68,6 +68,11 @@ class Symbol(anytree.NodeMixin):
     def name(self):
         """name of the node"""
         return self._name
+
+    @name.setter
+    def name(self, value):
+        assert isinstance(value, str)
+        self._name = value
 
     @property
     def domain(self):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -398,7 +398,7 @@ class IndefiniteIntegral(Integral):
     integration_variable : :class:`pybamm.IndependentVariable`
         The variable over which to integrate
 
-    **Extends:** :class:`SpatialOperator`
+    **Extends:** :class:`Integral`
     """
 
     def __init__(self, child, integration_variable):
@@ -408,7 +408,7 @@ class IndefiniteIntegral(Integral):
             child.name, integration_variable.name
         )
         if isinstance(integration_variable, pybamm.SpatialVariable):
-            self.name += "on {}".format(integration_variable.domain)
+            self.name += " on {}".format(integration_variable.domain)
         # the integrated variable has the same domain as the child
         self.domain = child.domain
 

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -382,7 +382,7 @@ class Integral(SpatialOperator):
         return self.__class__(child, self.integration_variable)
 
 
-class IndefiniteIntegral(SpatialOperator):
+class IndefiniteIntegral(Integral):
     """A node in the expression tree representing an indefinite integral operator
 
     .. math::
@@ -402,35 +402,15 @@ class IndefiniteIntegral(SpatialOperator):
     """
 
     def __init__(self, child, integration_variable):
+        super().__init__(child, integration_variable)
+        # Overwrite the name
+        self.name = "{} integrated w.r.t {}".format(
+            child.name, integration_variable.name
+        )
         if isinstance(integration_variable, pybamm.SpatialVariable):
-            # Check that child and integration_variable domains agree
-            if child.domain != integration_variable.domain:
-                raise pybamm.DomainError(
-                    """child and integration_variable must have the same domain"""
-                )
-        elif not isinstance(integration_variable, pybamm.IndependentVariable):
-            raise ValueError(
-                """integration_variable must be of type pybamm.IndependentVariable,
-                   not {}""".format(
-                    type(integration_variable)
-                )
-            )
-        name = "{} integrated w.r.t {}".format(child.name, integration_variable.name)
-        if isinstance(integration_variable, pybamm.SpatialVariable):
-            name += "on {}".format(integration_variable.domain)
-        super().__init__(name, child)
-        self._integration_variable = integration_variable
+            self.name += "on {}".format(integration_variable.domain)
         # the integrated variable has the same domain as the child
         self.domain = child.domain
-
-    @property
-    def integration_variable(self):
-        return self._integration_variable
-
-    def _unary_simplify(self, child):
-        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
-
-        return self.__class__(child, self.integration_variable)
 
 
 class BoundaryValue(SpatialOperator):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -222,7 +222,7 @@ class ParameterValues(dict):
             elif isinstance(symbol, pybamm.Function):
                 new_symbol = pybamm.Function(symbol.func, new_child)
             elif isinstance(symbol, pybamm.Integral):
-                new_symbol = pybamm.Integral(new_child, symbol.integration_variable)
+                new_symbol = symbol.__class__(new_child, symbol.integration_variable)
             elif isinstance(symbol, pybamm.BoundaryValue):
                 new_symbol = pybamm.BoundaryValue(new_child, symbol.side)
             else:


### PR DESCRIPTION
# Description

Refactor `IndefiniteIntegral` to remove duplicate code
Fixes #307 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
