### PR TITLE
#1056 added examples on how to pass custom drive cycle

### DIFF
--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -135,8 +135,8 @@
        " 'EC initial concentration in electrolyte [mol.m-3]': 4541.0,\n",
        " 'Electrode height [m]': 0.065,\n",
        " 'Electrode width [m]': 1.58,\n",
-       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f234684e1e0>,\n",
-       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f2391b5a268>,\n",
+       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f9afbc630d0>,\n",
+       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f9afbc63048>,\n",
        " 'Initial concentration in electrolyte [mol.m-3]': 1000.0,\n",
        " 'Initial concentration in negative electrode [mol.m-3]': 29866.0,\n",
        " 'Initial concentration in positive electrode [mol.m-3]': 17038.0,\n",
@@ -407,7 +407,7 @@
        " 'Negative electrode diffusivity [m2.s-1]': 3.3e-14,\n",
        " 'Negative electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Negative electrode electrons in reaction': 1.0,\n",
-       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f23886d5ea0>,\n",
+       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f9afbc9bea0>,\n",
        " 'Negative electrode porosity': 0.25,\n",
        " 'Negative electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Negative electrode surface area to volume ratio [m-1]': 383959.0,\n",
@@ -675,7 +675,7 @@
        " 'Positive electrode diffusivity [m2.s-1]': 4e-15,\n",
        " 'Positive electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Positive electrode electrons in reaction': 1.0,\n",
-       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f234684e0d0>,\n",
+       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f9afbc9bf28>,\n",
        " 'Positive electrode porosity': 0.335,\n",
        " 'Positive electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Positive electrode surface area to volume ratio [m-1]': 382184.0,\n",
@@ -730,8 +730,8 @@
      "output_type": "stream",
      "text": [
       "EC initial concentration in electrolyte [mol.m-3]\t4541.0\n",
-      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f234684e1e0>\n",
-      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f2391b5a268>\n",
+      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f9afbc630d0>\n",
+      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f9afbc63048>\n",
       "Initial concentration in electrolyte [mol.m-3]\t1000.0\n",
       "Negative electrode Bruggeman coefficient (electrolyte)\t1.5\n",
       "Positive electrode Bruggeman coefficient (electrolyte)\t1.5\n",
@@ -753,13 +753,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b5f87571fee74cbb90479e86401f1eb4",
+       "model_id": "972080a3919746689eafda23f53570fc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -796,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -829,13 +829,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "947dc63e8bf449028214c950ff6f6844",
+       "model_id": "2429167130dd43038d4689be994e39f9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -864,12 +864,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also simulate drive cycles by passing the data directly"
+    "### Drive cycle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also simulate the PyBaMM default drive cycles by calling the dataset directly"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,18 +887,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can just define the model and solve it"
+    "Then we can just define the model and solve it. In this case we do not need to specify a time interval to solve as PyBaMM automatically picks it from data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "08ca39eec4544f6b86e227156d3937b2",
+       "model_id": "899c5194ed124a76a3cbc9ea8c372956",
        "version_major": 2,
        "version_minor": 0
       },
@@ -914,12 +921,80 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Alternatively, you can implement your own drive cycles importing the dataset and creating an interpolant to pass as the current function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd    # needed to read the csv data file\n",
+    "\n",
+    "# Import drive cycle from file\n",
+    "drive_cycle = pd.read_csv(\"../../../pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
+    "\n",
+    "# Create interpolant\n",
+    "timescale = parameter_values.evaluate(model.timescale)\n",
+    "current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)\n",
+    "\n",
+    "# Set drive cycle\n",
+    "parameter_values[\"Current function [A]\"] = current_interpolant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, again, the model can be solved as usual but notice that now we do need to pass `t_eval` to the solver."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "349094f0a1dc43ecbf1fa0b67931823d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=600.0, step=6.0), Output()), _dom_classes=('…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "model = pybamm.lithium_ion.SPMe()\n",
+    "sim = pybamm.Simulation(model, parameter_values=parameter_values)\n",
+    "t_eval = drive_cycle[:, 0]    # define t_eval from the dataset\n",
+    "sim.solve(t_eval)\n",
+    "sim.plot([\"Current [A]\", \"Terminal voltage [V]\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom current function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Alternatively, we can define the current to be an arbitrary function of time"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,13 +1015,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e166a9f922d14eaebe4be57072829277",
+       "model_id": "d382e196729d4354a4e8fd50d700c50e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -976,9 +1051,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "PyBaMM development (env)",
    "language": "python",
