### PR TITLE
Enforce python interpreter in process spawned by test runner

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -31,6 +31,10 @@ def run_code_tests(executable=False, folder: str = "unit", interpreter="python")
         tests = "tests/" + folder
         if folder == "unit":
             pybamm.settings.debug_mode = True
+    if interpreter == "python":
+        # Make sure to refer to the interpreter for the
+        # currently activated virtual environment
+        interpreter = sys.executable
     if executable is False:
         suite = unittest.defaultTestLoader.discover(tests, pattern="test*.py")
         unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Since roughly a couple of days ago (11/10/2020) all tests on Windows for python 3.7 and 3.8 have been failing because numpy cannot be imported

After investigating this i've found that, in the case of both python versions, tests are executed with the base python interpreter on the GitHub runner, and not the one corresponding to the virtual environment created by Tox.

Before running tests, Tox first create a virtual environment in which PyBaMM is installed.
Moreover, in `run-tests.py`, the test suite is ran inside a a separate Python process:
```python
print("Running {} tests with executable '{}'".format(folder, interpreter))
        cmd = [interpreter, "-m", "unittest", "discover", "-v", tests]
        p = subprocess.Popen(cmd)
```
It just happens that with the value of `interpreter` being `"python"`, the python interpreter that is started in the sub-process isn't the one from the virtual environment, but the base system python. Setting `interpreter` to `sys.executable` should fix this.

Sadly, I don't understand why the wrong interpreter is started in the sub-process. I don't understand why only python 3.7 and 3.8 (3.6 works just fine) and Windows. I also don't understand how this issue appeared.
Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
