### PR TITLE
Issue 191 python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ matrix:
         #   env:
         #     - PYBAMM_UNIT=true
         #   if: type != cron
-        # - python: "3.5"
-        #   env:
-        #     - PYBAMM_UNIT=true
-        #   if: type != cron
+        - python: "3.5"
+          env:
+            - PYBAMM_UNIT=true
+          if: type != cron
         - python: "3.6"
           env:
             - PYBAMM_UNIT=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,20 @@ matrix:
                 - python3.6-dev
           env:
             - PYBAMM_UNIT=true
+        - python: "3.6"
+          addons:
+            apt:
+              sources:
+                - deadsnakes
+              packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
+                - python3.6-dev
+          env:
+            - PYBAMM_UNIT=true
             - PYBAMM_BOOKS=true
           if: type != cron
         #- python: "3.7"
@@ -141,8 +155,7 @@ install:
   - pip install pip==18
   - pip install .
   - if [[ $PYBAMM_DOCS == true ]]; then pip install -e .[docs]; fi;
-  - if [[ $PYBAMM_STYLE == true ]]; then pip install -e .[dev]; fi;
-  - if [[ $TRAVIS_EVENT_TYPE == 'cron' ]]; then pip install -e .[dev]; fi;
+  - if [[ $PYBAMM_STYLE == true || $PYBAMM_BOOKS ]]; then pip install -e .[dev]; fi;
   - if [[ $PYBAMM_COVER == true ]]; then pip install coverage codecov; fi;
   - source scripts/install_scikits_odes.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
             - PYBAMM_STYLE=true
           if: type != cron
         - python: "3.6"
-           addons:
+          addons:
             apt:
               packages:
               - python3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
           addons:
             apt:
               packages:
-              - python3.5-dev
+                - python3.5-dev
           env:
             - PYBAMM_UNIT=true
           if: type != cron
@@ -42,7 +42,7 @@ matrix:
           addons:
             apt:
               packages:
-              - python3.6-dev
+                - python3.6-dev
           env:
             - PYBAMM_UNIT=true
           if: type != cron
@@ -69,7 +69,7 @@ matrix:
           addons:
             apt:
               packages:
-              - python3.6-dev
+                - python3.6-dev
           env:
             - PYBAMM_COVER=true
           if: type != cron
@@ -78,7 +78,7 @@ matrix:
           addons:
             apt:
               packages:
-              - python3.6-dev
+                - python3.6-dev
           if: type == cron
 
 # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ matrix:
                 - python3.5-dev
           env:
             - PYBAMM_UNIT=true
-            - PYBAMM_BOOKS=true
           if: type != cron
         - python: "3.6"
           addons:
@@ -74,7 +73,6 @@ matrix:
                 - python3.6-dev
           env:
             - PYBAMM_UNIT=true
-            - PYBAMM_BOOKS=true
           if: type != cron
         #- python: "3.7"
         #  env:
@@ -145,6 +143,8 @@ matrix:
                 - liblapack-dev
                 - graphviz
                 - python3.6-dev
+          env:
+            - PYBAMM_BOOKS=true
           if: type == cron
 
 # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,34 @@ matrix:
         - python: "3.5"
           addons:
             apt:
+              sources:
+                - deadsnakes
               packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
                 - python3.5-dev
           env:
             - PYBAMM_UNIT=true
+            - PYBAMM_BOOKS=true
           if: type != cron
         - python: "3.6"
           addons:
             apt:
+              sources:
+                - deadsnakes
               packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
                 - python3.6-dev
           env:
             - PYBAMM_UNIT=true
+            - PYBAMM_BOOKS=true
           if: type != cron
         #- python: "3.7"
         #  env:
@@ -58,17 +74,46 @@ matrix:
         #   if: type != cron
         # Docs, style and cover checking, latest Python version only
         - python: "3.6"
+          addons:
+            apt:
+              sources:
+                - deadsnakes
+              packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
+                - python3.6-dev
           env:
             - PYBAMM_DOCS=true
           if: type != cron
         - python: "3.6"
+          addons:
+            apt:
+              sources:
+                - deadsnakes
+              packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
+                - python3.6-dev
           env:
             - PYBAMM_STYLE=true
           if: type != cron
         - python: "3.6"
           addons:
             apt:
+              sources:
+                - deadsnakes
               packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
                 - python3.6-dev
           env:
             - PYBAMM_COVER=true
@@ -77,7 +122,14 @@ matrix:
         - python: "3.6"
           addons:
             apt:
+              sources:
+                - deadsnakes
               packages:
+                - gfortran
+                - gcc
+                - libopenblas-dev
+                - liblapack-dev
+                - graphviz
                 - python3.6-dev
           if: type == cron
 
@@ -106,7 +158,7 @@ script:
   - if [[ $PYBAMM_DOCS == true ]]; then python run-tests.py --doctest; fi;
   - if [[ $PYBAMM_STYLE == true ]]; then python -m flake8; fi;
   - if [[ $PYBAMM_COVER == true ]]; then coverage run run-tests.py --nosub; fi;
