### PR TITLE
fix sim.t_eval when timescale is function of input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Raise error if saving to matlab with variable names that matlab can't read, and give option of providing alternative variable names ([#1206](https://github.com/pybamm-team/PyBaMM/pull/1206))
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
 -   Fix boundary conditions at r = 0 for Creating Models notebooks ([#1173](https://github.com/pybamm-team/PyBaMM/pull/1173))
+-   Make sure simulation solves when evaluated timescale is a function of an input parameter ([#1218](https://github.com/pybamm-team/PyBaMM/pull/1218))
 
 ## Breaking changes
 

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -405,7 +405,7 @@ class Simulation:
                 external_variables=external_variables,
                 inputs=inputs,
             )
-            self.t_eval = self._solution.t * self.model.timescale.evaluate()
+            self.t_eval = self._solution.t * self._solution.timescale_eval
 
         elif self.operating_mode == "with experiment":
             if t_eval is not None:

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -387,6 +387,18 @@ class TestSimulation(unittest.TestCase):
         sim.solve(t_eval=[0, 10])
         np.testing.assert_array_almost_equal(sim.t_eval, np.linspace(0, 10, 100))
 
+    def test_battery_model_with_input_height(self):
+        # load model
+        model = pybamm.lithium_ion.SPM()
+        # load parameter values and process model and geometry
+        param = model.default_parameter_values
+        param.update({"Electrode height [m]": "[input]"})
+        # solve model for 1 minute
+        t_eval = np.linspace(0, 60, 11)
+        inputs = {"Electrode height [m]": 0.2}
+        sim = pybamm.Simulation(model=model, parameter_values=param)
+        sim.solve(t_eval=t_eval, inputs=inputs)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

Use evaluated timescale from solution when doing sim solve

Fixes #1217 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
