### PR TITLE
#547 remove sto times zero

### DIFF
--- a/input/parameters/lithium-ion/anodes/graphite_mcmb2528_Marquis2019/graphite_mcmb2528_diffusivity_Dualfoil1998.py
+++ b/input/parameters/lithium-ion/anodes/graphite_mcmb2528_Marquis2019/graphite_mcmb2528_diffusivity_Dualfoil1998.py
@@ -32,7 +32,4 @@ def graphite_mcmb2528_diffusivity_Dualfoil1998(sto, T, T_inf, E_D_s, R_g):
     D_ref = 3.9 * 10 ** (-14)
     arrhenius = np.exp(E_D_s / R_g * (1 / T_inf - 1 / T))
 
-    # Removing the fudge factor 0 * sto requires different handling of either
-    # either simplifications or how sto is passed into this function.
-    # See #547
-    return D_ref * arrhenius + 0 * sto
+    return D_ref * arrhenius

--- a/input/parameters/lithium-ion/cathodes/lico2_Marquis2019/lico2_diffusivity_Dualfoil1998.py
+++ b/input/parameters/lithium-ion/cathodes/lico2_Marquis2019/lico2_diffusivity_Dualfoil1998.py
@@ -32,7 +32,4 @@ def lico2_diffusivity_Dualfoil1998(sto, T, T_inf, E_D_s, R_g):
     D_ref = 1 * 10 ** (-13)
     arrhenius = np.exp(E_D_s / R_g * (1 / T_inf - 1 / T))
 
-    # Removing the fudge factor 0 * sto requires different handling of either
-    # either simplifications or how sto is passed into this function.
-    # See #547
-    return D_ref * arrhenius + 0 * sto
+    return D_ref * arrhenius


### PR DESCRIPTION
# Description
Remove sto*0 in the solid diffusion coefficients. This was fixed by something in an earlier PR which makes binary operators preserve shape during simplify (specifically addition of a scalar and a matrix) 

Fixes #547 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
