### PR TITLE
make quickplot use scaling from solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
 -   Fix boundary conditions at r = 0 for Creating Models notebooks ([#1173](https://github.com/pybamm-team/PyBaMM/pull/1173))
 -   Make sure simulation solves when evaluated timescale is a function of an input parameter ([#1218](https://github.com/pybamm-team/PyBaMM/pull/1218))
+-   Quickplot now works when timescale or lengthscale is a function of an input parameter ([#1234](https://github.com/pybamm-team/PyBaMM/pull/1234))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,13 @@
 
 ## Bug fixes
 
+-   Quickplot now works when timescale or lengthscale is a function of an input parameter ([#1234](https://github.com/pybamm-team/PyBaMM/pull/1234))
 -   Fix bug that was slowing down creation of the EC reaction SEI submodel ([#1227](https://github.com/pybamm-team/PyBaMM/pull/1227))
 -   Add missing separator thermal parameters for the Ecker parameter set ([#1226](https://github.com/pybamm-team/PyBaMM/pull/1226))
+-   Make sure simulation solves when evaluated timescale is a function of an input parameter ([#1218](https://github.com/pybamm-team/PyBaMM/pull/1218))
 -   Raise error if saving to MATLAB with variable names that MATLAB can't read, and give option of providing alternative variable names ([#1206](https://github.com/pybamm-team/PyBaMM/pull/1206))
 -   Raise error if the boundary condition at the origin in a spherical domain is other than no-flux ([#1175](https://github.com/pybamm-team/PyBaMM/pull/1175))
 -   Fix boundary conditions at r = 0 for Creating Models notebooks ([#1173](https://github.com/pybamm-team/PyBaMM/pull/1173))
--   Make sure simulation solves when evaluated timescale is a function of an input parameter ([#1218](https://github.com/pybamm-team/PyBaMM/pull/1218))
--   Quickplot now works when timescale or lengthscale is a function of an input parameter ([#1234](https://github.com/pybamm-team/PyBaMM/pull/1234))
 
 ## Breaking changes
 

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -146,16 +146,20 @@ class QuickPlot(object):
         else:
             raise ValueError("spatial unit '{}' not recognized".format(spatial_unit))
 
-        # Set length scales
-        self.length_scales = {
-            domain: scale.evaluate() * self.spatial_factor
-            for domain, scale in models[0].length_scales.items()
-        }
+        try:
+            # Set length scales
+            self.length_scales = {
+                domain: scale.evaluate() * self.spatial_factor
+                for domain, scale in models[0].length_scales.items()
+            }
+        except KeyError:
+            # Length scales are probably function of input
+            # Use the evaluated length scales from the first solution
+            self.length_scales = solutions[0].length_scales_eval
 
         # Time parameters
-        model_timescale_in_seconds = models[0].timescale_eval
         self.ts_seconds = [
-            solution.t * model_timescale_in_seconds for solution in solutions
+            solution.t * solution.timescale_eval for solution in solutions
         ]
         min_t = np.min([t[0] for t in self.ts_seconds])
         max_t = np.max([t[-1] for t in self.ts_seconds])

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -146,17 +146,6 @@ class QuickPlot(object):
         else:
             raise ValueError("spatial unit '{}' not recognized".format(spatial_unit))
 
-        try:
-            # Set length scales
-            self.length_scales = {
-                domain: scale.evaluate() * self.spatial_factor
-                for domain, scale in models[0].length_scales.items()
-            }
-        except KeyError:
-            # Length scales are probably function of input
-            # Use the evaluated length scales from the first solution
-            self.length_scales = solutions[0].length_scales_eval
-
         # Time parameters
         self.ts_seconds = [
             solution.t * solution.timescale_eval for solution in solutions

--- a/tests/unit/test_quick_plot.py
+++ b/tests/unit/test_quick_plot.py
@@ -452,6 +452,36 @@ class TestQuickPlot(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "solutions must be"):
             pybamm.QuickPlot(1)
 
+    def test_model_with_inputs(self):
+        chemistry = pybamm.parameter_sets.Chen2020
+        parameter_values = pybamm.ParameterValues(chemistry=chemistry)
+        model = pybamm.lithium_ion.SPMe()
+        parameter_values.update({"Electrode height [m]": "[input]"})
+        solver = pybamm.CasadiSolver(mode='safe')
+        sim1 = pybamm.Simulation(model, parameter_values=parameter_values,
+                                 solver=solver)
+        inputs1 = {"Electrode height [m]": 1.00}
+        sol1 = sim1.solve(t_eval=np.linspace(0, 1000, 101), inputs=inputs1)
+        sim2 = pybamm.Simulation(model, parameter_values=parameter_values,
+                                 solver=solver)
+        inputs2 = {"Electrode height [m]": 2.00}
+        sol2 = sim2.solve(t_eval=np.linspace(0, 1000, 101), inputs=inputs2)
+        output_variables = [
+            "Terminal voltage [V]",
+            "Current [A]",
+            "Negative electrode potential [V]",
+            "Positive electrode potential [V]",
+            "Electrolyte potential [V]",
+            "Electrolyte concentration",
+            "Negative particle surface concentration",
+            "Positive particle surface concentration",
+        ]
+        quick_plot = pybamm.QuickPlot(solutions=[sol1, sol2],
+                                      output_variables=output_variables)
+        quick_plot.dynamic_plot(testing=True)
+        quick_plot.slider_update(1)
+        pybamm.close_plots()
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

Quickplot now uses timescale and lengthscale evals from the solution instead of evaluating them.

Fixes # 1233

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
