### PR TITLE
Issue 765 compute grad fem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+-   Added the gradient operation for the Finite Element Method ([#767](https://github.com/pybamm-team/PyBaMM/pull/767))
 -   Added `InputParameter` node for quickly changing parameter values ([#752](https://github.com/pybamm-team/PyBaMM/pull/752))
 -   Added submodels for operating modes other than current-controlled ([#751](https://github.com/pybamm-team/PyBaMM/pull/751))
 -   Changed finite volume discretisation to use exact values provided by Neumann boundary conditions when computing the gradient instead of adding ghost nodes([#748](https://github.com/pybamm-team/PyBaMM/pull/748))
@@ -35,6 +36,7 @@
 
 ## Bug fixes
 
+-   Fixed a bug which meant that the Ohmic heating in the current collectors was incorrect if using the Finite Element Method ([#767](https://github.com/pybamm-team/PyBaMM/pull/767))
 -   Improved automatic broadcasting ([#747](https://github.com/pybamm-team/PyBaMM/pull/747))
 -   Fixed bug with wrong temperature in initial conditions ([#737](https://github.com/pybamm-team/PyBaMM/pull/737))
 -   Improved flexibility of parameter values so that parameters (such as diffusivity or current) can be set as functions or scalars ([#723](https://github.com/pybamm-team/PyBaMM/pull/723))

--- a/docs/source/expression_tree/unary_operator.rst
+++ b/docs/source/expression_tree/unary_operator.rst
@@ -25,6 +25,9 @@ Unary Operators
 .. autoclass:: pybamm.Laplacian
   :members:
 
+.. autoclass:: pybamm.Gradient_Squared
+  :members:
+
 .. autoclass:: pybamm.Mass
   :members:
 
@@ -57,6 +60,8 @@ Unary Operators
 .. autofunction:: pybamm.div
 
 .. autofunction:: pybamm.laplacian
+
+.. autofunction:: pybamm.grad_squared
 
 .. autofunction:: pybamm.surf
 

--- a/docs/source/expression_tree/unary_operator.rst
+++ b/docs/source/expression_tree/unary_operator.rst
@@ -25,9 +25,6 @@ Unary Operators
 .. autoclass:: pybamm.Laplacian
   :members:
 
-.. autoclass:: pybamm.Gradient_Squared
-  :members:
-
 .. autoclass:: pybamm.Mass
   :members:
 
@@ -60,8 +57,6 @@ Unary Operators
 .. autofunction:: pybamm.div
 
 .. autofunction:: pybamm.laplacian
-
-.. autofunction:: pybamm.grad_squared
 
 .. autofunction:: pybamm.surf
 

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -730,6 +730,11 @@ class Discretisation(object):
             elif isinstance(symbol, pybamm.Laplacian):
                 return child_spatial_method.laplacian(child, disc_child, self.bcs)
 
+            elif isinstance(symbol, pybamm.Gradient_Squared):
+                return child_spatial_method.gradient_squared(
+                    child, disc_child, self.bcs
+                )
+
             elif isinstance(symbol, pybamm.Mass):
                 return child_spatial_method.mass_matrix(child, self.bcs)
 

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -730,11 +730,6 @@ class Discretisation(object):
             elif isinstance(symbol, pybamm.Laplacian):
                 return child_spatial_method.laplacian(child, disc_child, self.bcs)
 
-            elif isinstance(symbol, pybamm.Gradient_Squared):
-                return child_spatial_method.gradient_squared(
-                    child, disc_child, self.bcs
-                )
-
             elif isinstance(symbol, pybamm.Mass):
                 return child_spatial_method.mass_matrix(child, self.bcs)
 

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -322,23 +322,6 @@ class Laplacian(SpatialOperator):
         return False
 
 
-class Gradient_Squared(SpatialOperator):
-    """A node in the expression tree representing a the inner product of the grad
-    operator with itself. In particular, this is useful in the finite element
-    formualtion where we only require the (sclar valued) square of the gradient,
-    and  not the gradient itself.
-
-    **Extends:** :class:`SpatialOperator`
-    """
-
-    def __init__(self, child):
-        super().__init__("grad squared", child)
-
-    def evaluates_on_edges(self):
-        """ See :meth:`pybamm.Symbol.evaluates_on_edges()`. """
-        return True
-
-
 class Mass(SpatialOperator):
     """Returns the mass matrix for a given symbol, accounting for Dirchlet boundary
     conditions where necessary (e.g. in the finite element formualtion)
@@ -764,7 +747,7 @@ class BoundaryGradient(BoundaryOperator):
 
 
 #
-# Methods to call Gradient, Divergence, Laplacian and Gradient_Squared
+# Methods to call Gradient, Divergence and Laplacian
 #
 
 
@@ -823,26 +806,6 @@ def laplacian(expression):
     """
 
     return Laplacian(expression)
-
-
-def grad_squared(expression):
-    """convenience function for creating a :class:`Gradient_Squared`
-
-    Parameters
-    ----------
-
-    expression : :class:`Symbol`
-        the inner product of the gradient with itself will be performed on this
-        sub-expression
-
-    Returns
-    -------
-
-    :class:`Gradient_Squared`
-        inner product of the gradient of ``expression`` with itself
-    """
-
-    return Gradient_Squared(expression)
 
 
 #

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -322,6 +322,22 @@ class Laplacian(SpatialOperator):
         return False
 
 
+class Gradient_Squared(SpatialOperator):
+    """A node in the expression tree representing a the inner product of the grad
+    operator with itself. In particular, this is useful in the finite element
+    formualtion where we only require the (sclar valued) square of the gradient,
+    and  not the gradient itself.
+    **Extends:** :class:`SpatialOperator`
+    """
+
+    def __init__(self, child):
+        super().__init__("grad squared", child)
+
+    def evaluates_on_edges(self):
+        """ See :meth:`pybamm.Symbol.evaluates_on_edges()`. """
+        return True
+
+
 class Mass(SpatialOperator):
     """Returns the mass matrix for a given symbol, accounting for Dirchlet boundary
     conditions where necessary (e.g. in the finite element formualtion)
@@ -747,7 +763,7 @@ class BoundaryGradient(BoundaryOperator):
 
 
 #
-# Methods to call Gradient, Divergence and Laplacian
+# Methods to call Gradient, Divergence, Laplacian and Gradient_Squared
 #
 
 
@@ -806,6 +822,26 @@ def laplacian(expression):
     """
 
     return Laplacian(expression)
+
+
+def grad_squared(expression):
+    """convenience function for creating a :class:`Gradient_Squared`
+
+    Parameters
+    ----------
+
+    expression : :class:`Symbol`
+        the inner product of the gradient with itself will be performed on this
+        sub-expression
+
+    Returns
+    -------
+
+    :class:`Gradient_Squared`
+        inner product of the gradient of ``expression`` with itself
+    """
+
+    return Gradient_Squared(expression)
 
 
 #

--- a/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
+++ b/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
@@ -47,11 +47,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        # For now we use the approximation that current collector heating
-        # is uniform (see issue #765)
-        i_boundary_cc = variables["Current collector current density"]
-        Q_s_cn = i_boundary_cc / self.param.sigma_cn
-        Q_s_cp = i_boundary_cc / self.param.sigma_cp
+        phi_s_cn = variables["Negative current collector potential"]
+        phi_s_cp = variables["Positive current collector potential"]
+
+        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
+        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
         return Q_s_cn, Q_s_cp
 
     def _yz_average(self, var):

--- a/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
+++ b/pybamm/models/submodels/thermal/x_lumped/x_lumped_2D_current_collectors.py
@@ -47,12 +47,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        phi_s_cn = variables["Negative current collector potential"]
-        phi_s_cp = variables["Positive current collector potential"]
-        # Note: grad not implemented in 2D weak form, but can compute grad squared
-        # directly
-        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
-        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
+        # For now we use the approximation that current collector heating
+        # is uniform (see issue #765)
+        i_boundary_cc = variables["Current collector current density"]
+        Q_s_cn = i_boundary_cc / self.param.sigma_cn
+        Q_s_cp = i_boundary_cc / self.param.sigma_cp
         return Q_s_cn, Q_s_cp
 
     def _yz_average(self, var):

--- a/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
+++ b/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
@@ -23,12 +23,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        phi_s_cn = variables["Negative current collector potential"]
-        phi_s_cp = variables["Positive current collector potential"]
-        # Note: grad not implemented in 2D weak form, but can compute grad squared
-        # directly
-        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
-        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
+        # For now we use the approximation that current collector heating
+        # is uniform (see issue #765)
+        i_boundary_cc = variables["Current collector current density"]
+        Q_s_cn = i_boundary_cc / self.param.sigma_cn
+        Q_s_cp = i_boundary_cc / self.param.sigma_cp
         return Q_s_cn, Q_s_cp
 
     def _surface_cooling_coefficient(self):

--- a/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
+++ b/pybamm/models/submodels/thermal/xyz_lumped/xyz_lumped_2D_current_collector.py
@@ -23,11 +23,11 @@ class CurrentCollector2D(BaseModel):
 
     def _current_collector_heating(self, variables):
         """Returns the heat source terms in the 2D current collector"""
-        # For now we use the approximation that current collector heating
-        # is uniform (see issue #765)
-        i_boundary_cc = variables["Current collector current density"]
-        Q_s_cn = i_boundary_cc / self.param.sigma_cn
-        Q_s_cp = i_boundary_cc / self.param.sigma_cp
+        phi_s_cn = variables["Negative current collector potential"]
+        phi_s_cp = variables["Positive current collector potential"]
+
+        Q_s_cn = self.param.sigma_cn_prime * pybamm.grad_squared(phi_s_cn)
+        Q_s_cp = self.param.sigma_cp_prime * pybamm.grad_squared(phi_s_cp)
         return Q_s_cn, Q_s_cp
 
     def _surface_cooling_coefficient(self):

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -156,9 +156,10 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         gradient operator with itself.
         See :meth:`pybamm.SpatialMethod.gradient_squared`
         """
-        stiffness_matrix = self.stiffness_matrix(symbol, boundary_conditions)
-
-        return stiffness_matrix @ (discretised_symbol ** 2)
+        # NOTE: this is incorrect (see issue #765)
+        # stiffness_matrix = self.stiffness_matrix(symbol, boundary_conditions)
+        # return stiffness_matrix @ (discretised_symbol ** 2)
+        raise NotImplementedError
 
     def stiffness_matrix(self, symbol, boundary_conditions):
         """

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -122,6 +122,14 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
 
         return grad
 
+    def gradient_squared(self, symbol, discretised_symbol, boundary_conditions):
+        """Multiplication to implement the inner product of the gradient operator
+        with itself. See :meth:`pybamm.SpatialMethod.gradient_squared`
+        """
+        grad = self.gradient(symbol, discretised_symbol, boundary_conditions)
+        grad_y, grad_z = grad.orphans
+        return grad_y ** 2 + grad_z ** 2
+
     def gradient_matrix(self, symbol, boundary_conditions):
         """
         Gradient matrix for finite elements in the appropriate domain.

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -70,7 +70,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
     def gradient(self, symbol, discretised_symbol, boundary_conditions):
         """Matrix-vector multiplication to implement the gradient operator. The
         gradient w of the function u is approximated by the finite element method
-        using the same function space as w, i.e. we solve w = grad(u), which
+        using the same function space as u, i.e. we solve w = grad(u), which
         corresponds to the weak form w*v*dx = grad(u)*v*dx, where v is a suitable
         test function.
 
@@ -111,8 +111,8 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         mass_inv = pybamm.Matrix(inv(csc_matrix(mass)))
 
         # compute gradient
-        grad_y = mass_inv @ grad_y_matrix @ discretised_symbol
-        grad_z = mass_inv @ grad_z_matrix @ discretised_symbol
+        grad_y = mass_inv @ (grad_y_matrix @ discretised_symbol)
+        grad_z = mass_inv @ (grad_z_matrix @ discretised_symbol)
 
         # create concatenation
         grad = pybamm.Concatenation(
@@ -156,7 +156,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         def gradient_dy(u, du, v, dv, w):
             return du[0] * v[0]
 
-        # make form for the gradient in the \ direction
+        # make form for the gradient in the z direction
         @skfem.bilinear_form
         def gradient_dz(u, du, v, dv, w):
             return du[1] * v[1]

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -151,19 +151,19 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         domain = symbol.domain[0]
         mesh = self.mesh[domain][0]
 
-        # make form for the gradient in the x direction
-        @skfem.bilinear_form
-        def gradient_dx(u, du, v, dv, w):
-            return du[0] * v[0]
-
         # make form for the gradient in the y direction
         @skfem.bilinear_form
         def gradient_dy(u, du, v, dv, w):
+            return du[0] * v[0]
+
+        # make form for the gradient in the \ direction
+        @skfem.bilinear_form
+        def gradient_dz(u, du, v, dv, w):
             return du[1] * v[1]
 
         # assemble the matrices
-        grad_y = skfem.asm(gradient_dx, mesh.basis)
-        grad_z = skfem.asm(gradient_dy, mesh.basis)
+        grad_y = skfem.asm(gradient_dy, mesh.basis)
+        grad_z = skfem.asm(gradient_dz, mesh.basis)
 
         return pybamm.Matrix(grad_y), pybamm.Matrix(grad_z)
 

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -175,6 +175,28 @@ class SpatialMethod:
         """
         raise NotImplementedError
 
+    def gradient_squared(self, symbol, discretised_symbol, boundary_conditions):
+        """
+        Implements the inner product of the gradient with itself for a spatial method.
+
+        Parameters
+        ----------
+        symbol: :class:`pybamm.Symbol`
+            The symbol that we will take the gradient of.
+        discretised_symbol: :class:`pybamm.Symbol`
+            The discretised symbol of the correct size
+        boundary_conditions : dict
+            The boundary conditions of the model
+            ({symbol.id: {"left": left bc, "right": right bc}})
+
+        Returns
+        -------
+        :class: `pybamm.Array`
+            Contains the result of taking the inner product of the result of acting
+            the discretised gradient on the child discretised_symbol with itself
+        """
+        raise NotImplementedError
+
     def integral(self, child, discretised_child):
         """
         Implements the integral for a spatial method.

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -175,29 +175,6 @@ class SpatialMethod:
         """
         raise NotImplementedError
 
-    def gradient_squared(self, symbol, discretised_symbol, boundary_conditions):
-        """
-        Implements the inner product of the gradient with itself for a spatial method.
-
-        Parameters
-        ----------
-        symbol: :class:`pybamm.Symbol`
-            The symbol that we will take the gradient of.
-        discretised_symbol: :class:`pybamm.Symbol`
-            The discretised symbol of the correct size
-
-        boundary_conditions : dict
-            The boundary conditions of the model
-            ({symbol.id: {"left": left bc, "right": right bc}})
-
-        Returns
-        -------
-        :class: `pybamm.Array`
-            Contains the result of taking the inner product of the result of acting
-            the discretised gradient on the child discretised_symbol with itself
-        """
-        raise NotImplementedError
-
     def integral(self, child, discretised_child):
         """
         Implements the integral for a spatial method.

--- a/tests/unit/test_spatial_methods/test_base_spatial_method.py
+++ b/tests/unit/test_spatial_methods/test_base_spatial_method.py
@@ -20,8 +20,6 @@ class TestSpatialMethod(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             spatial_method.laplacian(None, None, None)
         with self.assertRaises(NotImplementedError):
-            spatial_method.gradient_squared(None, None, None)
-        with self.assertRaises(NotImplementedError):
             spatial_method.integral(None, None)
         with self.assertRaises(NotImplementedError):
             spatial_method.indefinite_integral(None, None)

--- a/tests/unit/test_spatial_methods/test_base_spatial_method.py
+++ b/tests/unit/test_spatial_methods/test_base_spatial_method.py
@@ -20,6 +20,8 @@ class TestSpatialMethod(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             spatial_method.laplacian(None, None, None)
         with self.assertRaises(NotImplementedError):
+            spatial_method.gradient_squared(None, None, None)
+        with self.assertRaises(NotImplementedError):
             spatial_method.integral(None, None)
         with self.assertRaises(NotImplementedError):
             spatial_method.indefinite_integral(None, None)

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -141,8 +141,20 @@ class TestScikitFiniteElement(unittest.TestCase):
         grad_disc = disc.process_symbol(gradient)
         grad_disc_y, grad_disc_z = grad_disc.children
 
-        np.testing.assert_array_almost_equal(grad_disc_y.evaluate(None, 5*y + 6*z), 5*np.ones_like(y)[:, np.newaxis])
-        np.testing.assert_array_almost_equal(grad_disc_z.evaluate(None, 5*y + 6*z), 6*np.ones_like(z)[:, np.newaxis])
+        np.testing.assert_array_almost_equal(
+            grad_disc_y.evaluate(None, 5 * y + 6 * z),
+            5 * np.ones_like(y)[:, np.newaxis],
+        )
+        np.testing.assert_array_almost_equal(
+            grad_disc_z.evaluate(None, 5 * y + 6 * z),
+            6 * np.ones_like(z)[:, np.newaxis],
+        )
+
+        # check grad_squared positive
+        eqn = pybamm.grad_squared(var)
+        eqn_disc = disc.process_symbol(eqn)
+        ans = eqn_disc.evaluate(None, 3 * y ** 2)
+        self.assertTrue(all(ans > 0))
 
     def test_manufactured_solution(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -154,7 +154,7 @@ class TestScikitFiniteElement(unittest.TestCase):
         eqn = pybamm.grad_squared(var)
         eqn_disc = disc.process_symbol(eqn)
         ans = eqn_disc.evaluate(None, 3 * y ** 2)
-        self.assertTrue(all(ans > 0))
+        np.testing.assert_array_less(0, ans)
 
     def test_manufactured_solution(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -14,8 +14,6 @@ class TestScikitFiniteElement(unittest.TestCase):
         spatial_method.build(mesh)
         self.assertEqual(spatial_method.mesh, mesh)
         with self.assertRaises(NotImplementedError):
-            spatial_method.gradient(None, None, None)
-        with self.assertRaises(NotImplementedError):
             spatial_method.divergence(None, None, None)
         with self.assertRaises(NotImplementedError):
             spatial_method.indefinite_integral(None, None)
@@ -123,19 +121,6 @@ class TestScikitFiniteElement(unittest.TestCase):
         x = pybamm.SpatialVariable("x", ["current collector"])
         with self.assertRaises(pybamm.GeometryError):
             disc.process_symbol(x)
-
-        # Grad-squared is incorrect, so for now should raise a NotImplementedError
-        # until it is fixed (see #765)
-        eqn = pybamm.grad_squared(var)
-        disc.set_variable_slices([var])
-        disc.bcs = {
-            var.id: {
-                "negative tab": (pybamm.Scalar(0), "Dirichlet"),
-                "positive tab": (pybamm.Scalar(1), "Dirichlet"),
-            }
-        }
-        with self.assertRaises(NotImplementedError):
-            disc.process_symbol(eqn)
 
     def test_manufactured_solution(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -54,7 +54,6 @@ class TestScikitFiniteElement(unittest.TestCase):
             pybamm.laplacian(var) - pybamm.source(unit_source, var, boundary=True),
             pybamm.laplacian(var)
             - pybamm.source(unit_source ** 2 + 1 / var, var, boundary=True),
-            pybamm.grad_squared(var),
         ]:
             # Check that equation can be evaluated in each case
             # Dirichlet
@@ -124,6 +123,19 @@ class TestScikitFiniteElement(unittest.TestCase):
         x = pybamm.SpatialVariable("x", ["current collector"])
         with self.assertRaises(pybamm.GeometryError):
             disc.process_symbol(x)
+
+        # Grad-squared is incorrect, so for now should raise a NotImplementedError
+        # until it is fixed (see #765)
+        eqn = pybamm.grad_squared(var)
+        disc.set_variable_slices([var])
+        disc.bcs = {
+            var.id: {
+                "negative tab": (pybamm.Scalar(0), "Dirichlet"),
+                "positive tab": (pybamm.Scalar(1), "Dirichlet"),
+            }
+        }
+        with self.assertRaises(NotImplementedError):
+            disc.process_symbol(eqn)
 
     def test_manufactured_solution(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=32, zpts=32)


### PR DESCRIPTION
# Description
Added the gradient operation in the finite element method. This has then been used to compute the ohmic heating in the current collector 

Fixes #765 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
