### PR TITLE
Workaround for macos brew update error

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,6 +50,10 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
+        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
+        brew untap local/homebrew-openssl
+        brew untap local/homebrew-python2
+        # End of fix
         brew update
         brew install graphviz
         brew install openblas


### PR DESCRIPTION
# Description

This workaround allows the macos tests to work until the issue with GitHub actions. This change can be reverted once [this PR](https://github.com/actions/virtual-environments/pull/1808) is merged.