-  - if [[ $TRAVIS_EVENT_TYPE == 'cron' ]]; then travis_wait 120 python run-tests.py --books; fi;
+  - if [[ $PYBAMM_BOOKS == true ]]; then travis_wait 120 python run-tests.py --books; fi;
 
 after_success:
   - if [[ $PYBAMM_COVER == true ]]; then codecov; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ language: python
 
 addons:
   apt:
+    sources:
+    - deadsnakes
     packages:
-    - python3-dev
     - gfortran
     - gcc
     - libopenblas-dev
@@ -30,10 +31,18 @@ matrix:
         #     - PYBAMM_UNIT=true
         #   if: type != cron
         - python: "3.5"
+          addons:
+            apt:
+              packages:
+              - python3.5-dev
           env:
             - PYBAMM_UNIT=true
           if: type != cron
         - python: "3.6"
+          addons:
+            apt:
+              packages:
+              - python3.6-dev
           env:
             - PYBAMM_UNIT=true
           if: type != cron
@@ -57,11 +66,19 @@ matrix:
             - PYBAMM_STYLE=true
           if: type != cron
         - python: "3.6"
+           addons:
+            apt:
+              packages:
+              - python3.6-dev
           env:
             - PYBAMM_COVER=true
           if: type != cron
           # Cron jobs
         - python: "3.6"
+          addons:
+            apt:
+              packages:
+              - python3.6-dev
           if: type == cron
 
 # Install dependencies

--- a/pybamm/meshes/submeshes.py
+++ b/pybamm/meshes/submeshes.py
@@ -39,8 +39,13 @@ class Uniform1DSubMesh(SubMesh1D):
         # currently accept lims and npts as dicts. This may get changed at a future
         # date depending on the form of mesh we desire for 2D/3D
 
-        spatial_lims = list(lims.values())[0]
-        npts = list(npts.values())[0]
+        # check that only one variable passed in
+        if len(lims) != 1:
+            raise ValueError("lims should only contain a single variable")
+
+        var = list(lims.keys())[0]
+        spatial_lims = lims[var]
+        npts = npts[var.id]
 
         edges = np.linspace(spatial_lims["min"], spatial_lims["max"], npts + 1)
 

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -145,9 +145,9 @@ class ParameterValues(dict):
         self.process_model(model, processing="update")
 
         # update discretised quantities using disc
