### PR TITLE
#367 move matplotlib imports inside functions, and add children docst…

### DIFF
--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -46,6 +46,13 @@ class Symbol(anytree.NodeMixin):
 
     @property
     def children(self):
+        """
+        returns the cached children of this node.
+
+        Note: it is assumed that children of a node are not modified after initial
+        creation
+
+        """
         return self.cached_children
 
     @property

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pybamm
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider
 
 
 class QuickPlot(object):
@@ -117,6 +115,9 @@ class QuickPlot(object):
         t : float
             Time at which to plot.
         """
+
+        import matplotlib.pyplot as plt
+
         self.fig, self.ax = plt.subplots(figsize=(15, 8))
         plt.tight_layout()
         plt.subplots_adjust(left=-0.1)
@@ -192,6 +193,9 @@ class QuickPlot(object):
         Generate a dynamic plot with a slider to control the time. We recommend using
         ipywidgets instead of this function if you are using jupyter notebooks
         """
+
+        import matplotlib.pyplot as plt
+        from matplotlib.widgets import Slider
 
         # create an initial plot at time 0
         self.plot(0)

--- a/tests/unit/test_models/standard_output_tests.py
+++ b/tests/unit/test_models/standard_output_tests.py
@@ -451,7 +451,7 @@ class CurrentTests(BaseOutputTest):
         current_param = pybamm.electrical_parameters.current_with_time
         parameter_values = self.model.default_parameter_values
         i_cell = parameter_values.process_symbol(current_param).evaluate(t=t)
-        np.testing.assert_array_almost_equal(self.i_s_n(t, x_n[0]), i_cell)
+        np.testing.assert_array_almost_equal(self.i_s_n(t, x_n[0]), i_cell, decimal=5)
         np.testing.assert_array_almost_equal(self.i_s_n(t, x_n[-1]), 0)
         np.testing.assert_array_almost_equal(self.i_s_p(t, x_p[-1]), i_cell)
         np.testing.assert_array_almost_equal(self.i_s_p(t, x_p[0]), 0)


### PR DESCRIPTION
…ring for Symbol

# Description

as per comment in `setup.py`, moved matplotlib imports to within functions 
(readthedocs for some reason does not pip install matplotlib for some reason)

added doctring to symbol.children, as otherwise the docstring for anytree is used instead

Fixes #367 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
