### PR TITLE
Added example conservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added an example script to check conservation of lithium ([#1186](https://github.com/pybamm-team/PyBaMM/pull/1186))
 
 ## Optimizations
 

--- a/examples/scripts/conservation_lithium.py
+++ b/examples/scripts/conservation_lithium.py
@@ -1,0 +1,48 @@
+#
+# Check conservation of lithium
+#
+
+import pybamm
+import matplotlib.pyplot as plt
+
+pybamm.set_logging_level("INFO")
+
+model = pybamm.lithium_ion.DFN()
+
+experiment = pybamm.Experiment(
+    [
+        "Discharge at 1C until 3.2 V",
+        "Rest for 2 hours",
+        "Charge at C/3 until 4 V",
+        "Charge at 4 V until 5 mA",
+        "Rest for 2 hours",
+    ]
+    * 3
+)
+
+sim = pybamm.Simulation(model, experiment=experiment)
+sim.solve()
+solution = sim.solution
+
+t = solution["Time [s]"].entries
+Ne = solution["Total concentration in electrolyte [mol]"].entries
+Np = solution["Total lithium in positive electrode [mol]"].entries
+Nn = solution["Total lithium in negative electrode [mol]"].entries
+Ntot = Np + Nn + Ne
+
+fig, ax = plt.subplots(1, 2, figsize=(12, 5))
+
+ax[0].plot(t, Ntot / Ntot[0] - 1)
+ax[0].set_xlabel("Time (s)")
+ax[0].set_ylabel("Variation of total lithium as fraction of initial value")
+
+ax[1].plot(t, Np + Nn, label="total")
+ax[1].plot(t, Np, label="positive")
+ax[1].plot(t, Nn, label="negative")
+ax[1].set_xlabel("Time (s)")
+ax[1].set_ylabel("Total lithium in electrode (mol)")
+ax[1].legend()
+
+fig.tight_layout()
+
+plt.show()


### PR DESCRIPTION
# Description

Added an example script for lithium conservation.

Fixes #1185

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas