### PR TITLE
Issue 315 elementwise function jac

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -80,7 +80,6 @@ from .expression_tree.unary_operators import (
     BoundaryValue,
     Integral,
     IndefiniteIntegral,
-    Diagonal,
     grad,
     div,
     surf,

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -6,7 +6,7 @@ from __future__ import print_function, unicode_literals
 import pybamm
 
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, vstack
+from scipy.sparse import vstack
 import copy
 
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -274,32 +274,14 @@ class SparseStack(Concatenation):
             if self.id not in known_evals:
                 children_eval = [None] * len(self.children)
                 for idx, child in enumerate(self.children):
-                    child_eval, known_evals = child.evaluate(t, y, known_evals)
-                    children_eval[idx] = self.sparsify(child_eval, y)
+                    children_eval[idx], known_evals = child.evaluate(t, y, known_evals)
                 known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:
             children_eval = [None] * len(self.children)
             for idx, child in enumerate(self.children):
-                child_eval = child.evaluate(t, y)
-                children_eval[idx] = self.sparsify(child_eval, y)
+                children_eval[idx] = child.evaluate(t, y)
             return self._concatenation_evaluate(children_eval)
-
-    def sparsify(self, child_eval, y):
-        """Turn child into sparse matrix; this function should eventually be removed"""
-        # NOTE: I think this probably a very hacky way of doing this, but need
-        # some way of concatenating sparse matrices with dense matrices that
-        # come from evaluate. The other way would be to make all the matrices
-        # dense and then do a NumpyConcatenation, but I fear this will be bad
-        # when the Jacobian is very large
-        if issparse(child_eval) is False:
-            if np.size(child_eval) == 1 and child_eval == 0:
-                # If rhs or algebraic was a constant, then the result is
-                # scalar zero and should be replaced with a row of zeros
-                child_eval = csr_matrix((1, np.size(y)))
-            else:
-                child_eval = csr_matrix(child_eval)
-        return child_eval
 
     def _concatenation_evaluate(self, children_eval):
         """ See :meth:`Concatenation.evaluate()`. """

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -173,7 +173,7 @@ class Function(UnaryOperator):
             jac = csr_matrix((1, np.size(variable_y_indices)))
             return pybamm.Matrix(jac)
         else:
-            jac_fun = Function(autograd.jacobian(self.func), child) @ child.jac(
+            jac_fun = Function(autograd.elementwise_grad(self.func), child) * child.jac(
                 variable
             )
             jac_fun.domain = self.domain

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -8,8 +8,7 @@ import pybamm
 import autograd
 import copy
 import numpy as np
-import numbers
-from scipy.sparse import csr_matrix, diags
+from scipy.sparse import csr_matrix
 from inspect import signature
 
 
@@ -219,48 +218,6 @@ class Index(UnaryOperator):
         """ See :meth:`pybamm.UnaryOperator.simplify()`. """
 
         return self.__class__(child, self.index)
-
-
-class Diagonal(UnaryOperator):
-    """A node in the expression tree representing an operator which creates a
-    diagonal matrix from a vector. If the child is already a matrix, it
-    simply returns the child.
-
-    **Extends:** :class:`UnaryOperator`
-    """
-
-    def __init__(self, child):
-        """ See :meth:`pybamm.UnaryOperator.__init__()`. """
-        super().__init__("diag", child)
-
-    def diff(self, variable):
-        """ See :meth:`pybamm.Symbol.diff()`. """
-        # We shouldn't need this
-        raise NotImplementedError
-
-    def jac(self, variable):
-        """ See :meth:`pybamm.Symbol.jac()`. """
-        # We shouldn't need this
-        raise NotImplementedError
-
-    def _unary_evaluate(self, child):
-        """ See :meth:`pybamm.Symbol.evaluate()`. """
-        if np.size(child) == 1:
-            return csr_matrix(child)
-        else:
-            return diags(child, 0)
-
-    def evaluates_to_number(self):
-        """ See :meth:`pybamm.Symbol.evaluates_to_number()`. """
-        result = self.evaluate_ignoring_errors()
-        if isinstance(result, numbers.Number):
-            return True
-        elif isinstance(result, csr_matrix) and isinstance(
-            result.toarray()[0][0], numbers.Number
-        ):
-            return True
-        else:
-            return False
 
 
 class SpatialOperator(UnaryOperator):

--- a/tests/unit/test_expression_tree/test_jac.py
+++ b/tests/unit/test_expression_tree/test_jac.py
@@ -99,12 +99,12 @@ class TestJacobian(unittest.TestCase):
         func = pybamm.Function(auto_np.sin, u)
         jacobian = np.array([[np.cos(1), 0, 0, 0], [0, np.cos(2), 0, 0]])
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_equal(jacobian, dfunc_dy)
+        np.testing.assert_array_equal(jacobian, dfunc_dy.toarray())
 
         func = pybamm.Function(auto_np.cos, v)
         jacobian = np.array([[0, 0, -np.sin(3), 0], [0, 0, 0, -np.sin(4)]])
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_equal(jacobian, dfunc_dy)
+        np.testing.assert_array_equal(jacobian, dfunc_dy.toarray())
 
         func = pybamm.Function(auto_np.sin, 3 * u * v)
         jacobian = np.array(
@@ -114,7 +114,7 @@ class TestJacobian(unittest.TestCase):
             ]
         )
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_equal(jacobian, dfunc_dy)
+        np.testing.assert_array_equal(jacobian, dfunc_dy.toarray())
 
         func = pybamm.Function(auto_np.cos, 5 * pybamm.Function(auto_np.exp, u + v))
         jacobian = np.array(
@@ -134,7 +134,7 @@ class TestJacobian(unittest.TestCase):
             ]
         )
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_equal(jacobian, dfunc_dy)
+        np.testing.assert_array_equal(jacobian, dfunc_dy.toarray())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

