### PR TITLE
#765 revert to uniform heating approximation

### DIFF
--- a/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
+++ b/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
@@ -47,12 +47,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        phi_s_cn = variables["Negative current collector potential"]
-        phi_s_cp = variables["Positive current collector potential"]
-        # Note: grad not implemented in 2D weak form, but can compute grad squared
-        # directly
-        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
-        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
+        # For now we use the approximation that current collector heating
+        # is uniform (see issue #765)
+        i_boundary_cc = variables["Current collector current density"]
+        Q_s_cn = i_boundary_cc / self.param.sigma_cn
+        Q_s_cp = i_boundary_cc / self.param.sigma_cp
         return Q_s_cn, Q_s_cp
 
     def _yz_average(self, var):

--- a/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
+++ b/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
@@ -23,12 +23,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        phi_s_cn = variables["Negative current collector potential"]
-        phi_s_cp = variables["Positive current collector potential"]
-        # Note: grad not implemented in 2D weak form, but can compute grad squared
-        # directly
-        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
-        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
+        # For now we use the approximation that current collector heating
+        # is uniform (see issue #765)
+        i_boundary_cc = variables["Current collector current density"]
+        Q_s_cn = i_boundary_cc / self.param.sigma_cn
+        Q_s_cp = i_boundary_cc / self.param.sigma_cp
         return Q_s_cn, Q_s_cp
 
     def _surface_cooling_coefficient(self):

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -156,9 +156,10 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         gradient operator with itself.
         See :meth:`pybamm.SpatialMethod.gradient_squared`
         """
-        stiffness_matrix = self.stiffness_matrix(symbol, boundary_conditions)
-
-        return stiffness_matrix @ (discretised_symbol ** 2)
+        # NOTE: this is incorrect (see issue #765)
+        # stiffness_matrix = self.stiffness_matrix(symbol, boundary_conditions)
+        # return stiffness_matrix @ (discretised_symbol ** 2)
+        raise NotImplementedError
 
     def stiffness_matrix(self, symbol, boundary_conditions):
         """

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -54,7 +54,6 @@ class TestScikitFiniteElement(unittest.TestCase):
             pybamm.laplacian(var) - pybamm.source(unit_source, var, boundary=True),
             pybamm.laplacian(var)
             - pybamm.source(unit_source ** 2 + 1 / var, var, boundary=True),
-            pybamm.grad_squared(var),
         ]:
             # Check that equation can be evaluated in each case
             # Dirichlet
@@ -124,6 +123,19 @@ class TestScikitFiniteElement(unittest.TestCase):
         x = pybamm.SpatialVariable("x", ["current collector"])
         with self.assertRaises(pybamm.GeometryError):
             disc.process_symbol(x)
+
+        # Grad-squared is incorrect, so for now should raise a NotImplementedError
+        # until it is fixed (see #765)
+        eqn = pybamm.grad_squared(var)
+        disc.set_variable_slices([var])
+        disc.bcs = {
+            var.id: {
+                "negative tab": (pybamm.Scalar(0), "Dirichlet"),
+                "positive tab": (pybamm.Scalar(1), "Dirichlet"),
+            }
+        }
+        with self.assertRaises(NotImplementedError):
+            disc.process_symbol(eqn)
 
     def test_manufactured_solution(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)


### PR DESCRIPTION
# Description
Reverts back to a uniform heating approximation in the current collectors. I probably won't get a chance to properly fix #765 for a little while as I'll be away for most on January, so I think it would be good to merge this approximation into master just so the solution gives the correct physical behavior. Then a proper fix can follow.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
