### PR TITLE
[master] Add manylinux wheels for python 3.8

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Build manylinux Python wheels
       if: matrix.os == 'ubuntu-latest'
       uses: './build_manylinux_wheels'
+      with:
+        python-versions: "cp36-cp36m cp37-cp37m cp38-cp38"
 
     - name: Install standard python dependencies
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -72,6 +72,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          password: ${{ secrets.TESTPYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -2,7 +2,7 @@ name: Build and deployment
 
 on:
   push:
-    branches: master
+    branches: fix_wheels_master
 
 jobs:
   build-wheels:
@@ -68,5 +68,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -72,6 +72,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -2,7 +2,7 @@ name: Build and deployment
 
 on:
   push:
-    branches: fix_wheels_master
+    branches: master
 
 jobs:
   build-wheels:
@@ -72,6 +72,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_TOKEN }}
 

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -37,6 +37,10 @@ jobs:
     - name: Install build-time deps for MacOS
       if: matrix.os == 'macos-latest'
       run: |
+        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
+        brew untap local/homebrew-openssl
+        brew untap local/homebrew-python2
+        # End of fix
         brew update
         brew install graphviz
         brew install sundials

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,6 +50,10 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
+        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
+        brew untap local/homebrew-openssl
+        brew untap local/homebrew-python2
+        # End of fix
         brew update
         brew install graphviz
         brew install openblas

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -2,7 +2,6 @@ name: PyBaMM
 
 on:
   push:
-    branches: master
     
   pull_request:
 

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -2,6 +2,7 @@ name: PyBaMM
 
 on:
   push:
+    branches: master
     
   pull_request:
 

--- a/build_manylinux_wheels/entrypoint.sh
+++ b/build_manylinux_wheels/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e -x
 
+# GitHub runners add "-e LD_LIBRARY_PATH" option to "docker run",
+# overriding default value of LD_LIBRARY_PATH in manylinux image. This
+# causes libcrypt.so.2 to be missing (it lives in /usr/local/lib)
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
 # CLI arguments
 PY_VERSIONS=$1
 

--- a/run-tests.py
+++ b/run-tests.py
@@ -31,6 +31,10 @@ def run_code_tests(executable=False, folder: str = "unit", interpreter="python")
         tests = "tests/" + folder
         if folder == "unit":
             pybamm.settings.debug_mode = True
+    if interpreter == "python":
+        # Make sure to refer to the interpreter for the
+        # currently activated virtual environment
+        interpreter = sys.executable
     if executable is False:
         suite = unittest.defaultTestLoader.discover(tests, pattern="test*.py")
         unittest.TextTestRunner(verbosity=2).run(suite)

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ with open("README.md") as f:
 
 setup(
     name="pybamm",
-    version=load_version() + ".post2",
+    version=load_version() + ".post3",
     description="Python Battery Mathematical Modelling.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Enabling and triggering the build of Python 3.8 wheels for GNU/Linux platforms.
This is effectively applying to master the changes applied to develop with #1197 and #1198 
