### PR TITLE
#803 make visualise fail only raise logger error

### DIFF
--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -285,9 +285,13 @@ class Symbol(anytree.NodeMixin):
 
         new_node, counter = self.relabel_tree(self, 0)
 
-        DotExporter(
-            new_node, nodeattrfunc=lambda node: 'label="{}"'.format(node.label)
-        ).to_picture(filename)
+        try:
+            DotExporter(
+                new_node, nodeattrfunc=lambda node: 'label="{}"'.format(node.label)
+            ).to_picture(filename)
+        except FileNotFoundError:
+            # raise error but only through logger so that test passes
+            pybamm.logger.error("Please install graphviz>=2.42.2 to use dot exporter")
 
     def relabel_tree(self, symbol, counter):
         """ Finds all children of a symbol and assigns them a new id so that they can be


### PR DESCRIPTION
# Description

Make visualise raise a logger error only if graphviz is not installed (so that graphviz is an optional dependency)
Fixes #803 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
