### PR TITLE
Issue 1225 slow sei model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug fixes
 
+-   Add missing separator thermal parameters for the Ecker parameter set ([#1226](https://github.com/pybamm-team/PyBaMM/pull/1226))
 -   Raise error if saving to matlab with variable names that matlab can't read, and give option of providing alternative variable names ([#1206](https://github.com/pybamm-team/PyBaMM/pull/1206))
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
 -   Fix boundary conditions at r = 0 for Creating Models notebooks ([#1173](https://github.com/pybamm-team/PyBaMM/pull/1173))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug fixes
 
+-   Fix bug that was slowing down creation of the EC reaction SEI submodel ([#1227](https://github.com/pybamm-team/PyBaMM/pull/1227))
 -   Add missing separator thermal parameters for the Ecker parameter set ([#1226](https://github.com/pybamm-team/PyBaMM/pull/1226))
 -   Raise error if saving to matlab with variable names that matlab can't read, and give option of providing alternative variable names ([#1206](https://github.com/pybamm-team/PyBaMM/pull/1206))
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))

--- a/pybamm/input/parameters/lithium-ion/separators/separator_Ecker2015/parameters.csv
+++ b/pybamm/input/parameters/lithium-ion/separators/separator_Ecker2015/parameters.csv
@@ -4,3 +4,6 @@ Name [units],Value,Reference,Notes
 Separator porosity,0.508,,
 Separator Bruggeman coefficient (electrolyte),1.9804586773134942, Solve for permeability factor B=0.304=eps^b,
 Separator Bruggeman coefficient (electrode),0,No Bruggeman correction to solid conductivity,
+Separator density [kg.m-3],397,default,
+Separator specific heat capacity [J.kg-1.K-1],700,default,
+Separator thermal conductivity [W.m-1.K-1],0.16,default,

--- a/pybamm/models/submodels/interface/sei/ec_reaction_limited.py
+++ b/pybamm/models/submodels/interface/sei/ec_reaction_limited.py
@@ -87,13 +87,18 @@ class EcReactionLimited(BaseModel):
         # it's ok to fall back on the total interfacial current density, j_tot
         # This should only happen when the interface submodel is "InverseButlerVolmer"
         # in which case j = j_tot (uniform) anyway
-        try:
+        if (
+            "Total "
+            + self.domain.lower()
+            + " electrode interfacial current density variable"
+            in variables
+        ):
             j = variables[
                 "Total "
                 + self.domain.lower()
-                + " electrode interfacial current density"
+                + " electrode interfacial current density variable"
             ]
-        except KeyError:
+        else:
             j = variables[
                 "X-averaged "
                 + self.domain.lower()

--- a/pybamm/models/submodels/interface/sei/reaction_limited.py
+++ b/pybamm/models/submodels/interface/sei/reaction_limited.py
@@ -41,9 +41,9 @@ class ReactionLimited(BaseModel):
         # it's ok to fall back on the total interfacial current density, j_tot
         # This should only happen when the interface submodel is "InverseButlerVolmer"
         # in which case j = j_tot (uniform) anyway
-        try:
+        if self.domain + " electrode interfacial current density" in variables:
             j = variables[self.domain + " electrode interfacial current density"]
-        except KeyError:
+        else:
             j = variables[
                 "X-averaged "
                 + self.domain.lower()


### PR DESCRIPTION
# Description

Avoid try-except block which was causing the EC SEI submodel to slow down because of the levenshtein ratio search

Fixes #1225 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
