### PR TITLE
Issue 684 casadi events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.tmp
 *.png
 /local/
+*.DS_Store
 
 # don't ignore important .txt files
 !requirements*

--- a/examples/scripts/compare-dae-solver.py
+++ b/examples/scripts/compare-dae-solver.py
@@ -16,7 +16,7 @@ param.process_geometry(geometry)
 
 # set mesh
 var = pybamm.standard_spatial_vars
-var_pts = {var.x_n: 50, var.x_s: 50, var.x_p: 50, var.r_n: 20, var.r_p: 20}
+var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 5, var.r_p: 5}
 mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
 
 # discretise model
@@ -31,7 +31,10 @@ klu_sol = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8).solve(model, t_eval)
 scikits_sol = pybamm.ScikitsDaeSolver(atol=1e-8, rtol=1e-8).solve(model, t_eval)
 
 # plot
+import warnings
+
+warnings.simplefilter("error")
 models = [model, model, model]
-solutions = [scikits_sol, klu_sol, casadi_sol]
-plot = pybamm.QuickPlot(models, mesh, solutions)
-plot.dynamic_plot()
+solutions = [casadi_sol, klu_sol, casadi_sol]
+# plot = pybamm.QuickPlot(models, mesh, solutions)
+# plot.dynamic_plot()

--- a/examples/scripts/compare-dae-solver.py
+++ b/examples/scripts/compare-dae-solver.py
@@ -16,7 +16,7 @@ param.process_geometry(geometry)
 
 # set mesh
 var = pybamm.standard_spatial_vars
-var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 5, var.r_p: 5}
+var_pts = {var.x_n: 50, var.x_s: 50, var.x_p: 50, var.r_n: 20, var.r_p: 20}
 mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
 
 # discretise model
@@ -31,10 +31,7 @@ klu_sol = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8).solve(model, t_eval)
 scikits_sol = pybamm.ScikitsDaeSolver(atol=1e-8, rtol=1e-8).solve(model, t_eval)
 
 # plot
-import warnings
-
-warnings.simplefilter("error")
 models = [model, model, model]
 solutions = [casadi_sol, klu_sol, casadi_sol]
-# plot = pybamm.QuickPlot(models, mesh, solutions)
-# plot.dynamic_plot()
+plot = pybamm.QuickPlot(models, mesh, solutions)
+plot.dynamic_plot()

--- a/examples/scripts/compare_lithium_ion.py
+++ b/examples/scripts/compare_lithium_ion.py
@@ -45,9 +45,9 @@ for model in models:
 
 # solve model
 solutions = [None] * len(models)
-t_eval = np.linspace(0, 0.17, 100)
+t_eval = np.linspace(0, 0.3, 100)
 for i, model in enumerate(models):
-    solutions[i] = model.default_solver.solve(model, t_eval)
+    solutions[i] = pybamm.CasadiSolver().solve(model, t_eval)
 
 # plot
 plot = pybamm.QuickPlot(models, mesh, solutions)

--- a/examples/scripts/compare_lithium_ion.py
+++ b/examples/scripts/compare_lithium_ion.py
@@ -47,7 +47,7 @@ for model in models:
 solutions = [None] * len(models)
 t_eval = np.linspace(0, 0.3, 100)
 for i, model in enumerate(models):
-    solutions[i] = pybamm.CasadiSolver().solve(model, t_eval)
+    solutions[i] = model.default_solver.solve(model, t_eval)
 
 # plot
 plot = pybamm.QuickPlot(models, mesh, solutions)

--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -405,7 +405,6 @@ class ProcessedVariable(object):
         elif self.dimensions == 3:
             out = self.call_3D(t, x, r, y, z)
         if warn is True and np.isnan(out).any():
-            raise ValueError
             pybamm.logger.warning(
                 "Calling variable outside interpolation range (returns 'nan')"
             )

--- a/pybamm/processed_variable.py
+++ b/pybamm/processed_variable.py
@@ -405,6 +405,7 @@ class ProcessedVariable(object):
         elif self.dimensions == 3:
             out = self.call_3D(t, x, r, y, z)
         if warn is True and np.isnan(out).any():
