### PR TITLE
Issue 1174 raise error bcs sphere other than no-flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug fixes
 
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
+-   Fix boundary conditions at r = 0 for Creating Models notebooks ([#1173](https://github.com/pybamm-team/PyBaMM/pull/1173))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [Unreleased](https://github.com/pybamm-team/PyBaMM)
+
+## Features
+
+
+## Optimizations
+
+
+## Bug fixes
+
+-   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
+
+## Breaking changes
+
+
 # [v0.2.4](https://github.com/pybamm-team/PyBaMM/tree/v0.2.4) - 2020-09-07
 
 This release adds new operators for more complex models, some basic sensitivity analysis, and a spectral volumes spatial method, as well as some small bug fixes.

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -492,6 +492,8 @@ class Discretisation(object):
         for key, bcs in model.boundary_conditions.items():
             processed_bcs[key.id] = {}
 
+            # check if the boundary condition at the origin for sphere domains is other
+            # than no flux
             if key not in model.external_variables:
                 for subdomain in key.domain:
                     if self.mesh[subdomain].coord_sys == "spherical polar":

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -492,15 +492,16 @@ class Discretisation(object):
         for key, bcs in model.boundary_conditions.items():
             processed_bcs[key.id] = {}
 
-            for subdomain in key.domain:
-                if self.mesh[subdomain].coord_sys == "spherical polar":
-                    if bcs["left"][0].value != 0 or bcs["left"][1] != "Neumann":
-                        raise pybamm.ModelError(
-                            """Boundary condition at r = 0 must be a homogeneous
-                             Neumann condition for {} coordinates""".format(
-                                self.mesh[subdomain].coord_sys
+            if key not in model.external_variables:
+                for subdomain in key.domain:
+                    if self.mesh[subdomain].coord_sys == "spherical polar":
+                        if bcs["left"][0].value != 0 or bcs["left"][1] != "Neumann":
+                            raise pybamm.ModelError(
+                                "Boundary condition at r = 0 must be a homogeneous "
+                                "Neumann condition for {} coordinates".format(
+                                    self.mesh[subdomain].coord_sys
+                                )
                             )
-                        )
 
             # Handle any boundary conditions applied on the tabs
             if any("tab" in side for side in list(bcs.keys())):

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -492,6 +492,15 @@ class Discretisation(object):
         for key, bcs in model.boundary_conditions.items():
             processed_bcs[key.id] = {}
 
+            for subdomain in key.domain:
+                if self.mesh[subdomain].coord_sys == "spherical polar":
+                    if bcs["left"][0].value != 0 or bcs["left"][1] != "Neumann":
+                        raise pybamm.ModelError(
+                            """Boundary condition at r = 0 must be a homogeneous Neumann condition for {} coordinates""".format(
+                                self.mesh[subdomain].coord_sys
+                            )
+                        )
+
             # Handle any boundary conditions applied on the tabs
             if any("tab" in side for side in list(bcs.keys())):
                 bcs = self.check_tab_conditions(key, bcs)

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -496,7 +496,8 @@ class Discretisation(object):
                 if self.mesh[subdomain].coord_sys == "spherical polar":
                     if bcs["left"][0].value != 0 or bcs["left"][1] != "Neumann":
                         raise pybamm.ModelError(
-                            """Boundary condition at r = 0 must be a homogeneous Neumann condition for {} coordinates""".format(
+                            """Boundary condition at r = 0 must be a homogeneous
+                             Neumann condition for {} coordinates""".format(
                                 self.mesh[subdomain].coord_sys
                             )
                         )

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -1348,7 +1348,7 @@ class TestFiniteVolume(unittest.TestCase):
         model.rhs = {c: pybamm.div(N)}
         model.initial_conditions = {c: pybamm.Scalar(0)}
         model.boundary_conditions = {
-            c: {"left": (0, "Dirichlet"), "right": (0, "Dirichlet")}
+            c: {"left": (0, "Neumann"), "right": (0, "Dirichlet")}
         }
         model.variables = {"c": c, "N": N}
         mesh = get_p2d_mesh_for_testing()


### PR DESCRIPTION
# Description

The code now raises an error if the boundary condition at the origin in a sphere geometry is other than a no-flux condition.

Fixes #1174

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