-   "name": "python3"
+   "name": "pybamm-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -990,7 +1065,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -18,9 +18,19 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2 is available.\n",
+      "You should consider upgrading via the '/home/ferranbrosa/PyBaMM/env/bin/python -m pip install --upgrade pip' command.\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
-    "#%pip install pybamm -q    # install PyBaMM if it is not installed\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "os.chdir(pybamm.__path__[0]+'/..')"
@@ -129,8 +139,8 @@
        " 'EC initial concentration in electrolyte [mol.m-3]': 4541.0,\n",
        " 'Electrode height [m]': 0.065,\n",
        " 'Electrode width [m]': 1.58,\n",
-       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f4414a2a268>,\n",
-       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f4414a2a1e0>,\n",
+       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f24ae784158>,\n",
+       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f24ae7840d0>,\n",
        " 'Initial concentration in electrolyte [mol.m-3]': 1000.0,\n",
        " 'Initial concentration in negative electrode [mol.m-3]': 29866.0,\n",
        " 'Initial concentration in positive electrode [mol.m-3]': 17038.0,\n",
@@ -401,7 +411,7 @@
        " 'Negative electrode diffusivity [m2.s-1]': 3.3e-14,\n",
        " 'Negative electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Negative electrode electrons in reaction': 1.0,\n",
-       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f4414a66ea0>,\n",
+       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f24ae7c1ae8>,\n",
        " 'Negative electrode porosity': 0.25,\n",
        " 'Negative electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Negative electrode surface area to volume ratio [m-1]': 383959.0,\n",
@@ -669,7 +679,7 @@
        " 'Positive electrode diffusivity [m2.s-1]': 4e-15,\n",
        " 'Positive electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Positive electrode electrons in reaction': 1.0,\n",
-       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f4414a2a158>,\n",
+       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f24ae7c1f28>,\n",
        " 'Positive electrode porosity': 0.335,\n",
        " 'Positive electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Positive electrode surface area to volume ratio [m-1]': 382184.0,\n",
@@ -724,8 +734,8 @@
      "output_type": "stream",
      "text": [
       "EC initial concentration in electrolyte [mol.m-3]\t4541.0\n",
-      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f4414a2a268>\n",
-      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f4414a2a1e0>\n",
+      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f24ae784158>\n",
+      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f24ae7840d0>\n",
       "Initial concentration in electrolyte [mol.m-3]\t1000.0\n",
       "Negative electrode Bruggeman coefficient (electrolyte)\t1.5\n",
       "Positive electrode Bruggeman coefficient (electrolyte)\t1.5\n",
@@ -753,7 +763,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f1d953c18b294933a33140e7b890cd1d",
+       "model_id": "2b686feb685b4668b970d49bb137c9d2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -829,7 +839,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "63c4c3143dd94d01b569a31435127435",
+       "model_id": "256191f9988349ffaf5396faf4bb1fef",
        "version_major": 2,
        "version_minor": 0
       },
