### PR TITLE
Issue 322 sparse

### DIFF
--- a/pybamm/solvers/scikits_ode_solver.py
+++ b/pybamm/solvers/scikits_ode_solver.py
@@ -46,7 +46,7 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
 
     def integrate(
         self, derivs, y0, t_eval, events=None, mass_matrix=None, jacobian=None,
-        linsolver = 'dense'
+        linsolver='dense'
     ):
         """
         Solve a model defined by dydt with initial conditions y0.
@@ -101,7 +101,7 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
                 return 0
 
         extra_options = {"old_api": False, "rtol": self.tol, "atol": self.tol,
-                "linsolver": linsolver}
+                         "linsolver": linsolver}
 
         if jacobian:
             if linsolver in ('dense', 'lapackdense'):

--- a/pybamm/solvers/scikits_ode_solver.py
+++ b/pybamm/solvers/scikits_ode_solver.py
@@ -95,19 +95,18 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
             Jv[:] = userdata._jac_eval * v
             return 0
 
-
         extra_options = {"old_api": False, "rtol": self.tol, "atol": self.tol,
-                "linsolver": linsolver}
+                         "linsolver": linsolver}
 
         if jacobian:
             if linsolver == 'dense':
                 extra_options.update({"jacfn": jacfn})
             else:
                 extra_options.update({
-                                      "jac_times_setupfn": jac_times_setupfn,
-                                      "jac_times_vecfn": jac_times_vecfn,
-                                      "user_data": self
-                                      })
+                    "jac_times_setupfn": jac_times_setupfn,
+                    "jac_times_vecfn": jac_times_vecfn,
+                    "user_data": self
+                })
 
         if events:
             extra_options.update({"rootfn": rootfn, "nr_rootfns": len(events)})
@@ -117,5 +116,3 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
 
         # return solution, we need to tranpose y to match scipy's ivp interface
         return sol.values.t, np.transpose(sol.values.y)
-
-

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -110,7 +110,7 @@ class TestScikitsSolver(unittest.TestCase):
         np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
         np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
 
-        solver = pybamm.ScikitsOdeSolver(tol=1e-8, linsolver = "spgmr")
+        solver = pybamm.ScikitsOdeSolver(tol=1e-8, linsolver="spgmr")
 
         t_sol, y_sol = solver.integrate(linear_ode, y0, t_eval, jacobian=jacobian)
         np.testing.assert_array_equal(t_sol, t_eval)
@@ -123,7 +123,6 @@ class TestScikitsSolver(unittest.TestCase):
         np.testing.assert_array_equal(t_sol, t_eval)
         np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
         np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
-
 
         # Nonlinear exponential grwoth
         solver = pybamm.ScikitsOdeSolver(tol=1e-8)

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -110,6 +110,21 @@ class TestScikitsSolver(unittest.TestCase):
         np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
         np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
 
+        solver = pybamm.ScikitsOdeSolver(tol=1e-8, linsolver = "spgmr")
+
+        t_sol, y_sol = solver.integrate(linear_ode, y0, t_eval, jacobian=jacobian)
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
+        np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
+
+        t_sol, y_sol = solver.integrate(
+            linear_ode, y0, t_eval, jacobian=sparse_jacobian)
+
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
+        np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
+
+
         # Nonlinear exponential grwoth
         solver = pybamm.ScikitsOdeSolver(tol=1e-8)
 
@@ -124,6 +139,26 @@ class TestScikitsSolver(unittest.TestCase):
 
         y0 = np.array([1.0, 1.0])
         t_eval = np.linspace(0, 1, 100)
+
+        t_sol, y_sol = solver.integrate(
+            exponential_growth, y0, t_eval, jacobian=jacobian
+        )
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(np.exp(t_sol), y_sol[0], rtol=1e-4)
+        np.testing.assert_allclose(
+            np.exp(1 + t_sol - np.exp(t_sol)), y_sol[1], rtol=1e-4
+        )
+
+        t_sol, y_sol = solver.integrate(
+            exponential_growth, y0, t_eval, jacobian=sparse_jacobian,
+        )
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(np.exp(t_sol), y_sol[0], rtol=1e-4)
+        np.testing.assert_allclose(
+            np.exp(1 + t_sol - np.exp(t_sol)), y_sol[1], rtol=1e-4
+        )
+
+        solver = pybamm.ScikitsOdeSolver(tol=1e-8, linsolver="spgmr")
 
         t_sol, y_sol = solver.integrate(
             exponential_growth, y0, t_eval, jacobian=jacobian

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -103,7 +103,8 @@ class TestScikitsSolver(unittest.TestCase):
 
         y0 = np.array([0.0, 0.0])
         t_eval = np.linspace(0, 1, 100)
-        t_sol, y_sol = solver.integrate(linear_ode, y0, t_eval, jacobian=sparse_jacobian)
+        t_sol, y_sol = solver.integrate(
+            linear_ode, y0, t_eval, jacobian=sparse_jacobian)
 
         np.testing.assert_array_equal(t_sol, t_eval)
         np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -9,6 +9,7 @@ from tests import get_mesh_for_testing, get_discretisation_for_testing
 
 import unittest
 import numpy as np
+import scipy.sparse as sparse
 
 
 @unittest.skipIf(scikits_odes_spec is None, "scikits.odes not installed")
@@ -82,10 +83,16 @@ class TestScikitsSolver(unittest.TestCase):
         solver = pybamm.ScikitsOdeSolver(tol=1e-8)
 
         def linear_ode(t, y):
-            return np.array([0.5 * np.ones_like(y[0]), 2 - y[0]])
+            return np.array([0.5, 2 - y[0]])
+
+        J = np.array([[0.0, 0.0], [-1.0, 0.0]])
+        sJ = sparse.csr_matrix(J)
 
         def jacobian(t, y):
-            return np.array([[0.0, 0.0], [-1.0, 0.0]])
+            return J
+
+        def sparse_jacobian(t, y):
+            return sJ
 
         y0 = np.array([0.0, 0.0])
         t_eval = np.linspace(0, 1, 100)
@@ -93,6 +100,14 @@ class TestScikitsSolver(unittest.TestCase):
         np.testing.assert_array_equal(t_sol, t_eval)
         np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
         np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
+
+        y0 = np.array([0.0, 0.0])
+        t_eval = np.linspace(0, 1, 100)
+        t_sol, y_sol = solver.integrate(linear_ode, y0, t_eval, jacobian=sparse_jacobian)
+
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(2.0 * t_sol - 0.25 * t_sol ** 2, y_sol[1], rtol=1e-4)
+        np.testing.assert_allclose(0.5 * t_sol, y_sol[0])
 
         # Nonlinear exponential grwoth
         solver = pybamm.ScikitsOdeSolver(tol=1e-8)
@@ -103,10 +118,23 @@ class TestScikitsSolver(unittest.TestCase):
         def jacobian(t, y):
             return np.array([[1.0, 0.0], [-y[1], 1 - y[0]]])
 
+        def sparse_jacobian(t, y):
+            return sparse.csr_matrix(jacobian(t, y))
+
         y0 = np.array([1.0, 1.0])
         t_eval = np.linspace(0, 1, 100)
+
         t_sol, y_sol = solver.integrate(
             exponential_growth, y0, t_eval, jacobian=jacobian
+        )
+        np.testing.assert_array_equal(t_sol, t_eval)
+        np.testing.assert_allclose(np.exp(t_sol), y_sol[0], rtol=1e-4)
+        np.testing.assert_allclose(
+            np.exp(1 + t_sol - np.exp(t_sol)), y_sol[1], rtol=1e-4
+        )
+
+        t_sol, y_sol = solver.integrate(
+            exponential_growth, y0, t_eval, jacobian=sparse_jacobian,
         )
         np.testing.assert_array_equal(t_sol, t_eval)
         np.testing.assert_allclose(np.exp(t_sol), y_sol[0], rtol=1e-4)


### PR DESCRIPTION
# Description

Fixes half (ode solver) of #322

Enables user to set `linsolver` for scikits_odes_solver. For the `dense` solver, the sparse jacobian changed to a dense array, for the iterative solvers ('spgmr', 'spbcgs', 'sptfqmr') the sparse matrix is used directly.

However, I found that using the iterative solvers generally made the solvers take significantly longer to run, so `dense` is currently left as the default

@rtimms, @tinosulzer: is an iterative solver the approach we want to take for the sparse jacobian? If so, do we need preconditioning? 

Note that I've only done this for the sundials ode solver, as scikits.odes only exposes this functionality for cvode. I would have to edit scikits.odes to get this working for ida

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
