### PR TITLE
Issue 354 quick plot

### DIFF
--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -291,16 +291,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pybamm.models.lithium_ion.spm.SPM at 0x7f8999d21be0>"
+       "<pybamm.models.lithium_ion.spm.SPM at 0x7fcd786b34e0>"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -528,11 +528,11 @@
     "ax1.set_xlabel(r'$t$')\n",
     "ax1.set_ylabel('Terminal voltage')\n",
     "\n",
-    "ax2.plot(solver.t, spc_n(t=solver.t, x=0))\n",
+    "ax2.plot(solver.t, c_s_n_surf(t=solver.t, x=0))\n",
     "ax2.set_xlabel(r'$t$')\n",
     "ax2.set_ylabel('Negative particle surface concentration')\n",
     "\n",
-    "ax3.plot(solver.t, spc_p(t=solver.t, x=1))\n",
+    "ax3.plot(solver.t, c_s_p_surf(t=solver.t, x=1))\n",
     "ax3.set_xlabel(r'$t$')\n",
     "ax3.set_ylabel('Positive particle surface concentration')\n",
     "\n",
@@ -549,13 +549,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d9a0a4b84d1647c2b75c4ef1e920e403",
+       "model_id": "9e0a4233df3f4ebe88630a31221191f2",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -291,16 +291,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pybamm.models.lithium_ion.spm.SPM at 0x7ffb6dc9b7b8>"
+       "<pybamm.models.lithium_ion.spm.SPM at 0x7f19f83b3320>"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -549,13 +549,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c339bda648043ddaabad7f56df91348",
+       "model_id": "7057c7e916564fe5b6f6fb784054a0ff",
        "version_major": 2,
        "version_minor": 0
       },
@@ -589,13 +591,35 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 37,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "\n",
-    "# pybamm.quick_plot(model, param, mesh, solver)"
+    "The QuickPlot class can be used to plot the common set of useful outputs which should give you a good initial overview of the model. The method Quickplot.plot(t) is simply a function like plot_concentrations(t) above. We can therefore either use it statically for a particularl t or employ the slider widget.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "756d5729c81740938c33b82b448fbf33",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=1.2525252525252526, step=0.05), Output()), _…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "quick_plot = pybamm.QuickPlot(model, param, mesh, solver)\n",
+    "widgets.interact(quick_plot.plot, t=widgets.FloatSlider(min=0,max=solver.t[-1],step=0.05,value=0));"
    ]
   },
   {

--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -123,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -291,16 +291,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pybamm.models.lithium_ion.spm.SPM at 0x7fcd786b34e0>"
+       "<pybamm.models.lithium_ion.spm.SPM at 0x7ffb6dc9b7b8>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -481,7 +481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -549,13 +549,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e0a4233df3f4ebe88630a31221191f2",
+       "model_id": "9c339bda648043ddaabad7f56df91348",
        "version_major": 2,
        "version_minor": 0
       },
