### PR TITLE
Issue 451 process variables

### DIFF
--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -157,8 +157,6 @@ class ProcessedVariable(object):
             space = nodes
         elif entries.shape[0] == len(edges):
             space = edges
-        else:
-            raise ValueError("variable shape does not match domain shape")
 
         # add points outside domain for extrapolation to boundaries
         extrap_space_left = np.array([2 * space[0] - space[1]])
@@ -214,7 +212,7 @@ class ProcessedVariable(object):
         elif entries.shape[1] == len(edges):
             r_sol = edges
         else:
-            raise ValueError("variable shape does not match domain shape")
+            raise ValueError("3D variable shape does not match domain shape")
 
         # Get x values
         if self.domain == ["negative particle"]:

--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -98,7 +98,8 @@ class ProcessedVariable(object):
         ):
             self.initialise_1D()
         else:
-            if len(self.mesh.combine_submeshes(*self.domain)) == 1:
+            n = self.mesh.combine_submeshes(*self.domain)[0].npts
+            if self.base_eval.shape[0] in [n, n + 1]:
                 self.initialise_2D()
             else:
                 self.initialise_3D()
@@ -199,7 +200,7 @@ class ProcessedVariable(object):
                 eval_and_known_evals = self.base_variable.evaluate(
                     t, y, self.known_evals[t]
                 )
