### PR TITLE
Doctests failing due to mismatch in unsorted output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ## Bug fixes
 
+-   Fix doctests failing due to mismatch in unsorted output.([#990](https://github.com/pybamm-team/PyBaMM/pull/990))
 -   Added extra checks when creating a model, for clearer errors ([#971](https://github.com/pybamm-team/PyBaMM/pull/971))
 -   Fixed `Interpolant` ids to allow processing ([#962](https://github.com/pybamm-team/PyBaMM/pull/962))
 -   Fixed a bug in the initial conditions of the potential pair model ([#954](https://github.com/pybamm-team/PyBaMM/pull/954))

--- a/pybamm/parameters_cli.py
+++ b/pybamm/parameters_cli.py
@@ -148,11 +148,11 @@ def list_parameters(arguments=None):
     >>> from pybamm.parameters_cli import list_parameters
     >>> list_parameters(["lithium-ion", "anodes"])
     Available package parameters:
-      * graphite_Ecker2015
       * graphite_Chen2020
-      * graphite_mcmb2528_Marquis2019
-      * graphite_UMBL_Mohtat2020
+      * graphite_Ecker2015
       * graphite_Kim2011
+      * graphite_UMBL_Mohtat2020
+      * graphite_mcmb2528_Marquis2019
     Available local parameters:
     """
     parser = argparse.ArgumentParser(
@@ -179,7 +179,7 @@ def list_parameters(arguments=None):
     root, package_dirs, files = next(os.walk(package_dir))
 
     print("Available package parameters:")
-    for dirname in package_dirs:
+    for dirname in sorted(package_dirs):
         print("  * {}".format(dirname))
 
     local_dir = os.path.join("input", "parameters", args.battery_type, args.component)
@@ -188,5 +188,5 @@ def list_parameters(arguments=None):
     else:
         local_dirs = []
     print("Available local parameters:")
-    for dirname in local_dirs:
+    for dirname in sorted(local_dirs):
         print("  * {}".format(dirname))


### PR DESCRIPTION
# Description

The doctest in `parameters_cli.list_parameters` sometimes fails due to the output of `os.walk` being in different order than the expected output. Adding `sorted(package_dirs)` when printing the output ensures the consistency of the output. 

The output of the test before this bug fix was:

```bash
Warning, treated as error:
**********************************************************************
File "../pybamm/parameters_cli.py", line ?, in default
Failed example:
    list_parameters(["lithium-ion", "anodes"])
Expected:
    Available package parameters:
      * graphite_Ecker2015
      * graphite_Chen2020
      * graphite_mcmb2528_Marquis2019
      * graphite_UMBL_Mohtat2020
      * graphite_Kim2011
    Available local parameters:
Got:
    Available package parameters:
      * graphite_Chen2020
      * graphite_Ecker2015
      * graphite_Kim2011
      * graphite_UMBL_Mohtat2020
      * graphite_mcmb2528_Marquis2019
    Available local parameters:
```

Correct values but wrong order. After sorting the directories, and updating the expected output, to the new - alphabetical - order, the tests pass.

Fixes: None

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
