### PR TITLE
#1037 fix timescale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ New SEI models, simplification of submodel structure, as well as optimisations a
 
 ## Bug fixes
 
+-   Fix a bug where slider plots do not update properly in notebooks ([#1041](https://github.com/pybamm-team/PyBaMM/pull/1041))
 -   Fix storing and plotting external variables in the solution ([#1026](https://github.com/pybamm-team/PyBaMM/pull/1026))
 -   Fix running a simulation with a model that is already discretized ([#1025](https://github.com/pybamm-team/PyBaMM/pull/1025))
 -   Fix CI not triggering for PR. ([#1013](https://github.com/pybamm-team/PyBaMM/pull/1013))

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -465,14 +465,14 @@ class QuickPlot(object):
         Parameters
         ----------
         t : float
-            Dimensional time (in hours) at which to plot.
+            Dimensional time (in 'time_units') at which to plot.
         """
 
         import matplotlib.pyplot as plt
         import matplotlib.gridspec as gridspec
         from matplotlib import cm, colors
 
-        t_in_seconds = t / self.time_scaling_factor
+        t_in_seconds = t * self.time_scaling_factor
         self.fig = plt.figure(figsize=self.figsize)
 
         self.gridspec = gridspec.GridSpec(self.n_rows, self.n_cols)

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -526,8 +526,8 @@ class QuickPlot(object):
                 ax.set_ylim(y_min, y_max)
                 (self.time_lines[key],) = ax.plot(
                     [
-                        t_in_seconds * self.time_scaling_factor,
-                        t_in_seconds * self.time_scaling_factor,
+                        t_in_seconds / self.time_scaling_factor,
+                        t_in_seconds / self.time_scaling_factor,
                     ],
                     [y_min, y_max],
                     "k--",


### PR DESCRIPTION
Fixes issue in notebooks where slider didn't update. Problem was the timescale in `plot` (the sliders update ok in notebook when the timescale is seconds). It worked in scripts as that called `slider_update` rather than `plot`

Fixes #1037 