### PR TITLE
Install scikits in coverage tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,9 @@ deps = flake8>=3
 commands = python -m flake8
 
 [testenv:coverage]
-deps = coverage
+deps = 
+     coverage
+     scikits.odes
 commands = 
      coverage run run-tests.py --nosub
      coverage xml


### PR DESCRIPTION
# Description

Install `scikits.odes` when running `tox -e coverage`.

Before merging it would be good that coverage installs all the dependencies required though.