- Compute Function jacobian elementwise 
- Remove `Diagonal` nodes and use elementwise multiplication/division instead 
- Remove `SparseStack.sparsify()` (no longer needed)

The `evaluate` hack from `Multiplication` is now used in `Division` as well, ideally will be removed by #320 
Part of #315 

## Speed-ups (tests on DFN)

Before:
```
In [1]: %timeit jac.evaluate(0,y0)                                                                                                            
61 ms ± 447 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [2]: %timeit jac.evaluate(0,y0,{})                                                                                                         
29 ms ± 219 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit self.integrate( residuals, y0, t_eval, events=events, mass_matrix=model.mass_matrix.entries, jacobian=jacobian)               
2.72 s ± 7.96 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %prun jac.evaluate(0,y0)
90456 function calls (89453 primitive calls) in 0.105 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      301    0.005    0.000    0.014    0.000 compressed.py:133(check_format)
      985    0.005    0.000    0.011    0.000 sputils.py:120(get_index_dtype)
     5424    0.005    0.000    0.005    0.000 {built-in method numpy.array}
 1073/828    0.004    0.000    0.012    0.000 tracer.py:35(f_wrapped)
     1970    0.003    0.000    0.003    0.000 getlimits.py:497(__init__)
       67    0.003    0.000    0.012    0.000 dia.py:348(tocoo)
    639/6    0.003    0.000    0.105    0.017 binary_operators.py:560(evaluate)
       82    0.002    0.000    0.006    0.000 coo.py:261(_check)
  301/261    0.002    0.000    0.025    0.000 compressed.py:25(__init__)
       45    0.002    0.000    0.015    0.000 core.py:17(backward_pass)
     1825    0.002    0.000    0.005    0.000 tracer.py:58(f_wrapped)
      324    0.002    0.000    0.002    0.000 {method 'reduce' of 'numpy.ufunc' objects}
      319    0.002    0.000    0.004    0.000 compressed.py:1077(prune)
      458    0.002    0.000    0.003    0.000 sputils.py:266(check_shape)
      245    0.002    0.000    0.004    0.000 core.py:28(__init__)
     1073    0.001    0.000    0.002    0.000 tracer.py:65(find_top_boxed_args)
      891    0.001    0.000    0.002    0.000 tracer.py:115(toposort)
       63    0.001    0.000    0.007    0.000 construct.py:65(diags)
      774    0.001    0.000    0.004    0.000 numpy_vjps.py:548(unbroadcast)
     4170    0.001    0.000    0.002    0.000 {built-in method builtins.isinstance}
       65    0.001    0.000    0.016    0.000 compressed.py:486(_mul_sparse_matrix)
       80    0.001    0.000    0.011    0.000 coo.py:368(tocsr)
     3765    0.001    0.000    0.004    0.000 numeric.py:469(asarray)
      484    0.001    0.000    0.001    0.000 {built-in method numpy.empty}
      334    0.001    0.000    0.001    0.000 sputils.py:209(isshape)
       16    0.001    0.000    0.006    0.000 graphite_mcmb2528_ocp_Dualfoil.py:4(graphite_mcmb2528_ocp_Dualfoil)
     7342    0.001    0.000    0.001    0.000 {built-in method builtins.len}
      175    0.001    0.000    0.002    0.000 binary_operators.py:759(_binary_evaluate)
       82    0.001    0.000    0.009    0.000 coo.py:126(__init__)
     1312    0.001    0.000    0.001    0.000 compressed.py:105(getnnz)
     3747    0.001    0.000    0.001    0.000 tracer.py:144(<lambda>)
     1749    0.001    0.000    0.003    0.000 base.py:243(nnz)
```
After:
```
In [2]: %timeit jac.evaluate(0,y0)                                                                                                            
37.3 ms ± 955 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [3]: %timeit jac.evaluate(0,y0,{})                                                                                                         
17.7 ms ± 161 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: %timeit self.integrate( residuals, y0, t_eval, events=events, mass_matrix=model.mass_matrix.entries, jacobian=jacobian)               
2.13 s ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %prun jac.evaluate(0,y0)  
         53361 function calls (52413 primitive calls) in 0.064 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      160    0.003    0.000    0.008    0.000 compressed.py:133(check_format)
      542    0.003    0.000    0.006    0.000 sputils.py:120(get_index_dtype)
  796/551    0.003    0.000    0.008    0.000 tracer.py:35(f_wrapped)
    613/6    0.002    0.000    0.062    0.010 binary_operators.py:558(evaluate)
     2604    0.002    0.000    0.002    0.000 {built-in method numpy.array}
     1084    0.002    0.000    0.002    0.000 getlimits.py:497(__init__)
       66    0.002    0.000    0.005    0.000 coo.py:261(_check)
       74    0.002    0.000    0.014    0.000 compressed.py:355(multiply)
      248    0.001    0.000    0.001    0.000 {method 'reduce' of 'numpy.ufunc' objects}
  160/136    0.001    0.000    0.015    0.000 compressed.py:25(__init__)
      198    0.001    0.000    0.002    0.000 compressed.py:1077(prune)
      235    0.001    0.000    0.018    0.000 binary_operators.py:751(_binary_evaluate)
       22    0.001    0.000    0.005    0.000 bsr.py:472(tocoo)
      796    0.001    0.000    0.001    0.000 tracer.py:65(find_top_boxed_args)
       58    0.001    0.000    0.010    0.000 coo.py:368(tocsr)
      238    0.001    0.000    0.001    0.000 sputils.py:266(check_shape)
     2925    0.001    0.000    0.002    0.000 {built-in method builtins.isinstance}
       16    0.001    0.000    0.005    0.000 graphite_mcmb2528_ocp_Dualfoil.py:4(graphite_mcmb2528_ocp_Dualfoil)
      696    0.001    0.000    0.002    0.000 tracer.py:58(f_wrapped)
      611    0.001    0.000    0.001    0.000 {method 'reshape' of 'numpy.ndarray' objects}
       13    0.001    0.000    0.005    0.000 core.py:17(backward_pass)
       16    0.001    0.000    0.003    0.000 lico2_ocp_Dualfoil.py:4(lico2_ocp_Dualfoil)
      860    0.001    0.000    0.001    0.000 compressed.py:105(getnnz)
        9    0.001    0.000    0.002    0.000 construct.py:401(_compressed_sparse_stack)
      193    0.001    0.000    0.001    0.000 sputils.py:209(isshape)
     1837    0.001    0.000    0.002    0.000 numeric.py:469(asarray)
      257    0.001    0.000    0.001    0.000 {built-in method numpy.empty}
    66/62    0.001    0.000    0.007    0.000 coo.py:126(__init__)
     1973    0.001    0.000    0.001    0.000 tracer.py:144(<lambda>)
       34    0.001    0.000    0.011    0.000 compressed.py:1147(_binopt)
     4257    0.001    0.000    0.001    0.000 {built-in method builtins.len}
     1112    0.001    0.000    0.002    0.000 base.py:243(nnz)
```
Not sure why the first three lines are still being called, will investigate

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
