### PR TITLE
Issue 264 simplify broadcast

### DIFF
--- a/docs/source/expression_tree/broadcasts.rst
+++ b/docs/source/expression_tree/broadcasts.rst
@@ -3,6 +3,3 @@ Broadcasting Operators
 
 .. autoclass:: pybamm.Broadcast
   :members:
-
-.. autoclass:: pybamm.NumpyBroadcast
-  :members:

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -89,7 +89,7 @@ from .expression_tree.unary_operators import (
     boundary_value,
 )
 from .expression_tree.parameter import Parameter, FunctionParameter
-from .expression_tree.broadcasts import Broadcast, NumpyBroadcast
+from .expression_tree.broadcasts import Broadcast
 from .expression_tree.scalar import Scalar
 from .expression_tree.variable import Variable
 from .expression_tree.independent_variable import (

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -395,7 +395,7 @@ class Discretisation(object):
             # Broadcast new_child to the domain specified by symbol.domain
             # Different discretisations may broadcast differently
             if symbol.domain == []:
-                symbol = pybamm.SpatialMethod(self.mesh).broadcast(new_child, [])
+                symbol = new_child * pybamm.Vector(np.array([1]))
             else:
                 symbol = self._spatial_methods[symbol.domain[0]].broadcast(
                     new_child, symbol.domain

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -395,7 +395,7 @@ class Discretisation(object):
             # Broadcast new_child to the domain specified by symbol.domain
             # Different discretisations may broadcast differently
             if symbol.domain == []:
-                symbol = pybamm.NumpyBroadcast(new_child, symbol.domain, {})
+                symbol = pybamm.SpatialMethod(self.mesh).broadcast(new_child, [])
             else:
                 symbol = self._spatial_methods[symbol.domain[0]].broadcast(
                     new_child, symbol.domain

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -561,25 +561,25 @@ class Discretisation(object):
             )
         )
 
-        # Check variables in variable list against rhs
-        # Be lenient with size check if the variable in model.variables is broadcasted
-        for var in model.rhs.keys():
-            if var.name in model.variables.keys():
-                if not (
-                    model.rhs[var].evaluate(0, y0).shape
-                    == model.variables[var.name].evaluate(0, y0).shape
-                    or isinstance(
-                        model.variables[var.name],
-                        (pybamm.NumpyBroadcast, pybamm.Concatenation),
-                    )
-                ):
-                    raise pybamm.ModelError(
-                        """
-                    variable and its eqn must have the same shape after discretisation
-                    but variable.shape = {} and rhs.shape = {} for variable '{}'.
-                    """.format(
-                            model.variables[var.name].evaluate(0, y0).shape,
-                            model.rhs[var].evaluate(0, y0).shape,
-                            var,
-                        )
-                    )
+        # # Check variables in variable list against rhs
+        # # Be lenient with size check if the variable in model.variables is broadcasted
+        # for var in model.rhs.keys():
+        #     if var.name in model.variables.keys():
+        #         if not (
+        #             model.rhs[var].evaluate(0, y0).shape
+        #             == model.variables[var.name].evaluate(0, y0).shape
+        #             or isinstance(
+        #                 model.variables[var.name],
+        #                 (pybamm.NumpyBroadcast, pybamm.Concatenation),
+        #             )
+        #         ):
+        #             raise pybamm.ModelError(
+        #                 """
+        #             variable and its eqn must have the same shape after discretisation
+        #             but variable.shape = {} and rhs.shape = {} for variable '{}'.
+        #             """.format(
+        #                     model.variables[var.name].evaluate(0, y0).shape,
+        #                     model.rhs[var].evaluate(0, y0).shape,
+        #                     var,
+        #                 )
+        #             )

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -359,16 +359,8 @@ class Multiplication(BinaryOperator):
         """ See :meth:`pybamm.BinaryOperator.simplify()`. """
 
         # anything multiplied by a scalar zero returns a scalar zero
-        if is_scalar_zero(left):
-            if right.shape == ():
-                return pybamm.Scalar(0)
-            else:
-                return pybamm.Array(np.zeros(right.shape))
-        if is_scalar_zero(right):
-            if left.shape == ():
-                return pybamm.Scalar(0)
-            else:
-                return pybamm.Array(np.zeros(left.shape))
+        if is_scalar_zero(left) or is_scalar_zero(right):
+            return pybamm.Scalar(0)
 
         # if one of the children is a zero matrix, we have to be careful about shapes
         if is_matrix_zero(left) or is_matrix_zero(right):
@@ -378,8 +370,10 @@ class Multiplication(BinaryOperator):
                 first_dim = 1
             else:
                 first_dim = left_shape[0]
-            second_dim = right_shape[1]
-            return pybamm.Matrix(csr_matrix((first_dim, second_dim)))
+            if len(right_shape) == 1:
+                return pybamm.Vector(np.zeros(first_dim * right.shape[0]))
+            else:
+                return pybamm.Matrix(csr_matrix((first_dim, right_shape[1])))
 
         # anything multiplied by a scalar one returns itself
         if is_one(left):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -372,16 +372,11 @@ class Multiplication(BinaryOperator):
 
         # if one of the children is a zero matrix, we have to be careful about shapes
         if is_matrix_zero(left) or is_matrix_zero(right):
-            left_shape = left.shape
-            right_shape = right.shape
-            if len(left_shape) == 0:
-                first_dim = 1
+            shape = (left * right).shape
+            if len(shape) == 1:
+                return pybamm.Vector(np.zeros(shape))
             else:
-                first_dim = left_shape[0]
-            if len(right_shape) == 1:
-                return pybamm.Vector(np.zeros(first_dim * right.shape[0]))
-            else:
-                return pybamm.Matrix(csr_matrix((first_dim, right_shape[1])))
+                return pybamm.Matrix(csr_matrix(shape))
 
         # anything multiplied by a scalar one returns itself
         if is_one(left):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -359,8 +359,16 @@ class Multiplication(BinaryOperator):
         """ See :meth:`pybamm.BinaryOperator.simplify()`. """
 
         # anything multiplied by a scalar zero returns a scalar zero
-        if is_scalar_zero(left) or is_scalar_zero(right):
-            return pybamm.Scalar(0)
+        if is_scalar_zero(left):
+            if isinstance(right, pybamm.Array):
+                return pybamm.Array(np.zeros(right.shape))
+            else:
+                return pybamm.Scalar(0)
+        if is_scalar_zero(right):
+            if isinstance(left, pybamm.Array):
+                return pybamm.Array(np.zeros(left.shape))
+            else:
+                return pybamm.Scalar(0)
 
         # if one of the children is a zero matrix, we have to be careful about shapes
         if is_matrix_zero(left) or is_matrix_zero(right):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -359,8 +359,16 @@ class Multiplication(BinaryOperator):
         """ See :meth:`pybamm.BinaryOperator.simplify()`. """
 
         # anything multiplied by a scalar zero returns a scalar zero
-        if is_scalar_zero(left) or is_scalar_zero(right):
-            return pybamm.Scalar(0)
+        if is_scalar_zero(left):
+            if right.shape == ():
+                return pybamm.Scalar(0)
+            else:
+                return pybamm.Array(np.zeros(right.shape))
+        if is_scalar_zero(right):
+            if left.shape == ():
+                return pybamm.Scalar(0)
+            else:
+                return pybamm.Array(np.zeros(left.shape))
 
         # if one of the children is a zero matrix, we have to be careful about shapes
         if is_matrix_zero(left) or is_matrix_zero(right):

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -99,17 +99,14 @@ class NumpyBroadcast(Broadcast):
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """
-        child = self.orphans[0]
-        if child.evaluates_to_number():
-            variable_y_indices = np.arange(
-                variable.y_slice.start, variable.y_slice.stop
-            )
-            jac = csr_matrix(
-                (self.broadcasting_vector_size, np.size(variable_y_indices))
-            )
-            return pybamm.Matrix(jac)
-        else:
-            return child.jac(variable)
+        variable_y_indices = np.arange(variable.y_slice.start, variable.y_slice.stop)
+        broad_jac = csr_matrix(
+            (self.broadcasting_vector_size, np.size(variable_y_indices))
+        )
+        import ipdb
+
+        ipdb.set_trace()
+        return self.child.jac(variable) * pybamm.Matrix(broad_jac)
 
     def _unary_simplify(self, child):
         """ See :meth:`pybamm.UnaryOperator.simplify()`. """

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -95,35 +95,7 @@ class NumpyBroadcast(Broadcast):
 
     def _unary_evaluate(self, child):
         """ See :meth:`pybamm.UnaryOperator._unary_evaluate()`. """
-        # Different broadcasting based on the shape of child
-        try:
-            child_size = child.size
-        except AttributeError:
-            child_size = 0
-
-        if child_size <= 1:
-            return child * self.broadcasting_vector
-        if child_size > 1:
-            # Possible shapes for a child with a shape:
-            # (n,) -> (e.g. time-like object) broadcast to (n, broadcasting_size)
-            # (1,n) -> (e.g. state-vector-like object) broadcast to
-            #          (n, broadcasting_size)
-            # (n,1) -> error
-            # (n,m) -> error
-            # (n,m,k,...) -> error
-            if child.ndim == 1:
-                # shape (n,)
-                return np.repeat(
-                    child[np.newaxis, :], self.broadcasting_vector_size, axis=0
-                )
-            elif child.ndim == 2:
-                if child.shape[0] == 1:
-                    # shape (1, m) since size > 1
-                    return np.repeat(child, self.broadcasting_vector_size, axis=0)
-            # All other cases
-            raise ValueError(
-                "cannot broadcast child with shape '{}'".format(child.shape)
-            )
+        return child * self.broadcasting_vector
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -5,7 +5,6 @@ import pybamm
 
 import numbers
 import numpy as np
-from scipy.sparse import csr_matrix
 
 
 class Broadcast(pybamm.SpatialOperator):
@@ -27,9 +26,12 @@ class Broadcast(pybamm.SpatialOperator):
     """
 
     def __init__(self, child, domain, name=None):
-        # Convert child to Scalar if it is a number
+        # Convert child to vector if it is a number or scalar
         if isinstance(child, numbers.Number):
-            child = pybamm.Scalar(child)
+            child = pybamm.Vector(np.array([child]))
+        if isinstance(child, pybamm.Scalar):
+            child = pybamm.Vector(np.array([child.value]))
+
         # Check domain
         if child.domain not in [[], domain]:
             raise pybamm.DomainError(
@@ -50,65 +52,3 @@ class Broadcast(pybamm.SpatialOperator):
         """ See :meth:`pybamm.UnaryOperator.simplify()`. """
 
         return self.__class__(child, self.domain)
-
-
-class NumpyBroadcast(Broadcast):
-    """A node in the expression tree implementing a broadcasting operator using numpy.
-    Broadcasts a child (which *must* have empty domain) to a specified domain. To do
-    this, creates a np array of ones of the same shape as the submesh domain, and then
-    multiplies the child by that array upon evaluation
-
-    Parameters
-    ----------
-    child : :class:`Symbol`
-        child node
-    domain : iterable of string
-        the domain to broadcast the child to
-    mesh : :class:`pybamm.Mesh`
-        the mesh on which to broadcast
-
-    **Extends:** :class:`SpatialOperator`
-    """
-
-    def __init__(self, child, domain, mesh):
-        super().__init__(child, domain, name="numpy broadcast")
-        # determine broadcasting vector size (size 1 if the domain is empty)
-        if domain == []:
-            self.broadcasting_vector_size = 1
-        else:
-            vector_size = 0
-            for dom in domain:
-                # just create a vector of the points even in 2 and 3D
-                for i in range(len(mesh[dom])):
-                    vector_size += mesh[dom][i].npts_for_broadcast
-            self.broadcasting_vector_size = vector_size
-        # create broadcasting vector (vector of ones with shape determined by the
-        # domain)
-        self.broadcasting_vector = np.ones(self.broadcasting_vector_size)
-
-        # store mesh
-        self._mesh = mesh
-
-    @property
-    def mesh(self):
-        return self._mesh
-
-    def _unary_evaluate(self, child):
-        """ See :meth:`pybamm.UnaryOperator._unary_evaluate()`. """
-        return child * self.broadcasting_vector
-
-    def jac(self, variable):
-        """ See :meth:`pybamm.Symbol.jac()`. """
-        variable_y_indices = np.arange(variable.y_slice.start, variable.y_slice.stop)
-        broad_jac = csr_matrix(
-            (self.broadcasting_vector_size, np.size(variable_y_indices))
-        )
-        import ipdb
-
-        ipdb.set_trace()
-        return self.child.jac(variable) * pybamm.Matrix(broad_jac)
-
-    def _unary_simplify(self, child):
-        """ See :meth:`pybamm.UnaryOperator.simplify()`. """
-
-        return self.__class__(child, self.domain, self.mesh)

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -270,12 +270,7 @@ class SparseStack(Concatenation):
                 children_eval = [None] * len(children)
                 for idx, child in enumerate(children):
                     children_eval[idx], known_evals = child.evaluate(t, y, known_evals)
-                try:
-                    known_evals[self.id] = self._concatenation_evaluate(children_eval)
-                except ValueError:
-                    import ipdb
-
-                    ipdb.set_trace()
+                known_evals[self.id] = self._concatenation_evaluate(children_eval)
             return known_evals[self.id], known_evals
         else:
             children_eval = [None] * len(children)

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -90,7 +90,7 @@ class NumpyConcatenation(Concatenation):
         # so that we can concatenate them
         for i, child in enumerate(children):
             if child.evaluates_to_number():
-                children[i] = pybamm.NumpyBroadcast(child, [], None)
+                children[i] = child * pybamm.Vector(np.array([1]))
         super().__init__(*children, name="numpy concatenation", check_domain=False)
 
     def _concatenation_evaluate(self, children_eval):

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -270,7 +270,12 @@ class SparseStack(Concatenation):
                 children_eval = [None] * len(children)
                 for idx, child in enumerate(children):
                     children_eval[idx], known_evals = child.evaluate(t, y, known_evals)
-                known_evals[self.id] = self._concatenation_evaluate(children_eval)
+                try:
+                    known_evals[self.id] = self._concatenation_evaluate(children_eval)
+                except ValueError:
+                    import ipdb
+
+                    ipdb.set_trace()
             return known_evals[self.id], known_evals
         else:
             children_eval = [None] * len(children)

--- a/pybamm/expression_tree/vector.py
+++ b/pybamm/expression_tree/vector.py
@@ -36,7 +36,7 @@ class Vector(pybamm.Array):
 
     def jac(self, variable):
         """ See :meth:`pybamm.Symbol.jac()`. """
-        # Get inices of state vector
+        # Get indices of state vector
         variable_y_indices = np.arange(variable.y_slice.start, variable.y_slice.stop)
         # Return zeros of correct size
         jac = csr_matrix((np.size(self), np.size(variable_y_indices)))

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -196,11 +196,7 @@ class ParameterValues(dict):
 
         elif isinstance(symbol, pybamm.UnaryOperator):
             new_child = self.process_symbol(symbol.children[0])
-            if isinstance(symbol, pybamm.NumpyBroadcast):
-                new_symbol = pybamm.NumpyBroadcast(
-                    new_child, symbol.domain, symbol.mesh
-                )
-            elif isinstance(symbol, pybamm.Broadcast):
+            if isinstance(symbol, pybamm.Broadcast):
                 new_symbol = pybamm.Broadcast(new_child, symbol.domain)
             elif isinstance(symbol, pybamm.Function):
                 new_symbol = pybamm.Function(symbol.func, new_child)

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -65,13 +65,10 @@ class SpatialMethod:
         broadcasted_symbol: class: `pybamm.Symbol`
             The discretised symbol of the correct size for the spatial method
         """
-        if domain == []:
-            vector_size = 1
-        else:
-            vector_size = 0
-            for dom in domain:
-                for i in range(len(self.mesh[dom])):
-                    vector_size += self.mesh[dom][i].npts_for_broadcast
+        vector_size = 0
+        for dom in domain:
+            for i in range(len(self.mesh[dom])):
+                vector_size += self.mesh[dom][i].npts_for_broadcast
 
         return symbol * pybamm.Vector(np.ones(vector_size), domain=domain)
 

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -2,6 +2,7 @@
 # A general spatial method class
 #
 import pybamm
+import numpy as np
 from scipy.sparse import eye, kron, coo_matrix
 
 
@@ -65,8 +66,15 @@ class SpatialMethod:
         broadcasted_symbol: class: `pybamm.Symbol`
             The discretised symbol of the correct size for the spatial method
         """
+        if domain == []:
+            vector_size = 1
+        else:
+            vector_size = 0
+            for dom in domain:
+                for i in range(len(self.mesh[dom])):
+                    vector_size += self.mesh[dom][i].npts_for_broadcast
         # Default behaviour: use NumpyBroadcast
-        return pybamm.NumpyBroadcast(symbol, domain, self.mesh)
+        return symbol * pybamm.Vector(np.ones(vector_size), domain=domain)
 
     def gradient(self, symbol, discretised_symbol, boundary_conditions):
         """

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -51,8 +51,7 @@ class SpatialMethod:
 
     def broadcast(self, symbol, domain):
         """
-        Broadcast symbol to a specified domain. To do this, calls
-        :class:`pybamm.NumpyBroadcast`
+        Broadcast symbol to a specified domain.
 
         Parameters
         ----------
@@ -73,7 +72,7 @@ class SpatialMethod:
             for dom in domain:
                 for i in range(len(self.mesh[dom])):
                     vector_size += self.mesh[dom][i].npts_for_broadcast
-        # Default behaviour: use NumpyBroadcast
+
         return symbol * pybamm.Vector(np.ones(vector_size), domain=domain)
 
     def gradient(self, symbol, discretised_symbol, boundary_conditions):

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -410,10 +410,12 @@ class TestDiscretise(unittest.TestCase):
         # grad and div are identity operators here
         np.testing.assert_array_equal(y0, model.concatenated_rhs.evaluate(None, y0))
 
-        S0 = model.initial_conditions[S].evaluate(
-        ) * np.ones_like(mesh[S.domain[0]][0].nodes)
-        T0 = model.initial_conditions[T].evaluate(
-        ) * np.ones_like(mesh[T.domain[0]][0].nodes)
+        S0 = model.initial_conditions[S].evaluate() * np.ones_like(
+            mesh[S.domain[0]][0].nodes
+        )
+        T0 = model.initial_conditions[T].evaluate() * np.ones_like(
+            mesh[T.domain[0]][0].nodes
+        )
         np.testing.assert_array_equal(S0 * T0, model.variables["ST"].evaluate(None, y0))
 
         # mass matrix is identity
@@ -601,14 +603,17 @@ class TestDiscretise(unittest.TestCase):
         self.assertEqual(broad.domain, whole_cell)
 
         broad_disc = disc.process_symbol(broad)
-        self.assertIsInstance(broad_disc, pybamm.NumpyBroadcast)
+        self.assertIsInstance(broad_disc, pybamm.Multiplication)
+        self.assertIsInstance(broad_disc.children[0], pybamm.Scalar)
+        self.assertIsInstance(broad_disc.children[1], pybamm.Vector)
 
         # process Broadcast variable
         disc._y_slices = {var.id: slice(53)}
         broad1 = pybamm.Broadcast(var, ["negative electrode"])
         broad1_disc = disc.process_symbol(broad1)
-        self.assertIsInstance(broad1_disc, pybamm.NumpyBroadcast)
+        self.assertIsInstance(broad1_disc, pybamm.Multiplication)
         self.assertIsInstance(broad1_disc.children[0], pybamm.StateVector)
+        self.assertIsInstance(broad1_disc.children[1], pybamm.Vector)
 
     def test_concatenation(self):
         a = pybamm.Symbol("a")

--- a/tests/unit/test_expression_tree/test_broadcasts.py
+++ b/tests/unit/test_expression_tree/test_broadcasts.py
@@ -30,56 +30,6 @@ class TestBroadcasts(unittest.TestCase):
         with self.assertRaises(pybamm.DomainError):
             pybamm.Broadcast(b, ["separator"])
 
-    def test_numpy_broadcast(self):
-        mesh = get_mesh_for_testing()
-        for dom in mesh.keys():
-            mesh[dom][0].npts_for_broadcast = mesh[dom][0].npts
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        combined_submeshes = mesh.combine_submeshes(*whole_cell)
-
-        # scalar
-        a = pybamm.Scalar(7)
-        broad = pybamm.NumpyBroadcast(a, whole_cell, mesh)
-        np.testing.assert_array_equal(
-            broad.evaluate(), 7 * np.ones_like(combined_submeshes[0].nodes)
-        )
-        self.assertEqual(broad.domain, whole_cell)
-
-        # state vector
-        state_vec = pybamm.StateVector(slice(1, 2))
-        broad = pybamm.NumpyBroadcast(state_vec, whole_cell, mesh)
-        y = np.linspace(0, 1)
-        np.testing.assert_array_equal(
-            broad.evaluate(y=y), (y[1:2] * np.ones_like(combined_submeshes[0].nodes))
-        )
-
-    @unittest.skip("")
-    def test_broadcast_jac(self):
-        mesh = get_mesh_for_testing()
-        for dom in mesh.keys():
-            mesh[dom][0].npts_for_broadcast = mesh[dom][0].npts
-        a = pybamm.Scalar(7)
-        y = pybamm.StateVector(slice(2, 3))
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        submesh = mesh.combine_submeshes(*whole_cell)
-
-        broad_a = pybamm.NumpyBroadcast(a, whole_cell, mesh)
-        broad_y = pybamm.NumpyBroadcast(y, whole_cell, mesh)
-        broad_y2 = pybamm.NumpyBroadcast(y ** 2, whole_cell, mesh)
-
-        # Create a y vector that is bigger than the mesh
-        y_jac = pybamm.StateVector(slice(0, 4))
-
-        y0 = np.ones(4)
-
-        dbroad_a_dyjac = broad_a.jac(y_jac).evaluate()
-        dbroad_y_dyjac = broad_y.jac(y_jac).evaluate()
-        dbroad_y2_dyjac = broad_y2.jac(y_jac).evaluate(y=y0)
-        import ipdb
-
-        ipdb.set_trace()
-        np.testing.assert_array_equal()
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_broadcasts.py
+++ b/tests/unit/test_expression_tree/test_broadcasts.py
@@ -47,36 +47,13 @@ class TestBroadcasts(unittest.TestCase):
         )
         self.assertEqual(broad.domain, whole_cell)
 
-        # time
-        t = 3 * pybamm.t + 4
-        broad = pybamm.NumpyBroadcast(t, whole_cell, mesh)
-        self.assertEqual(broad.domain, whole_cell)
-        np.testing.assert_array_equal(
-            broad.evaluate(t=3), 13 * np.ones_like(combined_submeshes[0].nodes)
-        )
-        np.testing.assert_array_equal(
-            broad.evaluate(t=np.linspace(0, 1)),
-            (
-                (3 * np.linspace(0, 1) + 4)[:, np.newaxis]
-                * np.ones_like(combined_submeshes[0].nodes)
-            ).T,
-        )
-
         # state vector
         state_vec = pybamm.StateVector(slice(1, 2))
         broad = pybamm.NumpyBroadcast(state_vec, whole_cell, mesh)
-        y = np.vstack([np.linspace(0, 1), np.linspace(0, 2)])
+        y = np.linspace(0, 1)
         np.testing.assert_array_equal(
-            broad.evaluate(y=y),
-            (y[1:2].T * np.ones_like(combined_submeshes[0].nodes)).T,
+            broad.evaluate(y=y), (y[1:2] * np.ones_like(combined_submeshes[0].nodes))
         )
-
-        # state vector - bad input
-        state_vec = pybamm.StateVector(slice(1, 5))
-        broad = pybamm.NumpyBroadcast(state_vec, whole_cell, mesh)
-        y = np.vstack([np.linspace(0, 1), np.linspace(0, 2)]).T
-        with self.assertRaisesRegex(ValueError, "cannot broadcast child with shape"):
-            broad.evaluate(y=y)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_broadcasts.py
+++ b/tests/unit/test_expression_tree/test_broadcasts.py
@@ -1,10 +1,9 @@
 #
-# Tests for the Broadcast classes
+# Tests for the Broadcast class
 #
 import pybamm
-from tests import get_mesh_for_testing
-import unittest
 import numpy as np
+import unittest
 
 
 class TestBroadcasts(unittest.TestCase):
@@ -22,8 +21,8 @@ class TestBroadcasts(unittest.TestCase):
     def test_broadcast_number(self):
         broad_a = pybamm.Broadcast(1, ["negative electrode"])
         self.assertEqual(broad_a.name, "broadcast")
-        self.assertIsInstance(broad_a.children[0], pybamm.Symbol)
-        self.assertEqual(broad_a.children[0].name, str(1.0))
+        self.assertIsInstance(broad_a.children[0], pybamm.Vector)
+        self.assertEqual(broad_a.children[0].evaluate(), np.array([1]))
         self.assertEqual(broad_a.domain, ["negative electrode"])
 
         b = pybamm.Symbol("b", domain=["negative electrode"])

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -88,7 +88,7 @@ class TestConcatenations(unittest.TestCase):
 
         a_dom = ["negative electrode"]
         b_dom = ["positive electrode"]
-        a = pybamm.NumpyBroadcast(pybamm.Scalar(2), a_dom, mesh)
+        a = 2 * pybamm.Vector(np.ones_like(mesh[a_dom[0]][0].nodes), domain=a_dom)
         b = pybamm.Vector(np.ones_like(mesh[b_dom[0]][0].nodes), domain=b_dom)
 
         # concatenate them the "wrong" way round to check they get reordered correctly
@@ -106,7 +106,7 @@ class TestConcatenations(unittest.TestCase):
         # check the reordering in case a child vector has to be split up
         a_dom = ["separator"]
         b_dom = ["negative electrode", "positive electrode"]
-        a = pybamm.NumpyBroadcast(pybamm.Scalar(2, domain=a_dom), a_dom, mesh)
+        a = 2 * pybamm.Vector(np.ones_like(mesh[a_dom[0]][0].nodes), domain=a_dom)
         b = pybamm.Vector(
             np.concatenate(
                 [np.full(mesh[b_dom[0]][0].npts, 1), np.full(mesh[b_dom[1]][0].npts, 3)]

--- a/tests/unit/test_expression_tree/test_simplify.py
+++ b/tests/unit/test_expression_tree/test_simplify.py
@@ -234,6 +234,17 @@ class TestSimplify(unittest.TestCase):
         self.assertIsInstance(expr, pybamm.Scalar)
         self.assertEqual(expr.evaluate(), 0)
 
+    def test_vector_zero_simplify(self):
+        a1 = pybamm.Scalar(0)
+        v1 = pybamm.Vector(np.zeros(10))
+        a2 = pybamm.Scalar(1)
+        v2 = pybamm.Vector(np.ones(10))
+
+        # for expr in [a1 * v1, v1 * a1, a2 * v1, v1 * a2, a1 * v2, v2 * a1, v1 * v2]:
+        for expr in [a1 * v1, v1 * a1, a2 * v1, v1 * a2, a1 * v2, v2 * a1, v1 * v2]:
+            self.assertIsInstance(expr.simplify(), pybamm.Vector)
+            np.testing.assert_array_equal(expr.simplify().entries, np.zeros(10))
+
     def test_function_simplify(self):
         a = pybamm.Parameter("a")
         funca = pybamm.Function(test_const_function, a).simplify()

--- a/tests/unit/test_expression_tree/test_simplify.py
+++ b/tests/unit/test_expression_tree/test_simplify.py
@@ -427,7 +427,7 @@ class TestSimplify(unittest.TestCase):
 
         a_dom = ["negative electrode"]
         b_dom = ["positive electrode"]
-        a = pybamm.NumpyBroadcast(pybamm.Scalar(2), a_dom, mesh)
+        a = 2 * pybamm.Vector(np.ones_like(mesh[a_dom[0]][0].nodes), domain=a_dom)
         b = pybamm.Vector(np.ones_like(mesh[b_dom[0]][0].nodes), domain=b_dom)
 
         conc = pybamm.DomainConcatenation([a, b], mesh)

--- a/tests/unit/test_models/test_simple_ode_model.py
+++ b/tests/unit/test_models/test_simple_ode_model.py
@@ -30,26 +30,23 @@ class TestSimpleODEModel(unittest.TestCase):
     def test_solution(self):
         model = pybamm.SimpleODEModel()
         modeltest = tests.StandardModelTest(model)
-        modeltest.test_all()
-        T, Y = modeltest.solver.t, modeltest.solver.y
+        t_eval = np.linspace(0, 1, 50)
+        modeltest.test_all(t_eval=t_eval)
+        t, y = modeltest.solver.t, modeltest.solver.y
         mesh = modeltest.disc.mesh
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        combined_submesh = mesh.combine_submeshes(*whole_cell)
 
         # check output
+        processed_variables = pybamm.post_process_variables(model.variables, t, y, mesh)
+        np.testing.assert_array_almost_equal(processed_variables["a"](t), 2 * t)
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        x = mesh.combine_submeshes(*whole_cell)[0].nodes
         np.testing.assert_array_almost_equal(
-            model.variables["a"].evaluate(T, Y), 2 * T[np.newaxis, :]
+            processed_variables["b broadcasted"](t, x), np.ones((len(x), len(t)))
         )
+        x_n_s = mesh.combine_submeshes("negative electrode", "separator")[0].nodes
         np.testing.assert_array_almost_equal(
-            model.variables["b broadcasted"].evaluate(T, Y),
-            np.ones((combined_submesh[0].npts, T.size)),
-        )
-        np.testing.assert_array_almost_equal(
-            model.variables["c broadcasted"].evaluate(T, Y),
-            np.ones(
-                sum([mesh[d][0].npts for d in ["negative electrode", "separator"]])
-            )[:, np.newaxis]
-            * np.exp(-T),
+            processed_variables["c broadcasted"](t, x_n_s),
+            np.ones_like(x_n_s)[:, np.newaxis] * np.exp(-t),
         )
 
 

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -89,8 +89,8 @@ class TestParameterValues(unittest.TestCase):
         processed_broad = parameter_values.process_symbol(broad)
         self.assertIsInstance(processed_broad, pybamm.Broadcast)
         self.assertEqual(processed_broad.domain, whole_cell)
-        self.assertIsInstance(processed_broad.children[0], pybamm.Scalar)
-        self.assertEqual(processed_broad.children[0].value, 1)
+        self.assertIsInstance(processed_broad.children[0], pybamm.Vector)
+        self.assertEqual(processed_broad.children[0].evaluate(), np.array([1]))
 
         # process concatenation
         conc = pybamm.Concatenation(a, b)


### PR DESCRIPTION
# Description

Switch to using explicit multiplication by a vector instead of `NumpyBroadcast`.
This speeds things up a bit as the vectors can then be simplified away, so we should think about doing something similar for concatenations.
Fixes part of #264 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
