### PR TITLE
Casadi solver step bugfix

### DIFF
--- a/examples/scripts/SPMe_step.py
+++ b/examples/scripts/SPMe_step.py
@@ -27,7 +27,7 @@ disc.process_model(model)
 
 # solve model
 t_eval = np.linspace(0, 3600, 100)
-solver = model.default_solver
+solver = pybamm.CasadiSolver()
 solution = solver.solve(model, t_eval)
 
 # step model
@@ -35,7 +35,7 @@ dt = 500
 time = 0
 timescale = model.timescale_eval
 end_time = solution.t[-1] * timescale
-step_solver = model.default_solver
+step_solver = pybamm.CasadiSolver()
 step_solution = None
 while time < end_time:
     step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -274,7 +274,11 @@ class CasadiSolver(pybamm.BaseSolver):
                     # assign temporary solve time
                     current_step_sol.solve_time = np.nan
                     # append solution from the current step to solution
-                    solution.append(current_step_sol)
+                    if solution is None:
+                        solution = current_step_sol
+                    else:
+                        # append solution from the current step to solution
+                        solution.append(current_step_sol)
                     solution.termination = "event"
                     solution.t_event = t_event
                     solution.y_event = y_event


### PR DESCRIPTION
# Description

Make sure when stepping that a None solution is not appended to when event is triggered

Fixes # 1212

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
