### PR TITLE
#505 see if warnings bug is fixed

### DIFF
--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -328,10 +328,8 @@ class TestBaseModel(unittest.TestCase):
         }
 
         # Check warning raised
-        # TODO: getting a strange bug here, related to CPython bug here:
-        #    https://bugs.python.org/issue29620
-        # with self.assertWarns(pybamm.ModelWarning):
-        model.check_well_posedness()
+        with self.assertWarns(pybamm.ModelWarning):
+            model.check_well_posedness()
 
         # Check None entries have been removed from the variables dictionary
         for key, item in model._variables.items():


### PR DESCRIPTION
# Description

Looks like the bug in warnings has now been fixed

Fixes #505 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
