### PR TITLE
Revert workaround macos errors

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -37,10 +37,6 @@ jobs:
     - name: Install build-time deps for MacOS
       if: matrix.os == 'macos-latest'
       run: |
-        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
-        brew untap local/homebrew-openssl
-        brew untap local/homebrew-python2
-        # End of fix
         brew update
         brew install graphviz
         brew install sundials

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,10 +50,6 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        # Temporary fix for https://github.com/actions/virtual-environments/issues/1811
-        brew untap local/homebrew-openssl
-        brew untap local/homebrew-python2
-        # End of fix
         brew update
         brew install graphviz
         brew install openblas


### PR DESCRIPTION
# Description

The issue with `brew update` on GitHub Actions has been fixed so the workaround can be reverted. It works fine with the PR workflow, I assume it will be fine with the publish workflow.