+            raise ValueError
             pybamm.logger.warning(
                 "Calling variable outside interpolation range (returns 'nan')"
             )

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -256,14 +256,26 @@ class QuickPlot(object):
             # Get min and max y values
             y_min = np.min(
                 [
-                    ax_min(var(self.ts[i], **{spatial_var_name: spatial_var_value}, warn=False))
+                    ax_min(
+                        var(
+                            self.ts[i],
+                            **{spatial_var_name: spatial_var_value},
+                            warn=False
+                        )
+                    )
                     for i, variable_list in enumerate(variable_lists)
                     for var in variable_list
                 ]
             )
             y_max = np.max(
                 [
-                    ax_max(var(self.ts[i], **{spatial_var_name: spatial_var_value}, warn=False))
+                    ax_max(
+                        var(
+                            self.ts[i],
+                            **{spatial_var_name: spatial_var_value},
+                            warn=False
+                        )
+                    )
                     for i, variable_list in enumerate(variable_lists)
                     for var in variable_list
                 ]

--- a/pybamm/quick_plot.py
+++ b/pybamm/quick_plot.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 
 def ax_min(data):
     "Calculate appropriate minimum axis value for plotting"
-    data_min = np.min(data)
+    data_min = np.nanmin(data)
     if data_min <= 0:
         return 1.04 * data_min
     else:
@@ -17,7 +17,7 @@ def ax_min(data):
 
 def ax_max(data):
     "Calculate appropriate maximum axis value for plotting"
-    data_max = np.max(data)
+    data_max = np.nanmax(data)
     if data_max <= 0:
         return 0.96 * data_max
     else:
@@ -256,14 +256,14 @@ class QuickPlot(object):
             # Get min and max y values
             y_min = np.min(
                 [
-                    ax_min(var(self.ts[i], **{spatial_var_name: spatial_var_value}))
+                    ax_min(var(self.ts[i], **{spatial_var_name: spatial_var_value}, warn=False))
                     for i, variable_list in enumerate(variable_lists)
                     for var in variable_list
                 ]
             )
             y_max = np.max(
                 [
-                    ax_max(var(self.ts[i], **{spatial_var_name: spatial_var_value}))
+                    ax_max(var(self.ts[i], **{spatial_var_name: spatial_var_value}, warn=False))
                     for i, variable_list in enumerate(variable_lists)
                     for var in variable_list
                 ]

--- a/pybamm/solvers/algebraic_solver.py
+++ b/pybamm/solvers/algebraic_solver.py
@@ -24,6 +24,7 @@ class AlgebraicSolver(object):
     def __init__(self, method="lm", tol=1e-6):
         self.method = method
         self.tol = tol
+        self.name = "Algebraic solver ({})".format(method)
 
     @property
     def method(self):
@@ -51,7 +52,7 @@ class AlgebraicSolver(object):
             equations.
 
         """
-        pybamm.logger.info("Start solving {}".format(model.name))
+        pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
         # Set up
         timer = pybamm.Timer()
@@ -87,7 +88,6 @@ class AlgebraicSolver(object):
 
         # Assign times
         solution.solve_time = timer.time() - solve_start_time
-        solution.total_time = timer.time() - start_time
         solution.set_up_time = set_up_time
 
         pybamm.logger.info("Finish solving {}".format(model.name))

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -96,7 +96,7 @@ class BaseSolver(object):
         )
         return solution
 
-    def step(self, model, dt, npts=2):
+    def step(self, model, dt, npts=2, log=True):
         """
         Step the solution of the model forward by a given time increment. The
         first time this method is called it executes the necessary setup by
@@ -128,11 +128,18 @@ class BaseSolver(object):
 
         # Run set up on first step
         if not hasattr(self, "y0"):
+            pybamm.logger.info(
+                "Start stepping {} with {}".format(model.name, self.name)
+            )
+
             if model.convert_to_format == "casadi" or isinstance(
                 self, pybamm.CasadiSolver
             ):
                 self.set_up_casadi(model)
             else:
+                pybamm.logger.debug(
+                    "Start stepping {} with {}".format(model.name, self.name)
+                )
                 self.set_up(model)
             self.t = 0.0
             set_up_time = timer.time()
@@ -140,7 +147,6 @@ class BaseSolver(object):
             set_up_time = None
 
         # Step
-        pybamm.logger.info("Start stepping {}".format(model.name))
         t_eval = np.linspace(self.t, self.t + dt, npts)
         solution, solve_time, termination = self.compute_solution(model, t_eval)
 
@@ -153,9 +159,9 @@ class BaseSolver(object):
         self.t = solution.t[-1]
         self.y0 = solution.y[:, -1]
 
-        pybamm.logger.info("Finish stepping {} ({})".format(model.name, termination))
+        pybamm.logger.debug("Finish stepping {} ({})".format(model.name, termination))
         if set_up_time:
-            pybamm.logger.info(
+            pybamm.logger.debug(
                 "Set-up time: {}, Step time: {}, Total time: {}".format(
                     timer.format(solution.set_up_time),
                     timer.format(solution.solve_time),
@@ -163,7 +169,7 @@ class BaseSolver(object):
                 )
             )
         else:
-            pybamm.logger.info(
+            pybamm.logger.debug(
                 "Step time: {}".format(timer.format(solution.solve_time))
             )
         return solution

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -20,6 +20,7 @@ class BaseSolver(object):
         self._method = method
         self._rtol = rtol
         self._atol = atol
+        self.name = "Base solver"
 
     @property
     def method(self):

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -64,7 +64,7 @@ class BaseSolver(object):
             If an empty model is passed (`model.rhs = {}` and `model.algebraic={}`)
 
         """
-        pybamm.logger.info("Start solving {}".format(model.name))
+        pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
         # Make sure model isn't empty
         if len(model.rhs) == 0 and len(model.algebraic) == 0:
@@ -84,7 +84,6 @@ class BaseSolver(object):
 
         # Assign times
         solution.solve_time = solve_time
-        solution.total_time = timer.time() - start_time
         solution.set_up_time = set_up_time
 
         pybamm.logger.info("Finish solving {} ({})".format(model.name, termination))
@@ -129,7 +128,6 @@ class BaseSolver(object):
 
         # Run set up on first step
         if not hasattr(self, "y0"):
-            start_time = timer.time()
             if model.convert_to_format == "casadi" or isinstance(
                 self, pybamm.CasadiSolver
             ):
@@ -137,7 +135,7 @@ class BaseSolver(object):
             else:
                 self.set_up(model)
             self.t = 0.0
-            set_up_time = timer.time() - start_time
+            set_up_time = timer.time()
         else:
             set_up_time = None
 
@@ -149,7 +147,6 @@ class BaseSolver(object):
         # Assign times
         solution.solve_time = solve_time
         if set_up_time:
-            solution.total_time = timer.time() - start_time
             solution.set_up_time = set_up_time
 
         # Set self.t and self.y0 to their values at the final step

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -21,7 +21,7 @@ class CasadiSolver(pybamm.DaeSolver):
 
     def __init__(
         self,
-        method="idas",
+        method="ida",
         rtol=1e-6,
         atol=1e-6,
         root_method="lm",
@@ -31,6 +31,68 @@ class CasadiSolver(pybamm.DaeSolver):
     ):
         super().__init__(method, rtol, atol, root_method, root_tol, max_steps)
         self.extra_options = extra_options
+        self.name = "CasADi solver ({})".format(method)
+
+    def solve(self, model, t_eval, mode="safe"):
+        """
+        Execute the solver setup and calculate the solution of the model at
+        specified times.
+
+        Parameters
+        ----------
+        model : :class:`pybamm.BaseModel`
+            The model whose solution to calculate. Must have attributes rhs and
+            initial_conditions
+        t_eval : numeric type
+            The times at which to compute the solution
+        mode : str
+            How to solve the model (default is "safe"):
+
+            - "fast": perform direct integration, without accounting for events. \
+            Recommended when simulating a drive cycle or other simulation where \
+            no events should be triggered.
+            - "safe": perform step-and-check integration, checking whether events have \
+            been triggered. Recommended for simulations of a full charge or discharge.    
+
+        Raises
+        ------
+        :class:`pybamm.ValueError`
+            If an invalid mode is passed.
+        :class:`pybamm.ModelError`
+            If an empty model is passed (`model.rhs = {}` and `model.algebraic={}`)
+
+        """
+        if mode == "fast":
+            # Solve model normally by calling the solve method from parent class
+            return super().solve(model, t_eval)
+        elif mode == "safe":
+            # Step-and-check
+            # old_event_signs = np.sign(
+            #     np.concatenate([event(0, y0) for event in self.events])
+            # )
+            timer = pybamm.Timer()
+            self.set_up_casadi(model)
+            set_up_time = timer.time()
+            self.t = 0.0
+            solution = None
+            for dt in np.diff(t_eval):
+                current_step_sol = self.step(model, dt)
+                if not solution:
+                    # create solution object on first step
+                    solution = current_step_sol
+                    solution.set_up_time = set_up_time
+                else:
+                    # append solution from the current step to solution
+                    solution.append(current_step_sol)
+            return solution
+        else:
+            raise ValueError(
+                """
+                invalid mode '{}'. Must be either 'safe', for solving with events, 
+                or 'fast', for solving quickly without events""".format(
+                    mode
+                )
+            )
 
     def compute_solution(self, model, t_eval):
         """Calculate the solution of the model at specified times. In this class, we

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -34,7 +34,7 @@ class CasadiSolver(pybamm.DaeSolver):
         The tolerance for root-finding. Default is 1e-6.
     max_step_decrease_counts : float, optional
         The maximum number of times step size can be decreased before an error is
-        raised. Default is 10.
+        raised. Default is 5.
     extra_options : keyword arguments, optional
         Any extra keyword-arguments; these are passed directly to the CasADi integrator.
         Please consult `CasADi documentation <https://tinyurl.com/y5rk76os>`_ for
@@ -50,7 +50,7 @@ class CasadiSolver(pybamm.DaeSolver):
         atol=1e-6,
         root_method="lm",
         root_tol=1e-6,
-        max_step_decrease_count=10,
+        max_step_decrease_count=5,
         **extra_options,
     ):
         super().__init__(method, rtol, atol, root_method, root_tol)
@@ -80,7 +80,7 @@ class CasadiSolver(pybamm.DaeSolver):
             initial_conditions
         t_eval : numeric type
             The times at which to compute the solution
-        
+
         Raises
         ------
         :class:`pybamm.ValueError`
@@ -128,7 +128,7 @@ class CasadiSolver(pybamm.DaeSolver):
                         if solution is None:
                             t = 0
                         else:
-                            t = solution.t
+                            t = solution.t[-1]
                         raise pybamm.SolverError(
                             """
                             Maximum number of decreased steps occurred at t={}. Try
@@ -160,8 +160,6 @@ class CasadiSolver(pybamm.DaeSolver):
                     else:
                         # append solution from the current step to solution
                         solution.append(current_step_sol)
-            if not hasattr(solution, "termination"):
-                solution.termination = "final time"
 
             # Calculate more exact termination reason
             solution.termination = self.get_termination_reason(solution, self.events)

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -68,7 +68,7 @@ class CasadiSolver(pybamm.DaeSolver):
             Recommended when simulating a drive cycle or other simulation where \
             no events should be triggered.
             - "safe": perform step-and-check integration, checking whether events have \
-            been triggered. Recommended for simulations of a full charge or discharge.   
+            been triggered. Recommended for simulations of a full charge or discharge.
 
         Raises
         ------

--- a/pybamm/solvers/dae_solver.py
+++ b/pybamm/solvers/dae_solver.py
@@ -39,6 +39,7 @@ class DaeSolver(pybamm.BaseSolver):
         self.root_method = root_method
         self.root_tol = root_tol
         self.max_steps = max_steps
+        self.name = "Base DAE solver"
 
     @property
     def root_method(self):

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -43,6 +43,7 @@ class IDAKLUSolver(pybamm.DaeSolver):
             raise ImportError("KLU is not installed")
 
         super().__init__("ida", rtol, atol, root_method, root_tol, max_steps)
+        self.name = "IDA KLU solver"
 
     def integrate(self, residuals, y0, t_eval, events, mass_matrix, jacobian):
         """

--- a/pybamm/solvers/ode_solver.py
+++ b/pybamm/solvers/ode_solver.py
@@ -19,6 +19,7 @@ class OdeSolver(pybamm.BaseSolver):
 
     def __init__(self, method=None, rtol=1e-6, atol=1e-6):
         super().__init__(method, rtol, atol)
+        self.name = "Base ODE solver"
 
     def compute_solution(self, model, t_eval):
         """Calculate the solution of the model at specified times.

--- a/pybamm/solvers/scikits_dae_solver.py
+++ b/pybamm/solvers/scikits_dae_solver.py
@@ -48,6 +48,7 @@ class ScikitsDaeSolver(pybamm.DaeSolver):
             raise ImportError("scikits.odes is not installed")
 
         super().__init__(method, rtol, atol, root_method, root_tol, max_steps)
+        self.name = "Scikits DAE solver ({})".format(method)
 
     def integrate(
         self, residuals, y0, t_eval, events=None, mass_matrix=None, jacobian=None

--- a/pybamm/solvers/scikits_ode_solver.py
+++ b/pybamm/solvers/scikits_ode_solver.py
@@ -40,6 +40,7 @@ class ScikitsOdeSolver(pybamm.OdeSolver):
 
         super().__init__(method, rtol, atol)
         self.linsolver = linsolver
+        self.name = "Scikits ODE solver ({})".format(method)
 
     def integrate(
         self, derivs, y0, t_eval, events=None, mass_matrix=None, jacobian=None

--- a/pybamm/solvers/scipy_solver.py
+++ b/pybamm/solvers/scipy_solver.py
@@ -22,6 +22,7 @@ class ScipySolver(pybamm.OdeSolver):
 
     def __init__(self, method="BDF", rtol=1e-6, atol=1e-6):
         super().__init__(method, rtol, atol)
+        self.name = "Scipy solver ({})".format(method)
 
     def integrate(
         self, derivs, y0, t_eval, events=None, mass_matrix=None, jacobian=None

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -93,3 +93,8 @@ class Solution(object):
         """
         self.t = np.concatenate((self.t, solution.t[1:]))
         self.y = np.concatenate((self.y, solution.y[:, 1:]), axis=1)
+        self.solve_time += solution.solve_time
+
+    @property
+    def total_time(self):
+        return self.set_up_time + self.solve_time

--- a/tests/unit/test_solvers/test_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_algebraic_solver.py
@@ -107,11 +107,6 @@ class TestAlgebraicSolver(unittest.TestCase):
             model.variables["var2"].evaluate(t=None, y=solution.y), sol[100:]
         )
 
-        # Test time
-        self.assertGreater(
-            solution.total_time, solution.solve_time + solution.set_up_time
-        )
-
         # Test without jacobian
         model.use_jacobian = False
         solution_no_jac = solver.solve(model)

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -61,11 +61,8 @@ class TestCasadiSolver(unittest.TestCase):
         warnings.simplefilter("default")
 
     def test_bad_mode(self):
-        solver = pybamm.CasadiSolver()
-        model = pybamm.BaseModel()
-        model.events = {1: 2}
         with self.assertRaisesRegex(ValueError, "invalid mode"):
-            solver.solve(model, None, "bad mode")
+            pybamm.CasadiSolver(mode="bad mode")
 
     def test_model_solver(self):
         # Create model
@@ -83,6 +80,13 @@ class TestCasadiSolver(unittest.TestCase):
         disc.process_model(model)
         # Solve
         solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8, method="idas")
+        t_eval = np.linspace(0, 1, 100)
+        solution = solver.solve(model, t_eval)
+        np.testing.assert_array_equal(solution.t, t_eval)
+        np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
+
+        # Fast mode
+        solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8, method="idas", mode="fast")
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -60,6 +60,11 @@ class TestCasadiSolver(unittest.TestCase):
         # Turn warnings back on
         warnings.simplefilter("default")
 
+    def test_bad_mode(self):
+        solver = pybamm.CasadiSolver()
+        with self.assertRaisesRegex(ValueError, "invalid mode"):
+            solver.solve(None, None, "bad mode")
+
     def test_model_solver(self):
         # Create model
         model = pybamm.BaseModel()
@@ -80,11 +85,6 @@ class TestCasadiSolver(unittest.TestCase):
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-
-        # Test time
-        self.assertGreater(
-            solution.total_time, solution.solve_time + solution.set_up_time
-        )
 
     def test_model_step(self):
         # Create model

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -411,11 +411,6 @@ class TestScikitsSolvers(unittest.TestCase):
         np.testing.assert_array_equal(solution.t, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
 
-        # Test time
-        self.assertGreater(
-            solution.total_time, solution.solve_time + solution.set_up_time
-        )
-
     def test_model_solver_ode_events(self):
         # Create model
         model = pybamm.BaseModel()
@@ -507,11 +502,6 @@ class TestScikitsSolvers(unittest.TestCase):
         np.testing.assert_array_equal(solution.t, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
         np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
-
-        # Test time
-        self.assertGreater(
-            solution.total_time, solution.solve_time + solution.set_up_time
-        )
 
     def test_model_solver_dae_bad_ics(self):
         # Create model

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -154,7 +154,7 @@ class TestScipySolver(unittest.TestCase):
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
 
         # Test time
-        self.assertGreater(
+        self.assertEqual(
             solution.total_time, solution.solve_time + solution.set_up_time
         )
 


### PR DESCRIPTION
# Description

Add 'safe' mode to casadi for solving with events. This is hacky and make the solver slower.

Fixes #684 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
