### PR TITLE
Remove tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,10 +6,9 @@ from __future__ import absolute_import, division
 from __future__ import print_function, unicode_literals
 
 from .unit.test_models.standard_model_tests import StandardModelTest, OptimisationsTest
-from .unit.test_models.standard_output_tests import standard_output_tests
+from .unit.test_models.standard_output_tests import StandardOutputTests
 from .shared import (
     get_mesh_for_testing,
     get_p2d_mesh_for_testing,
     get_discretisation_for_testing,
 )
-

--- a/tests/unit/test_models/standard_model_tests.py
+++ b/tests/unit/test_models/standard_model_tests.py
@@ -80,9 +80,10 @@ class StandardModelTest(object):
 
     def test_outputs(self):
         # run the standard output tests
-        tests.standard_output_tests(
+        std_out_test = tests.StandardOutputTests(
             self.model, self.disc, self.solver, self.parameter_values
         )
+        std_out_test.test_all()
 
     def test_all(self, param=None, disc=None, solver=None, t_eval=None):
         self.model.check_well_posedness()

--- a/tests/unit/test_models/standard_output_tests.py
+++ b/tests/unit/test_models/standard_output_tests.py
@@ -8,40 +8,40 @@ import pybamm
 import numpy as np
 
 
-def standard_output_tests(model, disc, solver, parameter_values):
+class StandardOutputTests(object):
+    "Calls all the tests on the standard output variables."
 
-    if isinstance(model, pybamm.LithiumIonBaseModel):
-        chemistry = "Lithium-ion"
-    elif isinstance(model, pybamm.LeadAcidBaseModel):
-        chemistry = "Lead acid"
+    def __init__(self, model, disc, solver, parameter_values):
+        self.model = model
+        self.disc = disc
+        self.solver = solver
 
-    current_sign = np.sign(parameter_values["Typical current density"])
-    if current_sign == 1:
-        operating_condition = "discharge"
-    elif current_sign == -1:
-        operating_condition = "charge"
-    else:
-        operating_condition = "off"
+        if isinstance(self.model, pybamm.LithiumIonBaseModel):
+            self.chemistry = "Lithium-ion"
+        elif isinstance(self.model, pybamm.LeadAcidBaseModel):
+            self.chemistry = "Lead acid"
 
-    voltage_tests = VoltageTests(model, disc, solver, operating_condition)
-    voltage_tests.test_all()
+        current_sign = np.sign(parameter_values["Typical current density"])
+        if current_sign == 1:
+            self.operating_condition = "discharge"
+        elif current_sign == -1:
+            self.operating_condition = "charge"
+        else:
+            self.operating_condition = "off"
 
-    electrolyte_tests = ElectrolyteConcentrationTests(
-        model, disc, solver, operating_condition
-    )
-    electrolyte_tests.test_all()
+    def run_test_class(self, ClassName):
+        "Run all tests from a class 'ClassName'"
+        tests = ClassName(self.model, self.disc, self.solver, self.operating_condition)
+        tests.test_all()
 
-    potential_tests = PotentialTests(model, disc, solver, operating_condition)
-    potential_tests.test_all()
+    def test_all(self):
+        self.run_test_class(VoltageTests)
+        self.run_test_class(ElectrolyteConcentrationTests)
+        self.run_test_class(PotentialTests)
+        self.run_test_class(CurrentTests)
 
-    current_tests = CurrentTests(model, disc, solver, operating_condition)
-    current_tests.test_all()
-
-    if chemistry == "Lithium-ion":
-        particle_tests = ParticleConcentrationTests(
-            model, disc, solver, operating_condition
-        )
-        particle_tests.test_all()
+        if self.chemistry == "Lithium-ion":
+            self.run_test_class(ParticleConcentrationTests)
 
 
 class BaseOutputTest(object):
@@ -414,4 +414,3 @@ class CurrentTests(BaseOutputTest):
     def test_all(self):
         self.test_interfacial_current_average()
         self.test_conservation()
-

--- a/tests/unit/test_models/test_lead_acid/test_composite.py
+++ b/tests/unit/test_models/test_lead_acid/test_composite.py
@@ -29,30 +29,6 @@ class TestLeadAcidComposite(unittest.TestCase):
         np.testing.assert_array_almost_equal(original, using_known_evals)
         np.testing.assert_array_almost_equal(original, simp_and_known)
 
-    def test_solution(self):
-        model = pybamm.lead_acid.Composite()
-        modeltest = tests.StandardModelTest(model)
-        modeltest.test_all()
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-
-        # Post-process variables
-        conc = pybamm.ProcessedVariable(
-            model.variables["Electrolyte concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        voltage = pybamm.ProcessedVariable(
-            model.variables["Terminal voltage"], t_sol, y_sol
-        )
-
-        # check output
-        # concentration and voltage should be monotonically decreasing for a discharge
-        np.testing.assert_array_less(conc.entries[:, 1:], conc.entries[:, :-1])
-        np.testing.assert_array_less(voltage.entries[1:], voltage.entries[:-1])
-        # Make sure the concentration is always positive (cut-off event working)
-        np.testing.assert_array_less(0, conc.entries)
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_models/test_lead_acid/test_loqs.py
+++ b/tests/unit/test_models/test_lead_acid/test_loqs.py
@@ -29,30 +29,6 @@ class TestLeadAcidLOQS(unittest.TestCase):
         np.testing.assert_array_almost_equal(original, using_known_evals)
         np.testing.assert_array_almost_equal(original, simp_and_known)
 
-    def test_solution(self):
-        model = pybamm.lead_acid.LOQS()
-        modeltest = tests.StandardModelTest(model)
-        modeltest.test_all(t_eval=np.linspace(0, 2))
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-
-        # Post-process variables
-        conc = pybamm.ProcessedVariable(
-            model.variables["Electrolyte concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        voltage = pybamm.ProcessedVariable(
-            model.variables["Terminal voltage"], t_sol, y_sol
-        )
-
-        # check output
-        # concentration and voltage should be monotonically decreasing for a discharge
-        np.testing.assert_array_less(conc.entries[:, 1:], conc.entries[:, :-1])
-        np.testing.assert_array_less(voltage.entries[1:], voltage.entries[:-1])
-        # Make sure the concentration is always positive (cut-off event working)
-        np.testing.assert_array_less(0, conc.entries)
-
     def test_charge(self):
         model = pybamm.lead_acid.LOQS()
         parameter_values = model.default_parameter_values

--- a/tests/unit/test_models/test_lead_acid/test_newman_tiedemann.py
+++ b/tests/unit/test_models/test_lead_acid/test_newman_tiedemann.py
@@ -33,39 +33,6 @@ class TestLeadAcidNewmanTiedemann(unittest.TestCase):
         np.testing.assert_array_almost_equal(original, using_known_evals)
         np.testing.assert_array_almost_equal(original, simp_and_known)
 
-    def test_solution(self):
-        model = pybamm.lead_acid.NewmanTiedemann()
-        # Make grid very coarse for quick test (note that r domain doesn't matter)
-        var = pybamm.standard_spatial_vars
-        model.default_var_pts = {
-            var.x_n: 3,
-            var.x_s: 3,
-            var.x_p: 3,
-            var.r_n: 1,
-            var.r_p: 1,
-        }
-        modeltest = tests.StandardModelTest(model)
-        modeltest.test_all(t_eval=np.linspace(0, 0.1, 5))
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-
-        # Post-process variables
-        conc = pybamm.ProcessedVariable(
-            model.variables["Electrolyte concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        voltage = pybamm.ProcessedVariable(
-            model.variables["Terminal voltage"], t_sol, y_sol
-        )
-
-        # check output
-        # concentration and voltage should be monotonically decreasing for a discharge
-        np.testing.assert_array_less(conc.entries[:, 1:], conc.entries[:, :-1])
-        np.testing.assert_array_less(voltage.entries[1:], voltage.entries[:-1])
-        # Make sure the concentration is always positive (cut-off event working)
-        np.testing.assert_array_less(0, conc.entries)
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_models/test_lithium_ion/test_lithium_ion_spm.py
+++ b/tests/unit/test_models/test_lithium_ion/test_lithium_ion_spm.py
@@ -27,37 +27,6 @@ class TestSPM(unittest.TestCase):
         np.testing.assert_array_almost_equal(original, using_known_evals)
         np.testing.assert_array_almost_equal(original, simp_and_known)
 
-    def test_surface_concentration(self):
-        model = pybamm.lithium_ion.SPM()
-        modeltest = tests.StandardModelTest(model)
-        modeltest.test_all()
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-
-        # check surface concentration decreases in negative particle and
-        # increases in positive particle for discharge
-        c_s_n_surf = pybamm.ProcessedVariable(
-            model.variables["Negative particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        c_s_p_surf = pybamm.ProcessedVariable(
-            model.variables["Positive particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        # neg surf concentration should be monotonically decreasing for a discharge
-        np.testing.assert_array_less(
-            c_s_n_surf.entries[:, 1:], c_s_n_surf.entries[:, :-1]
-        )
-        # pos surf concentration should be monotonically increasing for a discharge
-        np.testing.assert_array_less(
-            c_s_p_surf.entries[:, :-1], c_s_p_surf.entries[:, 1:]
-        )
-
-    # test that surface concentrations are all positive
-
     def test_charge(self):
         model = pybamm.lithium_ion.SPM()
         parameter_values = model.default_parameter_values
@@ -65,68 +34,12 @@ class TestSPM(unittest.TestCase):
         modeltest = tests.StandardModelTest(model, parameter_values=parameter_values)
         modeltest.test_all()
 
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-        # check surface concentration increases in negative particle and
-        # decreases in positive particle for charge
-        c_s_n_surf = pybamm.ProcessedVariable(
-            model.variables["Negative particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        c_s_p_surf = pybamm.ProcessedVariable(
-            model.variables["Positive particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        voltage = pybamm.ProcessedVariable(
-            model.variables["Terminal voltage"], t_sol, y_sol
-        )
-        # neg surf concentration should be monotonically increasing for a charge
-        np.testing.assert_array_less(
-            c_s_n_surf.entries[:, :-1], c_s_n_surf.entries[:, 1:]
-        )
-        # pos surf concentration should be monotonically decreasing for a charge
-        np.testing.assert_array_less(
-            c_s_p_surf.entries[:, 1:], c_s_p_surf.entries[:, :-1]
-        )
-
-        # test that surface concentrations are all positive
-        np.testing.assert_array_less(c_s_n_surf.entries, 1)
-        np.testing.assert_array_less(c_s_p_surf.entries, 1)
-
-        np.testing.assert_array_less(voltage.entries[:-1], voltage.entries[1:])
-
     def test_zero_current(self):
         model = pybamm.lithium_ion.SPM()
         parameter_values = model.default_parameter_values
         parameter_values.update({"Typical current density": 0})
         modeltest = tests.StandardModelTest(model, parameter_values=parameter_values)
         modeltest.test_all()
-
-        t_sol, y_sol = modeltest.solver.t, modeltest.solver.y
-        # check surface concentration increases in negative particle and
-        # decreases in positive particle for charge
-        c_s_n_surf = pybamm.ProcessedVariable(
-            model.variables["Negative particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        c_s_p_surf = pybamm.ProcessedVariable(
-            model.variables["Positive particle surface concentration"],
-            t_sol,
-            y_sol,
-            mesh=modeltest.disc.mesh,
-        )
-        voltage = pybamm.ProcessedVariable(
-            model.variables["Terminal voltage"], t_sol, y_sol
-        )
-        # variables should remain unchanged
-        np.testing.assert_almost_equal(c_s_n_surf.entries - c_s_n_surf.entries[0], 0)
-        np.testing.assert_almost_equal(c_s_p_surf.entries - c_s_p_surf.entries[0], 0)
-        np.testing.assert_almost_equal(voltage.entries - voltage.entries[0], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Remove redundant tests (now that we do the output tests as standard), and change `standard_output_tests` back to object-oriented
@Scottmar93  see if you like this

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
