### PR TITLE
#977 make casadi solver default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Optimizations
 
+-   Changed default solver for DAE models to `CasadiSolver` ([]())
 -   Added some extra simplifications to the expression tree ([#971](https://github.com/pybamm-team/PyBaMM/pull/971))
 -   Changed the behaviour of "safe" mode in `CasadiSolver` ([#956](https://github.com/pybamm-team/PyBaMM/pull/956))
 -   Sped up model building ([#927](https://github.com/pybamm-team/PyBaMM/pull/927))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Optimizations
 
--   Changed default solver for DAE models to `CasadiSolver` ([]())
+-   Changed default solver for DAE models to `CasadiSolver` ([#978](https://github.com/pybamm-team/PyBaMM/pull/978))
 -   Added some extra simplifications to the expression tree ([#971](https://github.com/pybamm-team/PyBaMM/pull/971))
 -   Changed the behaviour of "safe" mode in `CasadiSolver` ([#956](https://github.com/pybamm-team/PyBaMM/pull/956))
 -   Sped up model building ([#927](https://github.com/pybamm-team/PyBaMM/pull/927))

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -651,9 +651,6 @@ class BaseModel(object):
         "Return default solver based on whether model is ODE model or DAE model"
         if len(self.algebraic) == 0:
             return pybamm.ScipySolver()
-        elif pybamm.have_idaklu() and self.use_jacobian is True:
-            # KLU solver requires jacobian to be provided
-            return pybamm.IDAKLUSolver()
         else:
             return pybamm.CasadiSolver(mode="safe")
 
@@ -677,11 +674,7 @@ def find_symbol_in_dict(dic, name):
 
 
 def find_symbol_in_model(model, name):
-    dics = [
-        model.rhs,
-        model.algebraic,
-        model.variables,
-    ]
+    dics = [model.rhs, model.algebraic, model.variables]
     for dic in dics:
         dic_return = find_symbol_in_dict(dic, name)
         if dic_return:

--- a/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
+++ b/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
@@ -42,17 +42,6 @@ class BaseModel(pybamm.BaseBatteryModel):
         var = pybamm.standard_spatial_vars
         return {var.x_n: 25, var.x_s: 41, var.x_p: 34, var.y: 10, var.z: 10}
 
-    @property
-    def default_solver(self):
-        """
-        Return default solver based on whether model is ODE model or DAE model.
-        There are bugs with KLU on the lead-acid models.
-        """
-        if len(self.algebraic) == 0:
-            return pybamm.ScipySolver()
-        else:
-            return pybamm.CasadiSolver(mode="safe")
-
     def set_soc_variables(self):
         "Set variables relating to the state of charge."
         # State of Charge defined as function of dimensionless electrolyte concentration

--- a/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
+++ b/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
@@ -217,4 +217,4 @@ class EffectiveResistance2D(pybamm.BaseModel):
 
     @property
     def default_solver(self):
-        return pybamm.AlgebraicSolver()
+        return pybamm.CasadiAlgebraicSolver()

--- a/tests/unit/test_models/test_submodels/test_current_collector/test_effective_current_collector.py
+++ b/tests/unit/test_models/test_submodels/test_current_collector/test_effective_current_collector.py
@@ -19,7 +19,7 @@ class TestEffectiveResistance2D(unittest.TestCase):
 
     def test_default_solver(self):
         model = pybamm.current_collector.EffectiveResistance2D()
-        self.assertIsInstance(model.default_solver, pybamm.AlgebraicSolver)
+        self.assertIsInstance(model.default_solver, pybamm.CasadiAlgebraicSolver)
 
     def test_get_processed_potentials(self):
         # solve cheap SPM to test processed potentials (think of an alternative test?)


### PR DESCRIPTION
# Description

Makes `CasadiSolver` the default for DAE models

Fixes #977 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