-                entries[:, idx] = np.reshape(eval_and_known_evals[0], [len_x, len_r])
+                entries[:, :, idx] = np.reshape(eval_and_known_evals[0], [len_x, len_r])
                 self.known_evals[t] = eval_and_known_evals[1]
             else:
                 entries[:, :, idx] = np.reshape(

--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -3,6 +3,7 @@
 #
 import numbers
 import numpy as np
+import pybamm
 import scipy.interpolate as interp
 
 
@@ -31,10 +32,14 @@ def post_process_variables(variables, t_sol, y_sol, mesh=None, interp_kind="line
         Dictionary of processed variables
     """
     processed_variables = {}
+    known_evals = {t: {} for t in t_sol}
     for var, eqn in variables.items():
+        pybamm.logger.debug("Post-processing {}".format(var))
         processed_variables[var] = ProcessedVariable(
-            eqn, t_sol, y_sol, mesh, interp_kind
+            eqn, t_sol, y_sol, mesh, interp_kind, known_evals
         )
+        for t in known_evals:
+            known_evals[t].update(processed_variables[var].known_evals[t])
     return processed_variables
 
 
@@ -62,15 +67,29 @@ class ProcessedVariable(object):
         The method to use for interpolation
     """
 
-    def __init__(self, base_variable, t_sol, y_sol, mesh=None, interp_kind="linear"):
+    def __init__(
+        self,
+        base_variable,
+        t_sol,
+        y_sol,
+        mesh=None,
+        interp_kind="linear",
+        known_evals=None,
+    ):
         self.base_variable = base_variable
         self.t_sol = t_sol
         self.y_sol = y_sol
         self.mesh = mesh
         self.interp_kind = interp_kind
         self.domain = base_variable.domain
+        self.known_evals = known_evals
 
-        self.base_eval = base_variable.evaluate(t_sol[0], y_sol[:, 0])
+        if self.known_evals:
+            self.base_eval, self.known_evals[t_sol[0]] = base_variable.evaluate(
+                t_sol[0], y_sol[:, 0], self.known_evals[t_sol[0]]
+            )
+        else:
+            self.base_eval = base_variable.evaluate(t_sol[0], y_sol[:, 0])
 
         if (
             isinstance(self.base_eval, numbers.Number)
@@ -92,9 +111,18 @@ class ProcessedVariable(object):
         entries = np.empty(len(self.t_sol))
         # Evaluate the base_variable index-by-index
         for idx in range(len(self.t_sol)):
-            entries[idx] = self.base_variable.evaluate(
-                self.t_sol[idx], self.y_sol[:, idx]
-            )
+            if self.known_evals:
+                entries[idx], self.known_evals[
+                    self.t_sol[idx]
+                ] = self.base_variable.evaluate(
+                    self.t_sol[idx],
+                    self.y_sol[:, idx],
+                    self.known_evals[self.t_sol[idx]],
+                )
+            else:
+                entries[idx] = self.base_variable.evaluate(
+                    self.t_sol[idx], self.y_sol[:, idx]
+                )
 
         # No discretisation provided, or variable has no domain (function of t only)
         self._interpolation_function = interp.interp1d(
@@ -115,9 +143,18 @@ class ProcessedVariable(object):
 
         # Evaluate the base_variable index-by-index
         for idx in range(len(self.t_sol)):
-            entries[:, idx] = self.base_variable.evaluate(
-                self.t_sol[idx], self.y_sol[:, idx]
-            )[:, 0]
+            if self.known_evals:
+                eval_and_known_evals = self.base_variable.evaluate(
+                    self.t_sol[idx],
+                    self.y_sol[:, idx],
+                    self.known_evals[self.t_sol[idx]],
+                )
+                entries[:, idx] = eval_and_known_evals[0][:, 0]
+                self.known_evals[self.t_sol[idx]] = eval_and_known_evals[1]
+            else:
+                entries[:, idx] = self.base_variable.evaluate(
+                    self.t_sol[idx], self.y_sol[:, idx]
+                )[:, 0]
 
         # Process the discretisation to get x values
         nodes = self.mesh.combine_submeshes(*self.domain)[0].nodes

--- a/tests/integration/test_models/standard_output_comparison.py
+++ b/tests/integration/test_models/standard_output_comparison.py
@@ -9,6 +9,14 @@ class StandardOutputComparison(object):
     "Calls all the tests comparing standard output variables."
 
     def __init__(self, models, discs, solvers):
+        # Process variables
+        for model in models:
+            disc = discs[model]
+            solver = solvers[model]
+            model.variables = pybamm.post_process_variables(
+                model.variables, solver.t, solver.y, disc.mesh
+            )
+
         self.models = models
         self.discs = discs
         self.solvers = solvers
@@ -79,22 +87,10 @@ class BaseOutputComparison(object):
         self.mesh = mesh
         self.solvers = solvers
 
-    def get_vars(self, var):
-        "Helper function to reduce repeated code."
-        return [
-            pybamm.ProcessedVariable(
-                model.variables[var],
-                self.solvers[model].t,
-                self.solvers[model].y,
-                mesh=self.mesh,
-            )
-            for model in self.models
-        ]
-
     def compare(self, var, tol=1e-2):
         "Compare variables from different models"
         # Get variable for each model
-        model_variables = self.get_vars(var)
+        model_variables = [model.variables[var] for model in self.models]
         var0 = model_variables[0]
 
         if var0.domain == []:

--- a/tests/integration/test_models/test_lead_acid/test_composite.py
+++ b/tests/integration/test_models/test_lead_acid/test_composite.py
@@ -47,21 +47,7 @@ class TestLeadAcidCompositeCapacitance(unittest.TestCase):
         options = {"capacitance": "algebraic"}
         model = pybamm.lead_acid.Composite(options)
         modeltest = tests.StandardModelTest(model)
-
         modeltest.test_all()
-
-    def test_optimisations(self):
-        options = {"capacitance": "differential"}
-        model = pybamm.lead_acid.Composite(options)
-        optimtest = tests.OptimisationsTest(model)
-
-        original = optimtest.evaluate_model()
-        simplified = optimtest.evaluate_model(simplify=True)
-        using_known_evals = optimtest.evaluate_model(use_known_evals=True)
-        simp_and_known = optimtest.evaluate_model(simplify=True, use_known_evals=True)
-        np.testing.assert_array_almost_equal(original, simplified)
-        np.testing.assert_array_almost_equal(original, using_known_evals)
-        np.testing.assert_array_almost_equal(original, simp_and_known)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_models/test_lithium_ion/test_lithium_ion_dfn.py
+++ b/tests/integration/test_models/test_lithium_ion/test_lithium_ion_dfn.py
@@ -14,7 +14,7 @@ class TestDFN(unittest.TestCase):
     def test_basic_processing(self):
         model = pybamm.lithium_ion.DFN()
         var = pybamm.standard_spatial_vars
-        var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 10, var.r_p: 10}
+        var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 5, var.r_p: 5}
         modeltest = tests.StandardModelTest(model, var_pts=var_pts)
         modeltest.test_all()
 

--- a/tests/unit/test_processed_variable.py
+++ b/tests/unit/test_processed_variable.py
@@ -25,6 +25,7 @@ class TestProcessedVariable(unittest.TestCase):
         x = pybamm.SpatialVariable("x", domain=["negative electrode", "separator"])
         eqn = t * var + x
 
+        # On nodes
         disc = tests.get_discretisation_for_testing()
         disc.set_variable_slices([var])
         x_sol = disc.process_symbol(x).entries[:, 0]
@@ -45,6 +46,13 @@ class TestProcessedVariable(unittest.TestCase):
         np.testing.assert_array_equal(processed_var.entries[0], 2 * y_sol[0] - y_sol[1])
         np.testing.assert_array_equal(
             processed_var.entries[1], 2 * y_sol[-1] - y_sol[-2]
+        )
+
+        # On edges
+        x_s_edge = pybamm.Matrix(disc.mesh["separator"][0].edges, domain="separator")
+        processed_x_s_edge = pybamm.ProcessedVariable(x_s_edge, t_sol, y_sol, disc.mesh)
+        np.testing.assert_array_equal(
+            x_s_edge.entries[:, 0], processed_x_s_edge.entries[1:-1, 0]
         )
 
     def test_processed_variable_3D(self):
@@ -125,6 +133,16 @@ class TestProcessedVariable(unittest.TestCase):
         # 2 scalars
         self.assertEqual(processed_eqn(0.5, x_sol[-1]).shape, (1,))
 
+        # On microscale
+        r_n = pybamm.Matrix(
+            disc.mesh["negative particle"][0].nodes, domain="negative particle"
+        )
+        processed_r_n = pybamm.ProcessedVariable(r_n, t_sol, y_sol, disc.mesh)
+        np.testing.assert_array_equal(r_n.entries[:, 0], processed_r_n.entries[1:-1, 0])
+        np.testing.assert_array_almost_equal(
+            processed_r_n(0, r=np.linspace(0, 1))[:, 0], np.linspace(0, 1)
+        )
+
     def test_processed_var_3D_interpolation(self):
         var = pybamm.Variable("var", domain=["negative particle"])
         x = pybamm.SpatialVariable("x", domain=["negative electrode"])
@@ -158,6 +176,24 @@ class TestProcessedVariable(unittest.TestCase):
         # 3 scalars
         np.testing.assert_array_equal(processed_var(0.2, 0.2, 0.2).shape, ())
 
+        # positive particle
+        var = pybamm.Variable("var", domain=["positive particle"])
+        x = pybamm.SpatialVariable("x", domain=["positive electrode"])
+        r = pybamm.SpatialVariable("r", domain=["positive particle"])
+
+        disc.set_variable_slices([var])
+        x_sol = disc.process_symbol(x).entries[:, 0]
+        r_sol = disc.process_symbol(r).entries[:, 0]
+        var_sol = disc.process_symbol(var)
+        t_sol = np.linspace(0, 1)
+        y_sol = np.ones(len(x_sol) * len(r_sol))[:, np.newaxis] * np.linspace(0, 5)
+
+        processed_var = pybamm.ProcessedVariable(var_sol, t_sol, y_sol, mesh=disc.mesh)
+        # 3 vectors
+        np.testing.assert_array_equal(
+            processed_var(t_sol, x_sol, r_sol).shape, (35, 10, 50)
+        )
+
     def test_processed_variable_ode_pde_solution(self):
         # without space
         model = pybamm.StandardBatteryBaseModel()
@@ -176,9 +212,19 @@ class TestProcessedVariable(unittest.TestCase):
         whole_cell = ["negative electrode", "separator", "positive electrode"]
         model = pybamm.StandardBatteryBaseModel()
         c = pybamm.Variable("conc", domain=whole_cell)
-        model.rhs = {c: -c}
-        model.initial_conditions = {c: 1}
-        model.variables = {"c": c}
+        c_s = pybamm.Variable("particle conc", domain="negative particle")
+        model.rhs = {c: -c, c_s: 1 - c_s}
+        model.initial_conditions = {c: 1, c_s: 0.5}
+        model.boundary_conditions = {
+            c: {"left": (0, "Neumann"), "right": (0, "Neumann")},
+            c_s: {"left": (0, "Neumann"), "right": (0, "Neumann")},
+        }
+        model.variables = {
+            "c": c,
+            "N": pybamm.grad(c),
+            "c_s": c_s,
+            "N_s": pybamm.grad(c_s),
+        }
         modeltest = tests.StandardModelTest(model)
         modeltest.test_all()
         # set up testing
@@ -197,19 +243,11 @@ class TestProcessedVariable(unittest.TestCase):
 
     def test_failure(self):
         t = np.ones(25)
-        y = np.ones((15, 25))
-        mat = pybamm.Vector(np.ones(15), domain=["negative electrode"])
-        disc = tests.get_discretisation_for_testing()
-        with self.assertRaisesRegex(
-            ValueError, "variable shape does not match domain shape"
-        ):
-            pybamm.ProcessedVariable(mat, t, y, disc.mesh)
-
         y = np.ones((120, 25))
         mat = pybamm.Vector(np.ones(120), domain=["negative particle"])
         disc = tests.get_p2d_discretisation_for_testing()
         with self.assertRaisesRegex(
-            ValueError, "variable shape does not match domain shape"
+            ValueError, "3D variable shape does not match domain shape"
         ):
             pybamm.ProcessedVariable(mat, t, y, disc.mesh)
 


### PR DESCRIPTION
# Description

Use `known_evals` to post-process all of the variables more efficiently.
This provides quite a big speed-up, since most of the variables are small variations on each other.
Fixes #451 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
