### PR TITLE
Minor fixes regarding documentation

### DIFF
--- a/docs/install/install-from-source.rst
+++ b/docs/install/install-from-source.rst
@@ -128,7 +128,7 @@ Using Tox (recommended)
 	  python -m tox -e windows-dev # (Windows)
 
 
-This creates a virtual environment ``.tox/dev`` inside the ``PyBaMM/`` directory.
+This creates a virtual environment ``.tox/dev`` (or ``windows-dev``) inside the ``PyBaMM/`` directory.
 It comes ready with PyBaMM and some useful development tools like `flake8 <https://flake8.pycqa.org/en/latest/>`_ and `black <https://black.readthedocs.io/en/stable/>`_.
 
 You can now activate the environment with
@@ -137,7 +137,7 @@ You can now activate the environment with
 
 	  source .tox/dev/bin/activate # (GNU/Linux and MacOS)
 	  #
-	  .tox\dev\Scripts\activate.bat # (Windows)
+	  .tox\windows-dev\Scripts\activate.bat # (Windows)
 
 and run the tests to check your installation.
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ deps =
      guzzle-sphinx-theme
      sphinx-autobuild
 changedir = docs
-commands = sphinx-autobuild -BqT . {envtmpdir}/html
+commands = sphinx-autobuild --open-browser -qT . {envtmpdir}/html
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Just a couple of fixes regarding documentation
1. There was a misleading typo in the installation notes. When installing from source (using Tox), the development env. created by Tox on Windows is called `windows-dev` and not `dev`.
2. The `B` switch to `sphinx-autobuild` appears to have been deprecated and replaced by `--open-browser`.

