### PR TITLE
Issue 384 test scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
                 - python3.5-dev
           env:
             - PYBAMM_UNIT=true
-            - PYBAMM_BOOKS=true
+            - PYBAMM_EXAMPLES=true
           if: type != cron
         - python: "3.6"
           addons:
@@ -60,7 +60,7 @@ matrix:
                 - python3.6-dev
           env:
             - PYBAMM_UNIT=true
-            - PYBAMM_BOOKS=true
+            - PYBAMM_EXAMPLES=true
         - python: "3.6"
           addons:
             apt:
@@ -146,7 +146,7 @@ matrix:
                 - graphviz
                 - python3.6-dev
           env:
-            - PYBAMM_BOOKS=true
+            - PYBAMM_EXAMPLES=true
           if: type == cron
 
 # Install dependencies
@@ -157,7 +157,7 @@ install:
   - pip install pip==18
   - pip install .
   - if [[ $PYBAMM_DOCS == true ]]; then pip install -e .[docs]; fi;
-  - if [[ $PYBAMM_STYLE == true || $PYBAMM_BOOKS ]]; then pip install -e .[dev]; fi;
+  - if [[ $PYBAMM_STYLE == true || $PYBAMM_EXAMPLES ]]; then pip install -e .[dev]; fi;
   - if [[ $PYBAMM_COVER == true ]]; then pip install coverage codecov; fi;
   - source scripts/install_scikits_odes.sh
 
@@ -173,7 +173,7 @@ script:
   - if [[ $PYBAMM_DOCS == true ]]; then python run-tests.py --doctest; fi;
   - if [[ $PYBAMM_STYLE == true ]]; then python -m flake8; fi;
   - if [[ $PYBAMM_COVER == true ]]; then coverage run run-tests.py --nosub; fi;
-  - if [[ $PYBAMM_BOOKS == true ]]; then travis_wait 120 python run-tests.py --books; fi;
+  - if [[ $PYBAMM_EXAMPLES == true ]]; then travis_wait 120 python run-tests.py --examples; fi;
 
 after_success:
   - if [[ $PYBAMM_COVER == true ]]; then codecov; fi;

--- a/examples/scripts/SPMe.py
+++ b/examples/scripts/SPMe.py
@@ -25,5 +25,5 @@ t_eval = np.linspace(0, 2, 100)
 solver.solve(model, t_eval)
 
 # plot
-plot = pybamm.QuickPlot(model, param, mesh, solver)
+plot = pybamm.QuickPlot(model, mesh, solver)
 plot.dynamic_plot()

--- a/run-tests.py
+++ b/run-tests.py
@@ -99,7 +99,7 @@ def run_doc_tests():
         sys.exit(ret)
 
 
-def run_notebook_tests(skip_slow_books=False, executable="python"):
+def run_notebook_and_scripts(skip_slow_books=False, executable="python"):
     """
     Runs Jupyter notebook tests. Exits if they fail.
     """
@@ -120,14 +120,14 @@ def run_notebook_tests(skip_slow_books=False, executable="python"):
                 ignore_list.append(line)
 
     # Scan and run
-    print("Testing notebooks with executable `" + str(executable) + "`")
-    if not scan_for_notebooks("examples", True, executable, ignore_list):
+    print("Testing notebooks and scripts with executable `" + str(executable) + "`")
+    if not scan_for_notebooks_and_scripts("examples", True, executable, ignore_list):
         print("\nErrors encountered in notebooks")
         sys.exit(1)
     print("\nOK")
 
 
-def scan_for_notebooks(root, recursive=True, executable="python", ignore_list=[]):
+def scan_for_notebooks_and_scripts(root, recursive=True, executable="python", ignore_list=[]):
     """
     Scans for, and tests, all notebooks in a directory.
     """
