### PR TITLE
Apply workaround for brew update in publishing workflow

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -37,6 +37,10 @@ jobs:
     - name: Install build-time deps for MacOS
       if: matrix.os == 'macos-latest'
       run: |
+        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
+        brew untap local/homebrew-openssl
+        brew untap local/homebrew-python2
+        # End of fix
         brew update
         brew install graphviz
         brew install sundials


### PR DESCRIPTION
PR #1214 only modified the test workflow, but the `brew update` issue is also affecting the publishing workflow in the same way.
This is basically a duplicate of #1214 
