### PR TITLE
Rk4 solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+-   Added the RK4 Solver ([#995](https://github.com/pybamm-team/PyBaMM/pull/995))
 -   Added tab, edge, and surface cooling ([#965](https://github.com/pybamm-team/PyBaMM/pull/965))
 -   Added functionality to solver to automatically discretise a 0D model ([#947](https://github.com/pybamm-team/PyBaMM/pull/947))
 -   Added sensitivity to `CasadiAlgebraicSolver` ([#940](https://github.com/pybamm-team/PyBaMM/pull/940))

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -214,6 +214,7 @@ from .solvers.scikits_dae_solver import ScikitsDaeSolver
 from .solvers.scikits_ode_solver import ScikitsOdeSolver, have_scikits_odes
 from .solvers.scipy_solver import ScipySolver
 from .solvers.idaklu_solver import IDAKLUSolver, have_idaklu
+from .solvers.rk4_ode_solver import RK4Solver
 
 #
 # Experiments

--- a/pybamm/solvers/rk4_ode_solver.py
+++ b/pybamm/solvers/rk4_ode_solver.py
@@ -74,17 +74,6 @@ class RK4Solver(pybamm.BaseSolver):
             )
         pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
-<<<<<<< HEAD
-=======
-        if (
-            pybamm.logger.getEffectiveLevel() == 10
-            or pybamm.settings.debug_mode is True
-        ):
-            show_eval_warnings = True
-        else:
-            show_eval_warnings = False
-
->>>>>>> 6a18a7dacaed63beb88326b26bb563139211691f
         # set up and solve
         U = inputs
         DT = casadi.MX.sym("DT")

--- a/pybamm/solvers/rk4_ode_solver.py
+++ b/pybamm/solvers/rk4_ode_solver.py
@@ -51,8 +51,9 @@ class RK4Solver(pybamm.BaseSolver):
         # convert inputs to casadi format
         inputs = casadi.vertcat(*[x for x in inputs.values()])
 
-        integrator = self.get_integrator(model, t_eval, inputs)
+        integrator, F = self.get_integrator(model, t_eval, inputs)
         solution = self._run_integrator(integrator, model, model.y0, inputs, t_eval)
+        solution.F = F
         return solution
 
     def get_integrator(self, model, t_eval, inputs):
@@ -173,7 +174,7 @@ class RK4Solver(pybamm.BaseSolver):
 
             solution.termination = "final"
 
-        return solution
+        return solution, F
 
     def _run_integrator(self, integrator, model, y0, inputs, t_eval):
         try:

--- a/pybamm/solvers/rk4_ode_solver.py
+++ b/pybamm/solvers/rk4_ode_solver.py
@@ -1,0 +1,120 @@
+#
+# Solver class using fixed step Runge-Kutta 4 integrator
+#
+import casadi
+import pybamm
+import numpy as np
+
+
+class RK4Solver(pybamm.BaseSolver):
+    """Solve a discretised model, using RK4.
+
+    **Extends**: :class:`pybamm.BaseSolver`
+
+    Parameters
+    ----------
+
+
+    """
+
+    def __init__(
+        self,
+        N,  # number of control intervals
+        rtol=1e-6,
+        atol=1e-6,
+        root_method="casadi",
+        root_tol=1e-6,
+        # extra_options_setup=None,
+        # extra_options_call=None,
+    ):
+        super().__init__("problem dependent", rtol, atol, root_method, root_tol)
+        self.N = N
+        self.name = "RK4 ODE solver"
+
+        # self.extra_options_setup = extra_options_setup or {}
+        # self.extra_options_call = extra_options_call or {}
+
+    def _integrate(self, model, t_eval, inputs=None):
+        """
+        Solve a model defined by dydt with initial conditions y0.
+
+        Parameters
+        ----------
+        model : :class:`pybamm.BaseModel`
+            The model whose solution to calculate.
+        t_eval : numeric type
+            The times at which to compute the solution
+        inputs : dict, optional
+            Any input parameters to pass to the model when solving
+
+        """
+        inputs = inputs or {}
+        # convert inputs to casadi format
+        inputs = casadi.vertcat(*[x for x in inputs.values()])
+
+        integrator = self.get_integrator(model, t_eval, inputs)
+        solution = self._run_integrator(integrator, model, model.y0, inputs, t_eval)
+        solution.termination = "final time"
+        return solution
+
+    def get_integrator(self, model, t_eval, inputs):
+        # Only set up problem once
+        y0 = model.y0
+        rhs = model.casadi_rhs
+        # algebraic = model.casadi_algebraic
+
+        # When not in DEBUG mode (level=10), suppress warnings from CasADi
+        if (
+            pybamm.logger.getEffectiveLevel() == 10
+            or pybamm.settings.debug_mode is True
+        ):
+            show_eval_warnings = True
+        else:
+            show_eval_warnings = False
+
+        # set up and solve
+        U = inputs  # casadi.MX.sym("U", inputs.shape[0])
+        t = casadi.MX.sym("t")
+        # y_diff = casadi.MX.sym("y_diff", rhs(t_eval[0], y0, U).shape[0])
+
+        # Formulate discrete time dynamics
+        # Fixed step Runge-Kutta 4 integrator
+        M = self.N  # RK4 steps per interval
+        DT = casadi.MX.sym("DT")  # t_eval[-1] / M
+        # f = Function("f", [model.states, inputs], [derivs])
+        Y0 = casadi.MX.sym("Y0", y0.shape[0])
+        # U = MX.sym("U")
+        Y = Y0
+
+        for j in range(M):
+            k1 = rhs(t, Y, U)
+            k2 = rhs(t + DT / 2, Y + DT / 2 * k1, U)
+            k3 = rhs(t + DT / 2, Y + DT / 2 * k2, U)
+            k4 = rhs(t + DT, Y + DT * k3, U)
+            Y = Y + DT / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        F = casadi.Function("F", [t, Y0, DT], [Y], ["t", "y0", "dt"], ["yf"])
+
+        # Try solving
+        # Get the trajectory
+        xk = y0
+        sol = casadi.DM.zeros(y0.shape[0], t_eval.shape[0])
+        sol[:, 0] = y0
+        for k in range(t_eval.shape[0] - 1):
+            dt = (t_eval[k + 1] - t_eval[k]) / M
+            xk = F(t=t_eval[k], y0=xk, dt=dt)["yf"]
+            sol[:, k + 1] = xk
+
+        return sol
+
+    def _run_integrator(self, integrator, model, y0, inputs, t_eval):
+        # rhs_size = model.concatenated_rhs.size
+        # y0_diff, y0_alg = np.split(y0, [rhs_size])
+        try:
+            sol = integrator
+            # y_values = np.concatenate([sol["xf"].full(), sol["zf"].full()])
+            # y_values = np.reshape(np.array(sol), (y0.shape[0], t_eval.shape[0]))
+            y_values = sol.full()
+            return pybamm.Solution(t_eval, y_values)
+        except RuntimeError as e:
+            # If it doesn't work raise error
+            raise pybamm.SolverError(e.args[0])

--- a/pybamm/solvers/rk4_ode_solver.py
+++ b/pybamm/solvers/rk4_ode_solver.py
@@ -13,7 +13,8 @@ class RK4Solver(pybamm.BaseSolver):
 
     Parameters
     ----------
-
+    N : float
+        The number integration steps within a time step.
 
     """
 
@@ -24,15 +25,13 @@ class RK4Solver(pybamm.BaseSolver):
         atol=1e-6,
         root_method="casadi",
         root_tol=1e-6,
-        # extra_options_setup=None,
-        # extra_options_call=None,
+        max_step_decrease_count=20,
     ):
         super().__init__("problem dependent", rtol, atol, root_method, root_tol)
         self.N = N
         self.name = "RK4 ODE solver"
 
-        # self.extra_options_setup = extra_options_setup or {}
-        # self.extra_options_call = extra_options_call or {}
+        self.max_step_decrease_count = max_step_decrease_count
 
     def _integrate(self, model, t_eval, inputs=None):
         """
@@ -54,16 +53,27 @@ class RK4Solver(pybamm.BaseSolver):
 
         integrator = self.get_integrator(model, t_eval, inputs)
         solution = self._run_integrator(integrator, model, model.y0, inputs, t_eval)
-        solution.termination = "final time"
         return solution
 
     def get_integrator(self, model, t_eval, inputs):
         # Only set up problem once
         y0 = model.y0
+        if isinstance(y0, casadi.DM):
+            y0 = y0.full().flatten()
         rhs = model.casadi_rhs
         # algebraic = model.casadi_algebraic
+        if not model.events:
+            init_event_signs = np.array([1, 1])
+        else:
+            # Step-and-check
+            t0 = t_eval[0]
+            init_event_signs = np.sign(
+                np.concatenate(
+                    [event(t0, y0, inputs) for event in model.terminate_events_eval]
+                )
+            )
+        pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
-        # When not in DEBUG mode (level=10), suppress warnings from CasADi
         if (
             pybamm.logger.getEffectiveLevel() == 10
             or pybamm.settings.debug_mode is True
@@ -73,48 +83,111 @@ class RK4Solver(pybamm.BaseSolver):
             show_eval_warnings = False
 
         # set up and solve
-        U = inputs  # casadi.MX.sym("U", inputs.shape[0])
-        t = casadi.MX.sym("t")
-        # y_diff = casadi.MX.sym("y_diff", rhs(t_eval[0], y0, U).shape[0])
+        U = inputs
+        DT = casadi.MX.sym("DT")
+        t0 = casadi.MX.sym("t0")
+        t = t0
+
+        Y0 = casadi.MX.sym("Y0", y0.shape[0])
+        Y = Y0
 
         # Formulate discrete time dynamics
         # Fixed step Runge-Kutta 4 integrator
-        M = self.N  # RK4 steps per interval
-        DT = casadi.MX.sym("DT")  # t_eval[-1] / M
-        # f = Function("f", [model.states, inputs], [derivs])
-        Y0 = casadi.MX.sym("Y0", y0.shape[0])
-        # U = MX.sym("U")
-        Y = Y0
-
-        for j in range(M):
+        for j in range(self.N):
             k1 = rhs(t, Y, U)
-            k2 = rhs(t + DT / 2, Y + DT / 2 * k1, U)
-            k3 = rhs(t + DT / 2, Y + DT / 2 * k2, U)
-            k4 = rhs(t + DT, Y + DT * k3, U)
-            Y = Y + DT / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
-        F = casadi.Function("F", [t, Y0, DT], [Y], ["t", "y0", "dt"], ["yf"])
+            k2 = rhs(t + DT / 2 / self.N, Y + DT / 2 / self.N * k1, U)
+            k3 = rhs(t + DT / 2 / self.N, Y + DT / 2 / self.N * k2, U)
+            k4 = rhs(t + DT / self.N, Y + DT / self.N * k3, U)
+            Y = Y + DT / 6 / self.N * (k1 + 2 * k2 + 2 * k3 + k4)
+            t = t + DT / self.N
+        F = casadi.Function("F", [t0, Y0, DT], [Y], ["t0", "y0", "dt"], ["yf"])
 
         # Try solving
         # Get the trajectory
         xk = y0
-        sol = casadi.DM.zeros(y0.shape[0], t_eval.shape[0])
-        sol[:, 0] = y0
+        y_sol = casadi.DM.zeros(y0.shape[0], t_eval.shape[0])
+        y_sol[:, 0] = y0
         for k in range(t_eval.shape[0] - 1):
-            dt = (t_eval[k + 1] - t_eval[k]) / M
-            xk = F(t=t_eval[k], y0=xk, dt=dt)["yf"]
-            sol[:, k + 1] = xk
+            dt = t_eval[k + 1] - t_eval[k]
+            xkp1 = F(t0=t_eval[k], y0=xk, dt=dt)["yf"]
+            y_sol[:, k + 1] = xkp1
 
-        return sol
+            xk = xkp1
+
+            # Check most recent y to see if any events have been crossed
+            if not model.events:
+                new_event_signs = np.array([1, 1])
+            else:
+                new_event_signs = np.sign(
+                    np.concatenate(
+                        [
+                            event(t_eval[k + 1], xk.full().flatten(), inputs)
+                            for event in model.terminate_events_eval
+                        ]
+                    )
+                )
+            # Exit loop if the sign of an event changes
+            # Locate the event time using a root finding algorithm and
+            # event state using interpolation. The solution is then truncated
+            # so that only the times up to the event are returned
+            i = 1
+            if (new_event_signs != init_event_signs).any():
+                t_event = t_eval[k]
+                y_event = y_sol[:, k]
+                pre_event_signs = init_event_signs
+                s = 1
+                dt = dt / 2
+                while (i < self.max_step_decrease_count) and (dt > 1e-6):
+                    i += 1
+                    xk = F(t0=t_event, y0=y_event, dt=dt * s)["yf"]
+                    t_event = t_event + s * dt
+                    y_event = xk.full().flatten()
+
+                    new_event_signs = np.sign(
+                        np.concatenate(
+                            [
+                                event(t_event, y_event, inputs)
+                                for event in model.terminate_events_eval
+                            ]
+                        )
+                    )
+                    if (new_event_signs != pre_event_signs).any():
+                        s = -1 * s
+                    dt = dt / 2
+                    pre_event_signs = new_event_signs
+                y_sol[:, k + 1] = y_event
+                break
+
+        if i > 1:
+            # return truncated solution
+            t_truncated = np.append(t_eval[: k + 1], t_event)
+            y_trunctaed = y_sol[:, : k + 2].full()
+            truncated_step_sol = pybamm.Solution(t_truncated, y_trunctaed)
+            # assign temporary solve time
+            truncated_step_sol.solve_time = np.nan
+            # append solution from the current step to solution
+            solution = truncated_step_sol
+
+            solution.termination = "event"
+            solution.t_event = t_event
+            solution.y_event = y_event
+        else:
+            # return full solution
+            step_sol = pybamm.Solution(t_eval, y_sol.full())
+            # assign temporary solve time
+            step_sol.solve_time = np.nan
+            # append solution from the current step to solution
+            solution = step_sol
+
+            solution.termination = "final"
+
+        return solution
 
     def _run_integrator(self, integrator, model, y0, inputs, t_eval):
-        # rhs_size = model.concatenated_rhs.size
-        # y0_diff, y0_alg = np.split(y0, [rhs_size])
         try:
             sol = integrator
-            # y_values = np.concatenate([sol["xf"].full(), sol["zf"].full()])
-            # y_values = np.reshape(np.array(sol), (y0.shape[0], t_eval.shape[0]))
-            y_values = sol.full()
-            return pybamm.Solution(t_eval, y_values)
+            y_values = sol.y
+            return pybamm.Solution(sol.t, y_values)
         except RuntimeError as e:
             # If it doesn't work raise error
             raise pybamm.SolverError(e.args[0])

--- a/pybamm/solvers/rk4_ode_solver.py
+++ b/pybamm/solvers/rk4_ode_solver.py
@@ -74,14 +74,6 @@ class RK4Solver(pybamm.BaseSolver):
             )
         pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
-        if (
-            pybamm.logger.getEffectiveLevel() == 10
-            or pybamm.settings.debug_mode is True
-        ):
-            show_eval_warnings = True
-        else:
-            show_eval_warnings = False
-
         # set up and solve
         U = inputs
         DT = casadi.MX.sym("DT")

--- a/tests/unit/test_solvers/test_rk4_solver.py
+++ b/tests/unit/test_solvers/test_rk4_solver.py
@@ -1,0 +1,201 @@
+#
+# Tests for the RK4 Solver class
+#
+import pybamm
+import unittest
+import numpy as np
+from tests import get_mesh_for_testing, get_discretisation_for_testing
+from scipy.sparse import eye
+
+
+class TestRK4Solver(unittest.TestCase):
+    # def test_bad_mode(self):
+    #     with self.assertRaisesRegex(ValueError, "invalid mode"):
+    #         pybamm.RK4Solver(mode="bad mode")
+
+    def test_model_solver(self):
+        # Create model
+        model = pybamm.BaseModel()
+        var = pybamm.Variable("var")
+        model.rhs = {var: 0.1 * var}
+        model.initial_conditions = {var: 1}
+        # No need to set parameters; can use base discretisation (no spatial operators)
+
+        # create discretisation
+        disc = pybamm.Discretisation()
+        model_disc = disc.process_model(model, inplace=False)
+        # Solve
+        solver = pybamm.RK4Solver(N=20)
+        t_eval = np.linspace(0, 1, 100)
+        solution = solver.solve(model_disc, t_eval)
+        np.testing.assert_array_equal(solution.t, t_eval)
+        np.testing.assert_array_almost_equal(
+            solution.y[0], np.exp(0.1 * solution.t), decimal=5
+        )
+
+        # # Safe mode (enforce events that won't be triggered)
+        # model.events = [pybamm.Event("an event", var + 1)]
+        # disc.process_model(model)
+        # solver = pybamm.RK4Solver(N=20)
+        # t_eval = np.linspace(0, 1, 100)
+        # solution = solver.solve(model, t_eval)
+        # np.testing.assert_array_equal(solution.t, t_eval)
+        # np.testing.assert_array_almost_equal(
+        #     solution.y[0], np.exp(0.1 * solution.t), decimal=5
+        # )
+
+    def test_model_solver_python(self):
+        # Create model
+        pybamm.set_logging_level("ERROR")
+        model = pybamm.BaseModel()
+        model.convert_to_format = "python"
+        var = pybamm.Variable("var")
+        model.rhs = {var: 0.1 * var}
+        model.initial_conditions = {var: 1}
+        # No need to set parameters; can use base discretisation (no spatial operators)
+
+        # create discretisation
+        disc = pybamm.Discretisation()
+        disc.process_model(model)
+        # Solve
+        solver = pybamm.RK4Solver(N=20)
+        t_eval = np.linspace(0, 1, 100)
+        solution = solver.solve(model, t_eval)
+        np.testing.assert_array_equal(solution.t, t_eval)
+        np.testing.assert_array_almost_equal(
+            solution.y[0], np.exp(0.1 * solution.t), decimal=5
+        )
+        pybamm.set_logging_level("WARNING")
+
+    def test_model_step(self):
+        # Create model
+        model = pybamm.BaseModel()
+        domain = ["negative electrode", "separator", "positive electrode"]
+        var = pybamm.Variable("var", domain=domain)
+        model.rhs = {var: 0.1 * var}
+        model.initial_conditions = {var: 1}
+        # No need to set parameters; can use base discretisation (no spatial operators)
+
+        # create discretisation
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(model)
+
+        solver = pybamm.RK4Solver(N=20)
+
+        # Step once
+        dt = 1
+        step_sol = solver.step(None, model, dt)
+        np.testing.assert_array_equal(step_sol.t, [0, dt])
+        np.testing.assert_array_almost_equal(step_sol.y[0], np.exp(0.1 * step_sol.t))
+
+        # Step again (return 5 points)
+        step_sol_2 = solver.step(step_sol, model, dt, npts=5)
+        np.testing.assert_array_equal(
+            step_sol_2.t, np.concatenate([np.array([0]), np.linspace(dt, 2 * dt, 5)])
+        )
+        np.testing.assert_array_almost_equal(
+            step_sol_2.y[0], np.exp(0.1 * step_sol_2.t)
+        )
+
+        # Check steps give same solution as solve
+        t_eval = step_sol.t
+        solution = solver.solve(model, t_eval)
+        np.testing.assert_array_almost_equal(solution.y[0], step_sol.y[0])
+
+    def test_model_step_with_input(self):
+        # Create model
+        model = pybamm.BaseModel()
+        var = pybamm.Variable("var")
+        a = pybamm.InputParameter("a")
+        model.rhs = {var: a * var}
+        model.initial_conditions = {var: 1}
+        model.variables = {"a": a}
+        # No need to set parameters; can use base discretisation (no spatial operators)
+
+        # create discretisation
+        disc = pybamm.Discretisation()
+        disc.process_model(model)
+
+        solver = pybamm.RK4Solver(N=20)
+
+        # Step with an input
+        dt = 0.1
+        step_sol = solver.step(None, model, dt, npts=5, inputs={"a": 0.1})
+        np.testing.assert_array_equal(step_sol.t, np.linspace(0, dt, 5))
+        np.testing.assert_allclose(step_sol.y[0], np.exp(0.1 * step_sol.t))
+
+        # Step again with different inputs
+        step_sol_2 = solver.step(step_sol, model, dt, npts=5, inputs={"a": -1})
+        np.testing.assert_array_equal(step_sol_2.t, np.linspace(0, 2 * dt, 9))
+        np.testing.assert_array_equal(
+            step_sol_2["a"].entries, np.array([0.1, 0.1, 0.1, 0.1, 0.1, -1, -1, -1, -1])
+        )
+        np.testing.assert_allclose(
+            step_sol_2.y[0],
+            np.concatenate(
+                [
+                    np.exp(0.1 * step_sol.t[:5]),
+                    np.exp(0.1 * step_sol.t[4]) * np.exp(-(step_sol.t[5:] - dt)),
+                ]
+            ),
+        )
+
+    def test_model_solver_with_inputs(self):
+        # Create model
+        model = pybamm.BaseModel()
+        domain = ["negative electrode", "separator", "positive electrode"]
+        var = pybamm.Variable("var", domain=domain)
+        model.rhs = {var: -pybamm.InputParameter("rate") * var}
+        model.initial_conditions = {var: 1}
+        model.events = [pybamm.Event("var=0.5", pybamm.min(var - 0.5))]
+        # No need to set parameters; can use base discretisation (no spatial
+        # operators)
+
+        # create discretisation
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(model)
+        # Solve
+        solver = pybamm.RK4Solver(N=20)
+        t_eval = np.linspace(0, 10, 100)
+        solution = solver.solve(model, t_eval, inputs={"rate": 0.1})
+        # self.assertLess(len(solution.t), len(t_eval))
+        np.testing.assert_array_equal(solution.t, t_eval[: len(solution.t)])
+        np.testing.assert_allclose(solution.y[0], np.exp(-0.1 * solution.t), rtol=1e-06)
+
+    def test_model_solver_with_external(self):
+        # Create model
+        model = pybamm.BaseModel()
+        domain = ["negative electrode", "separator", "positive electrode"]
+        var1 = pybamm.Variable("var1", domain=domain)
+        var2 = pybamm.Variable("var2", domain=domain)
+        model.rhs = {var1: -var2}
+        model.initial_conditions = {var1: 1}
+        model.external_variables = [var2]
+        model.variables = {"var1": var1, "var2": var2}
+        # No need to set parameters; can use base discretisation (no spatial
+        # operators)
+
+        # create discretisation
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(model)
+        # Solve
+        solver = pybamm.RK4Solver(N=20)
+        t_eval = np.linspace(0, 10, 100)
+        solution = solver.solve(model, t_eval, external_variables={"var2": 0.5})
+        np.testing.assert_allclose(solution.y[0], 1 - 0.5 * solution.t, rtol=1e-06)
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    pybamm.settings.debug_mode = True
+    unittest.main()


### PR DESCRIPTION
# Description

Added the fixed-step Runge–Kutta method solver (RK4). The main motivation is that with a manual solver we can then build on with better solvers (which we can then export to C)

Fixes # (not an issue)

## Type of change

PR #s 995 was added to [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) 

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
