### PR TITLE
#319 cache children

### DIFF
--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -30,6 +30,7 @@ class Concatenation(pybamm.Symbol):
         else:
             domain = []
         super().__init__(name, children, domain=domain)
+        self.cached_children = self.children
 
     def get_children_domains(self, children):
         # combine domains from children
@@ -53,16 +54,17 @@ class Concatenation(pybamm.Symbol):
 
     def evaluate(self, t=None, y=None, known_evals=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
+        children = self.cached_children
         if known_evals is not None:
             if self.id not in known_evals:
-                children_eval = [None] * len(self.children)
-                for idx, child in enumerate(self.children):
+                children_eval = [None] * len(children)
+                for idx, child in enumerate(children):
                     children_eval[idx], known_evals = child.evaluate(t, y, known_evals)
                 known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:
-            children_eval = [None] * len(self.children)
-            for idx, child in enumerate(self.children):
+            children_eval = [None] * len(children)
+            for idx, child in enumerate(children):
                 children_eval[idx] = child.evaluate(t, y)
             return self._concatenation_evaluate(children_eval)
 
@@ -102,14 +104,15 @@ class NumpyConcatenation(Concatenation):
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """
-        if len(self.children) == 0:
+        children = self.cached_children
+        if len(children) == 0:
             return pybamm.Scalar(0)
         else:
-            return SparseStack(*[child.jac(variable) for child in self.children])
+            return SparseStack(*[child.jac(variable) for child in children])
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
-        children = [child.simplify() for child in self.children]
+        children = [child.simplify() for child in self.cached_children]
 
         new_node = self.__class__(*children)
 
@@ -171,7 +174,7 @@ class DomainConcatenation(Concatenation):
 
             # create disc of domain => slice for each child
             self._children_slices = [
-                self.create_slices(child) for child in self.children
+                self.create_slices(child) for child in self.cached_children
             ]
         else:
             self._mesh = copy.copy(copy_this._mesh)
@@ -217,14 +220,15 @@ class DomainConcatenation(Concatenation):
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """
-        if len(self.children) == 0:
+        children = self.cached_children
+        if len(children) == 0:
             return pybamm.Scalar(0)
         else:
-            return SparseStack(*[child.jac(variable) for child in self.children])
+            return SparseStack(*[child.jac(variable) for child in children])
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
-        children = self.children
+        children = self.cached_children
         # Simplify Concatenation of StateVectors to a single StateVector
         if all([isinstance(x, pybamm.StateVector) for x in children]) and all(
             [
@@ -270,17 +274,18 @@ class SparseStack(Concatenation):
 
     def evaluate(self, t=None, y=None, known_evals=None):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
+        children = self.cached_children
         if known_evals is not None:
             if self.id not in known_evals:
-                children_eval = [None] * len(self.children)
-                for idx, child in enumerate(self.children):
+                children_eval = [None] * len(children)
+                for idx, child in enumerate(children):
                     child_eval, known_evals = child.evaluate(t, y, known_evals)
                     children_eval[idx] = self.sparsify(child_eval, y)
                 known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:
-            children_eval = [None] * len(self.children)
-            for idx, child in enumerate(self.children):
+            children_eval = [None] * len(children)
+            for idx, child in enumerate(children):
                 child_eval = child.evaluate(t, y)
                 children_eval[idx] = self.sparsify(child_eval, y)
             return self._concatenation_evaluate(children_eval)
@@ -310,7 +315,7 @@ class SparseStack(Concatenation):
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
-        children = [child.simplify() for child in self.children]
+        children = [child.simplify() for child in self.cached_children]
 
         new_node = self.__class__(*children)
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -30,7 +30,6 @@ class Concatenation(pybamm.Symbol):
         else:
             domain = []
         super().__init__(name, children, domain=domain)
-        self.cached_children = self.children
 
     def get_children_domains(self, children):
         # combine domains from children

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -57,6 +57,9 @@ class Symbol(anytree.NodeMixin):
             # this also adds copy.copy(child) to self.children
             copy.copy(child).parent = self
 
+        # cache children
+        self.cached_children = super(Symbol, self).children
+
         # Set domain (and hence id)
         self.domain = domain
 
@@ -64,8 +67,9 @@ class Symbol(anytree.NodeMixin):
         self._has_left_ghost_cell = False
         self._has_right_ghost_cell = False
 
-        # cache children
-        self.cached_children = self.children
+    @property
+    def children(self):
+        return self.cached_children
 
     @property
     def name(self):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -64,6 +64,9 @@ class Symbol(anytree.NodeMixin):
         self._has_left_ghost_cell = False
         self._has_right_ghost_cell = False
 
+        # cache children
+        self.cached_children = self.children
+
     @property
     def name(self):
         """name of the node"""

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -32,14 +32,15 @@ class UnaryOperator(pybamm.Symbol):
 
     def __init__(self, name, child):
         super().__init__(name, children=[child], domain=child.domain)
+        self.child = self.children[0]
 
     def __str__(self):
         """ See :meth:`pybamm.Symbol.__str__()`. """
-        return "{}({!s})".format(self.name, self.children[0])
+        return "{}({!s})".format(self.name, self.child)
 
     def simplify(self):
         """ See :meth:`pybamm.Symbol.simplify()`. """
-        child = self.children[0].simplify()
+        child = self.child.simplify()
 
         # _binary_simplify defined in derived classes for specific rules
         new_node = self._unary_simplify(child)
@@ -59,11 +60,11 @@ class UnaryOperator(pybamm.Symbol):
         """ See :meth:`pybamm.Symbol.evaluate()`. """
         if known_evals is not None:
             if self.id not in known_evals:
-                child, known_evals = self.children[0].evaluate(t, y, known_evals)
+                child, known_evals = self.child.evaluate(t, y, known_evals)
                 known_evals[self.id] = self._unary_evaluate(child)
             return known_evals[self.id], known_evals
         else:
-            child = self.children[0].evaluate(t, y)
+            child = self.child.evaluate(t, y)
             return self._unary_evaluate(child)
 
 
@@ -79,18 +80,18 @@ class Negate(UnaryOperator):
 
     def __str__(self):
         """ See :meth:`pybamm.Symbol.__str__()`. """
-        return "{}{!s}".format(self.name, self.children[0])
+        return "{}{!s}".format(self.name, self.child)
 
     def diff(self, variable):
         """ See :meth:`pybamm.Symbol.diff()`. """
         if variable.id == self.id:
             return pybamm.Scalar(1)
         else:
-            return -self.children[0].diff(variable)
+            return -self.child.diff(variable)
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """
-        return -self.children[0].jac(variable)
+        return -self.child.jac(variable)
 
     def _unary_evaluate(self, child):
         """ See :meth:`UnaryOperator._unary_evaluate()`. """
@@ -193,7 +194,7 @@ class Function(UnaryOperator):
             # If self.func() takes no parameters then we can always simplify it
             return pybamm.Scalar(self.func())
         else:
-            child = self.children[0].simplify()
+            child = self.child.simplify()
 
             new_node = pybamm.Function(self.func, child)
 

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -17,6 +17,28 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual(sym.name, "a symbol")
         self.assertEqual(str(sym), "a symbol")
 
+    def test_cached_children(self):
+        symc1 = pybamm.Symbol("child1")
+        symc2 = pybamm.Symbol("child2")
+        symc3 = pybamm.Symbol("child3")
+        symp = pybamm.Symbol("parent", children=[symc1, symc2])
+
+        # test tuples of children for equality based on their name
+        def check_are_equal(children1, children2):
+            self.assertEqual(len(children1), len(children2))
+            for i in range(len(children1)):
+                self.assertEqual(children1[i].name, children2[i].name)
+
+        check_are_equal(symp.children, super(pybamm.Symbol, symp).children)
+        check_are_equal(symp.children, (symc1, symc2))
+
+        # update children, since we cache the children they will be unchanged
+        symc3.parent = symp
+        check_are_equal(symp.children, (symc1, symc2))
+
+        # check that the *actual* children are updated
+        check_are_equal(super(pybamm.Symbol, symp).children, (symc1, symc2, symc3))
+
     def test_symbol_simplify(self):
         a = pybamm.Scalar(0)
         b = pybamm.Scalar(1)


### PR DESCRIPTION
# Description

As discussed this morning, pre-assign children to get around slow anytree lookup
Fixes #319 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
