### PR TITLE
Build manylinux wheels for Python 3.8

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -2,7 +2,7 @@ name: Build and deployment
 
 on:
   push:
-    branches: master
+    branches: build_wheel_py38
 
 jobs:
   build-wheels:

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -27,7 +27,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: './build_manylinux_wheels'
       with:
-        python-versions: "cp36-cp36m cp37-cp37m cp38-38"
+        python-versions: "cp36-cp36m cp37-cp37m cp38-cp38"
 
     - name: Install standard python dependencies
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -54,7 +54,7 @@ jobs:
         path: dist
 
 
-  publish-pypi:
+  publish-pyi:
     name: Upload wheels to PyPI 
     needs: build-wheels
     runs-on: ubuntu-latest
@@ -68,6 +68,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -8,7 +8,6 @@ jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [macos-latest]
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Build manylinux Python wheels
       if: matrix.os == 'ubuntu-latest'
       uses: './build_manylinux_wheels'
+      with:
+        python-versions: "cp36-cp36m cp37-cp37m cp38-38"
 
     - name: Install standard python dependencies
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -8,6 +8,7 @@ jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest]
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -55,7 +55,7 @@ jobs:
         path: dist
 
 
-  publish-pyi:
+  publish-pypi:
     name: Upload wheels to PyPI 
     needs: build-wheels
     runs-on: ubuntu-latest
@@ -69,5 +69,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.TESTPYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -2,7 +2,7 @@ name: Build and deployment
 
 on:
   push:
-    branches: build_wheel_py38
+    branches: master
 
 jobs:
   build-wheels:

--- a/build_manylinux_wheels/entrypoint.sh
+++ b/build_manylinux_wheels/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# GitHub runners add "-e LD_LIBRARY_PATH" option to "docker run",
+# overriding default value of LD_LIBRARY_PATH in manylinux image. This
+# causes libcrypt.so.2 to be missing (it lives in /usr/local/lib)
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
 # CLI arguments
 PY_VERSIONS=$1
 

--- a/build_manylinux_wheels/entrypoint.sh
+++ b/build_manylinux_wheels/entrypoint.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -e -x
 
-# GitHub runners add "-e LD_LIBRARY_PATH" option to "docker run",
-# overriding default value of LD_LIBRARY_PATH in manylinux image. This
-# causes libcrypt.so.2 to be missing (it lives in /usr/local/lib)
-export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
 # CLI arguments
 PY_VERSIONS=$1
 


### PR DESCRIPTION
## Description

Since version 2.4, PyBaMM doesn't offer a Python wheel for GNU/Linux machines.
This corresponds to the time when we enabled support for Python 3.8.

For the record, installing PyBaMM 2.4 from PyPI on a Linux machine is possible, but
the package is not importable:

```
>>> import pybamm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/env/lib/python3.8/site-packages/pybamm/__init__.py", line 105, in <module>
    from .expression_tree.operations.evaluate import (
  File "/tmp/env/lib/python3.8/site-packages/pybamm/expression_tree/operations/evaluate.py", line 13, in <module>
    import jax
ModuleNotFoundError: No module named 'jax'
```

Here's why:
On GNU/Linux, running
```
pip install pybamm
```
will send a request to PyPI to get the latest version of PyBaMM (2.4.post2 at the time of writing). This version doesn't offer a platform wheel for GNU/Linux (as it does for MacOS, see for yourself [here](https://pypi.org/project/pybamm/#files)), so pip falls back to the non-platform, pure Python wheel:
```
pip install pybamm
Collecting pybamm
  Using cached pybamm-0.2.4.post2-py3-none-any.whl (520 kB)
  ...
  ...
```
This wheel is built on Windows and therefore does not include `jax` in its `install_requires` list.

Fixes #1196 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
