### PR TITLE
#941 filter out discon events after the end of the solver time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ New expression tree node types, models, parameter sets and solvers, as well as g
 
 ## Bug fixes
 
+-   Filter out discontinuities that occur after solve times 
+    ([#941](https://github.com/pybamm-team/PyBaMM/pull/945))
 -   Fixed tight layout for QuickPlot in jupyter notebooks ([#930](https://github.com/pybamm-team/PyBaMM/pull/930))
 -   Fixed bug raised if function returns a scalar ([#919](https://github.com/pybamm-team/PyBaMM/pull/919))
 -   Fixed event handling in `ScipySolver` ([#905](https://github.com/pybamm-team/PyBaMM/pull/905))

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -563,6 +563,13 @@ class BaseSolver(object):
             and v > 0
         ]
 
+        # remove any discontinuities after end of t_eval
+        discontinuities = [
+            v
+            for v in discontinuities
+            if v < t_eval_dimensionless[-1]
+        ]
+
         if len(discontinuities) > 0:
             pybamm.logger.info(
                 "Discontinuity events found at t = {}".format(discontinuities)

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -343,18 +343,16 @@ class TestScikitsSolvers(unittest.TestCase):
         def nonsmooth_mult(t):
             return int(t < discontinuity) + 1.0
 
-        rate = pybamm.Function(nonsmooth_rate, pybamm.t)
-        mult = pybamm.Function(nonsmooth_mult, pybamm.t)
         # put in an extra heaviside with no time dependence, this should be ignored by
         # the solver i.e. no extra discontinuities added
-        model.rhs = {var1: rate * var1 + (var1 < 0)}
-        model.algebraic = {var2: mult * var1 - var2}
+        model.rhs = {var1: 0.1 * var1}
+        model.algebraic = {var2: 2 * var1 - var2}
         model.initial_conditions = {var1: 1, var2: 2}
         disc = get_discretisation_for_testing()
         disc.process_model(model)
 
         # Solve
-        solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
+        solver = pybamm.ScikitsDaeSolver(rtol=1e-9, atol=1e-9, root_method="lm")
 
         # create two time series, one without a time point on the discontinuity,
         # and one with


### PR DESCRIPTION
# Description

Fixes #941

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
