### PR TITLE
Fix boundary condition types

### DIFF
--- a/examples/notebooks/Creating Models/2-a-pde-model.ipynb
+++ b/examples/notebooks/Creating Models/2-a-pde-model.ipynb
@@ -107,7 +107,7 @@
     "# boundary conditions\n",
     "lbc = pybamm.Scalar(0)\n",
     "rbc = pybamm.Scalar(2)\n",
-    "model.boundary_conditions = {c: {\"left\": (lbc, \"Dirichlet\"), \"right\": (rbc, \"Neumann\")}}"
+    "model.boundary_conditions = {c: {\"left\": (lbc, \"Neumann\"), \"right\": (rbc, \"Neumann\")}}"
    ]
   },
   {

--- a/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
+++ b/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
@@ -105,7 +105,7 @@
     "# boundary conditions \n",
     "lbc = pybamm.Scalar(0)\n",
     "rbc = -j / F / D\n",
-    "model.boundary_conditions = {c: {\"left\": (lbc, \"Dirichlet\"), \"right\": (rbc, \"Neumann\")}}\n",
+    "model.boundary_conditions = {c: {\"left\": (lbc, \"Neumann\"), \"right\": (rbc, \"Neumann\")}}\n",
     "\n",
     "# initial conditions \n",
     "model.initial_conditions = {c: c0}"

--- a/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
+++ b/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
@@ -140,7 +140,7 @@
     "# boundary conditions (only required for full model)\n",
     "lbc = pybamm.Scalar(0)\n",
     "rbc = -j / F / D\n",
-    "full_model.boundary_conditions = {c: {\"left\": (lbc, \"Dirichlet\"), \"right\": (rbc, \"Neumann\")}}"
+    "full_model.boundary_conditions = {c: {\"left\": (lbc, \"Neumann\"), \"right\": (rbc, \"Neumann\")}}"
    ]
   },
   {


### PR DESCRIPTION
# Description

Change boundary condition type in "Creating Models" notebooks, which were incorrectly given as Dirichlet but are in fact Neumann.

Note that this change does not affect the final result of any of the notebooks; the fact that the result is independent of boundary condition type is probably a bug. See also #1174.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

I have one failing test (test_add_rm_param) and one which errors (test_edit_param), but on my system this is the case prior to this PR too.
