### PR TITLE
#655 dont check size on new copy

### DIFF
--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -154,7 +154,7 @@ class Index(UnaryOperator):
         Whether to check if the slice size exceeds the child size. Default is True.
         This should always be True when creating a new symbol so that the appropriate
         check is performed, but should be False for creating a new copy to avoid
-        unecessarily repeating the check.
+        unnecessarily repeating the check.
     """
 
     def __init__(self, child, index, name=None, check_size=True):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -150,9 +150,14 @@ class Index(UnaryOperator):
         The index (if int) or indices (if slice) to extract from the symbol
     name : str, optional
         The name of the symbol
+    check_size : bool, optional
+        Whether to check if the slice size exceeds the child size. Default is True.
+        This should always be True when creating a new symbol so that the appropriate
+        check is performed, but should be False for creating a new copy to avoid
+        unecessarily repeating the check.
     """
 
-    def __init__(self, child, index, name=None):
+    def __init__(self, child, index, name=None, check_size=True):
         self.index = index
         if index == -1:
             self.slice = slice(index, None)
@@ -172,10 +177,11 @@ class Index(UnaryOperator):
         else:
             raise TypeError("index must be integer or slice")
 
-        if self.slice in (slice(0, 1), slice(-1, None)):
-            pass
-        elif self.slice.stop > child.size:
-            raise ValueError("slice size exceeds child size")
+        if check_size:
+            if self.slice in (slice(0, 1), slice(-1, None)):
+                pass
+            elif self.slice.stop > child.size:
+                raise ValueError("slice size exceeds child size")
 
         super().__init__(name, child)
 
@@ -217,7 +223,7 @@ class Index(UnaryOperator):
     def _unary_new_copy(self, child):
         """ See :meth:`UnaryOperator._unary_new_copy()`. """
 
-        return self.__class__(child, self.index)
+        return self.__class__(child, self.index, check_size=False)
 
     def evaluate_for_shape(self):
         return self._unary_evaluate(self.children[0].evaluate_for_shape())


### PR DESCRIPTION
# Description
Don't unnecessarily check that the slice size exceeds the child size when making a new copy of an Index node

Fixes #655 

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks: 

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
- [ ] Any dependent changes have been merged and published in downstream modules
