### PR TITLE
Issue 638 process post solve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # don't ignore important .txt files
 !requirements*
 !LICENSE.txt
+!CMakeLists.txt
 
 # running files
 *.pyc
@@ -64,3 +65,5 @@ pyvenv.cfg
 
 # sundials
 sundials
+sundials4
+SuiteSparse

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -692,35 +692,33 @@ class BaseBatteryModel(pybamm.BaseModel):
         """
         pass
 
-    def process_parameters_and_discretise(self, symbol):
+    def process_parameters_and_discretise(self, symbol, parameter_values, disc):
         """
-        Process parameters and discretise a symbol using default parameter values,
-        geometry, etc. Note that the model needs to be built first for this to be
-        possible.
+        Process parameters and discretise a symbol using supplied parameter values
+        and discretisation. Note: care should be taken if using spatial operators
+        on dimensional sysmbols. Operators in pybamm are written in non-dimensional
+        form, so may need to be scaled by the appropriate length scale. It is advised
+        to use this method on non-dimensional symbols.
 
         Parameters
         ----------
         symbol : :class:`pybamm.Symbol`
             Symbol to be processed
+        parameter_values : :class:`pybamm.ParameterValues`
+            The parameter values to use during processing
+        disc : :class:`pybamm.Discretisation`
+            The discrisation to use
 
         Returns
         -------
         :class:`pybamm.Symbol`
             Processed symbol
         """
-        if not self._built:
-            self.build_model()
 
-        # Set up parameters
-        geometry = self.default_geometry
-        parameter_values = self.default_parameter_values
-        parameter_values.process_geometry(geometry)
-
-        # Set up discretisation
-        mesh = pybamm.Mesh(geometry, self.default_submesh_types, self.default_var_pts)
-        disc = pybamm.Discretisation(mesh, self.default_spatial_methods)
-        variables = list(self.rhs.keys()) + list(self.algebraic.keys())
-        disc.set_variable_slices(variables)
+        # Set y slices
+        if disc.y_slices == {}:
+            variables = list(self.rhs.keys()) + list(self.algebraic.keys())
+            disc.set_variable_slices(variables)
 
         # Process
         param_symbol = parameter_values.process_symbol(symbol)

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -696,9 +696,9 @@ class BaseBatteryModel(pybamm.BaseModel):
         """
         Process parameters and discretise a symbol using supplied parameter values
         and discretisation. Note: care should be taken if using spatial operators
-        on dimensional sysmbols. Operators in pybamm are written in non-dimensional
-        form, so may need to be scaled by the appropriate length scale. It is advised
-        to use this method on non-dimensional symbols.
+        on dimensional symbols. Operators in pybamm are written in non-dimensional
+        form, so may need to be scaled by the appropriate length scale. It is
+        recommended to use this method on non-dimensional symbols.
 
         Parameters
         ----------
@@ -714,11 +714,14 @@ class BaseBatteryModel(pybamm.BaseModel):
         :class:`pybamm.Symbol`
             Processed symbol
         """
-
         # Set y slices
         if disc.y_slices == {}:
             variables = list(self.rhs.keys()) + list(self.algebraic.keys())
             disc.set_variable_slices(variables)
+
+        # Set boundary condtions
+        if disc.bcs == {}:
+            disc.bcs = disc.process_boundary_conditions(self)
 
         # Process
         param_symbol = parameter_values.process_symbol(symbol)

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -8,12 +8,20 @@ import unittest
 class TestBaseBatteryModel(unittest.TestCase):
     def test_process_parameters_and_discretise(self):
         model = pybamm.lithium_ion.SPM()
+        # Set up geometry and parameters
+        geometry = model.default_geometry
+        parameter_values = model.default_parameter_values
+        parameter_values.process_geometry(geometry)
+        # Set up discretisation
+        mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+        disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+        # Process expression
         c = pybamm.Parameter("Negative electrode thickness [m]") * pybamm.Variable(
             "X-averaged negative particle concentration",
             domain="negative particle",
             auxiliary_domains={"secondary": "current collector"},
         )
-        processed_c = model.process_parameters_and_discretise(c)
+        processed_c = model.process_parameters_and_discretise(c, parameter_values, disc)
         self.assertIsInstance(processed_c, pybamm.Multiplication)
         self.assertIsInstance(processed_c.left, pybamm.Scalar)
         self.assertIsInstance(processed_c.right, pybamm.StateVector)

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -25,6 +25,21 @@ class TestBaseBatteryModel(unittest.TestCase):
         self.assertIsInstance(processed_c, pybamm.Multiplication)
         self.assertIsInstance(processed_c.left, pybamm.Scalar)
         self.assertIsInstance(processed_c.right, pybamm.StateVector)
+        # Process flux manually and check result against flux computed in particle
+        # submodel
+        c_n = model.variables["X-averaged negative particle concentration"]
+        T = pybamm.PrimaryBroadcast(
+            model.variables["X-averaged negative electrode temperature"],
+            ["negative particle"],
+        )
+        D = model.param.D_n(c_n, T)
+        N = -D * pybamm.grad(c_n)
+
+        flux_1 = model.process_parameters_and_discretise(N, parameter_values, disc)
+        flux_2 = model.variables["X-averaged negative particle flux"]
+        param_flux_2 = parameter_values.process_symbol(flux_2)
+        disc_flux_2 = disc.process_symbol(param_flux_2)
+        self.assertEqual(flux_1.id, disc_flux_2.id)
 
     def test_default_geometry(self):
         var = pybamm.standard_spatial_vars


### PR DESCRIPTION
# Description

Changes `model.process_parameters_and_discretise` to accept parameter values and a discretisation so that users can define new expressions in scripts to be processed and discretised. 

Fixes #638 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
