### PR TITLE
fix bug with subtraction of subtractions

### DIFF
--- a/pybamm/expression_tree/simplify.py
+++ b/pybamm/expression_tree/simplify.py
@@ -131,7 +131,10 @@ def simplify_addition_subtraction(myclass, left, right):
         """
         ret = None
         if len(array) > 0:
-            ret = array[0]
+            if types[0] in [None, pybamm.Addition]:
+                ret = array[0]
+            elif types[0] == pybamm.Subtraction:
+                ret = -array[0]
             for child, typ in zip(array[1:], types[1:]):
                 if typ == pybamm.Addition:
                     ret += child
@@ -155,11 +158,18 @@ def simplify_addition_subtraction(myclass, left, right):
         for j, (term_j, typ_j) in enumerate(
             zip(numerator[i + 1 :], numerator_types[i + 1 :])
         ):
+            if isinstance(term_j, pybamm.Multiplication) and isinstance(
+                term_j.left, pybamm.Scalar
+            ):
+                factor = term_j.left.evaluate()
+                term_j = term_j.right
+            else:
+                factor = 1
             if term_i.id == term_j.id:
                 if typ_j == pybamm.Addition:
-                    term_i_count += 1
+                    term_i_count += factor
                 elif typ_j == pybamm.Subtraction:
-                    term_i_count -= 1
+                    term_i_count -= factor
                 del numerator[j + i + 1]
                 del numerator_types[j + i + 1]
 
@@ -188,15 +198,7 @@ def simplify_addition_subtraction(myclass, left, right):
     else:
         # or mix of both
         constant_expr = pybamm.simplify_if_constant(constant_expr)
-        if constant_types[0] is None and nonconstant_types[0] == pybamm.Addition:
-            new_expression = constant_expr + nonconstant_expr
-        elif constant_types[0] is None and nonconstant_types[0] == pybamm.Subtraction:
-            new_expression = constant_expr - nonconstant_expr
-        elif nonconstant_types[0] is None and constant_types[0] == pybamm.Addition:
-            new_expression = nonconstant_expr + constant_expr
-        else:
-            assert constant_types[0] == pybamm.Subtraction
-            new_expression = nonconstant_expr - constant_expr
+        new_expression = constant_expr + nonconstant_expr
 
     return new_expression
 

--- a/tests/unit/test_expression_tree/test_simplify.py
+++ b/tests/unit/test_expression_tree/test_simplify.py
@@ -16,8 +16,10 @@ class TestSimplify(unittest.TestCase):
     def test_symbol_simplify(self):
         a = pybamm.Scalar(0)
         b = pybamm.Scalar(1)
+        c = pybamm.Parameter("c")
         d = pybamm.Scalar(-1)
         e = pybamm.Scalar(2)
+        g = pybamm.Variable("g")
 
         # negate
         self.assertIsInstance((-a).simplify(), pybamm.Scalar)
@@ -103,7 +105,6 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual((a * a).simplify().evaluate(), 0)
 
         # test when other node is a parameter
-        c = pybamm.Parameter("c")
         self.assertIsInstance((a + c).simplify(), pybamm.Parameter)
         self.assertIsInstance((c + a).simplify(), pybamm.Parameter)
         self.assertIsInstance((c + b).simplify(), pybamm.Addition)
@@ -158,6 +159,14 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(expr.children[0].evaluate(), 4.0)
         self.assertIsInstance(expr.children[1], pybamm.Negate)
         self.assertIsInstance(expr.children[1].children[0], pybamm.Parameter)
+
+        expr = (e + (g - c)).simplify()
+        self.assertIsInstance(expr, pybamm.Addition)
+        self.assertIsInstance(expr.children[0], pybamm.Scalar)
+        self.assertEqual(expr.children[0].evaluate(), 2.0)
+        self.assertIsInstance(expr.children[1], pybamm.Subtraction)
+        self.assertIsInstance(expr.children[1].children[0], pybamm.Variable)
+        self.assertIsInstance(expr.children[1].children[1], pybamm.Parameter)
 
         expr = ((2 + c) + (c + 2)).simplify()
         self.assertIsInstance(expr, pybamm.Addition)


### PR DESCRIPTION
# Description

Fix a bug in `simplify-add-subtract` that was causing `1 - (b+c)` to get simplified to `1 - (b-c)`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
