### PR TITLE
#315 add flag to skip using jacobian for ODE models

### DIFF
--- a/pybamm/models/base_models.py
+++ b/pybamm/models/base_models.py
@@ -53,6 +53,9 @@ class BaseModel(object):
         self._mass_matrix = None
         self._jacobian = None
 
+        # Default behaviour is to use the jacobian
+        self.use_jacobian = True
+
     def _set_dict(self, dict, name):
         """
         Convert any scalar equations in dict to 'pybamm.Scalar'

--- a/pybamm/models/lead_acid/loqs.py
+++ b/pybamm/models/lead_acid/loqs.py
@@ -85,3 +85,8 @@ class LOQS(pybamm.LeadAcidBaseModel):
             ocp_p, eta_r_p, phi_e
         )
         self.variables.update(electrode_vars)
+
+        "-----------------------------------------------------------------------------"
+        "Settings"
+        # ODEs only (don't use jacobian)
+        self.use_jacobian = False

--- a/pybamm/models/simple_ode_model.py
+++ b/pybamm/models/simple_ode_model.py
@@ -40,3 +40,8 @@ class SimpleODEModel(pybamm.StandardBatteryBaseModel):
             "b broadcasted": pybamm.Broadcast(b, whole_cell),
             "c broadcasted": pybamm.Broadcast(c, ["negative electrode", "separator"]),
         }
+
+        "-----------------------------------------------------------------------------"
+        "Settings"
+        # ODEs only (don't use jacobian)
+        self.use_jacobian = False

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -66,14 +66,18 @@ class DaeSolver(pybamm.BaseSolver):
             rhs, algebraic, model.concatenated_initial_conditions
         )
 
-        # Create Jacobian from simplified rhs
-        y = pybamm.StateVector(slice(0, np.size(y0)))
-        jac_rhs = concatenated_rhs.jac(y).simplify()
-        jac_algebraic = concatenated_algebraic.jac(y).simplify()
-        jac = pybamm.SparseStack(jac_rhs, jac_algebraic)
+        if model.use_jacobian:
+            # Create Jacobian from simplified rhs
+            y = pybamm.StateVector(slice(0, np.size(y0)))
+            jac_rhs = concatenated_rhs.jac(y).simplify()
+            jac_algebraic = concatenated_algebraic.jac(y).simplify()
+            jac = pybamm.SparseStack(jac_rhs, jac_algebraic)
 
-        def jacobian(t, y):
-            return jac.evaluate(t, y, known_evals={})[0]
+            def jacobian(t, y):
+                return jac.evaluate(t, y, known_evals={})[0]
+
+        else:
+            jacobian = None
 
         self.t, self.y = self.integrate(
             residuals,

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -51,10 +51,9 @@ class OdeSolver(pybamm.BaseSolver):
 
         y0 = model.concatenated_initial_conditions
 
-        # Create Jacobian from simplified rhs
-        y = pybamm.StateVector(slice(0, np.size(y0)))
-
         if model.use_jacobian:
+            # Create Jacobian from simplified rhs
+            y = pybamm.StateVector(slice(0, np.size(y0)))
             jac_rhs = concatenated_rhs.jac(y).simplify()
 
             def jacobian(t, y):

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -53,10 +53,15 @@ class OdeSolver(pybamm.BaseSolver):
 
         # Create Jacobian from simplified rhs
         y = pybamm.StateVector(slice(0, np.size(y0)))
-        jac_rhs = concatenated_rhs.jac(y).simplify()
 
-        def jacobian(t, y):
-            return jac_rhs.evaluate(t, y, known_evals={})[0]
+        if model.use_jacobian:
+            jac_rhs = concatenated_rhs.jac(y).simplify()
+
+            def jacobian(t, y):
+                return jac_rhs.evaluate(t, y, known_evals={})[0]
+
+        else:
+            jacobian = None
 
         self.t, self.y = self.integrate(
             dydt,


### PR DESCRIPTION
# Description

Add a flag to the model to allow skipping the use of the jacobian (e.g. for ODE models, where the jacobian is almost full and inverting the matrix during an implicit time step is cheap, so we don't need the jacobian)
Part of #315 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