@@ -902,7 +912,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3966a3e7ea5040c197d4e23a3cb9dc11",
+       "model_id": "bb5a94d141e94425954d4c1963d0f14c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -964,7 +974,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b99031baebdc478499f3609a74144d96",
+       "model_id": "9534fe9341194950b1dc4169752331c2",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -29,7 +29,9 @@
    ],
    "source": [
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
-    "import pybamm"
+    "import pybamm\n",
+    "import os\n",
+    "os.chdir(pybamm.__path__[0]+'/..')"
    ]
   },
   {
@@ -135,8 +137,8 @@
        " 'EC initial concentration in electrolyte [mol.m-3]': 4541.0,\n",
        " 'Electrode height [m]': 0.065,\n",
        " 'Electrode width [m]': 1.58,\n",
-       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f9afbc630d0>,\n",
-       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f9afbc63048>,\n",
+       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f327d7b0a60>,\n",
+       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f327d7b0f28>,\n",
        " 'Initial concentration in electrolyte [mol.m-3]': 1000.0,\n",
        " 'Initial concentration in negative electrode [mol.m-3]': 29866.0,\n",
        " 'Initial concentration in positive electrode [mol.m-3]': 17038.0,\n",
@@ -407,7 +409,7 @@
        " 'Negative electrode diffusivity [m2.s-1]': 3.3e-14,\n",
        " 'Negative electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Negative electrode electrons in reaction': 1.0,\n",
-       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f9afbc9bea0>,\n",
+       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f327d7b0ea0>,\n",
        " 'Negative electrode porosity': 0.25,\n",
        " 'Negative electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Negative electrode surface area to volume ratio [m-1]': 383959.0,\n",
@@ -675,7 +677,7 @@
        " 'Positive electrode diffusivity [m2.s-1]': 4e-15,\n",
        " 'Positive electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Positive electrode electrons in reaction': 1.0,\n",
-       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f9afbc9bf28>,\n",
+       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f327d7720d0>,\n",
        " 'Positive electrode porosity': 0.335,\n",
        " 'Positive electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Positive electrode surface area to volume ratio [m-1]': 382184.0,\n",
@@ -730,8 +732,8 @@
      "output_type": "stream",
      "text": [
       "EC initial concentration in electrolyte [mol.m-3]\t4541.0\n",
-      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f9afbc630d0>\n",
-      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f9afbc63048>\n",
+      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f327d7b0a60>\n",
+      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f327d7b0f28>\n",
       "Initial concentration in electrolyte [mol.m-3]\t1000.0\n",
       "Negative electrode Bruggeman coefficient (electrolyte)\t1.5\n",
       "Positive electrode Bruggeman coefficient (electrolyte)\t1.5\n",
@@ -759,7 +761,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "972080a3919746689eafda23f53570fc",
+       "model_id": "400ba653a0f9412f8e12608a803cd60f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -835,7 +837,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2429167130dd43038d4689be994e39f9",
+       "model_id": "da167df5923e46fe9ff4a0873c97224d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -898,7 +900,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "899c5194ed124a76a3cbc9ea8c372956",
+       "model_id": "e690dcd0af224966b65bc23ff2442003",
        "version_major": 2,
        "version_minor": 0
       },
@@ -933,7 +935,7 @@
     "import pandas as pd    # needed to read the csv data file\n",
     "\n",
     "# Import drive cycle from file\n",
-    "drive_cycle = pd.read_csv(\"../../../pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
+    "drive_cycle = pd.read_csv(\"pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
     "\n",
     "# Create interpolant\n",
     "timescale = parameter_values.evaluate(model.timescale)\n",
@@ -958,7 +960,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "349094f0a1dc43ecbf1fa0b67931823d",
+       "model_id": "74baef19208a404496839654d684e38e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1021,7 +1023,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d382e196729d4354a4e8fd50d700c50e",
+       "model_id": "e413934add554d37a23d8a133b95152d",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -18,17 +18,9 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
+    "#%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "os.chdir(pybamm.__path__[0]+'/..')"
@@ -137,8 +129,8 @@
        " 'EC initial concentration in electrolyte [mol.m-3]': 4541.0,\n",
        " 'Electrode height [m]': 0.065,\n",
        " 'Electrode width [m]': 1.58,\n",
-       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f327d7b0a60>,\n",
-       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f327d7b0f28>,\n",
+       " 'Electrolyte conductivity [S.m-1]': <function electrolyte_conductivity_Nyman2008 at 0x7f4414a2a268>,\n",
+       " 'Electrolyte diffusivity [m2.s-1]': <function electrolyte_diffusivity_Nyman2008 at 0x7f4414a2a1e0>,\n",
        " 'Initial concentration in electrolyte [mol.m-3]': 1000.0,\n",
        " 'Initial concentration in negative electrode [mol.m-3]': 29866.0,\n",
        " 'Initial concentration in positive electrode [mol.m-3]': 17038.0,\n",
@@ -409,7 +401,7 @@
        " 'Negative electrode diffusivity [m2.s-1]': 3.3e-14,\n",
        " 'Negative electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Negative electrode electrons in reaction': 1.0,\n",
-       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f327d7b0ea0>,\n",
+       " 'Negative electrode exchange-current density [A.m-2]': <function graphite_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f4414a66ea0>,\n",
        " 'Negative electrode porosity': 0.25,\n",
        " 'Negative electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Negative electrode surface area to volume ratio [m-1]': 383959.0,\n",
@@ -677,7 +669,7 @@
        " 'Positive electrode diffusivity [m2.s-1]': 4e-15,\n",
        " 'Positive electrode double-layer capacity [F.m-2]': 0.2,\n",
        " 'Positive electrode electrons in reaction': 1.0,\n",
-       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f327d7720d0>,\n",
+       " 'Positive electrode exchange-current density [A.m-2]': <function nmc_LGM50_electrolyte_exchange_current_density_Chen2020 at 0x7f4414a2a158>,\n",
        " 'Positive electrode porosity': 0.335,\n",
        " 'Positive electrode specific heat capacity [J.kg-1.K-1]': 700.0,\n",
        " 'Positive electrode surface area to volume ratio [m-1]': 382184.0,\n",
@@ -732,8 +724,8 @@
      "output_type": "stream",
      "text": [
       "EC initial concentration in electrolyte [mol.m-3]\t4541.0\n",
-      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f327d7b0a60>\n",
-      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f327d7b0f28>\n",
+      "Electrolyte conductivity [S.m-1]\t<function electrolyte_conductivity_Nyman2008 at 0x7f4414a2a268>\n",
+      "Electrolyte diffusivity [m2.s-1]\t<function electrolyte_diffusivity_Nyman2008 at 0x7f4414a2a1e0>\n",
       "Initial concentration in electrolyte [mol.m-3]\t1000.0\n",
       "Negative electrode Bruggeman coefficient (electrolyte)\t1.5\n",
       "Positive electrode Bruggeman coefficient (electrolyte)\t1.5\n",
@@ -761,7 +753,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "400ba653a0f9412f8e12608a803cd60f",
+       "model_id": "f1d953c18b294933a33140e7b890cd1d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -837,7 +829,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da167df5923e46fe9ff4a0873c97224d",
+       "model_id": "63c4c3143dd94d01b569a31435127435",
        "version_major": 2,
        "version_minor": 0
       },
@@ -873,7 +865,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also simulate the PyBaMM default drive cycles by calling the dataset directly"
+    "You can implement drive cycles importing the dataset and creating an interpolant to pass as the current function."
    ]
   },
   {
@@ -882,14 +874,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_values[\"Current function [A]\"] = \"[current data]US06\""
+    "import pandas as pd    # needed to read the csv data file\n",
+    "\n",
+    "# Import drive cycle from file\n",
+    "drive_cycle = pd.read_csv(\"pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
+    "\n",
+    "# Create interpolant\n",
+    "timescale = parameter_values.evaluate(model.timescale)\n",
+    "current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)\n",
+    "\n",
+    "# Set drive cycle\n",
+    "parameter_values[\"Current function [A]\"] = current_interpolant"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can just define the model and solve it. In this case we do not need to specify a time interval to solve as PyBaMM automatically picks it from data"
+    "Note that your drive cycle data can be stored anywhere, you just need to pass the path of the file. Then, again, the model can be solved as usual but notice that now, if `t_eval` is not specified, the solver will take the time points from the data set."
    ]
   },
   {
@@ -900,7 +902,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e690dcd0af224966b65bc23ff2442003",
+       "model_id": "3966a3e7ea5040c197d4e23a3cb9dc11",
        "version_major": 2,
        "version_minor": 0
       },