@@ -586,6 +586,16 @@
     "    \n",
     "import ipywidgets as widgets\n",
     "widgets.interact(plot_concentrations, t=widgets.FloatSlider(min=0,max=1,step=0.1,value=0));\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# pybamm.quick_plot(model, param, mesh, solver)"
    ]
   },
   {

--- a/examples/scripts/SPMe.py
+++ b/examples/scripts/SPMe.py
@@ -25,4 +25,6 @@ t_eval = np.linspace(0, 2, 100)
 solver.solve(model, t_eval)
 
 # plot
-pybamm.quick_plot(model, param, mesh, solver)
+plot = pybamm.QuickPlot(model, param, mesh, solver)
+
+plot.dynamic_plot()

--- a/examples/scripts/SPMe.py
+++ b/examples/scripts/SPMe.py
@@ -1,0 +1,28 @@
+import pybamm
+import numpy as np
+
+# load model
+model = pybamm.lithium_ion.SPMe()
+
+# create geometry
+geometry = model.default_geometry
+
+# load parameter values and process model and geometry
+param = model.default_parameter_values
+param.process_model(model)
+param.process_geometry(geometry)
+
+# set mesh
+mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+
+# discretise model
+disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+disc.process_model(model)
+
+# solve model
+solver = model.default_solver
+t_eval = np.linspace(0, 2, 100)
+solver.solve(model, t_eval)
+
+# plot
+pybamm.quick_plot(model, param, mesh, solver)

--- a/examples/scripts/SPMe.py
+++ b/examples/scripts/SPMe.py
@@ -26,5 +26,4 @@ solver.solve(model, t_eval)
 
 # plot
 plot = pybamm.QuickPlot(model, param, mesh, solver)
-
 plot.dynamic_plot()

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -194,7 +194,7 @@ from .solvers.scikits_ode_solver import ScikitsOdeSolver
 # other
 #
 from .processed_variable import ProcessedVariable
-from .quick_plot import quick_plot
+from .quick_plot import QuickPlot
 
 #
 # Remove any imported modules, so we don't expose them as part of pybamm

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -194,6 +194,7 @@ from .solvers.scikits_ode_solver import ScikitsOdeSolver
 # other
 #
 from .processed_variable import ProcessedVariable
+from .quick_plot import quick_plot
 
 #
 # Remove any imported modules, so we don't expose them as part of pybamm

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -1,0 +1,177 @@
+import numpy as np
+import pybamm
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider
+
+
+def quick_plot(model, param, mesh, solver):
+    """
+    Generates a quick plot of a subset of key outputs of the model so that the model outputs can be easily assessed.
+
+    Parameters
+    ----------
+    model: :class: pybamm.BaseModel
+        The model to plot the outputs of.
+    mesh: :class: pybamm.Mesh
+        The mesh on which the model solved
+    solver: :class: pybamm.Solver
+        The numerical solver for the model which contained the solution to the model.
+    """
+
+    # obtain parameters values
+
+    l_n = param.process_symbol(pybamm.geometric_parameters.l_n).evaluate(0, 0)
+    l_s = param.process_symbol(pybamm.geometric_parameters.l_s).evaluate(0, 0)
+    l_p = param.process_symbol(pybamm.geometric_parameters.l_p).evaluate(0, 0)
+
+    # TODO: change mesh interface at somepoint (cannot just )
+    # unpack the mesh to obtain discrete spatial variables
+
+    x_n = np.linspace(0, l_n, 40)
+    x_s = np.linspace(l_n, l_n + l_s, 20)
+    x_p = np.linspace(l_n + l_s, 1, 40)
+    x = np.linspace(0, 1, 100)
+
+    r_n = np.linspace(0, 1, 100)
+    r_p = np.linspace(0, 1, 100)
+
+    all_time = solver.t
+
+    fig, ax = plt.subplots(figsize=(15, 8))
+    plt.subplots_adjust(left=0.25, bottom=0.25)
+
+    # electrolyte concentration
+
+    c_e = pybamm.ProcessedVariable(
+        model.variables["Electrolyte concentration"], solver.t, solver.y, mesh=mesh
+    )
+
+    plt.subplot(342)
+    plt.title("Electrolyte Concentration")
+    plt.xlabel("x")
+    plt.ylabel("c_e")
+    electrolyte_concentration, = plt.plot(x, c_e(t=0, x=x), lw=2)
+    plt.axis([0, 1, np.min(c_e(all_time, x)), np.max(c_e(all_time, x))])
+
+    # plt.subplot(342)
+    # plt.title("Negative Electrode")
+    # plt.xlabel("x")
+    # plt.ylabel("Lithium concentration")
+    # negCon, = plt.plot(sol.grid.xn, sol.cn[:, 1, 0], lw=2)
+    # plt.axis([0, sol.grid.xn[-1], 0, 1])
+
+    # plt.subplot(343)
+    # plt.title("Positive Electrode")
+    # plt.xlabel("x")
+    # plt.ylabel("Lithium concentration")
+    # posCon, = plt.plot(sol.grid.xp, sol.cn[:, 1, 0], lw=2)
+    # plt.axis([sol.grid.xp[0], sol.grid.xp[-1], 0, 1])
+
+    # plt.subplot(344)
+    # plt.xlabel("Time")
+    # plt.ylabel("Current")
+    # curr, = plt.plot(sol.time, sol.current * np.ones(np.shape(sol.time)), lw=2)
+    # plt.hold(True)
+    # curr_point, = plt.plot(
+    #     [sol.time[0]], [sol.current], marker="o", markersize=5, color="red"
+    # )
+
+    # plt.subplot(345)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrolyte Potential")
+    # Psi, = plt.plot(
+    #     sol.grid.x,
+    #     np.concatenate((sol.Psi_n[:, 0], sol.Psi_s[:, 0], sol.Psi_p[:, 0])),
+    #     lw=2,
+    # )
+    # plt.axis([0, 1, np.min(sol.Psi_n), np.max(sol.Psi_p)])
+
+    # plt.subplot(346)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrode Potential")
+    # psi_n, = plt.plot(sol.grid.xn, sol.psi_n[:, 0], lw=2)
+    # plt.axis([sol.grid.xn[0], sol.grid.xn[-1], -1, 1])
+
+    # plt.subplot(347)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrode Potential")
+    # psi_p, = plt.plot(sol.grid.xp, sol.psi_p[:, 0], lw=2)
+    # plt.axis([sol.grid.xp[0], sol.grid.xp[-1], 0, 5])
+
+    # plt.subplot(348)
+    # plt.xlabel("Time")
+    # plt.ylabel("Voltage")
+    # voltage, = plt.plot(sol.time, sol.voltage, lw=2)
+    # plt.hold(True)
+    # voltage_point, = plt.plot(
+    #     [sol.time[0]], [sol.voltage[0]], marker="o", markersize=5, color="red"
+    # )
+    # # plt.axis([sol.time[0], sol.time[-1], -1, 1])
+
+    # plt.subplot(349)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrolyte Current")
+    # J_sol = np.concatenate(
+    #     (sol.Jn[:, 0], sol.current * np.ones((sol.grid.sep - 1)), sol.Jp[:, 0])
+    # )
+    # J, = plt.plot(sol.grid.x_edge, J_sol, lw=2)
+    # # plt.axis([sol.grid.x[0], sol.grid.x[-1], 0, 1])
+
+    # plt.subplot(3, 4, 10)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrode Current")
+    # jn, = plt.plot(sol.grid.xn_edge, sol.jn[:, 0], lw=2)
+
+    # plt.subplot(3, 4, 11)
+    # plt.xlabel("x")
+    # plt.ylabel("Electrode Current")
+    # jp, = plt.plot(sol.grid.xp_edge, sol.jp[:, 0], lw=2)
+
+    # plt.subplot(3, 4, 12)
+    # plt.xlabel("Time")
+    # plt.ylabel("Normalised Capacity")
+    # plt.plot(sol.time, sol.capacity, lw=2)
+    # plt.hold(True)
+    # cap_point, = plt.plot(
+    #     [sol.time[0]], [sol.capacity[0]], marker="o", markersize=5, color="red"
+    # )
+    # plt.axis([sol.time[0], sol.time[-1], 0.9, 1.1])
+
+    axcolor = "lightgoldenrodyellow"
+    axfreq = plt.axes([0.315, 0.05, 0.37, 0.03], facecolor=axcolor)
+    sfreq = Slider(axfreq, "Time", 0, all_time.max(), valinit=0)
+
+    def update(val):
+        # t = int(round(sfreq.val))
+        time = sfreq.val
+        electrolyte_concentration.set_ydata(c_e(t=time, x=x))
+        # negCon.set_ydata(sol.cn[:, -1, t])
+        # posCon.set_ydata(sol.cp[:, -1, t])
+        # Psi.set_ydata(
+        #     np.concatenate((sol.Psi_n[:, t], sol.Psi_s[:, t], sol.Psi_p[:, t]))
+        # )
+        # psi_n.set_ydata(sol.psi_n[:, t])
+        # psi_p.set_ydata(sol.psi_p[:, t])
+
+        # voltage_point.set_data([sol.time[t]], [sol.voltage[t]])
+        # curr_point.set_data([sol.time[t]], [sol.current])
+        # cap_point.set_data([sol.time[t]], [sol.capacity[t]])
+
+        # J_sol = np.concatenate(
+        #     (sol.Jn[:, t], sol.current * np.ones((sol.grid.sep - 1)), sol.Jp[:, t])
+        # )
+        # J.set_ydata(J_sol)
+
+        # jn.set_ydata(sol.jn[:, t])
+        # jp.set_ydata(sol.jp[:, t])
+
+        fig.canvas.draw_idle()
+
+    sfreq.on_changed(update)
+
+    plt.subplots_adjust(
+        top=0.92, bottom=0.15, left=0.10, right=0.9, hspace=0.5, wspace=0.5
+    )
+
+    plt.show()
+

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -181,7 +181,7 @@ class QuickPlot(object):
         )
         plt.axis(self.axis["Terminal voltage [V]"])
 
