### PR TITLE
now works with python 3.8

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
         include:
           - os: ubuntu-latest
             python-version: 3.8

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/docs/install/GNU-linux.rst
+++ b/docs/install/GNU-linux.rst
@@ -7,8 +7,7 @@
 Prerequisites
 =============
 
-To use and/or contribute to PyBaMM, you must have Python 3.6 or 3.7
-installed (note that 3.8 is not yet supported).
+To use and/or contribute to PyBaMM, you must have Python 3.6, 3.7, or 3.8 installed.
 
 To install Python 3 on Debian-based distribution (Debian, Ubuntu, Linux
 mint), open a terminal and run
@@ -47,7 +46,7 @@ User install
 
 We recommend to install PyBaMM within a virtual environment, in order
 not to alter any distribution python files. 
-First, make sure you are using python 3.6 or 3.7. 
+First, make sure you are using python 3.6, 3.7, or 3.8. 
 To create a virtual environment ``env`` within your current directory type:
 
 .. code:: bash

--- a/docs/install/windows.rst
+++ b/docs/install/windows.rst
@@ -6,8 +6,7 @@ Windows
 Prerequisites
 -------------
 
-To use and/or contribute to PyBaMM, you must have Python 3.6 or 3.7
-installed (note that 3.8 is not yet supported).
+To use and/or contribute to PyBaMM, you must have Python 3.6, 3.7, or 3.8 installed.
 
 To install Python 3 download the installation files from `Python’s
 website <https://www.python.org/downloads/windows/>`__. Make sure to


### PR DESCRIPTION
# Description

Casadi now works with python 3.8, so pybamm should too. This PR updates the tests and install docs.