@@ -923,67 +925,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, you can implement your own drive cycles importing the dataset and creating an interpolant to pass as the current function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd    # needed to read the csv data file\n",
-    "\n",
-    "# Import drive cycle from file\n",
-    "drive_cycle = pd.read_csv(\"pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
-    "\n",
-    "# Create interpolant\n",
-    "timescale = parameter_values.evaluate(model.timescale)\n",
-    "current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)\n",
-    "\n",
-    "# Set drive cycle\n",
-    "parameter_values[\"Current function [A]\"] = current_interpolant"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then, again, the model can be solved as usual but notice that now we do need to pass `t_eval` to the solver."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "74baef19208a404496839654d684e38e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=0.0, description='t', max=600.0, step=6.0), Output()), _dom_classes=('…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "model = pybamm.lithium_ion.SPMe()\n",
-    "sim = pybamm.Simulation(model, parameter_values=parameter_values)\n",
-    "t_eval = drive_cycle[:, 0]    # define t_eval from the dataset\n",
-    "sim.solve(t_eval)\n",
-    "sim.plot([\"Current [A]\", \"Terminal voltage [V]\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Custom current function"
    ]
   },
@@ -996,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,13 +958,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e413934add554d37a23d8a133b95152d",
+       "model_id": "b99031baebdc478499f3609a74144d96",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/notebooks/change-input-current.ipynb
+++ b/examples/notebooks/change-input-current.ipynb
@@ -34,6 +34,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\u001b[33mWARNING: You are using pip version 20.1.1; however, version 20.2 is available.\n",
+      "You should consider upgrading via the '/home/ferranbrosa/PyBaMM/env/bin/python -m pip install --upgrade pip' command.\u001b[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
@@ -75,7 +77,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b90f73879a2c45cea9f0ffa6df8a0eaa",
+       "model_id": "55b83465a9ea4937bfd3444fa7198460",
        "version_major": 2,
        "version_minor": 0
       },
