### PR TITLE
Use known_evals in Jacobian (#115)

### DIFF
--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -57,7 +57,7 @@ class Array(pybamm.Symbol):
         # Slightly different syntax for sparse and non-sparse matrices
         entries = self._entries
         if issparse(entries):
-            entries_str = entries.data.tostring()
+            entries_str = entries.toarray().tostring()
         else:
             entries_str = entries.tostring()
 

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -57,7 +57,7 @@ class Array(pybamm.Symbol):
         # Slightly different syntax for sparse and non-sparse matrices
         entries = self._entries
         if issparse(entries):
-            entries_str = entries.toarray().tostring()
+            entries_str = str(entries.__dict__)
         else:
             entries_str = entries.tostring()
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -275,17 +275,17 @@ class SparseStack(Concatenation):
                 children_eval = [None] * len(self.children)
                 for idx, child in enumerate(self.children):
                     child_eval, known_evals = child.evaluate(t, y, known_evals)
-                    children_eval[idx] = self.sparsify(child_eval)
+                    children_eval[idx] = self.sparsify(child_eval, y)
                 known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:
             children_eval = [None] * len(self.children)
             for idx, child in enumerate(self.children):
                 child_eval = child.evaluate(t, y)
-                children_eval[idx] = self.sparsify(child_eval)
+                children_eval[idx] = self.sparsify(child_eval, y)
             return self._concatenation_evaluate(children_eval)
 
-    def sparsify(self, child_eval):
+    def sparsify(self, child_eval, y):
         """Turn child into sparse matrix; this function should eventually be removed"""
         # NOTE: I think this probably a very hacky way of doing this, but need
         # some way of concatenating sparse matrices with dense matrices that

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -287,6 +287,7 @@ class SparseStack(Concatenation):
                             child_eval = csr_matrix((1, np.size(y)))
                         else:
                             child_eval = csr_matrix(child_eval)
+                    children_eval[idx] = child_eval
                 known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -248,50 +248,59 @@ class DomainConcatenation(Concatenation):
         return pybamm.simplify_if_constant(new_node)
 
 
-class SparseStack(pybamm.Symbol):
+class SparseStack(Concatenation):
     """A node in the expression tree representing a concatenation of sparse
     matrices. As with NumpyConcatenation, we *don't* care about domains.
     The class :class:`pybamm.DomainConcatenation`, which *is* careful about
     domains and uses broadcasting where appropriate, should be used whenever
     possible instead.
 
-    **Extends**: :class:`pybamm.Symbol`
+    **Extends**: :class:`Concatenation`
 
     Parameters
     ----------
-    children : iterable of :class:`pybamm.Symbol`
+    children : iterable of :class:`Concatenation`
         The equations to concatenate
 
     """
 
     def __init__(self, *children):
-        super().__init__("model concatenation", children, domain=[])
+        children = list(children)
+        super().__init__(*children, name="sparse stack", check_domain=False)
 
-    def evaluate(self, t=None, y=None):
+    def evaluate(self, t=None, y=None, known_evals=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
-        if len(self.children) == 0:
-            return np.array([])
-        else:
-            return vstack([self.evaluate_child(child, t, y) for child in self.children])
-
-    def evaluate_child(self, child, t, y):
-        """ Evaluates the child and, if the results is dense, converts the
-        result as a sparse matrix.
-        """
         # NOTE: I think this probably a very hacky way of doing this, but need
         # some way of concatenating sparse matrices with dense matrices that
         # come from evaluate. The other way would be to make all the matrices
         # dense and then do a NumpyConcatenation, but I fear this will be bad
         # when the Jacobian is very large
-        evaluated_child = child.evaluate(t, y)
-        if issparse(evaluated_child) is False:
-            if np.size(evaluated_child) == 1 and evaluated_child == 0:
-                # If rhs or algebraic was a constant, then the result is scalar
-                # zero and should be replaced with a row of zeros
-                evaluated_child = csr_matrix((1, np.size(y)))
-            else:
-                evaluated_child = csr_matrix(evaluated_child)
-        return evaluated_child
+        if known_evals is not None:
+            if self.id not in known_evals:
+                children_eval = [None] * len(self.children)
+                for idx, child in enumerate(self.children):
+                    child_eval, known_evals = child.evaluate(t, y, known_evals)
+                    if issparse(child_eval) is False:
+                        if np.size(child_eval) == 1 and child_eval == 0:
+                            # If rhs or algebraic was a constant, then the result is
+                            # scalar zero and should be replaced with a row of zeros
+                            child_eval = csr_matrix((1, np.size(y)))
+                        else:
+                            child_eval = csr_matrix(child_eval)
+                known_evals[self.id] = self._concatenation_evaluate(children_eval)
+            return known_evals[self.id], known_evals
+        else:
+            children_eval = [None] * len(self.children)
+            for idx, child in enumerate(self.children):
+                children_eval[idx] = child.evaluate(t, y)
+            return self._concatenation_evaluate(children_eval)
+
+    def _concatenation_evaluate(self, children_eval):
+        """ See :meth:`Concatenation.evaluate()`. """
+        if len(children_eval) == 0:
+            return np.array([])
+        else:
+            return vstack(children_eval)
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -243,13 +243,12 @@ class Diagonal(UnaryOperator):
         # We shouldn't need this
         raise NotImplementedError
 
-    def evaluate(self, t=None, y=None):
+    def _unary_evaluate(self, child):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
-        evaluated_child = self.children[0].evaluate(t, y)
-        if np.size(evaluated_child) == 1:
-            return csr_matrix(evaluated_child)
+        if np.size(child) == 1:
+            return csr_matrix(child)
         else:
-            return diags(evaluated_child, 0)
+            return diags(child, 0)
 
     def evaluates_to_number(self):
         """ See :meth:`pybamm.Symbol.evaluates_to_number()`. """

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -9,6 +9,33 @@ import numpy as np
 from scipy import optimize
 
 
+class MyDict(dict):
+    def __init__(self, *args, **kwargs):
+        self.update(*args, **kwargs)
+
+    def __setitem__(self, key, value):
+        if key in self:
+            raise ValueError
+        super(MyDict, self).__setitem__(key, value)
+
+    def update(self, *args, **kwargs):
+        if args:
+            if len(args) > 1:
+                raise TypeError(
+                    "update expected at most 1 arguments, " "got %d" % len(args)
+                )
+            other = dict(args[0])
+            for key in other:
+                self[key] = other[key]
+        for key in kwargs:
+            self[key] = kwargs[key]
+
+    def setdefault(self, key, value=None):
+        if key not in self:
+            self[key] = value
+        return self[key]
+
+
 class DaeSolver(pybamm.BaseSolver):
     """Solve a discretised model.
 

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -9,33 +9,6 @@ import numpy as np
 from scipy import optimize
 
 
-class MyDict(dict):
-    def __init__(self, *args, **kwargs):
-        self.update(*args, **kwargs)
-
-    def __setitem__(self, key, value):
-        if key in self:
-            raise ValueError
-        super(MyDict, self).__setitem__(key, value)
-
-    def update(self, *args, **kwargs):
-        if args:
-            if len(args) > 1:
-                raise TypeError(
-                    "update expected at most 1 arguments, " "got %d" % len(args)
-                )
-            other = dict(args[0])
-            for key in other:
-                self[key] = other[key]
-        for key in kwargs:
-            self[key] = kwargs[key]
-
-    def setdefault(self, key, value=None):
-        if key not in self:
-            self[key] = value
-        return self[key]
-
-
 class DaeSolver(pybamm.BaseSolver):
     """Solve a discretised model.
 

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -73,7 +73,7 @@ class DaeSolver(pybamm.BaseSolver):
         jac = pybamm.SparseStack(jac_rhs, jac_algebraic)
 
         def jacobian(t, y):
-            return jac.evaluate(t, y)
+            return jac.evaluate(t, y, known_evals={})[0]
 
         self.t, self.y = self.integrate(
             residuals,

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -56,7 +56,7 @@ class OdeSolver(pybamm.BaseSolver):
         jac_rhs = concatenated_rhs.jac(y).simplify()
 
         def jacobian(t, y):
-            return jac_rhs.evaluate(t, y)
+            return jac_rhs.evaluate(t, y, known_evals={})[0]
 
         self.t, self.y = self.integrate(
             dydt,


### PR DESCRIPTION
# Description

Adapt Jacobian-specific functions to allow using the `known_evals` dict
Part of #315 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
