### PR TITLE
Issue 329 remove deepcopy param disc

### DIFF
--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 import pybamm
 
-import copy
 import numpy as np
 from scipy.sparse import block_diag, csr_matrix
 
@@ -380,6 +379,9 @@ class Discretisation(object):
 
         elif isinstance(symbol, pybamm.Array):
             return symbol.__class__(symbol.entries, symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.StateVector):
+            return symbol.__class__(symbol.y_slice, symbol.name, symbol.domain)
 
         elif isinstance(symbol, pybamm.Time):
             return pybamm.Time()

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -375,10 +375,19 @@ class Discretisation(object):
             new_symbol = pybamm.DomainConcatenation(new_children, self.mesh)
             return new_symbol
 
+        elif isinstance(symbol, pybamm.Scalar):
+            return pybamm.Scalar(symbol.value, symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.Array):
+            return symbol.__class__(symbol.entries, symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.Time):
+            return pybamm.Time()
+
         else:
-            new_symbol = copy.deepcopy(symbol)
-            new_symbol.parent = None
-            return new_symbol
+            raise NotImplementedError(
+                "Cannot discretise symbol of type '{}'".format(type(symbol))
+            )
 
     def process_binary_operators(self, bin_op):
         """Discretise binary operators in model equations.  Performs appropriate

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -447,7 +447,7 @@ class Symbol(anytree.NodeMixin):
         search_types = (pybamm.Variable, pybamm.StateVector, pybamm.IndependentVariable)
 
         # do the search, return true if no relevent nodes are found
-        return all([not (isinstance(n, search_types)) for n in self.pre_order()])
+        return not any((isinstance(n, search_types)) for n in self.pre_order())
 
     def evaluate_ignoring_errors(self):
         """
@@ -505,13 +505,11 @@ class Symbol(anytree.NodeMixin):
 
     def has_gradient(self):
         """Returns True if equation has a Gradient term."""
-        return any([isinstance(symbol, pybamm.Gradient) for symbol in self.pre_order()])
+        return any(isinstance(symbol, pybamm.Gradient) for symbol in self.pre_order())
 
     def has_divergence(self):
         """Returns True if equation has a Divergence term."""
-        return any(
-            [isinstance(symbol, pybamm.Divergence) for symbol in self.pre_order()]
-        )
+        return any(isinstance(symbol, pybamm.Divergence) for symbol in self.pre_order())
 
     def simplify(self):
         """

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -260,7 +260,9 @@ class ParameterValues(dict):
             return pybamm.Time()
 
         else:
-            raise NotImplementedError
+            raise NotImplementedError(
+                "Cannot process parameters for symbol of type '{}'".format(type(symbol))
+            )
 
     def update_scalars(self, symbol):
         """Update the value of any Scalars in the expression tree.

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -6,7 +6,6 @@ from __future__ import print_function, unicode_literals
 import pybamm
 
 import pandas as pd
-import copy
 
 
 class ParameterValues(dict):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -243,10 +243,24 @@ class ParameterValues(dict):
                 # Concatenation or NumpyConcatenation
                 return symbol.__class__(*new_children)
 
+        # Other cases: return new variable to avoid tree internal corruption
+        elif isinstance(symbol, pybamm.Variable):
+            return pybamm.Variable(symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.Scalar):
+            return pybamm.Scalar(symbol.value, symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.Array):
+            return symbol.__class__(symbol.entries, symbol.name, symbol.domain)
+
+        elif isinstance(symbol, pybamm.SpatialVariable):
+            return pybamm.SpatialVariable(symbol.name, symbol.domain, symbol.coord_sys)
+
+        elif isinstance(symbol, pybamm.Time):
+            return pybamm.Time()
+
         else:
-            new_symbol = copy.deepcopy(symbol)
-            new_symbol.parent = None
-            return new_symbol
+            raise NotImplementedError
 
     def update_scalars(self, symbol):
         """Update the value of any Scalars in the expression tree.

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -147,6 +147,11 @@ class TestDiscretise(unittest.TestCase):
         self.assertIsInstance(un2_disc, pybamm.AbsoluteValue)
         self.assertIsInstance(un2_disc.children[0], pybamm.Scalar)
 
+        # not implemented
+        sym = pybamm.Symbol("sym")
+        with self.assertRaises(NotImplementedError):
+            disc.process_symbol(sym)
+
     def test_process_complex_expression(self):
         var1 = pybamm.Variable("var1")
         var2 = pybamm.Variable("var2")
@@ -415,9 +420,7 @@ class TestDiscretise(unittest.TestCase):
 
         # jacobian is identity
         jacobian = model.concatenated_rhs.jac(y).evaluate(0, y0)
-        np.testing.assert_array_equal(
-            np.eye(np.size(y0)), jacobian.toarray()
-        )
+        np.testing.assert_array_equal(np.eye(np.size(y0)), jacobian.toarray())
 
         # test that not enough initial conditions raises an error
         model = pybamm.BaseModel()

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -128,6 +128,11 @@ class TestParameterValues(unittest.TestCase):
         self.assertIsInstance(processed_f, pybamm.Matrix)
         np.testing.assert_array_equal(processed_f.evaluate(), np.ones((5, 6)))
 
+        # not implemented
+        sym = pybamm.Symbol("sym")
+        with self.assertRaises(NotImplementedError):
+            parameter_values.process_symbol(sym)
+
     def test_process_function_parameter(self):
         parameter_values = pybamm.ParameterValues(
             {


### PR DESCRIPTION
# Description

Remove deepcopy operations from `ParameterValues` and `Discretisation` as they are slow.
Fixes half of #329 

## Speed tests 

Before:
![tmp2y5s0rd8](https://user-images.githubusercontent.com/20817509/57078066-6c316d80-6ce5-11e9-8562-d6dd79adcf72.png)
After:
![tmpex400bvh](https://user-images.githubusercontent.com/20817509/57078076-72274e80-6ce5-11e9-8a7d-fe00300f0a9c.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