@@ -124,7 +126,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a1b19df4edd47289d78802ff345bda2",
+       "model_id": "b827d913896b418caf161f6d8ee9df92",
        "version_major": 2,
        "version_minor": 0
       },
@@ -151,7 +153,7 @@
    "source": [
     "## Loading in current data <a name=\"data\"></a>\n",
     "\n",
-    "Data can be loaded in from a csv file by putting the file in the folder 'input/drive_cycles' and using the prefix \"[current data]\". As an example, we show how to solve the SPM using the US06 drive cycle"
+    "To run drive cycles from data we can create an interpolant and pass it as the current function. "
    ]
   },
   {
@@ -162,69 +164,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c5adb83033c84f06a8478ae913e89044",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=0.0, description='t', max=600.0, step=6.0), Output()), _dom_classes=('…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "model = pybamm.lithium_ion.DFN()\n",
-    "\n",
-    "# create geometry\n",
-    "geometry = model.default_geometry\n",
-    "\n",
-    "# load parameter values and process model and geometry\n",
-    "param = model.default_parameter_values\n",
-    "param[\"Current function [A]\"] = \"[current data]US06\"\n",
-    "param.process_model(model)\n",
-    "param.process_geometry(geometry)\n",
-    "\n",
-    "# set mesh\n",
-    "mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)\n",
-    "\n",
-    "# discretise model\n",
-    "disc = pybamm.Discretisation(mesh, model.default_spatial_methods)\n",
-    "disc.process_model(model)\n",
-    "\n",
-    "# simulate US06 drive cycle (duration 600 seconds)\n",
-    "t_eval = np.linspace(0, 600, 600)\n",
-    "solution = solver.solve(model, t_eval)\n",
-    "\n",
-    "# plot\n",
-    "quick_plot = pybamm.QuickPlot(solution)\n",
-    "quick_plot.dynamic_plot();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that some solvers try to evaluate the model equations at a very large value of `t` during the first step. This may raise a warning if the time requested by the solver is outside of the range of the data provided. However, this does not affect the solve since this large timestep is rejected by the solver, and a suitable shorter initial step is taken."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In some cases you might want to run a drive cycle that is not implemented in PyBaMM. In this case, you can create an interpolant from the custom data set and pass it as the current function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a61ea9c059754b40b790835e87774052",
+       "model_id": "64e6f94728be4ef5bfec800bc26f0768",
        "version_major": 2,
        "version_minor": 0
       },
@@ -279,6 +219,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that some solvers try to evaluate the model equations at a very large value of `t` during the first step. This may raise a warning if the time requested by the solver is outside of the range of the data provided. However, this does not affect the solve since this large timestep is rejected by the solver, and a suitable shorter initial step is taken."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Adding your own current function <a name=\"function\"></a>\n",
     "\n",
     "A user defined current function can be passed to any model by specifying either a function or a set of data points for interpolation.\n",
@@ -288,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,13 +288,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "75930d9bd3da40dab88ff2b69e0571a7",
+       "model_id": "c2a1fdc7aa5246aaa9543650d96894ca",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/notebooks/change-input-current.ipynb
+++ b/examples/notebooks/change-input-current.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -75,7 +75,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "807f6dec221b4226aea64326d51c751b",
+       "model_id": "b90f73879a2c45cea9f0ffa6df8a0eaa",
        "version_major": 2,
        "version_minor": 0
       },
