### PR TITLE
Set LD_LIBRARY_PATH in image's entry point

### DIFF
--- a/build_manylinux_wheels/entrypoint.sh
+++ b/build_manylinux_wheels/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# GitHub runners add "-e LD_LIBRARY_PATH" option to "docker run",
+# overriding default value of LD_LIBRARY_PATH in manylinux image. This
+# causes libcrypt.so.2 to be missing (it lives in /usr/local/lib)
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
 # CLI arguments
 PY_VERSIONS=$1
 


### PR DESCRIPTION
# Description

While testing building Python 3.8 wheels for #1197 , I noticed that any python 3.7 command (including `pip`) inside the manyinux image would fail, preventing any GNU/Linux wheel to be built.
```
opt/_internal/cpython-3.7.7/bin/python3.7: error while loading shared libraries: libcrypt.so.2: cannot open shared object file: No such file or directory
```
see for instance https://github.com/tlestang/PyBaMM/runs/1259747579?check_suite_focus=true

After pulling my hair out for a while, I noticed that - on the GitHub runner - the `docker run`
 command is ran with a `-e LD_LIBRARY_PATH` option, effectively overriding the value of `LD_LIBRARY_PATH` set by default in the image. This efault value includes `/usr/local/lib`, where `libcrypt.so.2` lives.

Strangely, this was not an issue before (the `-e` option wasn't passed to `docker run`). This issue was also reported [elsewhere](https://github.com/RalfG/python-wheels-manylinux-build/issues/26).