-    def dynamic_plot(self):
+    def dynamic_plot(self, testing=False):
 
         # create an initial plot at time 0
         self.plot(0)
@@ -195,7 +195,8 @@ class QuickPlot(object):
             top=0.92, bottom=0.15, left=0.10, right=0.9, hspace=0.5, wspace=0.5
         )
 
-        plt.show()
+        if not testing:
+            plt.show()
 
     def update(self, val):
         t = self.sfreq.val

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -63,24 +63,14 @@ class QuickPlot(object):
 
     def reset_axis(self):
         self.axis = {
-            "Negative particle surface concentration": [
-                0,
-                self.l_n,
-                np.min(self.c_s_n_surf(self.t, self.x_n)),
-                np.max(self.c_s_n_surf(self.t, self.x_n)),
-            ],
+            "Negative particle surface concentration": [0, self.l_n, 0, 1],
             "Electrolyte concentration": [
                 0,
                 1,
-                np.min(self.c_e(self.t, self.x)),
-                np.max(self.c_e(self.t, self.x)),
+                np.min(self.c_e(self.t, self.x) - 0.2),
+                np.max(self.c_e(self.t, self.x) + 0.2),
             ],
-            "Positive particle surface concentration": [
-                1 - self.l_p,
-                1,
-                np.min(self.c_s_p_surf(self.t, self.x_p)),
-                np.max(self.c_s_p_surf(self.t, self.x_p)),
-            ],
+            "Positive particle surface concentration": [1 - self.l_p, 1, 0, 1],
             "Total current density": [
                 self.t[0],
                 self.t[-1],
@@ -90,8 +80,8 @@ class QuickPlot(object):
             "Negative electrode potential [V]": [
                 0,
                 self.l_n,
-                np.min(self.phi_s_n(self.t, self.x_n)),
-                np.max(self.phi_s_n(self.t, self.x_n)),
+                np.min(self.phi_s_n(self.t, self.x_n)) - 0.01,
+                np.max(self.phi_s_n(self.t, self.x_n)) + 0.01,
             ],
             "Electrolyte potential [V]": [
                 0,
@@ -122,7 +112,8 @@ class QuickPlot(object):
             Time at which to plot.
         """
         self.fig, self.ax = plt.subplots(figsize=(15, 8))
-        plt.subplots_adjust(left=0.25, bottom=0.25)
+        plt.tight_layout()
+        plt.subplots_adjust(left=-0.1)
 
         plt.subplot(241)
         plt.xlabel("x")
@@ -142,7 +133,7 @@ class QuickPlot(object):
         plt.xlabel("x_p")
         plt.ylabel("Positive particle surface concentration")
         self.positive_particle_concentration, = plt.plot(
-            self.x_p, self.c_s_n_surf(t, self.x_p), lw=2
+            self.x_p, self.c_s_p_surf(t, self.x_p), lw=2
         )
         plt.axis(self.axis["Positive particle surface concentration"])
 
@@ -189,7 +180,7 @@ class QuickPlot(object):
             [t], [self.V(t)], marker="o", markersize=5, color="red"
         )
         plt.axis(self.axis["Terminal voltage [V]"])
-    
+
     def dynamic_plot(self):
 
         # create an initial plot at time 0

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -6,7 +6,10 @@ from matplotlib.widgets import Slider
 
 class QuickPlot(object):
     """
-    Generates a quick plot of a subset of key outputs of the model so that the model outputs can be easily assessed.
+    Generates a quick plot of a subset of key outputs of the model so that the model 
+    outputs can be easily assessed. The axis limits can be set using:
+        self.axis["Variable name"] = [x_min, x_max, y_min, y_max]
+    They can be reset to the default values by using self.reset_axis.
 
     Parameters
     ----------
@@ -62,6 +65,9 @@ class QuickPlot(object):
         )
 
     def reset_axis(self):
+        """
+        Reset the axis limits to the default values. 
+        """
         self.axis = {
             "Negative particle surface concentration": [0, self.l_n, 0, 1],
             "Electrolyte concentration": [
@@ -182,6 +188,9 @@ class QuickPlot(object):
         plt.axis(self.axis["Terminal voltage [V]"])
 
     def dynamic_plot(self, testing=False):
+        """
+        Generate a dynamic plot with a slider to control the time.
+        """
 
         # create an initial plot at time 0
         self.plot(0)
@@ -199,6 +208,9 @@ class QuickPlot(object):
             plt.show()
 
     def update(self, val):
+        """
+        Update the plot in self.plot() with values at new time
+        """
         t = self.sfreq.val
         self.negative_particle_concentration.set_ydata(self.c_s_n_surf(t, self.x_n))
         self.electrolyte_concentration.set_ydata(self.c_e(t, self.x))

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -6,7 +6,7 @@ from matplotlib.widgets import Slider
 
 class QuickPlot(object):
     """
-    Generates a quick plot of a subset of key outputs of the model so that the model 
+    Generates a quick plot of a subset of key outputs of the model so that the model
     outputs can be easily assessed. The axis limits can be set using:
         self.axis["Variable name"] = [x_min, x_max, y_min, y_max]
     They can be reset to the default values by using self.reset_axis.
@@ -66,7 +66,7 @@ class QuickPlot(object):
 
     def reset_axis(self):
         """
-        Reset the axis limits to the default values. 
+        Reset the axis limits to the default values.
         """
         self.axis = {
             "Negative particle surface concentration": [0, self.l_n, 0, 1],
@@ -189,7 +189,8 @@ class QuickPlot(object):
 
     def dynamic_plot(self, testing=False):
         """
-        Generate a dynamic plot with a slider to control the time.
+        Generate a dynamic plot with a slider to control the time. We recommend using
+        ipywidgets instead of this function if you are using jupyter notebooks
         """
 
         # create an initial plot at time 0

--- a/tests/unit/test_quick_plot.py
+++ b/tests/unit/test_quick_plot.py
@@ -1,0 +1,46 @@
+import pybamm
+import unittest
+import numpy as np
+
+
+class TestQuickPlot(unittest.TestCase):
+    """
+    Tests that QuickPlot is created correctly
+    """
+
+    def test_plot_creation(self):
+        model = pybamm.lithium_ion.SPMe()
+        geometry = model.default_geometry
+        param = model.default_parameter_values
+        param.process_model(model)
+        param.process_geometry(geometry)
+        mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+        disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+        disc.process_model(model)
+        solver = model.default_solver
+        t_eval = np.linspace(0, 2, 100)
+        solver.solve(model, t_eval)
+
+        quick_plot = pybamm.QuickPlot(model, param, mesh, solver)
+        quick_plot.plot(0)
+
+        # update the axis
+        new_axis = [0, 0.5, 0, 1]
+        quick_plot.axis.update({"Electrolyte concentration": new_axis})
+        self.assertEqual(quick_plot.axis["Electrolyte concentration"], new_axis)
+
+        # and now reset them
+        quick_plot.reset_axis()
+        self.assertNotEqual(quick_plot.axis["Electrolyte concentration"], new_axis)
+
+        # check dynamic plot loads
+        quick_plot.dynamic_plot(testing=True)
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()


### PR DESCRIPTION
# Description
Added a QuickPlot class which allows the user to quickly plot common output variables which are useful for getting a quick overview of a model. I have implemented this in such a way that you can use it in both a jupyter notebook with widgets or with a slider plot in matplotlib when you are within a script.

Fixes #354 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
