### PR TITLE
Issue 804 initialize casadi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+-   Changed rootfinding algorithm to CasADi, scipy.optimize.root still accessible as an option ([#844](https://github.com/pybamm-team/PyBaMM/pull/844))
 -   Added NCA parameter set ([#824](https://github.com/pybamm-team/PyBaMM/pull/824))
 -   Added functionality to `Solution` that automatically gets `t_eval` from the data when simulating drive cycles and performs checks to ensure the output has the required resolution to accurately capture the input current ([#819](https://github.com/pybamm-team/PyBaMM/pull/819))
 -   Added options to export a solution to matlab or csv ([#811](https://github.com/pybamm-team/PyBaMM/pull/811))

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -361,26 +361,21 @@ class BaseSolver(object):
             y = casadi.vertcat(y0_diff, y_alg)
             alg_root = model.casadi_algebraic(time, y, u)
             # Solve
-            try:
-                # set error_on_fail to False and just check the final output is small
-                # enough
-                roots = casadi.rootfinder(
-                    "roots",
-                    "newton",
-                    dict(x=y_alg, p=u, g=alg_root),
-                    {"error_on_fail": False},
-                )
-                y0_alg = roots(y0_alg_guess, u_stacked).full().flatten()
-                success = True
-                message = None
-                # Check final output
-                fun = model.casadi_algebraic(
-                    time, casadi.vertcat(y0_diff, y0_alg), u_stacked
-                )
-            except RuntimeError as err:
-                success = False
-                message = err.args[0]
-                fun = None
+            # set error_on_fail to False and just check the final output is small
+            # enough
+            roots = casadi.rootfinder(
+                "roots",
+                "newton",
+                dict(x=y_alg, p=u, g=alg_root),
+                {"error_on_fail": False},
+            )
+            y0_alg = roots(y0_alg_guess, u_stacked).full().flatten()
+            success = True
+            message = None
+            # Check final output
+            fun = model.casadi_algebraic(
+                time, casadi.vertcat(y0_diff, y0_alg), u_stacked
+            )
         else:
             algebraic = model.algebraic_eval
             jac = model.jac_algebraic_eval

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -47,7 +47,7 @@ class CasadiSolver(pybamm.BaseSolver):
         mode="safe",
         rtol=1e-6,
         atol=1e-6,
-        root_method="lm",
+        root_method="casadi",
         root_tol=1e-6,
         max_step_decrease_count=5,
         **extra_options,

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -36,7 +36,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
     """
 
     def __init__(
-        self, rtol=1e-6, atol=1e-6, root_method="lm", root_tol=1e-6, max_steps=1000
+        self, rtol=1e-6, atol=1e-6, root_method="casadi", root_tol=1e-6, max_steps=1000
     ):
 
         if idaklu_spec is None:

--- a/pybamm/solvers/scikits_dae_solver.py
+++ b/pybamm/solvers/scikits_dae_solver.py
@@ -40,7 +40,7 @@ class ScikitsDaeSolver(pybamm.BaseSolver):
         method="ida",
         rtol=1e-6,
         atol=1e-6,
-        root_method="lm",
+        root_method="casadi",
         root_tol=1e-6,
         max_steps=1000,
     ):

--- a/setup.py
+++ b/setup.py
@@ -492,7 +492,7 @@ setup(
     # List of dependencies
     install_requires=[
         "numpy>=1.16",
-        "scipy>=1.0",
+        "scipy>=1.3",
         "pandas>=0.24",
         "anytree>=2.4.3",
         "autograd>=1.2",

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Base Solver class
 #
+import casadi
 import pybamm
 import numpy as np
 from scipy.sparse import csr_matrix
@@ -49,9 +50,16 @@ class TestBaseSolver(unittest.TestCase):
     def test_find_consistent_initial_conditions(self):
         # Simple system: a single algebraic equation
         class ScalarModel:
-            concatenated_initial_conditions = np.array([[2]])
-            jac_algebraic_eval = None
-            timescale = 1
+            def __init__(self):
+                self.concatenated_initial_conditions = np.array([[2]])
+                self.jac_algebraic_eval = None
+                self.timescale = 1
+                t = casadi.MX.sym("t")
+                y = casadi.MX.sym("y")
+                u = casadi.MX.sym("u")
+                self.casadi_algebraic = casadi.Function(
+                    "alg", [t, y, u], [self.algebraic_eval(t, y)]
+                )
 
             def rhs_eval(self, t, y):
                 return np.array([])
@@ -59,18 +67,30 @@ class TestBaseSolver(unittest.TestCase):
             def algebraic_eval(self, t, y):
                 return y + 2
 
-        solver = pybamm.BaseSolver()
+        solver = pybamm.BaseSolver(root_method="lm")
         model = ScalarModel()
         init_cond = solver.calculate_consistent_state(model)
+        np.testing.assert_array_equal(init_cond, -2)
+        # with casadi
+        solver_with_casadi = pybamm.BaseSolver(root_method="casadi")
+        model = ScalarModel()
+        init_cond = solver_with_casadi.calculate_consistent_state(model)
         np.testing.assert_array_equal(init_cond, -2)
 
         # More complicated system
         vec = np.array([0.0, 1.0, 1.5, 2.0])
 
         class VectorModel:
-            concatenated_initial_conditions = np.zeros_like(vec)
-            jac_algebraic_eval = None
-            timescale = 1
+            def __init__(self):
+                self.concatenated_initial_conditions = np.zeros_like(vec)
+                self.jac_algebraic_eval = None
+                self.timescale = 1
+                t = casadi.MX.sym("t")
+                y = casadi.MX.sym("y", vec.size)
+                u = casadi.MX.sym("u")
+                self.casadi_algebraic = casadi.Function(
+                    "alg", [t, y, u], [self.algebraic_eval(t, y)]
+                )
 
             def rhs_eval(self, t, y):
                 return y[0:1]
@@ -80,6 +100,9 @@ class TestBaseSolver(unittest.TestCase):
 
         model = VectorModel()
         init_cond = solver.calculate_consistent_state(model)
+        np.testing.assert_array_almost_equal(init_cond, vec)
+        # with casadi
+        init_cond = solver_with_casadi.calculate_consistent_state(model)
         np.testing.assert_array_almost_equal(init_cond, vec)
 
         # With jacobian
@@ -102,9 +125,16 @@ class TestBaseSolver(unittest.TestCase):
 
     def test_fail_consistent_initial_conditions(self):
         class Model:
-            concatenated_initial_conditions = np.array([2])
-            jac_algebraic_eval = None
-            timescale = 1
+            def __init__(self):
+                self.concatenated_initial_conditions = np.array([2])
+                self.jac_algebraic_eval = None
+                self.timescale = 1
+                t = casadi.MX.sym("t")
+                y = casadi.MX.sym("y")
+                u = casadi.MX.sym("u")
+                self.casadi_algebraic = casadi.Function(
+                    "alg", [t, y, u], [self.algebraic_eval(t, y)]
+                )
 
             def rhs_eval(self, t, y):
                 return np.array([])
@@ -120,7 +150,14 @@ class TestBaseSolver(unittest.TestCase):
             "Could not find consistent initial conditions: The iteration is not making",
         ):
             solver.calculate_consistent_state(Model())
-        solver = pybamm.BaseSolver()
+        solver = pybamm.BaseSolver(root_method="lm")
+        with self.assertRaisesRegex(
+            pybamm.SolverError,
+            "Could not find consistent initial conditions: solver terminated",
+        ):
+            solver.calculate_consistent_state(Model())
+        # with casadi
+        solver = pybamm.BaseSolver(root_method="casadi")
         with self.assertRaisesRegex(
             pybamm.SolverError,
             "Could not find consistent initial conditions: solver terminated",

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -72,7 +72,7 @@ class TestBaseSolver(unittest.TestCase):
         init_cond = solver.calculate_consistent_state(model)
         np.testing.assert_array_equal(init_cond, -2)
         # with casadi
-        solver_with_casadi = pybamm.BaseSolver(root_method="casadi")
+        solver_with_casadi = pybamm.BaseSolver(root_method="casadi", root_tol=1e-12)
         model = ScalarModel()
         init_cond = solver_with_casadi.calculate_consistent_state(model)
         np.testing.assert_array_equal(init_cond, -2)
@@ -160,7 +160,7 @@ class TestBaseSolver(unittest.TestCase):
         solver = pybamm.BaseSolver(root_method="casadi")
         with self.assertRaisesRegex(
             pybamm.SolverError,
-            "Could not find consistent initial conditions: solver terminated",
+            "Could not find consistent initial conditions: .../casadi",
         ):
             solver.calculate_consistent_state(Model())
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -28,7 +28,7 @@ class TestIDAKLUSolver(unittest.TestCase):
             disc = pybamm.Discretisation()
             disc.process_model(model)
 
-            solver = pybamm.IDAKLUSolver()
+            solver = pybamm.IDAKLUSolver(root_method="lm")
 
             t_eval = np.linspace(0, 3, 100)
             solution = solver.solve(model, t_eval)
@@ -58,7 +58,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
         disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
         disc.process_model(model)
-        solver = pybamm.IDAKLUSolver()
+        solver = pybamm.IDAKLUSolver(root_method="lm")
 
         variable_tols = {"Electrolyte concentration": 1e-3}
         solver.set_atol_by_variable(variable_tols, model)
@@ -76,7 +76,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         disc = pybamm.Discretisation()
         disc.process_model(model)
 
-        solver = pybamm.IDAKLUSolver()
+        solver = pybamm.IDAKLUSolver(root_method="lm")
 
         t_eval = np.linspace(0, 3, 100)
         with self.assertRaisesRegex(pybamm.SolverError, "KLU requires the Jacobian"):

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -194,7 +194,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
@@ -214,7 +214,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
@@ -238,7 +238,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 5, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_less(solution.y[0], 1.5)
@@ -283,7 +283,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
 
         # create two time series, one without a time point on the discontinuity,
         # and one with
@@ -355,7 +355,7 @@ class TestScikitsSolvers(unittest.TestCase):
 
         model.jacobian = jacobian
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
@@ -372,7 +372,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
@@ -421,7 +421,7 @@ class TestScikitsSolvers(unittest.TestCase):
         disc = get_discretisation_for_testing()
         disc.process_model(model)
 
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
 
         # Step once
         dt = 1
@@ -514,7 +514,10 @@ class TestScikitsSolvers(unittest.TestCase):
             disc.process_model(model)
 
             # Solve
-            solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
+            if form == "python":
+                solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
+            else:
+                solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model, t_eval, inputs={"rate 1": 0.1, "rate 2": 2})
             np.testing.assert_array_less(solution.y[0], 1.5)


### PR DESCRIPTION
# Description

Add the (now default) option to use casadi's rootfinder to initialize the DAEs

Fixes #804 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
