### PR TITLE
Issue 530 debug within model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,7 @@ Figuring out where to start the debugger is the real challenge. Some good ways t
 ```python3
 pybamm.set_logging_level("DEBUG")
 ```
+6. In models that inherit from `pybamm.BaseBatteryModel` (i.e. any battery model), you can use `self.process_parameters_and_discretise` to process a symbol and see what it will look like.
 
 ### Profiling
 

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -19,6 +19,7 @@ class BaseBatteryModel(pybamm.BaseModel):
         self._extra_options = options
         self.set_standard_output_variables()
         self.submodels = OrderedDict()  # ordered dict not default in 3.5
+        self._built = False
 
     @property
     def default_parameter_values(self):
@@ -332,7 +333,9 @@ class BaseBatteryModel(pybamm.BaseModel):
             self.update(submodel)
 
         pybamm.logger.debug("Setting voltage variables")
-        # self.set_voltage_variables()
+        self.set_voltage_variables()
+
+        self._built = True
 
     def set_thermal_submodel(self):
 
@@ -466,6 +469,9 @@ class BaseBatteryModel(pybamm.BaseModel):
         :class:`pybamm.Symbol`
             Processed symbol
         """
+        if not self._built:
+            self.build_model()
+
         # Set up parameters
         geometry = self.default_geometry
         parameter_values = self.default_parameter_values
@@ -474,7 +480,6 @@ class BaseBatteryModel(pybamm.BaseModel):
         # Set up discretisation
         mesh = pybamm.Mesh(geometry, self.default_submesh_types, self.default_var_pts)
         disc = pybamm.Discretisation(mesh, self.default_spatial_methods)
-        self.build_model()
         variables = list(self.rhs.keys()) + list(self.algebraic.keys())
         disc.set_variable_slices(variables)
 

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -1,0 +1,25 @@
+#
+# Tests for the base battery model class
+#
+import pybamm
+import unittest
+
+
+class TestBaseBatteryModel(unittest.TestCase):
+    def test_process_parameters_and_discretise(self):
+        model = pybamm.SimpleODEModel()
+        c = pybamm.Parameter("Negative electrode width [m]") * pybamm.Variable("c")
+        processed_c = model.process_parameters_and_discretise(c)
+        self.assertIsInstance(processed_c, pybamm.Multiplication)
+        self.assertIsInstance(processed_c.left, pybamm.Scalar)
+        self.assertIsInstance(processed_c.right, pybamm.StateVector)
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    pybamm.settings.debug_mode = True
+    unittest.main()

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -7,8 +7,10 @@ import unittest
 
 class TestBaseBatteryModel(unittest.TestCase):
     def test_process_parameters_and_discretise(self):
-        model = pybamm.SimpleODEModel()
-        c = pybamm.Parameter("Negative electrode width [m]") * pybamm.Variable("c")
+        model = pybamm.ReactionDiffusionModel()
+        c = pybamm.Parameter("Negative electrode width [m]") * pybamm.Variable(
+            "Negative electrolyte concentration", domain="negative electrode"
+        )
         processed_c = model.process_parameters_and_discretise(c)
         self.assertIsInstance(processed_c, pybamm.Multiplication)
         self.assertIsInstance(processed_c.left, pybamm.Scalar)


### PR DESCRIPTION
# Description

Basic functionality to process symbol within model. Maybe not super useful in current form, but can be updated as we go along.
Fixes #530 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
- [x] Any dependent changes have been merged and published in downstream modules