@@ -124,7 +124,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "eaab57697cef4852b4fbab5ee1f7efd7",
+       "model_id": "7a1b19df4edd47289d78802ff345bda2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -162,7 +162,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a72be467b6f84733927cb2e7a5c4b3f9",
+       "model_id": "c5adb83033c84f06a8478ae913e89044",
        "version_major": 2,
        "version_minor": 0
       },
@@ -213,6 +213,72 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "In some cases you might want to run a drive cycle that is not implemented in PyBaMM. In this case, you can create an interpolant from the custom data set and pass it as the current function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a61ea9c059754b40b790835e87774052",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=600.0, step=6.0), Output()), _dom_classes=('…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pandas as pd    # needed to read the csv data file\n",
+    "\n",
+    "model = pybamm.lithium_ion.DFN()\n",
+    "\n",
+    "# create geometry\n",
+    "geometry = model.default_geometry\n",
+    "\n",
+    "# import drive cycle from file\n",
+    "drive_cycle = pd.read_csv(\"pybamm/input/drive_cycles/US06.csv\", comment=\"#\", header=None).to_numpy()\n",
+    "\n",
+    "# load parameter values\n",
+    "param = model.default_parameter_values\n",
+    "\n",
+    "# create interpolant\n",
+    "timescale = param.evaluate(model.timescale)\n",
+    "current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)\n",
+    "\n",
+    "# set drive cycle and process model and geometry\n",
+    "param[\"Current function [A]\"] = current_interpolant\n",
+    "param.process_model(model)\n",
+    "param.process_geometry(geometry)\n",
+    "\n",
+    "# set mesh\n",
+    "mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)\n",
+    "\n",
+    "# discretise model\n",
+    "disc = pybamm.Discretisation(mesh, model.default_spatial_methods)\n",
+    "disc.process_model(model)\n",
+    "\n",
+    "# simulate US06 drive cycle (duration 600 seconds)\n",
+    "t_eval = np.linspace(0, 600, 600)\n",
+    "solution = solver.solve(model, t_eval)\n",
+    "\n",
+    "# plot\n",
+    "quick_plot = pybamm.QuickPlot(solution)\n",
+    "quick_plot.dynamic_plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Adding your own current function <a name=\"function\"></a>\n",
     "\n",
     "A user defined current function can be passed to any model by specifying either a function or a set of data points for interpolation.\n",
@@ -222,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,13 +341,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7dff98a2d9a44f87b71abeb0a94e16c9",
+       "model_id": "75930d9bd3da40dab88ff2b69e0571a7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -324,9 +390,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "PyBaMM development (env)",
    "language": "python",
-   "name": "python3"
+   "name": "pybamm-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -338,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/examples/scripts/drive_cycle.py
+++ b/examples/scripts/drive_cycle.py
@@ -2,13 +2,30 @@
 # Simulate drive cycle loaded from csv file
 #
 import pybamm
+import pandas as pd
+import os
+
+os.chdir(pybamm.__path__[0] + "/..")
 
 pybamm.set_logging_level("INFO")
 
 # load model and update parameters so the input current is the US06 drive cycle
 model = pybamm.lithium_ion.SPMe({"thermal": "lumped"})
 param = model.default_parameter_values
-param["Current function [A]"] = "[current data]US06"
+
+
+# import drive cycle from file
+drive_cycle = pd.read_csv(
+    "pybamm/input/drive_cycles/US06.csv", comment="#", header=None
+).to_numpy()
+
+# create interpolant
+timescale = param.evaluate(model.timescale)
+current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)
+
+# set drive cycle
+param["Current function [A]"] = current_interpolant
+
 
 # create and run simulation using the CasadiSolver in "fast" mode, remembering to
 # pass in the updated parameters

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -89,7 +89,9 @@ class Simulation:
         if experiment is None:
             # Check to see if the current is provided as data (i.e. drive cycle)
             current = self._parameter_values.get("Current function [A]")
-            if isinstance(current, tuple):
+            if isinstance(current, pybamm.Interpolant):
+                self.operating_mode = "drive cycle"
+            elif isinstance(current, tuple):
                 self.operating_mode = "drive cycle"
             else:
                 self.operating_mode = "without experiment"
@@ -348,13 +350,17 @@ class Simulation:
                 # tests on t_eval (if provided) to ensure the returned solution
                 # captures the input. If the current is provided as data then the
                 # "Current function [A]" is the tuple (filename, data).