-        model.concatenated_rhs = disc.concatenate(*model.rhs.values())
-        model.concatenated_algebraic = disc.concatenate(*model.algebraic.values())
-        model.concatenated_initial_conditions = disc._concatenate_init(
+        model.concatenated_rhs = disc._concatenate_in_order(model.rhs)
+        model.concatenated_algebraic = disc._concatenate_in_order(model.algebraic)
+        model.concatenated_initial_conditions = disc._concatenate_in_order(
             model.initial_conditions
         ).evaluate(0, None)
 

--- a/pybamm/solvers/scikits_dae_solver.py
+++ b/pybamm/solvers/scikits_dae_solver.py
@@ -15,9 +15,6 @@ if scikits_odes_spec is not None:
     if scikits_odes_spec is not None:
         scikits_odes = importlib.util.module_from_spec(scikits_odes_spec)
         scikits_odes_spec.loader.exec_module(scikits_odes)
-        from scikits.odes.sundials import ida
-
-        jac_class = ida.IDA_JacRhsFunction
 else:
     jac_class = object
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/pybamm-team/PyBaMM",
     # List of dependencies
     install_requires=[
-        "numpy>=1.14",
+        "numpy>=1.16",
         "scipy>=1.0",
         "pandas>=0.23",
         "anytree>=2.4.3",

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -27,7 +27,7 @@ class TestDiscretise(unittest.TestCase):
         disc._y_slices = {c.id: slice(0, 1), a.id: slice(2, 3), b.id: slice(3, 4)}
         result = disc._concatenate_in_order(initial_conditions)
 
-        self.assertIsInstance(result, pybamm.NumpyConcatenation, check_complete=True)
+        self.assertIsInstance(result, pybamm.NumpyConcatenation)
         self.assertEqual(result.children[0].evaluate(), 1)
         self.assertEqual(result.children[1].evaluate(), 2)
         self.assertEqual(result.children[2].evaluate(), 3)
@@ -397,11 +397,13 @@ class TestDiscretise(unittest.TestCase):
         disc.process_model(model)
         y0 = model.concatenated_initial_conditions
         y0_expect = np.array([])
-        for var, init in model.initial_conditions.items():
-            if var.id == c.id:
-                vect = init.evaluate() * np.ones_like(combined_submesh[0].nodes)
+        for var_id, _ in sorted(disc._y_slices.items(), key=lambda kv: kv[1]):
+            if var_id == c.id:
+                vect = 2 * np.ones_like(combined_submesh[0].nodes)
+            elif var_id == T.id:
+                vect = 5 * np.ones_like(mesh["negative electrode"][0].nodes)
             else:
-                vect = init.evaluate() * np.ones_like(mesh[var.domain[0]][0].nodes)
+                vect = 8 * np.ones_like(mesh["negative electrode"][0].nodes)
 
             y0_expect = np.concatenate([y0_expect, vect])
 

--- a/tests/unit/test_geometry/test_geometry.py
+++ b/tests/unit/test_geometry/test_geometry.py
@@ -87,14 +87,14 @@ class TestGeometry(unittest.TestCase):
         geometry1Dmicro = pybamm.Geometry1DMicro()
         geometry = pybamm.Geometry(geometry1Dmacro, geometry1Dmicro)
         self.assertEqual(
-            list(geometry.keys()),
-            [
+            set(geometry.keys()),
+            set([
                 "negative electrode",
                 "separator",
                 "positive electrode",
                 "negative particle",
                 "positive particle",
-            ],
+            ]),
         )
 
         # update with custom geometry
@@ -117,14 +117,14 @@ class TestGeometry(unittest.TestCase):
         geometry1Dmicro = pybamm.Geometry1DMicro()
         geometry = pybamm.Geometry(geometry3Dmacro, geometry1Dmicro)
         self.assertEqual(
-            list(geometry.keys()),
-            [
+            set(geometry.keys()),
+            set([
                 "negative electrode",
                 "separator",
                 "positive electrode",
                 "negative particle",
                 "positive particle",
-            ],
+            ]),
         )
 
         with self.assertRaises(ValueError):
@@ -134,25 +134,25 @@ class TestGeometry(unittest.TestCase):
     def test_combine_geometries_strings(self):
         geometry = pybamm.Geometry("1D macro", "1D micro")
         self.assertEqual(
-            list(geometry.keys()),
-            [
+            set(geometry.keys()),
+            set([
                 "negative electrode",
                 "separator",
                 "positive electrode",
                 "negative particle",
                 "positive particle",
-            ],
+            ]),
         )
         geometry = pybamm.Geometry("3D macro", "1D micro")
         self.assertEqual(
-            list(geometry.keys()),
-            [
+            set(geometry.keys()),
+            set([
                 "negative electrode",
                 "separator",
                 "positive electrode",
                 "negative particle",
                 "positive particle",
-            ],
+            ]),
         )
 
 

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -162,6 +162,7 @@ class TestScipySolver(unittest.TestCase):
         var2 = pybamm.Variable("var2", domain=whole_cell)
         model.rhs = {var1: var1, var2: 1 - var1}
         model.initial_conditions = {var1: 1.0, var2: -1.0}
+        model.variables = {"var1": var1, "var2": var2}
 
         # create discretisation
         mesh = get_mesh_for_testing()
@@ -175,10 +176,18 @@ class TestScipySolver(unittest.TestCase):
         )
         N = combined_submesh[0].npts
 
+        # construct jacobian in order of model.rhs
+        J = []
+        for var in model.rhs.keys():
+            if var.id == var1.id:
+                J.append([np.eye(N), np.zeros((N, N))])
+            else:
+                J.append([-1.0 * np.eye(N), np.zeros((N, N))])
+
+        J = np.block(J)
+
         def jacobian(t, y):
-            return np.block(
-                [[np.eye(N), np.zeros((N, N))], [-1.0 * np.eye(N), np.zeros((N, N))]]
-            )
+            return J
 
         model.jacobian = jacobian
 
@@ -187,8 +196,16 @@ class TestScipySolver(unittest.TestCase):
         t_eval = np.linspace(0, 1, 100)
         solver.solve(model, t_eval)
         np.testing.assert_array_equal(solver.t, t_eval)
-        np.testing.assert_allclose(solver.y[0], np.exp(solver.t))
-        np.testing.assert_allclose(solver.y[-1], solver.t - np.exp(solver.t))
+
+        T, Y = solver.t, solver.y
+        np.testing.assert_array_almost_equal(
+            model.variables["var1"].evaluate(T, Y),
+            np.ones((N, T.size)) * np.exp(T[np.newaxis, :])
+        )
+        np.testing.assert_array_almost_equal(
+            model.variables["var2"].evaluate(T, Y),
+            np.ones((N, T.size)) * (T[np.newaxis, :] - np.exp(T[np.newaxis, :]))
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Fixes #191 

Key issue was that for python 3.5 (and lower) the `dict` class is unordered, so python is free to reorder things as it likes. We were assuming in a few places that the order of our `dicts` *was* fixed, so this was throwing errors. 

other issues were to do with scikits.odes:
1. there was a strange cython bug regarding multiple imports, which occured when we tried to import ida many times
2. need to make sure travis has the correct version of the python header files
3. scikits.odes actually depends on numpy v 1.16, so bumped this version in pybamm's requirements

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
