### PR TITLE
put debug in more informative places

### DIFF
--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -211,6 +211,7 @@ class Discretisation(object):
             processed_bcs[key.id] = {}
             for side, bc in bcs.items():
                 eqn, typ = bc
+                pybamm.logger.debug("Discretise {} ({} bc)".format(key, side))
                 processed_eqn = self.process_symbol(eqn)
                 processed_bcs[key.id][side] = (processed_eqn, typ)
 
@@ -235,8 +236,8 @@ class Discretisation(object):
         """
         # Discretise right-hand sides, passing domain from variable
         processed_rhs = self.process_dict(model.rhs)
-        # Concatenate rhs into a single state vector
 
+        # Concatenate rhs into a single state vector
         # Need to concatenate in order as the ordering of equations could be different
         # in processed_rhs and model.rhs (for Python Version <= 3.5)
         processed_concatenated_rhs = self._concatenate_in_order(processed_rhs)
@@ -342,7 +343,7 @@ class Discretisation(object):
 
             # note we are sending in the key.id here so we don't have to
             # keep calling .id
-            pybamm.logger.debug("**Discretise {!s}".format(eqn_key))
+            pybamm.logger.debug("Discretise {!r}".format(eqn_key))
             new_var_eqn_dict[eqn_key] = self.process_symbol(eqn)
         return new_var_eqn_dict
 

--- a/pybamm/expression_tree/simplify.py
+++ b/pybamm/expression_tree/simplify.py
@@ -553,7 +553,6 @@ class Simplification(object):
         :class:`pybamm.Symbol`
         Simplified symbol
         """
-        pybamm.logger.debug("Simplify {!s}".format(symbol))
         try:
             return self._simplified_symbols[symbol.id]
         except KeyError:

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -90,12 +90,25 @@ class ParameterValues(dict):
             processing_function = self.update_scalars
 
         for variable, equation in model.rhs.items():
+            pybamm.logger.debug(
+                "{} parameters for {!r} (rhs)".format(processing.capitalize(), variable)
+            )
             model.rhs[variable] = processing_function(equation)
 
         for variable, equation in model.algebraic.items():
+            pybamm.logger.debug(
+                "{} parameters for {!r} (algebraic)".format(
+                    processing.capitalize(), variable
+                )
+            )
             model.algebraic[variable] = processing_function(equation)
 
         for variable, equation in model.initial_conditions.items():
+            pybamm.logger.debug(
+                "{} parameters for {!r} (initial conditions)".format(
+                    processing.capitalize(), variable
+                )
+            )
             model.initial_conditions[variable] = processing_function(equation)
 
         # Boundary conditions are dictionaries {"left": left bc, "right": right bc}
@@ -105,14 +118,27 @@ class ParameterValues(dict):
             new_boundary_conditions[processed_variable] = {}
             for side in ["left", "right"]:
                 bc, typ = bcs[side]
+                pybamm.logger.debug(
+                    "{} parameters for {!r} ({} bc)".format(
+                        processing.capitalize(), variable, side
+                    )
+                )
                 processed_bc = (processing_function(bc), typ)
                 new_boundary_conditions[processed_variable][side] = processed_bc
         model.boundary_conditions = new_boundary_conditions
 
         for variable, equation in model.variables.items():
+            pybamm.logger.debug(
+                "{} parameters for {!r} (variables)".format(
+                    processing.capitalize(), variable
+                )
+            )
             model.variables[variable] = processing_function(equation)
 
         for idx, equation in enumerate(model.events):
+            pybamm.logger.debug(
+                "{} parameters for event {}".format(processing.capitalize(), idx)
+            )
             model.events[idx] = processing_function(equation)
 
         pybamm.logger.info("Finish setting parameters for {}".format(model.name))
@@ -153,6 +179,7 @@ class ParameterValues(dict):
             for prim_sec, variables in geometry[domain].items():
                 for spatial_variable, spatial_limits in variables.items():
                     for lim, sym in spatial_limits.items():
+                        pybamm.logger.debug("Set parameters for {!r}".format(sym))
                         sym_eval = self.process_symbol(sym).evaluate()
                         geometry[domain][prim_sec][spatial_variable][lim] = sym_eval
 
