### PR TITLE
#851 fix scaling bug in current data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ## Bug fixes
 
+-   Fixed a bug where current loaded from data was incorrectly scaled with the cell capacity ([#852](https://github.com/pybamm-team/PyBaMM/pull/852))
 -   Moved evaluation of initial conditions to solver ([#839](https://github.com/pybamm-team/PyBaMM/pull/839))
 -   Fixed a bug where the first line of the data wasn't loaded when parameters are loaded from data ([#819](https://github.com/pybamm-team/PyBaMM/pull/819))
 -   Made `graphviz` an optional dependency ([#810](https://github.com/pybamm-team/PyBaMM/pull/810))

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -5,6 +5,7 @@ import pybamm
 import pandas as pd
 import os
 import numbers
+import numpy as np
 
 
 class ParameterValues:
@@ -276,8 +277,8 @@ class ParameterValues:
                     value = CrateToCurrent(values["C-rate"], capacity)
                 elif isinstance(values["C-rate"], tuple):
                     data = values["C-rate"][1]
-                    data[:, 1] = data[:, 1] * capacity
-                    value = (values["C-rate"][0] + "_to_Crate", data)
+                    current_data = np.stack([data[:, 0], data[:, 1] * capacity], axis=1)
+                    value = (values["C-rate"][0] + "_to_current", current_data)
                 elif values["C-rate"] == "[input]":
                     value = CrateToCurrent(values["C-rate"], capacity, typ="input")
                 else:
@@ -288,8 +289,11 @@ class ParameterValues:
                     value = CurrentToCrate(values["Current function [A]"], capacity)
                 elif isinstance(values["Current function [A]"], tuple):
                     data = values["Current function [A]"][1]
-                    data[:, 1] = data[:, 1] / capacity
-                    value = (values["Current function [A]"][0] + "_to_current", data)
+                    c_rate_data = np.stack([data[:, 0], data[:, 1] / capacity], axis=1)
+                    value = (
+                        values["Current function [A]"][0] + "_to_Crate",
+                        c_rate_data,
+                    )
                 elif values["Current function [A]"] == "[input]":
                     value = CurrentToCrate(
                         values["Current function [A]"], capacity, typ="input"

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -101,7 +101,7 @@ class TestParameterValues(unittest.TestCase):
         linear = np.hstack([x, 2 * x])
         values = {"C-rate": ("linear", linear), "Cell capacity [A.h]": 10}
         param = pybamm.ParameterValues(values)
-        self.assertEqual(param["Current function [A]"][0], "linear_to_Crate")
+        self.assertEqual(param["Current function [A]"][0], "linear_to_current")
         np.testing.assert_array_equal(
             param["Current function [A]"][1], np.hstack([x, 20 * x])
         )
@@ -110,7 +110,7 @@ class TestParameterValues(unittest.TestCase):
         linear = np.hstack([x, 2 * x])
         values = {"Current function [A]": ("linear", linear), "Cell capacity [A.h]": 10}
         param = pybamm.ParameterValues(values)
-        self.assertEqual(param["C-rate"][0], "linear_to_current")
+        self.assertEqual(param["C-rate"][0], "linear_to_Crate")
         np.testing.assert_array_almost_equal(
             param["C-rate"][1], np.hstack([x, 0.2 * x])
         )


### PR DESCRIPTION
# Description
Fixes a bug where current data was being incorrectly scaled by the typical current

Fixes #851 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
