### PR TITLE
Issue 441 shape test

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -56,7 +56,7 @@ from .expression_tree.exceptions import (
     ShapeError,
     ModelWarning,
 )
-from .expression_tree.symbol import Symbol
+from .expression_tree.symbol import Symbol, DOMAIN_SIZES_FOR_TESTING
 from .expression_tree.binary_operators import (
     is_scalar_zero,
     is_matrix_zero,

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -29,10 +29,13 @@ def version(formatted=False):
 
 
 #
-# Set debug mode to false by default
+# Utility classes and methods
 #
-debug_mode = False
-
+from .util import Timer
+from .util import profile
+from .util import load_function
+from .logger import logger, set_logging_level
+from .settings import settings
 
 #
 # Constants
@@ -43,14 +46,6 @@ FLOAT_FORMAT = "{: .17e}"
 # Absolute path to the PyBaMM repo
 script_path = os.path.abspath(__file__)
 ABSOLUTE_PATH = os.path.join(os.path.split(script_path)[0], "..")
-
-#
-# Utility classes and methods
-#
-from .util import Timer
-from .util import profile
-from .util import load_function
-from .logger import logger, set_logging_level
 
 #
 # Classes for the Expression Tree

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -49,7 +49,7 @@ from .settings import settings
 #
 # Classes for the Expression Tree
 #
-from .expression_tree.symbol import Symbol
+from .expression_tree.symbol import Symbol, evaluate_for_shape_using_domain
 from .expression_tree.binary_operators import (
     is_scalar_zero,
     is_matrix_zero,

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -49,6 +49,13 @@ from .logger import logger, set_logging_level
 #
 # Classes for the Expression Tree
 #
+from .expression_tree.exceptions import (
+    DomainError,
+    ModelError,
+    SolverError,
+    ShapeError,
+    ModelWarning,
+)
 from .expression_tree.symbol import Symbol
 from .expression_tree.binary_operators import (
     is_scalar_zero,
@@ -103,13 +110,6 @@ from .expression_tree.independent_variable import (
 from .expression_tree.independent_variable import t
 from .expression_tree.vector import Vector, StateVector
 
-from .expression_tree.exceptions import (
-    DomainError,
-    ModelError,
-    SolverError,
-    ShapeError,
-    ModelWarning,
-)
 from .expression_tree.simplify import (
     Simplification,
     simplify_if_constant,

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -17,7 +17,7 @@ if sys.version_info[0] < 3:
     del (x)  # Before Python3, list comprehension iterators leaked
 
 #
-# Expose pints version
+# Expose pybamm version
 #
 
 
@@ -26,6 +26,12 @@ def version(formatted=False):
         return "PyBaMM " + VERSION
     else:
         return VERSION_INT
+
+
+#
+# Set debug mode to false by default
+#
+debug_mode = False
 
 
 #
@@ -49,13 +55,6 @@ from .logger import logger, set_logging_level
 #
 # Classes for the Expression Tree
 #
-from .expression_tree.exceptions import (
-    DomainError,
-    ModelError,
-    SolverError,
-    ShapeError,
-    ModelWarning,
-)
 from .expression_tree.symbol import Symbol
 from .expression_tree.binary_operators import (
     is_scalar_zero,
@@ -110,6 +109,13 @@ from .expression_tree.independent_variable import (
 from .expression_tree.independent_variable import t
 from .expression_tree.vector import Vector, StateVector
 
+from .expression_tree.exceptions import (
+    DomainError,
+    ModelError,
+    SolverError,
+    ShapeError,
+    ModelWarning,
+)
 from .expression_tree.simplify import (
     Simplification,
     simplify_if_constant,

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -56,7 +56,7 @@ from .expression_tree.exceptions import (
     ShapeError,
     ModelWarning,
 )
-from .expression_tree.symbol import Symbol, DOMAIN_SIZES_FOR_TESTING
+from .expression_tree.symbol import Symbol
 from .expression_tree.binary_operators import (
     is_scalar_zero,
     is_matrix_zero,

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -388,7 +388,6 @@ class Discretisation(object):
         elif isinstance(symbol, pybamm.UnaryOperator):
             child = symbol.child
             disc_child = self.process_symbol(child)
-            disc_child.test_shape()
             if child.domain != []:
                 child_spatial_method = self._spatial_methods[child.domain[0]]
             if isinstance(symbol, pybamm.Gradient):

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -388,7 +388,7 @@ class Discretisation(object):
         elif isinstance(symbol, pybamm.UnaryOperator):
             child = symbol.child
             disc_child = self.process_symbol(child)
-            pybamm.SpatialMethod.test_shape(disc_child)
+            disc_child.test_shape()
             if child.domain != []:
                 child_spatial_method = self._spatial_methods[child.domain[0]]
             if isinstance(symbol, pybamm.Gradient):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -475,7 +475,10 @@ class Division(BinaryOperator):
         if issparse(left):
             return left.multiply(1 / right)
         else:
-            return left / right
+            if isinstance(right, numbers.Number) and right == 0:
+                return left * np.inf
+            else:
+                return left / right
 
     def _binary_simplify(self, left, right):
         """ See :meth:`pybamm.BinaryOperator.simplify()`. """

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -143,9 +143,14 @@ class BinaryOperator(pybamm.Symbol):
 
     def evaluate_for_shape(self, t=None, y=None):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape()`. """
-        left = self.left.evaluate_for_shape(t, y)
-        right = self.right.evaluate_for_shape(t, y)
-        return self._binary_evaluate(left, right)
+        left = self.children[0].evaluate_for_shape()
+        right = self.children[1].evaluate_for_shape()
+        try:
+            return self._binary_evaluate(left, right)
+        except ZeroDivisionError:
+            import ipdb
+
+            ipdb.set_trace()
 
 
 class Power(BinaryOperator):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -145,12 +145,7 @@ class BinaryOperator(pybamm.Symbol):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape()`. """
         left = self.children[0].evaluate_for_shape()
         right = self.children[1].evaluate_for_shape()
-        try:
-            return self._binary_evaluate(left, right)
-        except ZeroDivisionError:
-            import ipdb
-
-            ipdb.set_trace()
+        return self._binary_evaluate(left, right)
 
 
 class Power(BinaryOperator):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -141,6 +141,12 @@ class BinaryOperator(pybamm.Symbol):
             right = self.right.evaluate(t, y)
             return self._binary_evaluate(left, right)
 
+    def evaluate_for_shape(self, t=None, y=None):
+        """ See :meth:`pybamm.Symbol.evaluate_for_shape()`. """
+        left = self.left.evaluate_for_shape(t, y)
+        right = self.right.evaluate_for_shape(t, y)
+        return self._binary_evaluate(left, right)
+
 
 class Power(BinaryOperator):
     """A node in the expression tree representing a `**` power operator

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -60,4 +60,9 @@ class Broadcast(pybamm.SpatialOperator):
         Returns a vector of NaNs to represent the shape of a Broadcast.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return self.evaluate_for_shape_using_domain()
+        child_eval = self.children[0].evaluate_for_shape()
+        vec = self.evaluate_for_shape_using_domain()
+        if self.children[0].domain == ["current collector"]:
+            return np.outer(child_eval, vec).reshape(-1, 1)
+        else:
+            return child_eval * vec

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -60,4 +60,5 @@ class Broadcast(pybamm.SpatialOperator):
         Returns a vector of NaNs to represent the shape of a Broadcast.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return np.nan * np.ones(1)
+        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
+        return self.children[0].evaluate_for_shape() * np.ones((size, 1))

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -60,5 +60,4 @@ class Broadcast(pybamm.SpatialOperator):
         Returns a vector of NaNs to represent the shape of a Broadcast.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
-        return self.children[0].evaluate_for_shape() * np.ones((size, 1))
+        return self.evaluate_for_shape_using_domain()

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -58,7 +58,7 @@ class Broadcast(pybamm.SpatialOperator):
     def evaluate_for_shape(self):
         """
         Returns a vector of NaNs to represent the shape of a Broadcast.
-        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()`
         """
         child_eval = self.children[0].evaluate_for_shape()
         vec = self.evaluate_for_shape_using_domain()

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -56,4 +56,8 @@ class Broadcast(pybamm.SpatialOperator):
         return Broadcast(child, self.domain)
 
     def evaluate_for_shape(self):
-        return np.random.rand(1)
+        """
+        Returns a vector of NaNs to represent the shape of a Broadcast.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return np.nan * np.ones(1)

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -2,6 +2,7 @@
 # Unary operator classes and methods
 #
 import numbers
+import numpy as np
 import pybamm
 
 
@@ -53,3 +54,6 @@ class Broadcast(pybamm.SpatialOperator):
         """ See :meth:`pybamm.UnaryOperator.simplify()`. """
 
         return Broadcast(child, self.domain)
+
+    def evaluate_for_shape(self):
+        return np.random.rand(1)

--- a/pybamm/expression_tree/broadcasts.py
+++ b/pybamm/expression_tree/broadcasts.py
@@ -61,7 +61,7 @@ class Broadcast(pybamm.SpatialOperator):
         See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()`
         """
         child_eval = self.children[0].evaluate_for_shape()
-        vec = self.evaluate_for_shape_using_domain()
+        vec = pybamm.evaluate_for_shape_using_domain(self.domain)
         if self.children[0].domain == ["current collector"]:
             return np.outer(child_eval, vec).reshape(-1, 1)
         else:

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -280,3 +280,9 @@ class SparseStack(Concatenation):
     def _concatenation_evaluate(self, children_eval):
         """ See :meth:`Concatenation.evaluate()`. """
         return vstack(children_eval)
+
+    def evaluate_for_shape(self):
+        if len(self.children) == 0:
+            return np.array([])
+        else:
+            return vstack([child.evaluate_for_shape() for child in self.children])

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -77,7 +77,12 @@ class Concatenation(pybamm.Symbol):
         return new_symbol
 
     def evaluate_for_shape(self):
-        return np.concatenate([child.evaluate_for_shape() for child in self.children])
+        if len(self.children) == 0:
+            return np.array([])
+        else:
+            return np.concatenate(
+                [child.evaluate_for_shape() for child in self.children]
+            )
 
 
 class NumpyConcatenation(Concatenation):

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -76,6 +76,9 @@ class Concatenation(pybamm.Symbol):
         new_symbol.domain = []
         return new_symbol
 
+    def evaluate_for_shape(self):
+        return np.concatenate([child.evaluate_for_shape() for child in self.children])
+
 
 class NumpyConcatenation(Concatenation):
     """A node in the expression tree representing a concatenation of equations, when we

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -97,7 +97,8 @@ class SpatialVariable(IndependentVariable):
         Returns a vector of NaNs to represent the shape of an IndependentVariable.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return np.nan * np.ones(1)
+        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
+        return np.nan * np.ones((size, 1))
 
 
 # the independent variable time

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -1,6 +1,7 @@
 #
 # IndependentVariable class
 #
+import numpy as np
 import pybamm
 
 KNOWN_SPATIAL_VARS = ["x", "y", "z", "r", "x_n", "x_s", "x_p", "r_n", "r_p"]
@@ -44,6 +45,13 @@ class Time(IndependentVariable):
             raise ValueError("t must be provided")
         return t
 
+    def evaluate_for_shape(self):
+        """
+        Return the scalar '0' to represent the shape of the independent variable `Time`.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return 0
+
 
 class SpatialVariable(IndependentVariable):
     """A node in the expression tree representing a spatial variable
@@ -83,6 +91,9 @@ class SpatialVariable(IndependentVariable):
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
         return SpatialVariable(self.name, self.domain, self.coord_sys)
+
+    def evaluate_for_shape(self):
+        return np.random.rand(1)
 
 
 # the independent variable time

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -97,8 +97,7 @@ class SpatialVariable(IndependentVariable):
         Returns a vector of NaNs to represent the shape of an IndependentVariable.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
-        return np.nan * np.ones((size, 1))
+        return self.evaluate_for_shape_using_domain()
 
 
 # the independent variable time

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -25,10 +25,7 @@ class IndependentVariable(pybamm.Symbol):
         super().__init__(name, domain=domain)
 
     def evaluate_for_shape(self):
-        """
-        Returns a vector of NaNs to represent the shape of an IndependentVariable.
-        See :meth:`pybamm.Symbol.evaluate_for_shape()`
-        """
+        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
         return self.evaluate_for_shape_using_domain()
 
 

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -29,7 +29,7 @@ class IndependentVariable(pybamm.Symbol):
 
     def evaluate_for_shape(self):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
-        return self.evaluate_for_shape_using_domain()
+        return pybamm.evaluate_for_shape_using_domain(self.domain)
 
 
 class Time(IndependentVariable):

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -1,7 +1,6 @@
 #
 # IndependentVariable class
 #
-import numpy as np
 import pybamm
 
 KNOWN_SPATIAL_VARS = ["x", "y", "z", "r", "x_n", "x_s", "x_p", "r_n", "r_p"]

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -93,7 +93,11 @@ class SpatialVariable(IndependentVariable):
         return SpatialVariable(self.name, self.domain, self.coord_sys)
 
     def evaluate_for_shape(self):
-        return np.random.rand(1)
+        """
+        Returns a vector of NaNs to represent the shape of an IndependentVariable.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return np.nan * np.ones(1)
 
 
 # the independent variable time

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -25,6 +25,13 @@ class IndependentVariable(pybamm.Symbol):
     def __init__(self, name, domain=[]):
         super().__init__(name, domain=domain)
 
+    def evaluate_for_shape(self):
+        """
+        Returns a vector of NaNs to represent the shape of an IndependentVariable.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return self.evaluate_for_shape_using_domain()
+
 
 class Time(IndependentVariable):
     """A node in the expression tree representing time
@@ -91,13 +98,6 @@ class SpatialVariable(IndependentVariable):
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
         return SpatialVariable(self.name, self.domain, self.coord_sys)
-
-    def evaluate_for_shape(self):
-        """
-        Returns a vector of NaNs to represent the shape of an IndependentVariable.
-        See :meth:`pybamm.Symbol.evaluate_for_shape()`
-        """
-        return self.evaluate_for_shape_using_domain()
 
 
 # the independent variable time

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -1,6 +1,7 @@
 #
 # Parameter classes
 #
+import numpy as np
 import pybamm
 
 
@@ -31,7 +32,7 @@ class Parameter(pybamm.Symbol):
         Returns the scalar '1' to represent the shape of a parameter.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return 1
+        return np.random.rand()
 
 
 class FunctionParameter(pybamm.UnaryOperator):

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -26,6 +26,13 @@ class Parameter(pybamm.Symbol):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
         return Parameter(self.name, self.domain)
 
+    def evaluate_for_shape(self, t=None, y=None):
+        """
+        Returns the scalar '1' to represent the shape of a parameter.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return 1
+
 
 class FunctionParameter(pybamm.UnaryOperator):
     """A node in the expression tree representing a function parameter

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -29,10 +29,10 @@ class Parameter(pybamm.Symbol):
 
     def evaluate_for_shape(self, t=None, y=None):
         """
-        Returns the scalar '1' to represent the shape of a parameter.
+        Returns the scalar 'NaN' to represent the shape of a parameter.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return np.random.rand()
+        return np.nan
 
 
 class FunctionParameter(pybamm.UnaryOperator):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -11,6 +11,18 @@ import autograd.numpy as np
 from anytree.exporter import DotExporter
 
 
+def evaluate_for_shape_using_domain(domain):
+    """
+    Return a vector of the appropriate shape, based on the domain.
+    Domain 'sizes' can clash, but are unlikely to, and won't cause failures if they do.
+    """
+    if domain == []:
+        size = 1
+    else:
+        size = sum(hash(dom) % 100 for dom in domain)
+    return np.nan * np.ones((size, 1))
+
+
 class Symbol(anytree.NodeMixin):
     """Base node class for the expression tree
 
@@ -411,18 +423,6 @@ class Symbol(anytree.NodeMixin):
         See :meth:`pybamm.Symbol.evaluate()`
         """
         return self.evaluate()
-
-    def evaluate_for_shape_using_domain(self):
-        """
-        Return a vector of the appropriate shape, based on the symbol's domain.
-        Domain 'sizes' can clash, but are unlikely to, and won't cause failures if they
-        do.
-        """
-        if self.domain == []:
-            size = 1
-        else:
-            size = sum(hash(dom) % 100 for dom in self.domain)
-        return np.nan * np.ones((size, 1))
 
     def is_constant(self):
         """returns true if evaluating the expression is not dependent on `t` or `y`

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -87,12 +87,13 @@ class Symbol(anytree.NodeMixin):
             self.set_id()
             # Test shape on everything but nodes that contain the base Symbol class or
             # the base BinaryOperator class
-            if not any(
-                issubclass(pybamm.Symbol, type(x))
-                or issubclass(pybamm.BinaryOperator, type(x))
-                for x in self.pre_order()
-            ):
-                self.test_shape()
+            if pybamm.debug_mode is True:
+                if not any(
+                    issubclass(pybamm.Symbol, type(x))
+                    or issubclass(pybamm.BinaryOperator, type(x))
+                    for x in self.pre_order()
+                ):
+                    self.test_shape()
 
     @property
     def id(self):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -44,7 +44,7 @@ class Symbol(anytree.NodeMixin):
 
         # Test shape on everything but nodes that contain the base Symbol class or
         # the base BinaryOperator class
-        if pybamm.debug_mode is True:
+        if pybamm.settings.debug_mode is True:
             if not any(
                 issubclass(pybamm.Symbol, type(x))
                 or issubclass(pybamm.BinaryOperator, type(x))

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -48,6 +48,10 @@ class Symbol(anytree.NodeMixin):
         # Set domain (and hence id)
         self.domain = domain
 
+        # Test shape on everything but the symbol node
+        if not isinstance(self, type(self)):
+            self.test_shape()
+
     @property
     def children(self):
         """
@@ -396,14 +400,14 @@ class Symbol(anytree.NodeMixin):
         else:
             return self._base_evaluate(t, y)
 
-    def evaluate_for_shape(self, t=None, y=None):
+    def evaluate_for_shape(self):
         """Evaluate expression tree to find its shape. For symbols that cannot be
         evaluated directly (e.g. `Variable` or `Parameter`), a vector of the appropriate
         shape is returned instead, using arbitrary domain sizes from the dictionary
         `DOMAIN_SIZES_FOR_TESTING`
         See :meth:`pybamm.Symbol.evaluate()`
         """
-        return self.evaluate(t, y)
+        return self.evaluate()
 
     def is_constant(self):
         """returns true if evaluating the expression is not dependent on `t` or `y`
@@ -512,16 +516,16 @@ class Symbol(anytree.NodeMixin):
         instead given an arbitrary domain-dependent shape from the dictionary
         `pybamm.DOMAIN_SIZES_FOR_TESTING` (note that this only works for some domains)
         """
-        state_vectors_in_node = [
-            x for x in self.pre_order() if isinstance(x, pybamm.StateVector)
-        ]
-        if state_vectors_in_node == []:
-            y = None
-        else:
-            min_y_size = max(x.y_slice.stop for x in state_vectors_in_node)
-            # Pick a y that won't cause RuntimeWarnings
-            y = np.linspace(0.1, 0.9, min_y_size)
-        evaluated_self = self.evaluate_for_shape(t=0, y=y)
+        # state_vectors_in_node = []
+        #     x for x in self.pre_order() if isinstance(x, pybamm.StateVector)
+        # ]
+        # if state_vectors_in_node == []:
+        #     y = None
+        # else:
+        #     min_y_size = max(x.y_slice.stop for x in state_vectors_in_node)
+        #     # Pick a y that won't cause RuntimeWarnings
+        #     y = np.linspace(0.1, 0.9, min_y_size)
+        evaluated_self = self.evaluate_for_shape()
         if isinstance(evaluated_self, numbers.Number):
             return ()
         else:

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -401,13 +401,17 @@ class Symbol(anytree.NodeMixin):
     def evaluate_for_shape(self):
         """Evaluate expression tree to find its shape. For symbols that cannot be
         evaluated directly (e.g. `Variable` or `Parameter`), a vector of the appropriate
-        shape is returned instead, using arbitrary domain sizes from the dictionary
-        `DOMAIN_SIZES_FOR_TESTING`
+        shape is returned instead, using the symbol's domain.
         See :meth:`pybamm.Symbol.evaluate()`
         """
         return self.evaluate()
 
     def evaluate_for_shape_using_domain(self):
+        """
+        Return a vector of the appropriate shape, based on the symbol's domain.
+        Domain 'sizes' can clash, but are unlikely to, and won't cause failures if they
+        do.
+        """
         if self.domain == []:
             size = 1
         else:

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -570,8 +570,6 @@ class Symbol(anytree.NodeMixin):
             If the shape of the object cannot be found
         """
         try:
-            self.shape
-        except (NotImplementedError, AttributeError):
             self.shape_for_testing
         except ValueError as e:
             raise pybamm.ShapeError("Cannot find shape (original error: {})".format(e))

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -42,6 +42,16 @@ class Symbol(anytree.NodeMixin):
         # Set domain (and hence id)
         self.domain = domain
 
+        # Test shape on everything but nodes that contain the base Symbol class or
+        # the base BinaryOperator class
+        if pybamm.debug_mode is True:
+            if not any(
+                issubclass(pybamm.Symbol, type(x))
+                or issubclass(pybamm.BinaryOperator, type(x))
+                for x in self.pre_order()
+            ):
+                self.test_shape()
+
     @property
     def children(self):
         """
@@ -85,15 +95,6 @@ class Symbol(anytree.NodeMixin):
             self._domain = domain
             # Update id since domain has changed
             self.set_id()
-            # Test shape on everything but nodes that contain the base Symbol class or
-            # the base BinaryOperator class
-            if pybamm.debug_mode is True:
-                if not any(
-                    issubclass(pybamm.Symbol, type(x))
-                    or issubclass(pybamm.BinaryOperator, type(x))
-                    for x in self.pre_order()
-                ):
-                    self.test_shape()
 
     @property
     def id(self):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -516,16 +516,21 @@ class Symbol(anytree.NodeMixin):
         instead given an arbitrary domain-dependent shape from the dictionary
         `pybamm.DOMAIN_SIZES_FOR_TESTING` (note that this only works for some domains)
         """
-        # state_vectors_in_node = []
-        #     x for x in self.pre_order() if isinstance(x, pybamm.StateVector)
-        # ]
-        # if state_vectors_in_node == []:
-        #     y = None
-        # else:
-        #     min_y_size = max(x.y_slice.stop for x in state_vectors_in_node)
-        #     # Pick a y that won't cause RuntimeWarnings
-        #     y = np.linspace(0.1, 0.9, min_y_size)
-        evaluated_self = self.evaluate_for_shape()
+        try:
+            # Default behaviour is to try to evaluate the object directly
+            state_vectors_in_node = [
+                x for x in self.pre_order() if isinstance(x, pybamm.StateVector)
+            ]
+            if state_vectors_in_node == []:
+                y = None
+            else:
+                min_y_size = max(x.y_slice.stop for x in state_vectors_in_node)
+                # Pick a y that won't cause RuntimeWarnings
+                y = np.linspace(0.1, 0.9, min_y_size)
+            evaluated_self = self.evaluate(0, y)
+        except NotImplementedError:
+            # If that doesn't work, fall back on `self.evaluate_for_shape`
+            evaluated_self = self.evaluate_for_shape()
         if isinstance(evaluated_self, numbers.Number):
             return ()
         else:

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -71,7 +71,7 @@ class UnaryOperator(pybamm.Symbol):
         Default behaviour: unary operator has same shape as child
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return self.child.evaluate_for_shape(t, y)
+        return self.children[0].evaluate_for_shape()
 
 
 class Negate(UnaryOperator):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -66,6 +66,13 @@ class UnaryOperator(pybamm.Symbol):
             child = self.child.evaluate(t, y)
             return self._unary_evaluate(child)
 
+    def evaluate_for_shape(self, t=None, y=None):
+        """
+        Default behaviour: unary operator has same shape as child
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return self.child.evaluate_for_shape(t, y)
+
 
 class Negate(UnaryOperator):
     """A node in the expression tree representing a `-` negation operator

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -404,6 +404,9 @@ class Integral(SpatialOperator):
 
         return self.__class__(child, self.integration_variable)
 
+    def evaluate_for_shape(self):
+        return self.evaluate_for_shape_using_domain()
+
 
 class IndefiniteIntegral(Integral):
     """A node in the expression tree representing an indefinite integral operator
@@ -434,6 +437,9 @@ class IndefiniteIntegral(Integral):
             self.name += " on {}".format(integration_variable.domain)
         # the integrated variable has the same domain as the child
         self.domain = child.domain
+
+    def evaluate_for_shape(self):
+        return self.children[0].evaluate_for_shape()
 
 
 class BoundaryOperator(SpatialOperator):
@@ -489,6 +495,9 @@ class BoundaryValue(BoundaryOperator):
 
     def __init__(self, child, side):
         super().__init__("boundary value", child, side)
+
+    def evaluate_for_shape(self):
+        return self.evaluate_for_shape_using_domain()
 
 
 class BoundaryFlux(BoundaryOperator):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -408,6 +408,7 @@ class Integral(SpatialOperator):
         return self.__class__(child, self.integration_variable)
 
     def evaluate_for_shape(self):
+        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
         return self.evaluate_for_shape_using_domain()
 
 
@@ -482,6 +483,10 @@ class BoundaryOperator(SpatialOperator):
         """ See :meth:`UnaryOperator._unary_new_copy()`. """
         return self.__class__(child, self.side)
 
+    def evaluate_for_shape(self):
+        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
+        return self.evaluate_for_shape_using_domain()
+
 
 class BoundaryValue(BoundaryOperator):
     """A node in the expression tree which gets the boundary value of a variable.
@@ -498,9 +503,6 @@ class BoundaryValue(BoundaryOperator):
 
     def __init__(self, child, side):
         super().__init__("boundary value", child, side)
-
-    def evaluate_for_shape(self):
-        return self.evaluate_for_shape_using_domain()
 
 
 class BoundaryFlux(BoundaryOperator):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -413,7 +413,7 @@ class Integral(SpatialOperator):
 
     def evaluate_for_shape(self):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
-        return self.evaluate_for_shape_using_domain()
+        return pybamm.evaluate_for_shape_using_domain(self.domain)
 
 
 class IndefiniteIntegral(Integral):
@@ -489,7 +489,7 @@ class BoundaryOperator(SpatialOperator):
 
     def evaluate_for_shape(self):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
-        return self.evaluate_for_shape_using_domain()
+        return pybamm.evaluate_for_shape_using_domain(self.domain)
 
 
 class BoundaryValue(BoundaryOperator):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -268,6 +268,9 @@ class Index(UnaryOperator):
 
         return self.__class__(child, self.index)
 
+    def evaluate_for_shape(self):
+        return self.children[0].evaluate_for_shape()[self.slice]
+
 
 class SpatialOperator(UnaryOperator):
     """A node in the expression tree representing a unary spatial operator

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -35,4 +35,5 @@ class Variable(pybamm.Symbol):
         Returns a vector of NaNs to represent the shape of a Variable.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        return np.nan * np.ones(1)
+        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
+        return np.nan * np.ones((size, 1))

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -35,5 +35,4 @@ class Variable(pybamm.Symbol):
         Returns a vector of NaNs to represent the shape of a Variable.
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        size = sum(pybamm.DOMAIN_SIZES_FOR_TESTING[dom] for dom in self.domain)
-        return np.nan * np.ones((size, 1))
+        return self.evaluate_for_shape_using_domain()

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -31,4 +31,4 @@ class Variable(pybamm.Symbol):
 
     def evaluate_for_shape(self):
         """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
-        return self.evaluate_for_shape_using_domain()
+        return pybamm.evaluate_for_shape_using_domain(self.domain)

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -31,4 +31,8 @@ class Variable(pybamm.Symbol):
         return Variable(self.name, self.domain)
 
     def evaluate_for_shape(self):
-        return np.random.rand(1)
+        """
+        Returns a vector of NaNs to represent the shape of a Variable.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        return np.nan * np.ones(1)

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -1,7 +1,6 @@
 #
 # Variable class
 #
-import numpy as np
 import pybamm
 
 

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -1,6 +1,7 @@
 #
 # Variable class
 #
+import numpy as np
 import pybamm
 
 
@@ -28,3 +29,6 @@ class Variable(pybamm.Symbol):
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
         return Variable(self.name, self.domain)
+
+    def evaluate_for_shape(self):
+        return np.random.rand(1)

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -30,8 +30,5 @@ class Variable(pybamm.Symbol):
         return Variable(self.name, self.domain)
 
     def evaluate_for_shape(self):
-        """
-        Returns a vector of NaNs to represent the shape of a Variable.
-        See :meth:`pybamm.Symbol.evaluate_for_shape()`
-        """
+        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
         return self.evaluate_for_shape_using_domain()

--- a/pybamm/expression_tree/vector.py
+++ b/pybamm/expression_tree/vector.py
@@ -142,3 +142,6 @@ class StateVector(pybamm.Symbol):
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
         return StateVector(self.y_slice, self.name, domain=[])
+
+    def evaluate_for_shape(self):
+        return np.random.rand(self.y_slice.stop - self.y_slice.start, 1)

--- a/pybamm/expression_tree/vector.py
+++ b/pybamm/expression_tree/vector.py
@@ -144,4 +144,9 @@ class StateVector(pybamm.Symbol):
         return StateVector(self.y_slice, self.name, domain=[])
 
     def evaluate_for_shape(self):
-        return np.random.rand(self.y_slice.stop - self.y_slice.start, 1)
+        """
+        Returns a vector of NaNs to represent the shape of a StateVector.
+        See :meth:`pybamm.Symbol.evaluate_for_shape()`
+        """
+        start = self.y_slice.start or 0
+        return np.nan * np.ones((self.y_slice.stop - start, 1))

--- a/pybamm/models/submodels/electrolyte_current.py
+++ b/pybamm/models/submodels/electrolyte_current.py
@@ -202,7 +202,6 @@ class ElectrolyteCurrentBaseModel(pybamm.SubModel):
                 + (1 - l_p) / kappa_s
             )
         )
-
         phi_e = pybamm.Concatenation(phi_e_n, phi_e_s, phi_e_p)
 
         "Ohmic losses and overpotentials"

--- a/pybamm/settings.py
+++ b/pybamm/settings.py
@@ -1,0 +1,19 @@
+#
+# Settings class for PyBaMM
+#
+
+
+class Settings(object):
+    _debug_mode = True
+
+    @property
+    def debug_mode(self):
+        return self._debug_mode
+
+    @debug_mode.setter
+    def debug_mode(self, value):
+        assert isinstance(value, bool)
+        self._debug_mode = value
+
+
+settings = Settings()

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -84,7 +84,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         gradient_matrix = self.gradient_matrix(domain)
 
         out = gradient_matrix @ discretised_symbol
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def gradient_matrix(self, domain):
@@ -152,7 +152,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             out = divergence_matrix @ discretised_symbol
 
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def divergence_matrix(self, domain):
@@ -209,7 +209,7 @@ class FiniteVolume(pybamm.SpatialMethod):
             out = integration_vector @ discretised_symbol
         out.domain = []
 
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def definite_integral_vector(self, domain):
@@ -262,7 +262,7 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         out.domain = domain
 
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def indefinite_integral_matrix(self, domain):
@@ -496,7 +496,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             boundary_value.domain = []
 
-        self.test_shape(boundary_value)
+        boundary_value.test_shape()
         return boundary_value
 
     def process_binary_operators(self, bin_op, left, right, disc_left, disc_right):
@@ -537,7 +537,7 @@ class FiniteVolume(pybamm.SpatialMethod):
             disc_left = self.compute_diffusivity(disc_left)
         # Return new binary operator with appropriate class
         out = bin_op.__class__(disc_left, disc_right)
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def compute_diffusivity(self, discretised_symbol):
@@ -599,5 +599,5 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             out = arithmetic_mean(discretised_symbol)
 
-        self.test_shape(out)
+        out.test_shape()
         return out

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -84,12 +84,6 @@ class FiniteVolume(pybamm.SpatialMethod):
         gradient_matrix = self.gradient_matrix(domain)
 
         out = gradient_matrix @ discretised_symbol
-        try:
-            out.test_shape()
-        except pybamm.ShapeError:
-            import ipdb
-
-            ipdb.set_trace()
         return out
 
     def gradient_matrix(self, domain):
@@ -157,7 +151,6 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             out = divergence_matrix @ discretised_symbol
 
-        out.test_shape()
         return out
 
     def divergence_matrix(self, domain):
@@ -214,7 +207,6 @@ class FiniteVolume(pybamm.SpatialMethod):
             out = integration_vector @ discretised_symbol
         out.domain = []
 
-        out.test_shape()
         return out
 
     def definite_integral_vector(self, domain):
@@ -267,7 +259,6 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         out.domain = domain
 
-        out.test_shape()
         return out
 
     def indefinite_integral_matrix(self, domain):
@@ -501,7 +492,6 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             boundary_value.domain = []
 
-        boundary_value.test_shape()
         return boundary_value
 
     def process_binary_operators(self, bin_op, left, right, disc_left, disc_right):
@@ -542,7 +532,6 @@ class FiniteVolume(pybamm.SpatialMethod):
             disc_left = self.compute_diffusivity(disc_left)
         # Return new binary operator with appropriate class
         out = bin_op.__class__(disc_left, disc_right)
-        out.test_shape()
         return out
 
     def compute_diffusivity(self, discretised_symbol):
@@ -604,5 +593,4 @@ class FiniteVolume(pybamm.SpatialMethod):
         else:
             out = arithmetic_mean(discretised_symbol)
 
-        out.test_shape()
         return out

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -84,7 +84,12 @@ class FiniteVolume(pybamm.SpatialMethod):
         gradient_matrix = self.gradient_matrix(domain)
 
         out = gradient_matrix @ discretised_symbol
-        out.test_shape()
+        try:
+            out.test_shape()
+        except pybamm.ShapeError:
+            import ipdb
+
+            ipdb.set_trace()
         return out
 
     def gradient_matrix(self, domain):

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -76,7 +76,6 @@ class SpatialMethod:
             )
         else:
             out = symbol * pybamm.Vector(np.ones(vector_size_2D), domain=domain)
-        out.test_shape()
         return out
 
     def gradient(self, symbol, discretised_symbol, boundary_conditions):
@@ -200,7 +199,13 @@ class SpatialMethod:
             # as above, but now we want a single point with value 1 at (0, n-1)
             right_vector = coo_matrix(([1], ([0], [n - 1])), shape=(1, n))
             bv_vector = pybamm.Matrix(right_vector)
-        out = bv_vector @ discretised_child
+
+        try:
+            out = bv_vector @ discretised_child
+        except pybamm.ShapeError:
+            import ipdb
+
+            ipdb.set_trace()
         # boundary value removes domain
         out.domain = []
         return out

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -76,7 +76,7 @@ class SpatialMethod:
             )
         else:
             out = symbol * pybamm.Vector(np.ones(vector_size_2D), domain=domain)
-        self.test_shape(out)
+        out.test_shape()
         return out
 
     def gradient(self, symbol, discretised_symbol, boundary_conditions):
@@ -266,30 +266,3 @@ class SpatialMethod:
 
         """
         return bin_op.__class__(disc_left, disc_right)
-
-    @staticmethod
-    def test_shape(symbol):
-        """
-        Check that the discretised symbol has a pybamm `shape`, i.e. can be evaluated
-
-        Parameters
-        ----------
-        symbol : :class:`pybamm.Symbol`
-            The symbol to be tested
-
-        Raises
-        ------
-        pybamm.ShapeError
-            If the shape of the object cannot be found
-        """
-        try:
-            symbol.shape
-        except ValueError as e:
-            raise pybamm.ShapeError(
-                """
-                Cannot evaluate the discretised symbol to find its shape
-                (original error: {})
-                """.format(
-                    e
-                )
-            )

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -200,12 +200,7 @@ class SpatialMethod:
             right_vector = coo_matrix(([1], ([0], [n - 1])), shape=(1, n))
             bv_vector = pybamm.Matrix(right_vector)
 
-        try:
-            out = bv_vector @ discretised_child
-        except pybamm.ShapeError:
-            import ipdb
-
-            ipdb.set_trace()
+        out = bv_vector @ discretised_child
         # boundary value removes domain
         out.domain = []
         return out

--- a/run-tests.py
+++ b/run-tests.py
@@ -7,6 +7,7 @@
 #
 import re
 import os
+import pybamm
 import sys
 import argparse
 import unittest
@@ -30,6 +31,8 @@ def run_code_tests(executable=None, folder: str = "unit"):
         tests = "tests/"
     else:
         tests = "tests/" + folder
+        if folder == "unit":
+            pybamm.settings.debug_mode = True
     if executable is None:
         suite = unittest.defaultTestLoader.discover(tests, pattern="test*.py")
         unittest.TextTestRunner(verbosity=2).run(suite)
@@ -203,9 +206,9 @@ def test_notebook(path, executable="python"):
                 j = str(1 + i)
                 print(j + " " * (5 - len(j)) + line)
             print("-- stdout " + "-" * (79 - 10))
-            print(str(stdout, 'utf-8'))
+            print(str(stdout, "utf-8"))
             print("-- stderr " + "-" * (79 - 10))
-            print(str(stderr, 'utf-8'))
+            print(str(stderr, "utf-8"))
             print("-" * 79)
             return False
     except KeyboardInterrupt:
@@ -244,9 +247,9 @@ def test_script(path, executable="python"):
             # Show failing code, output and errors before returning
             print("ERROR")
             print("-- stdout " + "-" * (79 - 10))
-            print(str(stdout, 'utf-8'))
+            print(str(stdout, "utf-8"))
             print("-- stderr " + "-" * (79 - 10))
-            print(str(stderr, 'utf-8'))
+            print(str(stderr, "utf-8"))
             print("-" * 79)
             return False
     except KeyboardInterrupt:

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -112,7 +112,7 @@ class TestDiscretise(unittest.TestCase):
         # variable
         var = pybamm.Variable("var")
         var_vec = pybamm.Variable("var vec", domain=["negative electrode"])
-        disc._y_slices = {var.id: slice(53), var_vec.id: slice(53, 102)}
+        disc._y_slices = {var.id: slice(53), var_vec.id: slice(53, 93)}
         var_disc = disc.process_symbol(var)
         self.assertIsInstance(var_disc, pybamm.StateVector)
         self.assertEqual(var_disc._y_slice, disc._y_slices[var.id])
@@ -185,7 +185,7 @@ class TestDiscretise(unittest.TestCase):
         # create discretisation
         disc = get_discretisation_for_testing()
 
-        disc._y_slices = {var1.id: slice(53), var2.id: slice(53, 59)}
+        disc._y_slices = {var1.id: slice(53), var2.id: slice(53, 106)}
         exp_disc = disc.process_symbol(expression)
         self.assertIsInstance(exp_disc, pybamm.Division)
         # left side

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -233,10 +233,10 @@ class TestBinaryOperators(unittest.TestCase):
         np.testing.assert_array_equal(
             (pybammS2 * pybammD2).evaluate().toarray(), S2.toarray() * D2
         )
-        with self.assertRaisesRegex(ValueError, "inconsistent shapes"):
-            (pybammS1 * pybammS2).evaluate()
-        with self.assertRaisesRegex(ValueError, "inconsistent shapes"):
-            (pybammS2 * pybammS1).evaluate()
+        with self.assertRaisesRegex(pybamm.ShapeError, "inconsistent shapes"):
+            pybammS1 * pybammS2
+        with self.assertRaisesRegex(pybamm.ShapeError, "inconsistent shapes"):
+            pybammS2 * pybammS1
 
         # Matrix multiplication is normal matrix multiplication
         np.testing.assert_array_equal(
@@ -249,10 +249,10 @@ class TestBinaryOperators(unittest.TestCase):
         np.testing.assert_array_equal((pybammD2 @ pybammS1).evaluate(), D2 * S1)
         np.testing.assert_array_equal((pybammS2 @ pybammD1).evaluate(), S2 * D1)
         np.testing.assert_array_equal((pybammD1 @ pybammS2).evaluate(), D1 * S2)
-        with self.assertRaisesRegex(ValueError, "dimension mismatch"):
-            (pybammS1 @ pybammS1).evaluate()
-        with self.assertRaisesRegex(ValueError, "dimension mismatch"):
-            (pybammS2 @ pybammS2).evaluate()
+        with self.assertRaisesRegex(pybamm.ShapeError, "dimension mismatch"):
+            pybammS1 @ pybammS1
+        with self.assertRaisesRegex(pybamm.ShapeError, "dimension mismatch"):
+            pybammS2 @ pybammS2
 
     def test_sparse_divide(self):
         row = np.array([0, 3, 1, 0])

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -202,6 +202,7 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(prod.evaluate(), 12)
 
     def test_sparse_multiply(self):
+        pybamm.debug_mode = True
         row = np.array([0, 3, 1, 0])
         col = np.array([0, 3, 1, 2])
         data = np.array([4, 5, 7, 9])
@@ -253,6 +254,7 @@ class TestBinaryOperators(unittest.TestCase):
             pybammS1 @ pybammS1
         with self.assertRaisesRegex(pybamm.ShapeError, "dimension mismatch"):
             pybammS2 @ pybammS2
+        pybamm.debug_mode = False
 
     def test_sparse_divide(self):
         row = np.array([0, 3, 1, 0])

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -202,7 +202,6 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(prod.evaluate(), 12)
 
     def test_sparse_multiply(self):
-        pybamm.debug_mode = True
         row = np.array([0, 3, 1, 0])
         col = np.array([0, 3, 1, 2])
         data = np.array([4, 5, 7, 9])
@@ -235,9 +234,9 @@ class TestBinaryOperators(unittest.TestCase):
             (pybammS2 * pybammD2).evaluate().toarray(), S2.toarray() * D2
         )
         with self.assertRaisesRegex(pybamm.ShapeError, "inconsistent shapes"):
-            pybammS1 * pybammS2
+            (pybammS1 * pybammS2).test_shape()
         with self.assertRaisesRegex(pybamm.ShapeError, "inconsistent shapes"):
-            pybammS2 * pybammS1
+            (pybammS2 * pybammS1).test_shape()
 
         # Matrix multiplication is normal matrix multiplication
         np.testing.assert_array_equal(
@@ -251,10 +250,9 @@ class TestBinaryOperators(unittest.TestCase):
         np.testing.assert_array_equal((pybammS2 @ pybammD1).evaluate(), S2 * D1)
         np.testing.assert_array_equal((pybammD1 @ pybammS2).evaluate(), D1 * S2)
         with self.assertRaisesRegex(pybamm.ShapeError, "dimension mismatch"):
-            pybammS1 @ pybammS1
+            (pybammS1 @ pybammS1).test_shape()
         with self.assertRaisesRegex(pybamm.ShapeError, "dimension mismatch"):
-            pybammS2 @ pybammS2
-        pybamm.debug_mode = False
+            (pybammS2 @ pybammS2).test_shape()
 
     def test_sparse_divide(self):
         row = np.array([0, 3, 1, 0])

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -18,9 +18,9 @@ class TestConcatenations(unittest.TestCase):
         self.assertEqual(conc.children[0].name, "a")
         self.assertEqual(conc.children[1].name, "b")
         self.assertEqual(conc.children[2].name, "c")
-        d = pybamm.Scalar(2)
-        e = pybamm.Scalar(1)
-        f = pybamm.Scalar(3)
+        d = pybamm.Vector(np.array([2]))
+        e = pybamm.Vector(np.array([1]))
+        f = pybamm.Vector(np.array([3]))
         conc2 = pybamm.Concatenation(d, e, f)
         with self.assertRaises(NotImplementedError):
             conc2.evaluate()
@@ -160,9 +160,9 @@ class TestConcatenations(unittest.TestCase):
         )
 
     def test_concatenation_orphans(self):
-        a = pybamm.Variable("a")
-        b = pybamm.Variable("b")
-        c = pybamm.Variable("c")
+        a = pybamm.Variable("a", domain=["negative electrode"])
+        b = pybamm.Variable("b", domain=["separator"])
+        c = pybamm.Variable("c", domain=["positive electrode"])
         conc = pybamm.Concatenation(a, b, c)
         a_new, b_new, c_new = conc.orphans
 

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -22,7 +22,7 @@ class TestConcatenations(unittest.TestCase):
         e = pybamm.Vector(np.array([1]))
         f = pybamm.Vector(np.array([3]))
         conc2 = pybamm.Concatenation(d, e, f)
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(TypeError):
             conc2.evaluate()
 
     def test_concatenation_domains(self):

--- a/tests/unit/test_expression_tree/test_copy.py
+++ b/tests/unit/test_expression_tree/test_copy.py
@@ -31,7 +31,7 @@ class TestSimplify(unittest.TestCase):
             pybamm.BoundaryValue(a, "right"),
             pybamm.BoundaryFlux(a, "right"),
             pybamm.Broadcast(a, "domain"),
-            pybamm.Concatenation(a, b, v_n),
+            pybamm.Concatenation(v_n, v_s),
             pybamm.NumpyConcatenation(a, b, v_s),
             pybamm.DomainConcatenation([v_n, v_s], mesh),
             pybamm.Parameter("param"),

--- a/tests/unit/test_expression_tree/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_evaluate.py
@@ -32,13 +32,14 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(variable_symbols.keys())[2], expr.id)
 
         # test values of variable_symbols
-        self.assertEqual(list(variable_symbols.values())[0], 'y[0:1]')
-        self.assertEqual(list(variable_symbols.values())[1], 'y[1:2]')
+        self.assertEqual(list(variable_symbols.values())[0], "y[0:1]")
+        self.assertEqual(list(variable_symbols.values())[1], "y[1:2]")
 
         var_a = pybamm.id_to_python_variable(a.id)
         var_b = pybamm.id_to_python_variable(b.id)
-        self.assertEqual(list(variable_symbols.values())[
-                         2], '{} + {}'.format(var_a, var_b))
+        self.assertEqual(
+            list(variable_symbols.values())[2], "{} + {}".format(var_a, var_b)
+        )
 
         # test identical subtree
         constant_symbols = OrderedDict()
@@ -54,14 +55,16 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(variable_symbols.keys())[3], expr.id)
 
         # test values of variable_symbols
-        self.assertEqual(list(variable_symbols.values())[0], 'y[0:1]')
-        self.assertEqual(list(variable_symbols.values())[1], 'y[1:2]')
-        self.assertEqual(list(variable_symbols.values())[
-                         2], '{} + {}'.format(var_a, var_b))
+        self.assertEqual(list(variable_symbols.values())[0], "y[0:1]")
+        self.assertEqual(list(variable_symbols.values())[1], "y[1:2]")
+        self.assertEqual(
+            list(variable_symbols.values())[2], "{} + {}".format(var_a, var_b)
+        )
 
         var_child = pybamm.id_to_python_variable(expr.children[0].id)
-        self.assertEqual(list(variable_symbols.values())[
-                         3], '{} + {}'.format(var_child, var_b))
+        self.assertEqual(
+            list(variable_symbols.values())[3], "{} + {}".format(var_child, var_b)
+        )
 
         # test unary op
         constant_symbols = OrderedDict()
@@ -77,12 +80,13 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(variable_symbols.keys())[3], expr.id)
 
         # test values of variable_symbols
-        self.assertEqual(list(variable_symbols.values())[0], 'y[0:1]')
-        self.assertEqual(list(variable_symbols.values())[1], 'y[1:2]')
-        self.assertEqual(list(variable_symbols.values())[2], '-{}'.format(var_b))
+        self.assertEqual(list(variable_symbols.values())[0], "y[0:1]")
+        self.assertEqual(list(variable_symbols.values())[1], "y[1:2]")
+        self.assertEqual(list(variable_symbols.values())[2], "-{}".format(var_b))
         var_child = pybamm.id_to_python_variable(expr.children[1].id)
-        self.assertEqual(list(variable_symbols.values())[3],
-                         '{} + {}'.format(var_a, var_child))
+        self.assertEqual(
+            list(variable_symbols.values())[3], "{} + {}".format(var_a, var_child)
+        )
 
         # test function
         constant_symbols = OrderedDict()
@@ -93,10 +97,11 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(constant_symbols.values())[0], test_function)
         self.assertEqual(list(variable_symbols.keys())[0], a.id)
         self.assertEqual(list(variable_symbols.keys())[1], expr.id)
-        self.assertEqual(list(variable_symbols.values())[0], 'y[0:1]')
+        self.assertEqual(list(variable_symbols.values())[0], "y[0:1]")
         var_funct = pybamm.id_to_python_variable(expr.id, True)
-        self.assertEqual(list(variable_symbols.values())[1], '{}({})'.format(var_funct,
-                                                                             var_a))
+        self.assertEqual(
+            list(variable_symbols.values())[1], "{}({})".format(var_funct, var_a)
+        )
 
         # test matrix
         constant_symbols = OrderedDict()
@@ -105,8 +110,9 @@ class TestEvaluate(unittest.TestCase):
         pybamm.find_symbols(A, constant_symbols, variable_symbols)
         self.assertEqual(len(variable_symbols), 0)
         self.assertEqual(list(constant_symbols.keys())[0], A.id)
-        np.testing.assert_allclose(list(constant_symbols.values())[0],
-                                   np.array([[1, 2], [3, 4]]))
+        np.testing.assert_allclose(
+            list(constant_symbols.values())[0], np.array([[1, 2], [3, 4]])
+        )
 
         # test sparse matrix
         constant_symbols = OrderedDict()
@@ -115,8 +121,9 @@ class TestEvaluate(unittest.TestCase):
         pybamm.find_symbols(A, constant_symbols, variable_symbols)
         self.assertEqual(len(variable_symbols), 0)
         self.assertEqual(list(constant_symbols.keys())[0], A.id)
-        np.testing.assert_allclose(list(constant_symbols.values())[
-                                   0].toarray(), A.entries.toarray())
+        np.testing.assert_allclose(
+            list(constant_symbols.values())[0].toarray(), A.entries.toarray()
+        )
 
         # test numpy concatentate
         constant_symbols = OrderedDict()
@@ -127,9 +134,10 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(variable_symbols.keys())[0], a.id)
         self.assertEqual(list(variable_symbols.keys())[1], b.id)
         self.assertEqual(list(variable_symbols.keys())[2], expr.id)
-        self.assertEqual(list(variable_symbols.values())[2],
-                         "np.concatenate(({},{}))".format(var_a, var_b)
-                         )
+        self.assertEqual(
+            list(variable_symbols.values())[2],
+            "np.concatenate(({},{}))".format(var_a, var_b),
+        )
 
         # test domain concatentate
         constant_symbols = OrderedDict()
@@ -140,22 +148,10 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(list(variable_symbols.keys())[0], a.id)
         self.assertEqual(list(variable_symbols.keys())[1], b.id)
         self.assertEqual(list(variable_symbols.keys())[2], expr.id)
-        self.assertEqual(list(variable_symbols.values())[2],
-                         "np.concatenate(({},{}))".format(var_a, var_b)
-                         )
-
-        # test sparse stack
-        constant_symbols = OrderedDict()
-        variable_symbols = OrderedDict()
-        expr = pybamm.SparseStack(a, b)
-        pybamm.find_symbols(expr, constant_symbols, variable_symbols)
-        self.assertEqual(len(constant_symbols), 0)
-        self.assertEqual(list(variable_symbols.keys())[0], a.id)
-        self.assertEqual(list(variable_symbols.keys())[1], b.id)
-        self.assertEqual(list(variable_symbols.keys())[2], expr.id)
-        self.assertEqual(list(variable_symbols.values())[2],
-                         "scipy.sparse.vstack(({},{}))".format(var_a, var_b)
-                         )
+        self.assertEqual(
+            list(variable_symbols.values())[2],
+            "np.concatenate(({},{}))".format(var_a, var_b),
+        )
 
         # test that Concatentation throws
         expr = pybamm.Concatenation(a, b)
@@ -163,7 +159,7 @@ class TestEvaluate(unittest.TestCase):
             pybamm.find_symbols(expr, constant_symbols, variable_symbols)
 
         # test that these nodes throw
-        for expr in (pybamm.Variable('a'), pybamm.Parameter('a')):
+        for expr in (pybamm.Variable("a"), pybamm.Parameter("a")):
             with self.assertRaises(NotImplementedError):
                 pybamm.find_symbols(expr, constant_symbols, variable_symbols)
 
@@ -194,10 +190,10 @@ class TestEvaluate(unittest.TestCase):
         var_a = pybamm.id_to_python_variable(a.id)
         var_b = pybamm.id_to_python_variable(b.id)
         self.assertEqual(len(constant_symbols), 0)
-        self.assertEqual(list(variable_symbols.values())[2],
-                         "np.concatenate(({}[0:{}],{}[0:{}]))".format(
-                             var_a, a_pts, var_b, b_pts)
-                         )
+        self.assertEqual(
+            list(variable_symbols.values())[2],
+            "np.concatenate(({}[0:{}],{}[0:{}]))".format(var_a, a_pts, var_b, b_pts),
+        )
 
         evaluator = pybamm.EvaluatorPython(expr)
         result = evaluator.evaluate(y=y)
@@ -217,9 +213,7 @@ class TestEvaluate(unittest.TestCase):
         b1_pts = mesh[b_dom[1]][0].npts
 
         a = pybamm.StateVector(slice(0, a0_pts), domain=a_dom)
-        b = pybamm.StateVector(slice(a0_pts, a0_pts + b0_pts + b1_pts),
-                               domain=b_dom,
-                               )
+        b = pybamm.StateVector(slice(a0_pts, a0_pts + b0_pts + b1_pts), domain=b_dom)
 
         y = np.empty((a0_pts + b0_pts + b1_pts, 1))
         for i in range(len(y)):
@@ -237,9 +231,10 @@ class TestEvaluate(unittest.TestCase):
         b1_str = "{}[{}:{}]".format(var_b, b0_pts, b0_pts + b1_pts)
 
         self.assertEqual(len(constant_symbols), 0)
-        self.assertEqual(list(variable_symbols.values())[2],
-                         "np.concatenate(({},{},{}))".format(b0_str, a0_str, b1_str)
-                         )
+        self.assertEqual(
+            list(variable_symbols.values())[2],
+            "np.concatenate(({},{},{}))".format(b0_str, a0_str, b1_str),
+        )
 
         evaluator = pybamm.EvaluatorPython(expr)
         result = evaluator.evaluate(y=y)
@@ -252,10 +247,11 @@ class TestEvaluate(unittest.TestCase):
         # test a * b
         expr = a + b
         constant_str, variable_str = pybamm.to_python(expr)
-        expected_str = \
-            "self\.var_[0-9m]+ = y\[0:1\].*\\n" \
-            "self\.var_[0-9m]+ = y\[1:2\].*\\n" \
+        expected_str = (
+            "self\.var_[0-9m]+ = y\[0:1\].*\\n"
+            "self\.var_[0-9m]+ = y\[1:2\].*\\n"
             "self\.var_[0-9m]+ = self\.var_[0-9m]+ \+ self\.var_[0-9m]+"
+        )
 
         self.assertRegex(variable_str, expected_str)
 
@@ -287,7 +283,7 @@ class TestEvaluate(unittest.TestCase):
         self.assertEqual(result, 6)
 
         # test a larger expression
-        expr = a * b + b + a**2 / b + 2 * a + b / 2 + 4
+        expr = a * b + b + a ** 2 / b + 2 * a + b / 2 + 4
         evaluator = pybamm.EvaluatorPython(expr)
         for y in y_tests:
             result = evaluator.evaluate(t=None, y=y)

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -2,7 +2,6 @@
 # Tests for the Parameter class
 #
 import pybamm
-
 import unittest
 
 
@@ -13,6 +12,10 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(a.domain, [])
         c = pybamm.Parameter("c", domain=["test"])
         self.assertEqual(c.domain[0], "test")
+
+    def test_evaluate_for_shape(self):
+        a = pybamm.Parameter("a")
+        self.assertEqual(a.evaluate_for_shape(), 1)
 
 
 class TestFunctionParameter(unittest.TestCase):
@@ -28,6 +31,11 @@ class TestFunctionParameter(unittest.TestCase):
         var = pybamm.Variable("var")
         func = pybamm.FunctionParameter("a", var).diff(var)
         self.assertEqual(func.diff_variable, var)
+
+    def test_evaluate_for_shape(self):
+        a = pybamm.Parameter("a")
+        func = pybamm.FunctionParameter("func", 2 * a)
+        self.assertEqual(func.evaluate_for_shape(), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Parameter class
 #
+import numbers
 import pybamm
 import unittest
 
@@ -15,7 +16,7 @@ class TestParameter(unittest.TestCase):
 
     def test_evaluate_for_shape(self):
         a = pybamm.Parameter("a")
-        self.assertEqual(a.evaluate_for_shape(), 1)
+        self.assertIsInstance(a.evaluate_for_shape(), numbers.Number)
 
 
 class TestFunctionParameter(unittest.TestCase):
@@ -35,7 +36,7 @@ class TestFunctionParameter(unittest.TestCase):
     def test_evaluate_for_shape(self):
         a = pybamm.Parameter("a")
         func = pybamm.FunctionParameter("func", 2 * a)
-        self.assertEqual(func.evaluate_for_shape(), 2)
+        self.assertIsInstance(func.evaluate_for_shape(), numbers.Number)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_simplify.py
+++ b/tests/unit/test_expression_tree/test_simplify.py
@@ -256,18 +256,15 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(funca.evaluate(), 1)
 
     def test_matrix_simplifications(self):
-        a = pybamm.Scalar(0)
-        b = pybamm.Scalar(1)
-        c = pybamm.Parameter("c")
+        a = pybamm.Matrix(np.zeros((2, 2)))
+        b = pybamm.Matrix(np.ones((2, 2)))
 
         # matrix multiplication
         A = pybamm.Matrix(np.array([[1, 0], [0, 1]]))
-        self.assertIsInstance((a @ A).simplify(), pybamm.Scalar)
-        self.assertEqual((a @ A).simplify().evaluate(), 0)
-        self.assertIsInstance((A @ a).simplify(), pybamm.Scalar)
-        self.assertEqual((A @ a).simplify().evaluate(), 0)
-
-        self.assertIsInstance((A @ c).simplify(), pybamm.MatrixMultiplication)
+        self.assertIsInstance((a @ A).simplify(), pybamm.Matrix)
+        np.testing.assert_array_equal((a @ A).simplify().evaluate(), 0)
+        self.assertIsInstance((A @ a).simplify(), pybamm.Matrix)
+        np.testing.assert_array_equal((A @ a).simplify().evaluate(), 0)
 
         # matrix * matrix
         m1 = pybamm.Matrix(np.array([[2, 0], [0, 2]]))
@@ -290,11 +287,11 @@ class TestSimplify(unittest.TestCase):
                 expr.children[0].entries, np.array([[3, 0], [0, 3]])
             )
 
-        expr = ((v @ v) / 2).simplify()
+        expr = ((v * v) / 2).simplify()
         self.assertIsInstance(expr, pybamm.Multiplication)
         self.assertIsInstance(expr.children[0], pybamm.Scalar)
         self.assertEqual(expr.children[0].evaluate(), 0.5)
-        self.assertIsInstance(expr.children[1], pybamm.MatrixMultiplication)
+        self.assertIsInstance(expr.children[1], pybamm.Multiplication)
 
         # mat-mul on numerator and denominator
         expr = (m2 @ (m1 @ v) / (m2 @ (m1 @ v))).simplify()
@@ -321,6 +318,7 @@ class TestSimplify(unittest.TestCase):
         )
 
         # scalar * matrix
+        b = pybamm.Scalar(1)
         for expr in [
             ((b * m1) @ v).simplify(),
             (b * (m1 @ v)).simplify(),
@@ -366,7 +364,7 @@ class TestSimplify(unittest.TestCase):
         )
         self.assertEqual(expr2.id, expr2simp.id)
 
-        expr3 = m1 @ ((m2 @ v1) * (m3 @ v2))
+        expr3 = m1 @ ((m2 @ v2) * (m2 @ v2))
         expr3simp = expr3.simplify()
         self.assertEqual(expr3.id, expr3simp.id)
 

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -309,6 +309,14 @@ class TestSymbol(unittest.TestCase):
         concat = pybamm.Concatenation(state, state)
         self.assertEqual(concat.shape, (30, 1))
 
+        var = pybamm.Variable("var", domain="negative electrode")
+        broadcast = pybamm.Broadcast(0, domain="negative electrode")
+        self.assertEqual(var.shape, (17, 1))
+        self.assertEqual(var.shape, broadcast.shape)
+        self.assertEqual((var + broadcast).shape, broadcast.shape)
+        broadcast2 = pybamm.Broadcast(0, domain="separator")
+        self.assertNotEqual(var.shape, broadcast2.shape)
+
         sym = pybamm.Symbol("sym")
         with self.assertRaises(NotImplementedError):
             sym.shape

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -318,7 +318,6 @@ class TestSymbol(unittest.TestCase):
 
         var = pybamm.Variable("var", domain="negative electrode")
         broadcast = pybamm.Broadcast(0, domain="negative electrode")
-        self.assertEqual(var.shape_for_testing, (17, 1))
         self.assertEqual(var.shape_for_testing, broadcast.shape_for_testing)
         self.assertEqual(
             (var + broadcast).shape_for_testing, broadcast.shape_for_testing
@@ -338,11 +337,6 @@ class TestSymbol(unittest.TestCase):
         y2 = pybamm.StateVector(slice(0, 5))
         with self.assertRaises(pybamm.ShapeError):
             (y1 + y2).test_shape()
-
-        var = pybamm.Variable("var", domain="negative electrode")
-        broadcast = pybamm.Broadcast(0, domain="separator")
-        with self.assertRaises(pybamm.ShapeError):
-            (var + broadcast).test_shape()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -290,7 +290,11 @@ class TestSymbol(unittest.TestCase):
     def test_shape(self):
         scal = pybamm.Scalar(1)
         self.assertEqual(scal.shape, ())
+        self.assertEqual(scal.size, 1)
 
+        state = pybamm.StateVector(slice(10))
+        self.assertEqual(state.shape, (10, 1))
+        self.assertEqual(state.size, 10)
         state = pybamm.StateVector(slice(10, 25))
         self.assertEqual(state.shape, (15, 1))
 
@@ -299,6 +303,11 @@ class TestSymbol(unittest.TestCase):
 
         func = pybamm.FunctionParameter("func", state)
         self.assertEqual(func.shape, state.shape)
+
+        concat = pybamm.Concatenation()
+        self.assertEqual(concat.shape, (0,))
+        concat = pybamm.Concatenation(state, state)
+        self.assertEqual(concat.shape, (30, 1))
 
         sym = pybamm.Symbol("sym")
         with self.assertRaises(NotImplementedError):

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -294,9 +294,24 @@ class TestSymbol(unittest.TestCase):
         state = pybamm.StateVector(slice(10, 25))
         self.assertEqual(state.shape, (15, 1))
 
+        param = pybamm.Parameter("a")
+        self.assertEqual(param.shape, ())
+
+        func = pybamm.FunctionParameter("func", state)
+        self.assertEqual(func.shape, state.shape)
+
         sym = pybamm.Symbol("sym")
         with self.assertRaises(NotImplementedError):
             sym.shape
+
+    def test_test_shape(self):
+        # right shape, passes
+        y1 = pybamm.StateVector(slice(0, 10))
+        y1.test_shape()
+        # bad shape, fails
+        y2 = pybamm.StateVector(slice(0, 5))
+        with self.assertRaises(pybamm.ShapeError):
+            (y1 + y2).test_shape()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -236,7 +236,7 @@ class TestBaseModel(unittest.TestCase):
         model = pybamm.BaseModel()
         model.algebraic = {
             c: 1,
-            d: pybamm.StateVector(slice(0, 15)) - pybamm.StateVector(slice(15, 25)),
+            d: pybamm.StateVector(slice(0, 15)) - pybamm.StateVector(slice(15, 30)),
         }
         with self.assertRaisesRegex(
             pybamm.ModelError,

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -93,12 +93,14 @@ class TestParameterValues(unittest.TestCase):
         self.assertEqual(processed_broad.children[0].evaluate(), np.array([1]))
 
         # process concatenation
-        conc = pybamm.Concatenation(a, b)
+        conc = pybamm.Concatenation(
+            pybamm.Vector(np.ones(10)), pybamm.Vector(2 * np.ones(15))
+        )
         processed_conc = parameter_values.process_symbol(conc)
-        self.assertIsInstance(processed_conc.children[0], pybamm.Scalar)
-        self.assertIsInstance(processed_conc.children[1], pybamm.Scalar)
-        self.assertEqual(processed_conc.children[0].value, 1)
-        self.assertEqual(processed_conc.children[1].value, 2)
+        self.assertIsInstance(processed_conc.children[0], pybamm.Vector)
+        self.assertIsInstance(processed_conc.children[1], pybamm.Vector)
+        np.testing.assert_array_equal(processed_conc.children[0].entries, 1)
+        np.testing.assert_array_equal(processed_conc.children[1].entries, 2)
 
         # process variable
         c = pybamm.Variable("c")

--- a/tests/unit/test_spatial_methods/test_spatial_methods.py
+++ b/tests/unit/test_spatial_methods/test_spatial_methods.py
@@ -34,17 +34,6 @@ class TestSpatialMethod(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, "Cannot process 2D symbol"):
             spatial_method.boundary_value_or_flux(symbol, child)
 
-    def test_test_shape(self):
-        mesh = get_mesh_for_testing()
-        spatial_method = pybamm.SpatialMethod(mesh)
-        # right shape, passes
-        y1 = pybamm.StateVector(slice(0, 10))
-        y1.test_shape()
-        # bad shape, fails
-        y2 = pybamm.StateVector(slice(0, 5))
-        with self.assertRaises(pybamm.ShapeError):
-            (y1 + y2).test_shape()
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_spatial_methods/test_spatial_methods.py
+++ b/tests/unit/test_spatial_methods/test_spatial_methods.py
@@ -39,11 +39,11 @@ class TestSpatialMethod(unittest.TestCase):
         spatial_method = pybamm.SpatialMethod(mesh)
         # right shape, passes
         y1 = pybamm.StateVector(slice(0, 10))
-        spatial_method.test_shape(y1)
+        y1.test_shape()
         # bad shape, fails
         y2 = pybamm.StateVector(slice(0, 5))
         with self.assertRaises(pybamm.ShapeError):
-            spatial_method.test_shape(y1 + y2)
+            (y1 + y2).test_shape()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Add a test on node initialisation to check that the node can be evaluated without any shape errors.
Works even for nodes that can't be evaluated directly (creates a vector of the appropriate shape instead).
Will hopefully help with catching errors earlier when creating new models, but isn't flawless (there can still be errors in the discretisation, for example). 
Checking for shape on every node initialisation makes the models pretty slow, so I have added a settings class with a `debug_mode` attribute, which is `False` by default but can be set to `True` from anywhere. Not sure whether this is a good idea ...
Fixes #441

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
