### PR TITLE
Issue 486 divide outer bug

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -112,12 +112,15 @@ class BinaryOperator(pybamm.Symbol):
 
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
+
         # process children
         new_left = self.left.new_copy()
         new_right = self.right.new_copy()
+
         # make new symbol, ensure domain remains the same
         out = self.__class__(new_left, new_right)
         out.domain = self.domain
+
         return out
 
     def evaluate(self, t=None, y=None, known_evals=None):

--- a/pybamm/expression_tree/simplify.py
+++ b/pybamm/expression_tree/simplify.py
@@ -70,6 +70,9 @@ def simplify_addition_subtraction(myclass, left, right):
 
         outputs to lists `numerator` and `numerator_types`
 
+        Note that domains are all set to [] as we do not wish to consider domains once
+        simplifications are applied
+
         e.g.
 
         (1 + 2) + 3       -> [1, 2, 3]    and [None, Addition, Addition]
@@ -77,6 +80,9 @@ def simplify_addition_subtraction(myclass, left, right):
         1 - (2 + 3)       -> [1, 2, 3]    and [None, Subtraction, Subtraction]
         (1 + 2) - (2 + 3) -> [1, 2, 2, 3] and [None, Addition, Subtraction, Subtraction]
         """
+
+        left_child.domain = []
+        right_child.domain = []
         for side, child in [("left", left_child), ("right", right_child)]:
             if isinstance(child, (pybamm.Addition, pybamm.Subtraction)):
                 left, right = child.orphans
@@ -264,6 +270,9 @@ def simplify_multiplication_division(myclass, left, right):
         Note that multiplication *within* matrix multiplications, e.g. a@(b*c), are not
         flattened into a@b*c, as this would be incorrect (see #253)
 
+        Note that the domains are all set to [] as we do not wish to consider domains
+        once simplifications are applied
+
         outputs to lists `numerator`, `denominator` and `numerator_types`
 
         e.g.
@@ -272,6 +281,9 @@ def simplify_multiplication_division(myclass, left, right):
         (1 @ 2) / 3 ->  [1, 2]       [3]       [None, MatrixMultiplication]
         1 / (c / 2) ->  [1, 2]       [c]       [None, Multiplication]
         """
+
+        left_child.domain = []
+        right_child.domain = []
         for side, child in [("left", left_child), ("right", right_child)]:
 
             if side == "left":

--- a/pybamm/expression_tree/vector.py
+++ b/pybamm/expression_tree/vector.py
@@ -141,7 +141,7 @@ class StateVector(pybamm.Symbol):
 
     def new_copy(self):
         """ See :meth:`pybamm.Symbol.new_copy()`. """
-        return StateVector(self.y_slice, self.name, domain=[])
+        return StateVector(self.y_slice, self.name, domain=self.domain)
 
     def evaluate_for_shape(self):
         """

--- a/tests/unit/test_expression_tree/test_simplify.py
+++ b/tests/unit/test_expression_tree/test_simplify.py
@@ -540,6 +540,23 @@ class TestSimplify(unittest.TestCase):
         self.assertIsInstance(outer_simp, pybamm.Vector)
         np.testing.assert_array_equal(outer_simp.evaluate(), 2 * np.ones((15, 1)))
 
+    def test_simplify_divide_outer(self):
+        u = pybamm.Scalar(1)
+        v = pybamm.StateVector(slice(0, 5), domain="current collector")
+        outer = pybamm.Outer(v, u)
+
+        exp1 = pybamm.Division(pybamm.Division(outer, u), u)
+        self.assertIsInstance(exp1.simplify(), pybamm.Outer)
+
+        exp2 = pybamm.Division(pybamm.Division(outer, 2 * u), u)
+        self.assertIsInstance(exp2.simplify(), pybamm.Multiplication)
+
+        exp3 = pybamm.Division(pybamm.Division(outer, u), 2 * u)
+        self.assertIsInstance(exp3.simplify(), pybamm.Multiplication)
+
+        exp4 = pybamm.Division(pybamm.Division(outer, 2 * u), 2 * u)
+        exp4.simplify()
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

fix outer product bug. problem was that the outer product expects a particular domain, and the domains were getting wiped due to the new_copy in Statevector.

@rtimms: Other (integration) tests fail, is this expected for the issue-477-2plus-li-ion branch?

Fixes #486

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