@@ -146,7 +146,7 @@ def scan_for_notebooks(root, recursive=True, executable="python", ignore_list=[]
             # Ignore hidden directories
             if filename[:1] == ".":
                 continue
-            ok &= scan_for_notebooks(path, recursive, executable)
+            ok &= scan_for_notebooks_and_scripts(path, recursive, executable)
 
         # Test notebooks
         if os.path.splitext(path)[1] == ".ipynb":
@@ -154,6 +154,12 @@ def scan_for_notebooks(root, recursive=True, executable="python", ignore_list=[]
                 print(path)
             else:
                 ok &= test_notebook(path, executable)
+        # Test scripts
+        elif os.path.splitext(path)[1] == ".py":
+            if debug:
+                print(path)
+            else:
+                ok &= test_script(path, executable)
 
     # Return True if every notebook is ok
     return ok
@@ -197,9 +203,51 @@ def test_notebook(path, executable="python"):
                 j = str(1 + i)
                 print(j + " " * (5 - len(j)) + line)
             print("-- stdout " + "-" * (79 - 10))
-            print(stdout)
+            print(str(stdout, 'utf-8'))
             print("-- stderr " + "-" * (79 - 10))
-            print(stderr)
+            print(str(stderr, 'utf-8'))
+            print("-" * 79)
+            return False
+    except KeyboardInterrupt:
+        p.terminate()
+        print("ABORTED")
+        sys.exit(1)
+
+    # Sucessfully run
+    print("ok (" + b.format() + ")")
+    return True
+
+
+def test_script(path, executable="python"):
+    """
+    Tests a single notebook, exists if it doesn't finish.
+    """
+    import nbconvert
+    import pybamm
+
+    b = pybamm.Timer()
+    print("Test " + path + " ... ", end="")
+    sys.stdout.flush()
+
+    # Tell matplotlib not to produce any figures
+    env = dict(os.environ)
+    env["MPLBACKEND"] = "Template"
+
+    # Run in subprocess
+    cmd = [executable] + [path]
+    try:
+        p = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+        stdout, stderr = p.communicate()
+        # TODO: Use p.communicate(timeout=3600) if Python3 only
+        if p.returncode != 0:
+            # Show failing code, output and errors before returning
+            print("ERROR")
+            print("-- stdout " + "-" * (79 - 10))
+            print(str(stdout, 'utf-8'))
+            print("-- stderr " + "-" * (79 - 10))
+            print(str(stderr, 'utf-8'))
             print("-" * 79)
             return False
     except KeyboardInterrupt:
@@ -275,14 +323,14 @@ if __name__ == "__main__":
     )
     # Notebook tests
     parser.add_argument(
-        "--books",
+        "--examples",
         action="store_true",
-        help="Test only the fast Jupyter notebooks in `examples`.",
+        help="Test only the fast Jupyter notebooks and scripts in `examples`.",
     )
     parser.add_argument(
-        "--allbooks",
+        "--allexamples",
         action="store_true",
-        help="Test all Jupyter notebooks in `examples`.",
+        help="Test all Jupyter notebooks and scripts in `examples`.",
     )
     parser.add_argument(
         "-debook",
@@ -337,12 +385,12 @@ if __name__ == "__main__":
         has_run = True
         run_doc_tests()
     # Notebook tests
-    if args.allbooks:
+    if args.allexamples:
         has_run = True
-        run_notebook_tests()
-    elif args.books:
+        run_notebook_and_scripts()
+    elif args.examples:
         has_run = True
-        run_notebook_tests(True)
+        run_notebook_and_scripts(True)
     if args.debook:
         has_run = True
         export_notebook(*args.debook)

--- a/run-tests.py
+++ b/run-tests.py
@@ -121,15 +121,15 @@ def run_notebook_and_scripts(skip_slow_books=False, executable="python"):
 
     # Scan and run
     print("Testing notebooks and scripts with executable `" + str(executable) + "`")
-    if not scan_for_notebooks_and_scripts("examples", True, executable, ignore_list):
+    if not scan_for_nb_and_scripts("examples", True, executable, ignore_list):
         print("\nErrors encountered in notebooks")
         sys.exit(1)
     print("\nOK")
 
 
-def scan_for_notebooks_and_scripts(root, recursive=True, executable="python", ignore_list=[]):
+def scan_for_nb_and_scripts(root, recursive=True, executable="python", ignore_list=[]):
     """
-    Scans for, and tests, all notebooks in a directory.
+    Scans for, and tests, all notebooks and scripts in a directory.
     """
     ok = True
     debug = False
@@ -146,7 +146,7 @@ def scan_for_notebooks_and_scripts(root, recursive=True, executable="python", ig
             # Ignore hidden directories
             if filename[:1] == ".":
                 continue
-            ok &= scan_for_notebooks_and_scripts(path, recursive, executable)
+            ok &= scan_for_nb_and_scripts(path, recursive, executable)
 
         # Test notebooks
         if os.path.splitext(path)[1] == ".ipynb":
@@ -222,7 +222,6 @@ def test_script(path, executable="python"):
     """
     Tests a single notebook, exists if it doesn't finish.
     """
-    import nbconvert
     import pybamm
 
     b = pybamm.Timer()


### PR DESCRIPTION
# Description

modify run_tests.py to test both notebooks and example scripts:

usage:
```bash
./run_tests.py --examples
```
will run both notebooks and scripts

Fixes #384 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
