### PR TITLE
#1108 change t_eval list to linspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Features
 
+-   Added support for sensitivity calculations to the casadi solver ([#1109](https://github.com/pybamm-team/PyBaMM/pull/1109))
 -   Added support for index 1 semi-explicit dae equations and sensitivity calculations to JAX BDF solver ([#1107](https://github.com/pybamm-team/PyBaMM/pull/1107))
 -   Allowed keyword arguments to be passed to `Simulation.plot()` ([#1099](https://github.com/pybamm-team/PyBaMM/pull/1099))
 
 ## Optimizations
 
 ## Bug fixes
+
+-   `t_eval` now gets changed to a `linspace` if a list of length 2 is passed ([#1113](https://github.com/pybamm-team/PyBaMM/pull/1113))
+-   Fixed bug when setting a function with an `InputParameter` ([#1111](https://github.com/pybamm-team/PyBaMM/pull/1111))
 
 ## Breaking changes
 

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -330,17 +330,6 @@ class Simulation:
             solver = self.solver
 
         if self.operating_mode in ["without experiment", "drive cycle"]:
-            # If t_eval is provided as [t0, tf] return the solution at 100 points
-            if isinstance(t_eval, list):
-                if len(t_eval) != 2:
-                    raise pybamm.SolverError(
-                        "'t_eval' can be provided as an array of times at which to "
-                        "return the solution, or as a list [t0, tf] where t0 is the "
-                        "initial time and tf is the final time, but has been provided "
-                        "as a list of length {}.".format(len(t_eval))
-                    )
-                else:
-                    t_eval = np.linspace(t_eval[0], t_eval[-1], 100)
 
             if self.operating_mode == "without experiment":
                 if t_eval is None:
@@ -403,13 +392,13 @@ class Simulation:
                             pybamm.SolverWarning,
                         )
 
-            self.t_eval = t_eval
             self._solution = solver.solve(
                 self.built_model,
                 t_eval,
                 external_variables=external_variables,
                 inputs=inputs,
             )
+            self.t_eval = self._solution.t * self.model.timescale.evaluate()
 
         elif self.operating_mode == "with experiment":
             if t_eval is not None:

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -510,6 +510,19 @@ class BaseSolver(object):
                 t_eval = np.array([0])
             else:
                 raise ValueError("t_eval cannot be None")
+        # If t_eval is provided as [t0, tf] return the solution at 100 points
+        elif isinstance(t_eval, list):
+            if len(t_eval) == 1 and self.algebraic_solver is True:
+                pass
+            elif len(t_eval) != 2:
+                raise pybamm.SolverError(
+                    "'t_eval' can be provided as an array of times at which to "
+                    "return the solution, or as a list [t0, tf] where t0 is the "
+                    "initial time and tf is the final time, but has been provided "
+                    "as a list of length {}.".format(len(t_eval))
+                )
+            else:
+                t_eval = np.linspace(t_eval[0], t_eval[-1], 100)
 
         # Make sure t_eval is monotonic
         if (np.diff(t_eval) < 0).any():

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -370,7 +370,7 @@ class TestSimulation(unittest.TestCase):
 
         # tets list gets turned into np.linspace(t0, tf, 100)
         sim.solve(t_eval=[0, 10])
-        np.testing.assert_array_equal(sim.t_eval, np.linspace(0, 10, 100))
+        np.testing.assert_array_almost_equal(sim.t_eval, np.linspace(0, 10, 100))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

If a solver sees a list of length 2 for t_eval, change it to linspace
Fixes #1108 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
