### PR TITLE
#475 add scikit-fem mesh and spatial method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ matrix:
             - PYBAMM_UNIT=true
             - PYBAMM_EXAMPLES=true
             - PYBAMM_SCIKITS_ODES=true
+            - PYBAMM_SCIKIT_FEM=true
         - python: "3.6"
           addons:
             apt:
@@ -78,6 +79,7 @@ matrix:
           env:
             - PYBAMM_UNIT=true
             - PYBAMM_SCIKITS_ODES=true
+            - PYBAMM_SCIKIT_FEM=true
         - python: "3.6"
           addons:
             apt:
@@ -109,6 +111,7 @@ matrix:
             - PYBAMM_UNIT=true
             - PYBAMM_EXAMPLES=true
             - PYBAMM_SCIKITS_ODES=true
+            - PYBAMM_SCIKIT_FEM=true
           if: type != cron
         # Unit testing on OS/X
         - os: osx
@@ -163,6 +166,7 @@ matrix:
           env:
             - PYBAMM_COVER=true
             - PYBAMM_SCIKITS_ODES=true
+            - PYBAMM_SCIKIT_FEM=true
           if: type != cron
           # Cron jobs
         - python: "3.6"
@@ -180,12 +184,13 @@ matrix:
           env:
             - PYBAMM_EXAMPLES=true
             - PYBAMM_SCIKITS_ODES=true
+            - PYBAMM_SCIKIT_FEM=true
           if: type == cron
 
-# Install graphviz for macs 
+# Install graphviz for macs
 before_install: |
   # below is reproduced from https://pythonhosted.org/CodeChat/.travis.yml.html
-  if [[ $TRAVIS_OS_NAME == "osx" ]]; then 
+  if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     brew update;
     # Per the `pyenv homebrew recommendations <https://github.com/yyuu/pyenv/wiki#suggested-build-environment>`_.
     brew install graphviz openssl readline;
@@ -217,6 +222,7 @@ install:
   - if [[ $PYBAMM_STYLE == true || $PYBAMM_EXAMPLES ]]; then pip install -e .[dev]; fi;
   - if [[ $PYBAMM_COVER == true ]]; then pip install coverage codecov; fi;
   - if [[ $PYBAMM_SCIKITS_ODES == true ]]; then source scripts/install_scikits_odes.sh; fi;
