### PR TITLE
Put evaluated timescale and length_scales on solution

### DIFF
--- a/examples/scripts/compare_comsol/compare_comsol_DFN.py
+++ b/examples/scripts/compare_comsol/compare_comsol_DFN.py
@@ -140,9 +140,7 @@ comsol_model.variables = {
 
 # Make new solution with same t and y
 comsol_solution = pybamm.Solution(pybamm_solution.t, pybamm_solution.y)
-# Update model and solution scales to match the pybamm model
-comsol_model.timescale = pybamm_model.timescale
-comsol_model.length_scales = pybamm_model.length_scales
+# Update solution scales to match the pybamm model
 comsol_solution.timescale_eval = pybamm_model.timescale_eval
 comsol_solution.length_scales_eval = pybamm_model.length_scales_eval
 comsol_solution.model = comsol_model

--- a/examples/scripts/compare_comsol/compare_comsol_DFN.py
+++ b/examples/scripts/compare_comsol/compare_comsol_DFN.py
@@ -140,9 +140,11 @@ comsol_model.variables = {
 
 # Make new solution with same t and y
 comsol_solution = pybamm.Solution(pybamm_solution.t, pybamm_solution.y)
-# Update model scales to match the pybamm model
+# Update model and solution scales to match the pybamm model
 comsol_model.timescale = pybamm_model.timescale
 comsol_model.length_scales = pybamm_model.length_scales
+comsol_solution.timescale_eval = pybamm_model.timescale_eval
+comsol_solution.length_scales_eval = pybamm_model.length_scales_eval
 comsol_solution.model = comsol_model
 
 # plot

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -118,6 +118,11 @@ class BaseModel(object):
         # Default timescale is 1 second
         self.timescale = pybamm.Scalar(1)
         self.length_scales = {}
+        self.timescale_eval = self.timescale.evaluate()
+        self.length_scales_eval = {
+            domain: scale.evaluate()
+            for domain, scale in self.length_scales.items()
+        }
 
     @property
     def name(self):

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -118,11 +118,6 @@ class BaseModel(object):
         # Default timescale is 1 second
         self.timescale = pybamm.Scalar(1)
         self.length_scales = {}
-        self.timescale_eval = self.timescale.evaluate()
-        self.length_scales_eval = {
-            domain: scale.evaluate()
-            for domain, scale in self.length_scales.items()
-        }
 
     @property
     def name(self):

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -8,7 +8,6 @@ import numbers
 import numpy as np
 import sys
 import itertools
-import warnings
 
 
 class BaseSolver(object):
@@ -169,9 +168,9 @@ class BaseSolver(object):
         model.timescale_eval = model.timescale.evaluate(inputs=inputs)
         # Set model lengthscales
         model.length_scales_eval = {
-                domain: scale.evaluate(inputs=inputs)
-                for domain, scale in model.length_scales.items()
-            }
+            domain: scale.evaluate(inputs=inputs)
+            for domain, scale in model.length_scales.items()
+        }
         if (
             isinstance(self, (pybamm.CasadiSolver, pybamm.CasadiAlgebraicSolver))
         ) and model.convert_to_format != "casadi":

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -795,8 +795,8 @@ class BaseSolver(object):
                 old_dom_eval = old_solution.length_scales_eval[domain]
                 if temp_length_scales_eval[domain] != old_dom_eval:
                     pybamm.logger.error(
-                        "The model lengthscale is a function of an input "
-                        "parameter {} and the value has changed between "
+                        "The {} domain lengthscale is a function of an input "
+                        "parameter and the value has changed between "
                         "steps!".format(domain)
                     )
         # Run set up on first step

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -8,6 +8,7 @@ import numbers
 import numpy as np
 import sys
 import itertools
+import warnings
 
 
 class BaseSolver(object):
@@ -165,14 +166,12 @@ class BaseSolver(object):
         inputs = inputs or {}
 
         # Set model timescale
-        try:
-            model.timescale_eval = model.timescale.evaluate()
-        except KeyError as e:
-            raise pybamm.SolverError(
-                "The model timescale is a function of an input parameter "
-                "(original error: {})".format(e)
-            )
-
+        model.timescale_eval = model.timescale.evaluate(inputs=inputs)
+        # Set model lengthscales
+        model.length_scales_eval = {
+                domain: scale.evaluate(inputs=inputs)
+                for domain, scale in model.length_scales.items()
+            }
         if (
             isinstance(self, (pybamm.CasadiSolver, pybamm.CasadiAlgebraicSolver))
         ) and model.convert_to_format != "casadi":

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -60,12 +60,12 @@ class ProcessedVariable(object):
         self.warn = warn
 
         # Set timescale
-        self.timescale = solution.model.timescale_eval
+        self.timescale = solution.timescale_eval
         self.t_pts = self.t_sol * self.timescale
 
         # Store length scales
         if solution.model:
-            self.length_scales = solution.model.length_scales_eval
+            self.length_scales = solution.length_scales_eval
 
         # Evaluate base variable at initial time
         if self.known_evals:

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -60,15 +60,12 @@ class ProcessedVariable(object):
         self.warn = warn
 
         # Set timescale
-        self.timescale = solution.model.timescale.evaluate()
+        self.timescale = solution.model.timescale_eval
         self.t_pts = self.t_sol * self.timescale
 
         # Store length scales
         if solution.model:
-            self.length_scales = {
-                domain: scale.evaluate()
-                for domain, scale in solution.model.length_scales.items()
-            }
+            self.length_scales = solution.model.length_scales_eval
 
         # Evaluate base variable at initial time
         if self.known_evals:

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -70,6 +70,10 @@ class _BaseSolution(object):
         for time in t:
             self._known_evals[time] = {}
 
+        # Copy the timescale_eval and lengthscale_evals
+        self.timescale_eval = self._model.timescale_eval
+        self.length_scales_eval = self._model.length_scales_eval
+
     @property
     def t(self):
         "Times at which the solution is evaluated"

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -70,9 +70,19 @@ class _BaseSolution(object):
         for time in t:
             self._known_evals[time] = {}
 
-        # Copy the timescale_eval and lengthscale_evals
-        self.timescale_eval = self._model.timescale_eval
-        self.length_scales_eval = self._model.length_scales_eval
+        # Copy the timescale_eval and lengthscale_evals if they exist
+        if hasattr(self._model, "timescale_eval"):
+            self.timescale_eval = self._model.timescale_eval
+        else:
+            self.timescale_eval = self._model.timescale.evaluate()
+        # self.timescale_eval = self._model.timescale_eval
+        if hasattr(self._model, "length_scales_eval"):
+            self.length_scales_eval = self._model.length_scales_eval
+        else:
+            self.length_scales_eval = {
+                domain: scale.evaluate()
+                for domain, scale in self._model.length_scales.items()
+            }
 
     @property
     def t(self):

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -276,9 +276,11 @@ class TestBaseSolver(unittest.TestCase):
         model.initial_conditions = {v: 1}
         a = pybamm.InputParameter("a")
         model.timescale = a
-        solver = pybamm.BaseSolver()
+        solver = pybamm.CasadiSolver()
+        solver.set_up(model, inputs={"a": 10})
+        sol = solver.step(old_solution=None, model=model, dt=1.0, inputs={"a": 10})
         with self.assertRaisesRegex(pybamm.SolverError, "The model timescale"):
-            solver.set_up(model, inputs={"a": 10})
+            sol = solver.step(old_solution=sol, model=model, dt=1.0, inputs={"a": 20})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Previously models would not evaluate timescales if they are functions of input parameters. If an input parameter doesn't change during a solution but was created for purposed of reusing models with different input parameters then it should result in consistent scaling and should be allowed. To address the problem the scaling are saved to the solution and used here for processed variables. A check is made when stepping that the inputs that affect scaling do not change

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