-                filename = self._parameter_values["Current function [A]"][0]
-                time_data = self._parameter_values["Current function [A]"][1][:, 0]
+                if isinstance(
+                    self._parameter_values["Current function [A]"], pybamm.Interpolant
+                ):
+                    time_data = self._parameter_values["Current function [A]"].data[
+                        :, 0
+                    ]
+                else:
+                    time_data = self._parameter_values["Current function [A]"][1][:, 0]
                 # If no t_eval is provided, we use the times provided in the data.
                 if t_eval is None:
-                    pybamm.logger.info(
-                        "Setting t_eval as specified by the data '{}'".format(filename)
-                    )
+                    pybamm.logger.info("Setting t_eval as specified by the data")
                     t_eval = time_data
                 # If t_eval is provided we first check if it contains all of the
                 # times in the data to within 10-12. If it doesn't, we then check
@@ -368,11 +374,9 @@ class Simulation:
                     warnings.warn(
                         """
                         t_eval does not contain all of the time points in the data
-                        '{}'. Note: passing t_eval = None automatically sets t_eval
+                        set. Note: passing t_eval = None automatically sets t_eval
                         to be the points in the data.
-                        """.format(
-                            filename
-                        ),
+                        """,
                         pybamm.SolverWarning,
                     )
                     dt_data_min = np.min(np.diff(time_data))

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -92,7 +92,10 @@ class Simulation:
             if isinstance(current, pybamm.Interpolant):
                 self.operating_mode = "drive cycle"
             elif isinstance(current, tuple):
-                self.operating_mode = "drive cycle"
+                raise NotImplementedError(
+                    "Drive cycle from data has been deprecated. " +
+                    "Define an Interpolant instead."
+                )
             else:
                 self.operating_mode = "without experiment"
                 if C_rate:

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -351,16 +351,8 @@ class Simulation:
             elif self.operating_mode == "drive cycle":
                 # For drive cycles (current provided as data) we perform additional
                 # tests on t_eval (if provided) to ensure the returned solution
-                # captures the input. If the current is provided as data then the
-                # "Current function [A]" is the tuple (filename, data).
-                if isinstance(
-                    self._parameter_values["Current function [A]"], pybamm.Interpolant
-                ):
-                    time_data = self._parameter_values["Current function [A]"].data[
-                        :, 0
-                    ]
-                else:
-                    time_data = self._parameter_values["Current function [A]"][1][:, 0]
+                # captures the input.
+                time_data = self._parameter_values["Current function [A]"].data[:, 0]
                 # If no t_eval is provided, we use the times provided in the data.
                 if t_eval is None:
                     pybamm.logger.info("Setting t_eval as specified by the data")

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -306,33 +306,8 @@ class TestSimulation(unittest.TestCase):
         param = model.default_parameter_values
         param["Current function [A]"] = "[current data]US06"
 
-        drive_cycle = pd.read_csv(
-            pybamm.get_parameters_filepath(
-                os.path.join("input", "drive_cycles", "US06.csv")
-            ),
-            comment="#",
-            skip_blank_lines=True,
-            header=None,
-        )
-        time_data = drive_cycle.values[:, 0]
-
-        sim = pybamm.Simulation(model, parameter_values=param)
-
-        # check solution is returned at the times in the data
-        sim.solve()
-        tau = sim.model.timescale.evaluate()
-        np.testing.assert_array_almost_equal(sim.solution.t, time_data / tau)
-
-        # check warning raised if the largest gap in t_eval is bigger than the
-        # smallest gap in the data
-        with self.assertWarns(pybamm.SolverWarning):
-            sim.solve(t_eval=np.linspace(0, 1, 100))
-
-        # check warning raised if t_eval doesnt contain time_data , but has a finer
-        # resolution (can still solve, but good for users to know they dont have
-        # the solution returned at the data points)
-        with self.assertWarns(pybamm.SolverWarning):
-            sim.solve(t_eval=np.linspace(0, time_data[-1], 800))
+        with self.assertRaisesRegex(NotImplementedError, "Drive cycle from data"):
+            pybamm.Simulation(model, parameter_values=param)
 
     def test_drive_cycle_interpolant(self):
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Added examples in the corresponding notebooks on how to pass a custom drive cycle to PyBaMM. Given that it is a change in the examples only, I didn't add any line to CHANGELOG.

Fixes #1056

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