@@ -171,7 +198,6 @@ class ParameterValues(dict):
             Symbol with Parameter instances replaced by Value
 
         """
-        pybamm.logger.debug("Set parameters for {!s}".format(symbol))
         try:
             return self._processed_symbols[symbol.id]
         except KeyError:

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -86,6 +86,7 @@ class DaeSolver(pybamm.BaseSolver):
         else:
             jacobian = None
 
+        pybamm.logger.info("Calling DAE solver")
         self.t, self.y = self.integrate(
             residuals,
             y0,
@@ -133,24 +134,29 @@ class DaeSolver(pybamm.BaseSolver):
         if model.use_simplify:
             # set up simplification object, for re-use of dict
             simp = pybamm.Simplification()
+            pybamm.logger.info("Simplifying RHS")
             concatenated_rhs = simp.simplify(concatenated_rhs)
+            pybamm.logger.info("Simplifying algebraic")
             concatenated_algebraic = simp.simplify(concatenated_algebraic)
+            pybamm.logger.info("Simplifying events")
             events = [simp.simplify(event) for event in events]
 
         if model.use_jacobian:
             # Create Jacobian from simplified rhs
             y = pybamm.StateVector(
-                slice(0, np.size(model.concatenated_initial_conditions)))
+                slice(0, np.size(model.concatenated_initial_conditions))
+            )
+            pybamm.logger.info("Calculating jacobian")
             jac_rhs = concatenated_rhs.jac(y)
             jac_algebraic = concatenated_algebraic.jac(y)
-
-            if model.use_simplify:
-                jac_rhs = jac_rhs.simplify()
-                jac_algebraic = jac_algebraic.simplify()
-
             jac = pybamm.SparseStack(jac_rhs, jac_algebraic)
 
+            if model.use_simplify:
+                pybamm.logger.info("Simplifying jacobian")
+                jac = jac.simplify()
+
             if model.use_to_python:
+                pybamm.logger.info("Converting jacobian to python")
                 jac = pybamm.EvaluatorPython(jac)
 
         else:

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -50,12 +50,14 @@ class OdeSolver(pybamm.BaseSolver):
 
         # Create function to evaluate jacobian
         if jac_rhs is not None:
+
             def jacobian(t, y):
                 return jac_rhs.evaluate(t, y, known_evals={})[0]
 
         else:
             jacobian = None
 
+        pybamm.logger.info("Calling ODE solver")
         self.t, self.y = self.integrate(
             dydt,
             y0,
@@ -105,7 +107,9 @@ class OdeSolver(pybamm.BaseSolver):
             # set up simplification object, for re-use of dict
             simp = pybamm.Simplification()
             # create simplified rhs and event expressions
+            pybamm.logger.info("Simplifying RHS")
             concatenated_rhs = simp.simplify(concatenated_rhs)
+            pybamm.logger.info("Simplifying events")
             events = [simp.simplify(event) for event in events]
 
         y0 = model.concatenated_initial_conditions[:, 0]
@@ -113,8 +117,10 @@ class OdeSolver(pybamm.BaseSolver):
         if model.use_jacobian:
             # Create Jacobian from simplified rhs
             y = pybamm.StateVector(slice(0, np.size(y0)))
+            pybamm.logger.info("Calculating jacobian")
             jac_rhs = concatenated_rhs.jac(y)
             if model.use_simplify:
+                pybamm.logger.info("Simplifying jacobian")
                 jac_rhs = simp.simplify(jac_rhs)
 
             if model.use_to_python:

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -65,6 +65,9 @@ class TestBinaryOperators(unittest.TestCase):
         outer = pybamm.Outer(v, w)
         np.testing.assert_array_equal(outer.evaluate(), 2 * np.ones((15, 1)))
         self.assertEqual(outer.domain, w.domain)
+        self.assertEqual(
+            str(outer), "outer(Column vector of length 5, Column vector of length 3)"
+        )
 
         # outer function
         # if there is no domain clash, normal multiplication is retured


### PR DESCRIPTION
# Description

Move the logger.debug statements to be less noisy and more informative

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
