### PR TITLE
#585 electrolyte bug

### DIFF
--- a/pybamm/models/submodels/electrolyte/base_electrolyte_conductivity.py
+++ b/pybamm/models/submodels/electrolyte/base_electrolyte_conductivity.py
@@ -61,7 +61,8 @@ class BaseElectrolyteConductivity(pybamm.BaseSubModel):
             "Positive electrolyte potential": phi_e_p,
             "Positive electrolyte potential [V]": -param.U_n_ref + pot_scale * phi_e_p,
             "Electrolyte potential": phi_e,
-            "Electrolyte potential [V]": phi_e,
+            "Electrolyte potential [V]": -param.U_n_ref
+            + pot_scale * phi_e,
             "X-averaged electrolyte potential": phi_e_av,
             "X-averaged electrolyte potential [V]": -param.U_n_ref
             + pot_scale * phi_e_av,


### PR DESCRIPTION
# Description
The variable "Electrolyte potential [V]" was returning the non-dimensional potential instead of the dimensional version 

Fixes #585 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