+  - if [[ $PYBAMM_SCIKIT_FEM == true ]]; then pip install scikit-fem; fi;
 
 before_script:
 - python --version

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ generate meshes and assemble discrete operators for use in the finite element me
 the finite element method is only implemented for a small number of submodels in PyBaMM
 (for example, see the [current collector submodel](https://github.com/pybamm-team/PyBaMM/blob/master/pybamm/models/submodels/current_collector.py)).
 
-To install scikit-fem, on the command-line type:
+Note that scikit-fem requires Python 3.6+. To install scikit-fem, on the command-line type:
 
 ```bash
 pip install scikit-fem

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You'll need the following requirements:
 
 The first step is to get the code by cloning this repository
 
-```bash 
+```bash
 git clone https://github.com/pybamm-team/PyBaMM.git
 cd PyBaMM
 ```
@@ -40,21 +40,21 @@ python3 -m venv env
 
 You can then "activate" the environment using:
 
-```bash 
-source env/bin/activate 
+```bash
+source env/bin/activate
 ```
 
 Now all the calls to pip described below will install PyBaMM and its dependencies into
 the environment `env`. When you are ready to exit the environment and go back to your
 original system, just type:
 
-```bash 
-deactivate 
+```bash
+deactivate
 ```
 
 PyBaMM has the following python libraries as dependencies: `numpy`, `scipy`, `pandas`,
 `matplotlib`. These, along with PyBaMM, can easily be installed using `pip`. First, make
-sure you have activated your virtual environment as above, and that you have the latest 
+sure you have activated your virtual environment as above, and that you have the latest
 version of pip installed:
 
 ```bash
@@ -92,8 +92,8 @@ wrapped SUNDIALS ODE and DAE
 Before installing odes, you need to have installed:
 
 - Python header files (`python-dev/python3-dev` on Debian/Ubuntu-based distributions)
-- C compiler 
-- Fortran compiler (e.g. gfortran) 
+- C compiler
+- Fortran compiler (e.g. gfortran)
 - BLAS/LAPACK install (OpenBLAS is recommended by the scikits.odes developers)
 - Sundials 3.1.1
 
@@ -135,6 +135,20 @@ Please see the [scikits.odes
 documentation](https://scikits-odes.readthedocs.io/en/latest/installation.html) for more
 detailed installation instructions.
 
+### [scikit.fem](https://github.com/kinnala/scikit-fem)
+
+Users can install [scikit.fem](https://github.com/kinnala/scikit-fem) in order to
+generate meshes and assemble discrete operators for use in the finite element method. At present,
+the finite element method is only implemented for a small number of submodels in PyBaMM
+(for example, see the [current collector submodel](https://github.com/pybamm-team/PyBaMM/blob/master/pybamm/models/submodels/current_collector.py)).
+
+To install scikit-fem, on the command-line type:
+
+```bash
+pip install scikit-fem
+```
+
+Please see the [scikit.fem documentation](https://kinnala.github.io/scikit-fem-docs/learning.html) for more information.
 
 ## How can I contribute to PyBaMM?
 

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -196,12 +196,14 @@ from .geometry import standard_spatial_vars
 from .discretisations.discretisation import Discretisation
 from .meshes.meshes import Mesh
 from .meshes.submeshes import SubMesh1D, Uniform1DSubMesh
+from .meshes.scikit_fem_submeshes import Scikit2DSubMesh
 
 #
 # Spatial Methods
 #
 from .spatial_methods.spatial_method import SpatialMethod
 from .spatial_methods.finite_volume import FiniteVolume
+from .spatial_methods.scikit_finite_element import ScikitFiniteElement
 
 #
 # Solver classes

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -196,7 +196,7 @@ from .geometry import standard_spatial_vars
 from .discretisations.discretisation import Discretisation
 from .meshes.meshes import Mesh
 from .meshes.submeshes import SubMesh1D, Uniform1DSubMesh
-from .meshes.scikit_fem_submeshes import Scikit2DSubMesh
+from .meshes.scikit_fem_submeshes import Scikit2DSubMesh, have_scikit_fem
 
 #
 # Spatial Methods

--- a/pybamm/geometry/geometry.py
+++ b/pybamm/geometry/geometry.py
@@ -287,29 +287,26 @@ class Geometryxp0p1DMicro(Geometry1DMicro):
 
         var = pybamm.standard_spatial_vars
 
+        # Add secondary domains to x-domains
         if cc_dimension == 1:
             for domain in self.keys():
-                self[domain] = {
-                    "secondary": {
-                        var.z: {
-                            "min": pybamm.Scalar(0),
-                            "max": pybamm.geometric_parameters.l_z,
-                        }
+                self[domain]["secondary"] = {
+                    var.z: {
+                        "min": pybamm.Scalar(0),
+                        "max": pybamm.geometric_parameters.l_z,
                     }
                 }
         elif cc_dimension == 2:
             for domain in self.keys():
-                self[domain] = {
-                    "secondary": {
-                        var.y: {
-                            "min": pybamm.Scalar(0),
-                            "max": pybamm.geometric_parameters.l_y,
-                        },
-                        var.z: {
-                            "min": pybamm.Scalar(0),
-                            "max": pybamm.geometric_parameters.l_z,
-                        },
-                    }
+                self[domain]["secondary"] = {
+                    var.y: {
+                        "min": pybamm.Scalar(0),
+                        "max": pybamm.geometric_parameters.l_y,
+                    },
+                    var.z: {
+                        "min": pybamm.Scalar(0),
+                        "max": pybamm.geometric_parameters.l_z,
+                    },
                 }
         else:
             raise pybamm.GeometryError(
@@ -346,51 +343,44 @@ class Geometryxp1p1DMicro(Geometry1DMicro):
         l_n = pybamm.geometric_parameters.l_n
         l_s = pybamm.geometric_parameters.l_s
 
+        # Add secondary domains to x-domains
         if cc_dimension == 1:
-            self["negative particle"] = {
-                "secondary": {
-                    var.x_n: {"min": pybamm.Scalar(0), "max": l_n},
-                    var.z: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_z,
-                    },
-                }
+            self["negative particle"]["secondary"] = {
+                var.x_n: {"min": pybamm.Scalar(0), "max": l_n},
+                var.z: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_z,
+                },
             }
-            self["positive particle"] = {
-                "secondary": {
-                    var.x_p: {"min": l_n + l_s, "max": pybamm.Scalar(1)},
-                    var.z: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_z,
-                    },
-                }
+            self["negative particle"]["secondary"] = {
+                var.x_p: {"min": l_n + l_s, "max": pybamm.Scalar(1)},
+                var.z: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_z,
+                },
             }
         elif cc_dimension == 2:
-            self["negative particle"] = {
-                "secondary": {
-                    var.x_n: {"min": pybamm.Scalar(0), "max": l_n},
-                    var.y: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_y,
-                    },
-                    var.z: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_z,
-                    },
-                }
+            self["negative particle"]["secondary"] = {
+                var.x_n: {"min": pybamm.Scalar(0), "max": l_n},
+                var.y: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_y,
+                },
+                var.z: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_z,
+                },
             }
-            self["positive particle"] = {
-                "secondary": {
-                    var.x_p: {"min": l_n + l_s, "max": pybamm.Scalar(1)},
-                    var.y: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_y,
-                    },
-                    var.z: {
-                        "min": pybamm.Scalar(0),
-                        "max": pybamm.geometric_parameters.l_z,
-                    },
-                }
+            self["negative particle"]["secondary"] = {
+                var.x_p: {"min": l_n + l_s, "max": pybamm.Scalar(1)},
+                var.y: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_y,
+                },
+                var.z: {
+                    "min": pybamm.Scalar(0),
+                    "max": pybamm.geometric_parameters.l_z,
+                },
             }
         else:
             raise pybamm.GeometryError(

--- a/pybamm/meshes/scikit_fem_submeshes.py
+++ b/pybamm/meshes/scikit_fem_submeshes.py
@@ -1,0 +1,139 @@
+#
+# scikit-fem meshes for use in PyBaMM
+#
+import pybamm
+
+import numpy as np
+import importlib
+
+skfem_spec = importlib.util.find_spec("skfem")
+if skfem_spec is not None:
+    skfem = importlib.util.module_from_spec(skfem_spec)
+    skfem_spec.loader.exec_module(skfem)
+
+
+class Scikit2DSubMesh:
+    """ Submesh class.
+        Contains information about the 2D finite element mesh.
+        Note: This class only allows for the use of piecewise-linear triangular
+        finite elements.
+
+        Parameters
+        ----------
+        lims : dict
+            A dictionary that contains the limits of each
+            spatial variable
+        npts : dict
+            A dictionary that contains the number of points to be used on each
+            spatial variable
+        tabs : dict
+            A dictionary that contains information about the size and location of
+            the tabs
+        """
+
+    def __init__(self, lims, npts, tabs):
+        if skfem_spec is None:
+            raise ImportError("scikit-fem is not installed")
+
+        # check that two variables have been passed in
+        if len(lims) != 2:
+            raise pybamm.GeometryError(
+                "lims should contain exactly two variables, not {}".format(len(lims))
+            )
+
+        # get spatial variables
+        spatial_vars = list(lims.keys())
+
+        # check coordinate system agrees
+        if spatial_vars[0].coord_sys == spatial_vars[1].coord_sys:
+            self.coord_sys = spatial_vars[0].coord_sys
+        else:
+            raise pybamm.DomainError(
+                """spatial variables should have the same domain,
+                but have domians {} and {}""".format(
+                    spatial_vars[0].coord_sys, spatial_vars[1].coord_sys
+                )
+            )
+
+        # set limits and number of points
+        self.npts = 1
+        self.edges = {}
+        self.nodes = {}
+        for var in spatial_vars:
+            if var.name not in ["y", "z"]:
+                raise pybamm.DomainError(
+                    "spatial variable must be y or z not {}".format(var.name)
+                )
+            else:
+                self.npts *= npts[var.id]
+                self.edges[var.name] = np.linspace(
+                    lims[var]["min"], lims[var]["max"], npts[var.id]
+                )
+                self.nodes[var.name] = (
+                    self.edges[var.name][1:] + self.edges[var.name][:-1]
+                ) / 2
+
+        # create mesh
+        self.fem_mesh = skfem.MeshTri.init_tensor(self.edges["y"], self.edges["z"])
+
+        # get coordinates (returns a vector size 2*(Ny*Nz))
+        self.coordinates = self.fem_mesh.p
+
+        # create elements and basis
+        self.element = skfem.ElementTriP1()
+        self.basis = skfem.InteriorBasis(self.fem_mesh, self.element)
+        self.facet_basis = skfem.FacetBasis(self.fem_mesh, self.element)
+
+        # get degrees of freedom which correspond to tabs
+        self.negative_tab = self.basis.get_dofs(
+            lambda y, z: self.on_boundary(y, z, tabs["negative"])
+        ).all()
+        self.positive_tab = self.basis.get_dofs(
+            lambda y, z: self.on_boundary(y, z, tabs["positive"])
+        ).all()
+
+    def on_boundary(self, y, z, tab):
+        """
+        A method to get the degrees of freedom corresponding to the subdomains
+        for the tabs.
+        """
+
+        l_y = self.edges["y"][-1]
+        l_z = self.edges["z"][-1]
+
+        def near(x, point, tol=1e-6):
+            return abs(x - point) < tol
+
+        def between(x, interval, tol=1e-6):
+            return x > interval[0] - tol and x < interval[1] + tol
+
+        # Tab on top
+        if near(tab["z_centre"], l_z):
+            tab_left = tab["y_centre"] - tab["width"] / 2
+            tab_right = tab["y_centre"] + tab["width"] / 2
+            return [
+                near(Z, l_z) and between(Y, [tab_left, tab_right]) for Y, Z in zip(y, z)
+            ]
+        # Tab on bottom
+        elif near(tab["z_centre"], 0):
+            tab_left = tab["y_centre"] - tab["width"] / 2
+            tab_right = tab["y_centre"] + tab["width"] / 2
+            return [
+                near(Z, 0) and between(Y, [tab_left, tab_right]) for Y, Z in zip(y, z)
+            ]
+        # Tab on left
+        elif near(tab["y_centre"], 0):
+            tab_bottom = tab["z_centre"] - tab["width"] / 2
+            tab_top = tab["z_centre"] + tab["width"] / 2
+            return [
+                near(Y, 0) and between(Z, [tab_bottom, tab_top]) for Y, Z in zip(y, z)
+            ]
+        # Tab on right
+        elif near(tab["y_centre"], l_y):
+            tab_bottom = tab["z_centre"] - tab["width"] / 2
+            tab_top = tab["z_centre"] + tab["width"] / 2
+            return [
+                near(Y, l_y) and between(Z, [tab_bottom, tab_top]) for Y, Z in zip(y, z)
+            ]
+        else:
+            raise pybamm.GeometryError("tab location not valid")

--- a/pybamm/meshes/scikit_fem_submeshes.py
+++ b/pybamm/meshes/scikit_fem_submeshes.py
@@ -49,8 +49,8 @@ class Scikit2DSubMesh:
             self.coord_sys = spatial_vars[0].coord_sys
         else:
             raise pybamm.DomainError(
-                """spatial variables should have the same domain,
-                but have domians {} and {}""".format(
+                """spatial variables should have the same coordinate system,
+                but have coordinate systems {} and {}""".format(
                     spatial_vars[0].coord_sys, spatial_vars[1].coord_sys
                 )
             )

--- a/pybamm/meshes/scikit_fem_submeshes.py
+++ b/pybamm/meshes/scikit_fem_submeshes.py
@@ -12,6 +12,10 @@ if skfem_spec is not None:
     skfem_spec.loader.exec_module(skfem)
 
 
+def have_scikit_fem():
+    return skfem_spec is None
+
+
 class Scikit2DSubMesh:
     """ Submesh class.
         Contains information about the 2D finite element mesh.

--- a/pybamm/models/lithium_ion/spm.py
+++ b/pybamm/models/lithium_ion/spm.py
@@ -139,7 +139,7 @@ class SPM(pybamm.LithiumIonBaseModel):
         if dimensionality in [0, 1]:
             return base_submeshes
         elif dimensionality == 2:
-            base_submeshes["current collector"] = pybamm.FenicsMesh2D
+            base_submeshes["current collector"] = pybamm.Scikit2DSubMesh
             return base_submeshes
 
     @property
@@ -154,7 +154,7 @@ class SPM(pybamm.LithiumIonBaseModel):
         if dimensionality in [0, 1]:
             return base_spatial_methods
         elif dimensionality == 2:
-            base_spatial_methods["current collector"] = pybamm.FiniteElementFenics
+            base_spatial_methods["current collector"] = pybamm.ScikitFiniteElement
             return base_spatial_methods
 
     @property

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -1,0 +1,320 @@
+#
+# Finite Element discretisation class which uses fenics
+#
+import pybamm
+
+from scipy.sparse import csr_matrix
+import autograd.numpy as np
+
+import importlib
+
+skfem_spec = importlib.util.find_spec("skfem")
+if skfem_spec is not None:
+    skfem = importlib.util.module_from_spec(skfem_spec)
+    skfem_spec.loader.exec_module(skfem)
+
+
+class ScikitFiniteElement(pybamm.SpatialMethod):
+    """
+    A class which implements the steps specific to the finite element method during
+    discretisation. The class uses scikit-fem to discretise the problem to obtain
+    the mass and stifnness matrices. At present, this class is only used for
+    solving the Poisson problem -grad^2 u = f in the y-z plane (i.e. not the
+    through-cell direction).
+
+    For broadcast we follow the default behaviour from SpatialMethod.
+
+    Parameters
+    ----------
+    mesh : :class:`pybamm.Mesh`
+        Contains all the submeshes for discretisation
+
+    **Extends:"": :class:`pybamm.SpatialMethod`
+    """
+
+    def __init__(self, mesh):
+        if skfem_spec is None:
+            raise ImportError("scikit-fem is not installed")
+
+        super().__init__(mesh)
+        # add npts_for_broadcast to mesh domains for this particular discretisation
+        for dom in mesh.keys():
+            for i in range(len(mesh[dom])):
+                mesh[dom][i].npts_for_broadcast = mesh[dom][i].npts
+
+    def spatial_variable(self, symbol):
+        """
+        Creates a discretised spatial variable compatible with
+        the FiniteElement method.
+
+        Parameters
+        -----------
+        symbol : :class:`pybamm.SpatialVariable`
+            The spatial variable to be discretised.
+
+        Returns
+        -------
+        :class:`pybamm.Vector`
+            Contains the discretised spatial variable
+        """
+        # only implemented in y-z plane
+        if symbol.name in ["y", "z"]:
+            symbol_mesh = self.mesh
+            return pybamm.Vector(symbol_mesh[0].npts, domain=symbol.domain)
+        else:
+            raise NotImplementedError(
+                "FiniteElementFenics only implemented in the y-z plane"
+            )
+
+    def gradient(self, symbol, discretised_symbol, boundary_conditions):
+        """Matrix-vector multiplication to implement the gradient operator.
+        See :meth:`pybamm.SpatialMethod.gradient`
+        """
+        raise NotImplementedError
+
+    def divergence(self, symbol, discretised_symbol, boundary_conditions):
+        """Matrix-vector multiplication to implement the divergence operator.
+        See :meth:`pybamm.SpatialMethod.divergence`
+        """
+        raise NotImplementedError
+
+    def laplacian(self, symbol, discretised_symbol, boundary_conditions):
+        """Matrix-vector multiplication to implement the laplacian operator.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Symbol`
+            The symbol that we will take the laplacian of.
+        discretised_symbol: :class:`pybamm.Symbol`
+            The discretised symbol of the correct size
+        boundary_conditions : dict
+            The boundary conditions of the model
+            ({symbol.id: {"left": left bc, "right": right bc}})
+
+        Returns
+        -------
+        :class: `pybamm.Array`
+            Contains the result of acting the discretised gradient on
+            the child discretised_symbol
+        """
+        domain = symbol.domain[0]
+        mesh = self.mesh[domain][0]
+
+        stiffness_matrix = self.stiffness_matrix(symbol, boundary_conditions)
+
+        # get boundary conditions and type, here lbc: negative tab, rbc: positive tab
+        lbc_value, lbc_type = boundary_conditions[symbol.id]["left"]
+        rbc_value, rbc_type = boundary_conditions[symbol.id]["right"]
+        boundary_load = pybamm.Vector(np.zeros(mesh.npts))
+
+        # assemble boundary load if Neumann boundary conditions
+        if "Neumann" in [lbc_type, rbc_type]:
+            # make form for unit load at the boundary
+            @skfem.linear_form
+            def unit_bc_load_form(v, dv, w):
+                return v
+            # assemble form
+            unit_load = skfem.asm(unit_bc_load_form, mesh.facet_basis)
+
+        if lbc_type == "Neumann":
+            # value multiplied by weights
+            lbc_load = np.zeros(mesh.npts)
+            lbc_load[mesh.negative_tab] = unit_load[mesh.negative_tab]
+            boundary_load = boundary_load + lbc_value * pybamm.Vector(lbc_load)
+        elif lbc_type == "Dirichlet":
+            lbc_load = np.zeros(mesh.npts)
+            lbc_load[mesh.negative_tab] = 1
+            boundary_load = boundary_load + lbc_value * pybamm.Vector(lbc_load)
+        else:
+            raise ValueError(
+                "boundary condition must be Dirichlet or Neumann, not '{}'".format(
+                    lbc_type
+                )
+            )
+
+        if rbc_type == "Neumann":
+            # value multiplied by weights
+            rbc_load = np.zeros(mesh.npts)
+            rbc_load[mesh.positive_tab] = unit_load[mesh.positive_tab]
+            boundary_load = boundary_load + rbc_value * pybamm.Vector(rbc_load)
+        elif rbc_type == "Dirichlet":
+            rbc_load = np.zeros(mesh.npts)
+            rbc_load[mesh.positive_tab] = 1
+            boundary_load = boundary_load + rbc_value * pybamm.Vector(rbc_load)
+        else:
+            raise ValueError(
+                "boundary condition must be Dirichlet or Neumann, not '{}'".format(
+                    rbc_type
+                )
+            )
+
+        return -stiffness_matrix @ discretised_symbol + boundary_load
+
+    def stiffness_matrix(self, symbol, boundary_conditions):
+        """
+        Laplacian (stiffness) matrix for finite elements in the appropriate domain.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Symbol`
+            The symbol for which we want to calculate the laplacian matrix
+        boundary_conditions : dict
+            The boundary conditions of the model
+            ({symbol.id: {"left": left bc, "right": right bc}})
+
+        Returns
+        -------
+        :class:`pybamm.Matrix`
+            The (sparse) finite element stiffness matrix for the domain
+        """
+        # get primary domain mesh
+        domain = symbol.domain[0]
+        mesh = self.mesh[domain][0]
+
+        # make form for the stiffness
+        @skfem.bilinear_form
+        def stiffness_form(u, du, v, dv, w):
+            return sum(du * dv)
+
+        # assemble the stifnness matrix
+        stiffness = skfem.asm(stiffness_form, mesh.basis)
+
+        # get boundary conditions and type, here lbc: negative tab, rbc: positive tab
+        _, lbc_type = boundary_conditions[symbol.id]["left"]
+        _, rbc_type = boundary_conditions[symbol.id]["right"]
+
+        # adjust matrix for Dirichlet boundary conditions
+        if lbc_type == "Dirichlet":
+            self.bc_apply(stiffness, mesh.negative_tab)
+        if rbc_type == "Dirichlet":
+            self.bc_apply(stiffness, mesh.positive_tab)
+
+        return pybamm.Matrix(stiffness)
+
+    def integral(self, domain, symbol, discretised_symbol):
+        """Vector-vector dot product to implement the integral operator.
+        See :meth:`pybamm.BaseDiscretisation.integral`
+        """
+
+        # Calculate integration vector
+        integration_vector = self.definite_integral_vector(domain[0])
+
+        out = integration_vector @ discretised_symbol
+        out.domain = []
+        return out
+
+    def definite_integral_vector(self, domain):
+        """
+        Vector for finite-element implementation of the definite integral over
+        the entire domain
+
+        .. math::
+            I = \\int_{\Omega}\\!f(s)\\,dx
+
+        for where :math:`\Omega` is the domain.
+
+        Parameters
+        ----------
+        domain : list
+            The domain(s) of integration
+
+        Returns
+        -------
+        :class:`pybamm.Vector`
+            The finite volume integral vector for the domain
+        """
+        # get primary domain mesh
+        mesh = self.mesh[domain][0]
+
+        # make form for the integral
+        @skfem.linear_form
+        def integral_form(v, dv, w):
+            return v
+
+        # assemble
+        vector = skfem.asm(integral_form, mesh.basis)
+        return pybamm.Matrix(vector[np.newaxis, :])
+
+    def indefinite_integral(self, domain, symbol, discretised_symbol):
+        """Implementation of the indefinite integral operator. The
+        input discretised symbol must be defined on the internal mesh edges.
+        See :meth:`pybamm.BaseDiscretisation.indefinite_integral`
+        """
+        raise NotImplementedError
+
+    def boundary_value_or_flux(self, symbol, discretised_child):
+        """
+        Uses linear extrapolation to get the boundary value or flux of a variable in the
+        Finite Element Method.
+
+        See :meth:`pybamm.SpatialMethod.boundary_value`
+        """
+        raise NotImplementedError
+
+    def mass_matrix(self, symbol, boundary_conditions):
+        """
+        Calculates the mass matrix for the finite element method.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Variable`
+            The variable corresponding to the equation for which we are
+            calculating the mass matrix.
+        boundary_conditions : dict
+            The boundary conditions of the model
+            ({symbol.id: {"left": left bc, "right": right bc}})
+
+        Returns
+        -------
+        :class:`pybamm.Matrix`
+            The (sparse) mass matrix for the spatial method.
+        """
+        # get primary domain mesh
+        domain = symbol.domain[0]
+        mesh = self.mesh[domain][0]
+
+        # create form for mass
+        @skfem.bilinear_form
+        def mass_form(u, du, v, dv, w):
+            return u * v
+
+        # assemble mass matrix
+        mass = skfem.asm(mass_form, mesh.basis)
+
+        # get boundary conditions and type, here lbc: negative tab, rbc: positive tab
+        _, lbc_type = boundary_conditions[symbol.id]["left"]
+        _, rbc_type = boundary_conditions[symbol.id]["right"]
+
+        if lbc_type == "Dirichlet":
+            # set source terms to zero on boundary by zeroing out mass matrix
+            self.bc_apply(mass, mesh.negative_tab)
+        if rbc_type == "Dirichlet":
+            # set source terms to zero on boundary by zeroing out mass matrix
+            self.bc_apply(mass, mesh.positive_tab)
+
+        return pybamm.Matrix(mass)
+
+    def bc_apply(self, M, boundary, zero=False):
+        """
+        Adjusts the assemled finite element matrices to account for bpundary conditons.
+
+        Parameters
+        ----------
+        M: :class:`scipy.sparse.coo_matrix`
+            The assemled finite element matrix to adjust.
+        boundary: :class:`numpy.array`
+            Array of the indicies which correspond to the boundary.
+        zero: bool, optional
+            If True, the rows of M given by the indicies in boundary are set to zero.
+            If False, the diagonal element is set to one. Defualt is False.
+        """
+
+        row = np.arange(0, np.size(boundary))
+        if zero:
+            data = np.zeros_like(boundary)
+        else:
+            data = np.ones_like(boundary)
+        bc_matrix = csr_matrix(
+            (data, (row, boundary)), shape=(np.size(boundary), np.shape(M)[1])
+        )
+        M[boundary] = bc_matrix

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -1,17 +1,13 @@
 #
-# Finite Element discretisation class which uses fenics
+# Finite Element discretisation class which uses scikit-fem
 #
 import pybamm
 
 from scipy.sparse import csr_matrix
 import autograd.numpy as np
 
-import importlib
-
-skfem_spec = importlib.util.find_spec("skfem")
-if skfem_spec is not None:
-    skfem = importlib.util.module_from_spec(skfem_spec)
-    skfem_spec.loader.exec_module(skfem)
+if not pybamm.have_scikit_fem():
+    import skfem
 
 
 class ScikitFiniteElement(pybamm.SpatialMethod):
@@ -33,7 +29,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
     """
 
     def __init__(self, mesh):
-        if skfem_spec is None:
+        if pybamm.have_scikit_fem() is None:
             raise ImportError("scikit-fem is not installed")
 
         super().__init__(mesh)
@@ -187,7 +183,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
 
     def integral(self, domain, symbol, discretised_symbol):
         """Vector-vector dot product to implement the integral operator.
-        See :meth:`pybamm.BaseDiscretisation.integral`
+        See :meth:`pybamm.SpatialMethod.integral`
         """
 
         # Calculate integration vector
@@ -232,7 +228,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
     def indefinite_integral(self, domain, symbol, discretised_symbol):
         """Implementation of the indefinite integral operator. The
         input discretised symbol must be defined on the internal mesh edges.
-        See :meth:`pybamm.BaseDiscretisation.indefinite_integral`
+        See :meth:`pybamm.SpatialMethod.indefinite_integral`
         """
         raise NotImplementedError
 

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -57,14 +57,8 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Vector`
             Contains the discretised spatial variable
         """
-        # only implemented in y-z plane
-        if symbol.name in ["y", "z"]:
-            symbol_mesh = self.mesh
-            return pybamm.Vector(symbol_mesh[0].npts, domain=symbol.domain)
-        else:
-            raise NotImplementedError(
-                "FiniteElementFenics only implemented in the y-z plane"
-            )
+        symbol_mesh = self.mesh
+        return pybamm.Vector(symbol_mesh[0].npts, domain=symbol.domain)
 
     def gradient(self, symbol, discretised_symbol, boundary_conditions):
         """Matrix-vector multiplication to implement the gradient operator.
@@ -287,10 +281,10 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
 
         if lbc_type == "Dirichlet":
             # set source terms to zero on boundary by zeroing out mass matrix
-            self.bc_apply(mass, mesh.negative_tab)
+            self.bc_apply(mass, mesh.negative_tab, zero=True)
         if rbc_type == "Dirichlet":
             # set source terms to zero on boundary by zeroing out mass matrix
-            self.bc_apply(mass, mesh.positive_tab)
+            self.bc_apply(mass, mesh.positive_tab, zero=True)
 
         return pybamm.Matrix(mass)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,10 @@ from .shared import (
     get_mesh_for_testing,
     get_p2d_mesh_for_testing,
     get_1p1d_mesh_for_testing,
+    get_2p1d_mesh_for_testing,
     get_discretisation_for_testing,
     get_p2d_discretisation_for_testing,
     get_1p1d_discretisation_for_testing,
+    get_2p1d_discretisation_for_testing,
+    get_unit_2p1D_mesh_for_testing,
 )

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -95,6 +95,48 @@ def get_1p1d_mesh_for_testing(xpts=None, zpts=15):
     return get_mesh_for_testing(xpts=xpts, zpts=zpts, geometry=geometry)
 
 
+def get_2p1d_mesh_for_testing(
+    xpts=None, ypts=15, zpts=15, cc_submesh=pybamm.Scikit2DSubMesh,
+):
+    geometry = pybamm.Geometry("2+1D macro")
+    return get_mesh_for_testing(
+        xpts=xpts, zpts=zpts, geometry=geometry, cc_submesh=cc_submesh
+    )
+
+
+def get_unit_2p1D_mesh_for_testing(ypts=15, zpts=15):
+    param = pybamm.ParameterValues(
+        base_parameters={
+            "Electrode depth [m]": 1,
+            "Electrode height [m]": 1,
+            "Negative tab width [m]": 1,
+            "Negative tab centre y-coordinate [m]": 0.5,
+            "Negative tab centre z-coordinate [m]": 0,
+            "Positive tab width [m]": 1,
+            "Positive tab centre y-coordinate [m]": 0.5,
+            "Positive tab centre z-coordinate [m]": 1,
+            "Negative electrode width [m]": 0.3,
+            "Separator width [m]": 0.3,
+            "Positive electrode width [m]": 0.3,
+        }
+    )
+
+    geometry = pybamm.Geometryxp1DMacro(cc_dimension=2)
+    param.process_geometry(geometry)
+
+    var = pybamm.standard_spatial_vars
+    var_pts = {var.x_n: 3, var.x_s: 3, var.x_p: 3, var.y: ypts, var.z: zpts}
+
+    submesh_types = {
+        "negative electrode": pybamm.Uniform1DSubMesh,
+        "separator": pybamm.Uniform1DSubMesh,
+        "positive electrode": pybamm.Uniform1DSubMesh,
+        "current collector": pybamm.Scikit2DSubMesh,
+    }
+
+    return pybamm.Mesh(geometry, submesh_types, var_pts)
+
+
 def get_discretisation_for_testing(xpts=None, rpts=10, mesh=None):
     if mesh is None:
         mesh = get_mesh_for_testing(xpts=xpts, rpts=rpts)
@@ -114,3 +156,9 @@ def get_p2d_discretisation_for_testing(xpts=None, rpts=10):
 
 def get_1p1d_discretisation_for_testing(xpts=None, zpts=15):
     return get_discretisation_for_testing(mesh=get_1p1d_mesh_for_testing(xpts, zpts))
+
+
+def get_2p1d_discretisation_for_testing(xpts=None, ypts=15, zpts=15):
+    return get_discretisation_for_testing(
+        mesh=get_2p1d_mesh_for_testing(xpts, ypts, zpts)
+    )

--- a/tests/unit/test_meshes/test_scikit_fem_submesh.py
+++ b/tests/unit/test_meshes/test_scikit_fem_submesh.py
@@ -3,10 +3,9 @@
 #
 import pybamm
 import unittest
-from pybamm.meshes.scikit_fem_submeshes import skfem_spec
 
 
-@unittest.skipIf(skfem_spec is None, "scikit-fem not installed")
+@unittest.skipIf(pybamm.have_scikit_fem(), "scikit-fem not installed")
 class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
     def test_mesh_creation(self):
         param = pybamm.ParameterValues(

--- a/tests/unit/test_meshes/test_scikit_fem_submesh.py
+++ b/tests/unit/test_meshes/test_scikit_fem_submesh.py
@@ -1,0 +1,135 @@
+#
+# Test for the scikit-fem Finite Element Mesh class
+#
+import pybamm
+import unittest
+from pybamm.meshes.scikit_fem_submeshes import skfem_spec
+
+
+@unittest.skipIf(skfem_spec is None, "scikit-fem not installed")
+class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
+    def test_mesh_creation(self):
+        param = pybamm.ParameterValues(
+            base_parameters={
+                "Electrode depth [m]": 0.4,
+                "Electrode height [m]": 0.5,
+                "Negative tab width [m]": 0.1,
+                "Negative tab centre y-coordinate [m]": 0.1,
+                "Negative tab centre z-coordinate [m]": 0.5,
+                "Positive tab width [m]": 0.1,
+                "Positive tab centre y-coordinate [m]": 0.3,
+                "Positive tab centre z-coordinate [m]": 0.5,
+                "Negative electrode width [m]": 0.3,
+                "Separator width [m]": 0.3,
+                "Positive electrode width [m]": 0.3,
+            }
+        )
+
+        geometry = pybamm.Geometryxp1DMacro(cc_dimension=2)
+        param.process_geometry(geometry)
+
+        var = pybamm.standard_spatial_vars
+        var_pts = {var.x_n: 10, var.x_s: 7, var.x_p: 12, var.y: 16, var.z: 24}
+
+        submesh_types = {
+            "negative electrode": pybamm.Uniform1DSubMesh,
+            "separator": pybamm.Uniform1DSubMesh,
+            "positive electrode": pybamm.Uniform1DSubMesh,
+            "current collector": pybamm.Scikit2DSubMesh,
+        }
+
+        mesh_type = pybamm.Mesh
+
+        # create mesh
+        mesh = mesh_type(geometry, submesh_types, var_pts)
+
+        # check boundary locations
+        self.assertEqual(mesh["negative electrode"][0].edges[0], 0)
+        self.assertEqual(mesh["positive electrode"][0].edges[-1], 1)
+
+        # check internal boundary locations
+        self.assertEqual(
+            mesh["negative electrode"][0].edges[-1], mesh["separator"][0].edges[0]
+        )
+        self.assertEqual(
+            mesh["positive electrode"][0].edges[0], mesh["separator"][0].edges[-1]
+        )
+        for domain in mesh:
+            if domain == "current collector":
+                # NOTE: only for degree 1
+                npts = var_pts[var.y] * var_pts[var.z]
+                self.assertEqual(mesh[domain][0].npts, npts)
+            else:
+                self.assertEqual(
+                    len(mesh[domain][0].edges), len(mesh[domain][0].nodes) + 1
+                )
+
+    def test_init_failure(self):
+        geometry = pybamm.Geometryxp1DMacro(cc_dimension=2)
+        with self.assertRaises(KeyError):
+            pybamm.Mesh(geometry, None, {})
+
+        var = pybamm.standard_spatial_vars
+        var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.y: 10, var.z: 10}
+        with self.assertRaises(TypeError):
+            pybamm.Mesh(geometry, None, var_pts)
+
+        lims = {var.x_n: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}}
+        with self.assertRaises(pybamm.GeometryError):
+            pybamm.Scikit2DSubMesh(lims, None, None)
+
+        lims = {
+            var.y: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
+            var.z: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
+        }
+        npts = {var.y.id: 10, var.z.id: 10}
+        var.z.coord_sys = "not cartesian"
+        with self.assertRaises(pybamm.DomainError):
+            pybamm.Scikit2DSubMesh(lims, npts, None)
+        var.z.coord_sys = "cartesian"
+
+    def test_tab_placement(self):
+        # set variables and submesh types
+        var = pybamm.standard_spatial_vars
+        var_pts = {var.x_n: 2, var.x_s: 2, var.x_p: 2, var.y: 64, var.z: 64}
+
+        submesh_types = {
+            "negative electrode": pybamm.Uniform1DSubMesh,
+            "separator": pybamm.Uniform1DSubMesh,
+            "positive electrode": pybamm.Uniform1DSubMesh,
+            "current collector": pybamm.Scikit2DSubMesh,
+        }
+
+        mesh_type = pybamm.Mesh
+
+        # set base parameters
+        param = pybamm.ParameterValues(
+            base_parameters={
+                "Electrode depth [m]": 0.4,
+                "Electrode height [m]": 0.5,
+                "Negative tab width [m]": 0.1,
+                "Negative tab centre y-coordinate [m]": 0.1,
+                "Negative tab centre z-coordinate [m]": 0.5,
+                "Positive tab centre y-coordinate [m]": 10,
+                "Positive tab centre z-coordinate [m]": 10,
+                "Positive tab width [m]": 0.1,
+                "Negative electrode width [m]": 0.3,
+                "Separator width [m]": 0.3,
+                "Positive electrode width [m]": 0.3,
+            }
+        )
+
+        # check error raised if tab not on boundary
+        geometry = pybamm.Geometryxp1DMacro(cc_dimension=2)
+        param.process_geometry(geometry)
+        with self.assertRaises(pybamm.GeometryError):
+            mesh_type(geometry, submesh_types, var_pts)
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()

--- a/tests/unit/test_meshes/test_scikit_fem_submesh.py
+++ b/tests/unit/test_meshes/test_scikit_fem_submesh.py
@@ -79,6 +79,13 @@ class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
             pybamm.Scikit2DSubMesh(lims, None, None)
 
         lims = {
+            var.x_n: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
+            var.x_p: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
+        }
+        with self.assertRaises(pybamm.DomainError):
+            pybamm.Scikit2DSubMesh(lims, None, None)
+
+        lims = {
             var.y: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
             var.z: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)},
         }
@@ -88,7 +95,7 @@ class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
             pybamm.Scikit2DSubMesh(lims, npts, None)
         var.z.coord_sys = "cartesian"
 
-    def test_tab_placement(self):
+    def test_tab_error(self):
         # set variables and submesh types
         var = pybamm.standard_spatial_vars
         var_pts = {var.x_n: 2, var.x_s: 2, var.x_p: 2, var.y: 64, var.z: 64}
@@ -124,6 +131,42 @@ class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
         param.process_geometry(geometry)
         with self.assertRaises(pybamm.GeometryError):
             mesh_type(geometry, submesh_types, var_pts)
+
+    def test_tab_left_right(self):
+        # set variables and submesh types
+        var = pybamm.standard_spatial_vars
+        var_pts = {var.x_n: 2, var.x_s: 2, var.x_p: 2, var.y: 64, var.z: 64}
+
+        submesh_types = {
+            "negative electrode": pybamm.Uniform1DSubMesh,
+            "separator": pybamm.Uniform1DSubMesh,
+            "positive electrode": pybamm.Uniform1DSubMesh,
+            "current collector": pybamm.Scikit2DSubMesh,
+        }
+
+        mesh_type = pybamm.Mesh
+
+        # set base parameters
+        param = pybamm.ParameterValues(
+            base_parameters={
+                "Electrode depth [m]": 0.4,
+                "Electrode height [m]": 0.5,
+                "Negative tab width [m]": 0.1,
+                "Negative tab centre y-coordinate [m]": 0.0,
+                "Negative tab centre z-coordinate [m]": 0.25,
+                "Positive tab centre y-coordinate [m]": 0.4,
+                "Positive tab centre z-coordinate [m]": 0.25,
+                "Positive tab width [m]": 0.1,
+                "Negative electrode width [m]": 0.3,
+                "Separator width [m]": 0.3,
+                "Positive electrode width [m]": 0.3,
+            }
+        )
+
+        # check error raised if tab not on boundary
+        geometry = pybamm.Geometryxp1DMacro(cc_dimension=2)
+        param.process_geometry(geometry)
+        mesh_type(geometry, submesh_types, var_pts)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -1,0 +1,222 @@
+#
+# Test for the operator class
+#
+import pybamm
+from tests import get_2p1d_mesh_for_testing, get_unit_2p1D_mesh_for_testing
+import numpy as np
+import unittest
+from pybamm.spatial_methods.scikit_finite_element import skfem_spec
+
+
+@unittest.skipIf(skfem_spec is None, "scikits-fem not installed")
+class TestScikitFiniteElement(unittest.TestCase):
+    def test_not_implemented(self):
+        mesh = get_2p1d_mesh_for_testing()
+        spatial_method = pybamm.ScikitFiniteElement(mesh)
+        self.assertEqual(spatial_method.mesh, mesh)
+        with self.assertRaises(NotImplementedError):
+            spatial_method.gradient(None, None, None)
+        with self.assertRaises(NotImplementedError):
+            spatial_method.divergence(None, None, None)
+        with self.assertRaises(NotImplementedError):
+            spatial_method.indefinite_integral(None, None, None)
+        with self.assertRaises(NotImplementedError):
+            spatial_method.boundary_value_or_flux(None, None)
+
+    def test(self):
+        # get mesh
+        mesh = get_2p1d_mesh_for_testing()
+        spatial_methods = {
+            "macroscale": pybamm.FiniteVolume,
+            "current collector": pybamm.ScikitFiniteElement,
+        }
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        # discretise some equations
+        var = pybamm.Variable("var", domain="current collector")
+        y = pybamm.SpatialVariable("y", ["current collector"])
+        z = pybamm.SpatialVariable("z", ["current collector"])
+        disc.set_variable_slices([var])
+        y_test = np.ones(mesh["current collector"][0].npts)
+        unit_source = pybamm.Broadcast(1, "current collector")
+        disc.bcs = {
+            var.id: {
+                "left": (pybamm.Scalar(0), "Neumann"),
+                "right": (pybamm.Scalar(0), "Neumann"),
+            }
+        }
+
+        for eqn in [
+            pybamm.laplacian(var),
+            pybamm.source(unit_source, var),
+            pybamm.laplacian(var) - pybamm.source(unit_source, var),
+            pybamm.source(var, var),
+            pybamm.laplacian(var) - pybamm.source(2 * var, var),
+            pybamm.laplacian(var) - pybamm.source(unit_source ** 2 + 1 / var, var),
+            pybamm.Integral(var, [y, z]) - 1,
+        ]:
+            # Check that equation can be evaluated in each case
+            # Dirichlet
+            disc.bcs = {
+                var.id: {
+                    "left": (pybamm.Scalar(0), "Dirichlet"),
+                    "right": (pybamm.Scalar(1), "Dirichlet"),
+                }
+            }
+            eqn_disc = disc.process_symbol(eqn)
+            eqn_disc.evaluate(None, y_test)
+            # Neumann
+            disc.bcs = {
+                var.id: {
+                    "left": (pybamm.Scalar(0), "Neumann"),
+                    "right": (pybamm.Scalar(1), "Neumann"),
+                }
+            }
+            eqn_disc = disc.process_symbol(eqn)
+            eqn_disc.evaluate(None, y_test)
+            # One of each
+            disc.bcs = {
+                var.id: {
+                    "left": (pybamm.Scalar(0), "Neumann"),
+                    "right": (pybamm.Scalar(1), "Dirichlet"),
+                }
+            }
+            eqn_disc = disc.process_symbol(eqn)
+            eqn_disc.evaluate(None, y_test)
+            # One of each
+            disc.bcs = {
+                var.id: {
+                    "left": (pybamm.Scalar(0), "Dirichlet"),
+                    "right": (pybamm.Scalar(1), "Neumann"),
+                }
+            }
+            eqn_disc = disc.process_symbol(eqn)
+            eqn_disc.evaluate(None, y_test)
+
+        # check  ValueError raised for non Dirichlet or Neumann BCs
+        eqn = pybamm.laplacian(var) - pybamm.source(unit_source, var)
+        disc.bcs = {
+            var.id: {
+                "left": (pybamm.Scalar(0), "Dirichlet"),
+                "right": (pybamm.Scalar(1), "Other BC"),
+            }
+        }
+        with self.assertRaises(ValueError):
+            eqn_disc = disc.process_symbol(eqn)
+        disc.bcs = {
+            var.id: {
+                "left": (pybamm.Scalar(0), "Other BC"),
+                "right": (pybamm.Scalar(1), "Neumann"),
+            }
+        }
+        with self.assertRaises(ValueError):
+            eqn_disc = disc.process_symbol(eqn)
+
+    def test_manufactured_solution(self):
+        mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)
+        spatial_methods = {
+            "macroscale": pybamm.FiniteVolume,
+            "current collector": pybamm.ScikitFiniteElement,
+        }
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+
+        # linear u = z (to test coordinates to degree of freedom mapping)
+        var = pybamm.Variable("var", domain="current collector")
+        disc.set_variable_slices([var])
+        var_disc = disc.process_symbol(var)
+        z_vertices = mesh["current collector"][0].coordinates[1, :]
+        np.testing.assert_array_almost_equal(
+            var_disc.evaluate(None, z_vertices),
+            z_vertices[:, np.newaxis]
+        )
+
+        # linear u = 6*y (to test coordinates to degree of freedom mapping)
+        y_vertices = mesh["current collector"][0].coordinates[0, :]
+        np.testing.assert_array_almost_equal(
+            var_disc.evaluate(None, 6 * y_vertices),
+            6 * y_vertices[:, np.newaxis]
+        )
+
+        # mixed u = y*z (to test coordinates to degree of freedom mapping)
+        np.testing.assert_array_almost_equal(
+            var_disc.evaluate(None, y_vertices * z_vertices),
+            y_vertices[:, np.newaxis] * z_vertices[:, np.newaxis]
+        )
+
+        # laplace of u = sin(pi*z)
+        var = pybamm.Variable("var", domain="current collector")
+        eqn_zz = pybamm.laplacian(var)
+        # set boundary conditions ("left" = bottom of unit square, "right" = top
+        # of unit square, elsewhere normal derivative is zero)
+        disc.bcs = {
+            var.id: {
+                "left": (pybamm.Scalar(0), "Dirichlet"),
+                "right": (pybamm.Scalar(0), "Dirichlet"),
+            }
+        }
+        disc.set_variable_slices([var])
+        eqn_zz_disc = disc.process_symbol(eqn_zz)
+        z_vertices = mesh["current collector"][0].coordinates[1, :][:, np.newaxis]
+        u = np.sin(np.pi * z_vertices)
+        mass = pybamm.Mass(var)
+        mass_disc = disc.process_symbol(mass)
+        soln = -np.pi ** 2 * u
+        np.testing.assert_array_almost_equal(
+            eqn_zz_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            decimal=3
+        )
+
+        # laplace of u = cos(pi*y)*sin(pi*z)
+        var = pybamm.Variable("var", domain="current collector")
+        laplace_eqn = pybamm.laplacian(var)
+        # set boundary conditions ("left" = bottom of unit square, "right" = top
+        # of unit square, elsewhere normal derivative is zero)
+        disc.bcs = {
+            var.id: {
+                "left": (pybamm.Scalar(0), "Dirichlet"),
+                "right": (pybamm.Scalar(0), "Dirichlet"),
+            }
+        }
+        disc.set_variable_slices([var])
+        laplace_eqn_disc = disc.process_symbol(laplace_eqn)
+        y_vertices = mesh["current collector"][0].coordinates[0, :][:, np.newaxis]
+        z_vertices = mesh["current collector"][0].coordinates[1, :][:, np.newaxis]
+        u = np.cos(np.pi * y_vertices) * np.sin(np.pi * z_vertices)
+        mass = pybamm.Mass(var)
+        mass_disc = disc.process_symbol(mass)
+        soln = -np.pi ** 2 * u
+        np.testing.assert_array_almost_equal(
+            laplace_eqn_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            decimal=2
+        )
+
+    def test_definite_integral(self):
+        mesh = get_2p1d_mesh_for_testing()
+        spatial_methods = {
+            "macroscale": pybamm.FiniteVolume,
+            "current collector": pybamm.ScikitFiniteElement,
+        }
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        var = pybamm.Variable("var", domain="current collector")
+        y = pybamm.SpatialVariable("y", ["current collector"])
+        z = pybamm.SpatialVariable("z", ["current collector"])
+        integral_eqn = pybamm.Integral(var, [y, z])
+        disc.set_variable_slices([var])
+        integral_eqn_disc = disc.process_symbol(integral_eqn)
+        y_test = 6 * np.ones(mesh["current collector"][0].npts)
+        fem_mesh = mesh["current collector"][0]
+        ly = fem_mesh.coordinates[0, -1]
+        lz = fem_mesh.coordinates[1, -1]
+        np.testing.assert_array_almost_equal(
+            integral_eqn_disc.evaluate(None, y_test), 6 * ly * lz
+        )
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    unittest.main()

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -8,7 +8,7 @@ import unittest
 from pybamm.spatial_methods.scikit_finite_element import skfem_spec
 
 
-@unittest.skipIf(skfem_spec is None, "scikits-fem not installed")
+@unittest.skipIf(skfem_spec is None, "scikit-fem not installed")
 class TestScikitFiniteElement(unittest.TestCase):
     def test_not_implemented(self):
         mesh = get_2p1d_mesh_for_testing()

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -5,10 +5,9 @@ import pybamm
 from tests import get_2p1d_mesh_for_testing, get_unit_2p1D_mesh_for_testing
 import numpy as np
 import unittest
-from pybamm.spatial_methods.scikit_finite_element import skfem_spec
 
 
-@unittest.skipIf(skfem_spec is None, "scikit-fem not installed")
+@unittest.skipIf(pybamm.have_scikit_fem(), "scikit-fem not installed")
 class TestScikitFiniteElement(unittest.TestCase):
     def test_not_implemented(self):
         mesh = get_2p1d_mesh_for_testing()
@@ -23,7 +22,7 @@ class TestScikitFiniteElement(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             spatial_method.boundary_value_or_flux(None, None)
 
-    def test(self):
+    def test_discretise_equations(self):
         # get mesh
         mesh = get_2p1d_mesh_for_testing()
         spatial_methods = {


### PR DESCRIPTION
# Description

Add scikit-fem mesh and spatial method for 2D current collector submodels

To do: 
- implement 2D submodel in li-ion models (as separate issue)

Fixes #475 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
