### PR TITLE
Issue 1235 jax sparse mat vec

### DIFF
--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -111,6 +111,7 @@ from .expression_tree.operations.evaluate import (
 
 if system() != "Windows":
     from .expression_tree.operations.evaluate import EvaluatorJax
+    from .expression_tree.operations.evaluate import JaxCooMatrix
 
 from .expression_tree.operations.jacobian import Jacobian
 from .expression_tree.operations.convert_to_casadi import CasadiConverter

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -424,6 +424,7 @@ class JaxCooMatrix:
     def __matmul__(self, b):
         return self.dot_product(b)
 
+
 class EvaluatorJax:
     """
     Converts a pybamm expression tree into pure python code that will calculate the

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -19,11 +19,11 @@ if system() != "Windows":
 
     class JaxCooMatrix:
         def __init__(self, row, col, data, shape):
-            self.row = row
-            self.col = col
-            self.data = data
+            self.row = jax.numpy.array(row)
+            self.col = jax.numpy.array(col)
+            self.data = jax.numpy.array(data)
             self.shape = shape
-            self.nnz = len(data)
+            self.nnz = len(self.data)
 
         def toarray(self):
             result = jax.numpy.zeros(self.shape, dtype=self.data.dtype)

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -223,7 +223,7 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
             dummy_eval_left = symbol.children[0].evaluate_for_shape()
             dummy_eval_right = symbol.children[1].evaluate_for_shape()
             if output_jax and (
-                    scipy.sparse.issparse(dummy_eval_left) or
+                    scipy.sparse.issparse(dummy_eval_left) and
                     scipy.sparse.issparse(dummy_eval_right)
             ):
                 raise NotImplementedError('sparse mat-mat multiplication not supported '

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -29,13 +29,11 @@ if system() != "Windows":
             result = jax.numpy.zeros(self.shape, dtype=self.data.dtype)
             return result.at[self.row, self.col].add(self.data)
 
-        @jax.partial(jax.jit, static_argnums=(0,))
         def dot_product(self, b):
             # assume b is a column vector
             result = jax.numpy.zeros((self.shape[0], 1), dtype=b.dtype)
             return result.at[self.row].add(self.data.reshape(-1, 1) * b[self.col])
 
-        @jax.partial(jax.jit, static_argnums=(0,))
         def scalar_multiply(self, b):
             # assume b is a scalar or ndarray with 1 element
             return JaxCooMatrix(
@@ -44,11 +42,9 @@ if system() != "Windows":
                 self.shape
             )
 
-        @jax.partial(jax.jit, static_argnums=(0,))
         def multiply(self, b):
             raise NotImplementedError
 
-        @jax.partial(jax.jit, static_argnums=(0,))
         def __matmul__(self, b):
             return self.dot_product(b)
 

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -365,11 +365,6 @@ class EvaluatorJax:
     so any sparse matrices and operations involved sparse matrices are converted to
     their dense equivilents before compilation
 
-    Raises
-    ------
-    RuntimeError
-        if any sparse matrices are present in the expression tree
-
     Parameters
     ----------
 

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -180,6 +180,7 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
                 symbol_str = "{0} * {1}".format(children_vars[0], children_vars[1])
         elif isinstance(symbol, pybamm.Division):
             dummy_eval_left = symbol.children[0].evaluate_for_shape()
+            dummy_eval_right = symbol.children[1].evaluate_for_shape()
             if scipy.sparse.issparse(dummy_eval_left):
                 if output_jax and is_scalar(dummy_eval_right):
                     symbol_str = "{0}.scalar_multiply(1/{1})"\

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -65,7 +65,7 @@ if system() != "Windows":
         return JaxCooMatrix(row, col, data, value.shape)
 else:
 
-    def create_jax_coo_matrix(value):
+    def create_jax_coo_matrix(value):  # pragma: no cover
         raise NotImplementedError('Jax is not available on Windows')
 
 

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -226,8 +226,8 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
                     scipy.sparse.issparse(dummy_eval_left) or
                     scipy.sparse.issparse(dummy_eval_right)
             ):
-                raise NotImplementedError('mat-mat multiplication not supported for '
-                                          'output_jax == True')
+                raise NotImplementedError('sparse mat-mat multiplication not supported '
+                                          'for output_jax == True')
             else:
                 symbol_str = children_vars[0] + " " + symbol.name + " " \
                     + children_vars[1]

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -48,7 +48,7 @@ if system() != "Windows":
         def __matmul__(self, b):
             return self.dot_product(b)
 
-    def createJaxCooMatrix(value):
+    def create_jax_coo_matrix(value):
         """
         Creates a JaxCooMatrix from a scipy.sparse matrix
 
@@ -65,7 +65,7 @@ if system() != "Windows":
         return JaxCooMatrix(row, col, data, value.shape)
 else:
 
-    def createJaxCooMatrix(value):
+    def create_jax_coo_matrix(value):
         raise NotImplementedError('Jax is not available on Windows')
 
 
@@ -132,7 +132,7 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
         if not isinstance(value, numbers.Number):
             if output_jax and scipy.sparse.issparse(value):
                 # convert any remaining sparse matrices to our custom coo matrix
-                constant_symbols[symbol.id] = createJaxCooMatrix(value)
+                constant_symbols[symbol.id] = create_jax_coo_matrix(value)
 
             else:
                 constant_symbols[symbol.id] = value
@@ -515,6 +515,9 @@ class EvaluatorJax:
 
         # store a copy of examine_jaxpr
         python_str = python_str + "\nself._evaluate_jax = evaluate_jax"
+
+        # store the final generated code
+        self._python_str = python_str
 
         # compile and run the generated python code,
         compiled_function = compile(python_str, result_var, "exec")

--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -205,7 +205,7 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
                     symbol_str = "{0}.multiply({1})"\
                         .format(children_vars[0], children_vars[1])
             elif scipy.sparse.issparse(dummy_eval_right):
-                if output_jax and is_sparse(dummy_eval_left):
+                if output_jax and is_scalar(dummy_eval_left):
                     symbol_str = "{1}.scalar_multiply({0})"\
                         .format(children_vars[0], children_vars[1])
                 else:
@@ -229,9 +229,8 @@ def find_symbols(symbol, constant_symbols, variable_symbols, output_jax=False):
                 raise NotImplementedError('mat-mat multiplication not supported for '
                                           'output_jax == True')
             else:
-                symbol_str = children_vars[0] + " " \
-                             + symbol.name + " " \
-                             + children_vars[1]
+                symbol_str = children_vars[0] + " " + symbol.name + " " \
+                    + children_vars[1]
         else:
             symbol_str = children_vars[0] + " " + symbol.name + " " + children_vars[1]
 

--- a/pybamm/solvers/jax_solver.py
+++ b/pybamm/solvers/jax_solver.py
@@ -192,10 +192,10 @@ class JaxSolver(pybamm.BaseSolver):
         if model not in self._cached_solves:
             self._cached_solves[model] = self.create_solve(model, t_eval)
 
-        y = self._cached_solves[model](inputs)
+        y = self._cached_solves[model](inputs).block_until_ready()
         integration_time = timer.time()
 
-        # note - the actual solve is not done until this line!
+        # convert to a normal numpy array
         y = onp.array(y)
 
         termination = "final time"

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -662,7 +662,7 @@ class TestEvaluate(unittest.TestCase):
         np.testing.assert_allclose(A.scalar_multiply(3.0).toarray(), Adense * 3.0)
 
         with self.assertRaises(NotImplementedError):
-            a = A.multiply(v)
+            A.multiply(v)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -130,17 +130,6 @@ class TestEvaluate(unittest.TestCase):
             list(constant_symbols.values())[0].toarray(), A.entries.toarray()
         )
 
-        # test sparse to dense conversion
-        constant_symbols = OrderedDict()
-        variable_symbols = OrderedDict()
-        A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[0, 2], [0, 4]])))
-        pybamm.find_symbols(A, constant_symbols, variable_symbols, numpy_only=True)
-        self.assertEqual(len(variable_symbols), 0)
-        self.assertEqual(list(constant_symbols.keys())[0], A.id)
-        np.testing.assert_allclose(
-            list(constant_symbols.values())[0].toarray(), A.entries.toarray()
-        )
-
         # test numpy concatentate
         constant_symbols = OrderedDict()
         variable_symbols = OrderedDict()
@@ -466,6 +455,19 @@ class TestEvaluate(unittest.TestCase):
         for t, y in zip(t_tests, y_tests):
             result = evaluator.evaluate(t=t, y=y)
             np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
+
+    @unittest.skipIf(system() == "Windows", "JAX not supported on windows")
+    def test_find_symbols_jax(self):
+        # test sparse conversion
+        constant_symbols = OrderedDict()
+        variable_symbols = OrderedDict()
+        A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[0, 2], [0, 4]])))
+        pybamm.find_symbols(A, constant_symbols, variable_symbols, output_jax=True)
+        self.assertEqual(len(variable_symbols), 0)
+        self.assertEqual(list(constant_symbols.keys())[0], A.id)
+        np.testing.assert_allclose(
+            list(constant_symbols.values())[0].toarray(), A.entries.toarray()
+        )
 
     @unittest.skipIf(system() == "Windows", "JAX not supported on windows")
     def test_evaluator_jax(self):

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -440,11 +440,11 @@ class TestEvaluate(unittest.TestCase):
 
         v = pybamm.StateVector(slice(0, 2))
         A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))
-        expr = pybamm.Inner(A, v)
-        evaluator = pybamm.EvaluatorPython(expr)
-        for t, y in zip(t_tests, y_tests):
-            result = evaluator.evaluate(t=t, y=y).toarray()
-            np.testing.assert_allclose(result, expr.evaluate(t=t, y=y).toarray())
+        for expr in [pybamm.Inner(A, v), pybamm.Inner(v, A)]:
+            evaluator = pybamm.EvaluatorPython(expr)
+            for t, y in zip(t_tests, y_tests):
+                result = evaluator.evaluate(t=t, y=y).toarray()
+                np.testing.assert_allclose(result, expr.evaluate(t=t, y=y).toarray())
 
         y_tests = [np.array([[2], [3], [4], [5]]), np.array([[1], [3], [2], [1]])]
         t_tests = [1, 2]
@@ -660,6 +660,9 @@ class TestEvaluate(unittest.TestCase):
         np.testing.assert_allclose(A.toarray(), Adense)
         np.testing.assert_allclose(A @ v, Adense @ v)
         np.testing.assert_allclose(A.scalar_multiply(3.0).toarray(), Adense * 3.0)
+
+        with self.assertRaises(NotImplementedError):
+            a = A.multiply(v)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -560,7 +560,7 @@ class TestEvaluate(unittest.TestCase):
             result = evaluator.evaluate(t=t, y=y)
             self.assertEqual(result, expr.evaluate(t=t, y=y))
 
-        # test something with a sparse matrix multiplication
+        # test something with a sparse matrix-vector multiplication
         A = pybamm.Matrix(np.array([[1, 2], [3, 4]]))
         B = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))
         C = pybamm.Matrix(scipy.sparse.coo_matrix(np.array([[1, 0], [0, 4]])))
@@ -569,6 +569,18 @@ class TestEvaluate(unittest.TestCase):
         for t, y in zip(t_tests, y_tests):
             result = evaluator.evaluate(t=t, y=y)
             np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
+
+        # test the sparse-scalar multiplication
+        A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))
+        for expr in [
+                A * pybamm.t @ pybamm.StateVector(slice(0, 2)),
+                pybamm.t * A @ pybamm.StateVector(slice(0, 2)),
+        ]:
+            print('doing ',expr)
+            evaluator = pybamm.EvaluatorJax(expr)
+            for t, y in zip(t_tests, y_tests):
+                result = evaluator.evaluate(t=t, y=y)
+                np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
 
         # test sparse stack
         A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -137,7 +137,6 @@ class TestEvaluate(unittest.TestCase):
         pybamm.find_symbols(A, constant_symbols, variable_symbols, numpy_only=True)
         self.assertEqual(len(variable_symbols), 0)
         self.assertEqual(list(constant_symbols.keys())[0], A.id)
-        print(list(constant_symbols.values())[0].toarray())
         np.testing.assert_allclose(
             list(constant_symbols.values())[0].toarray(), A.entries.toarray()
         )
@@ -574,13 +573,8 @@ class TestEvaluate(unittest.TestCase):
         B = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[2, 0], [5, 0]])))
         a = pybamm.StateVector(slice(0, 1))
         expr = pybamm.SparseStack(A, a * B)
-        evaluator = pybamm.EvaluatorJax(expr)
-        for t, y in zip(t_tests, y_tests):
-            result = evaluator.evaluate(t=t, y=y)
-            np.testing.assert_allclose(
-                result.toarray(),
-                expr.evaluate(t=t, y=y).toarray()
-            )
+        with self.assertRaises(NotImplementedError):
+            evaluator = pybamm.EvaluatorJax(expr)
 
         # test numpy concatenation
         a = pybamm.Vector(np.array([[1], [2]]))

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -134,11 +134,12 @@ class TestEvaluate(unittest.TestCase):
         constant_symbols = OrderedDict()
         variable_symbols = OrderedDict()
         A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[0, 2], [0, 4]])))
-        pybamm.find_symbols(A, constant_symbols, variable_symbols, to_dense=True)
+        pybamm.find_symbols(A, constant_symbols, variable_symbols, numpy_only=True)
         self.assertEqual(len(variable_symbols), 0)
         self.assertEqual(list(constant_symbols.keys())[0], A.id)
+        print(list(constant_symbols.values())[0].toarray())
         np.testing.assert_allclose(
-            list(constant_symbols.values())[0], A.entries.toarray()
+            list(constant_symbols.values())[0].toarray(), A.entries.toarray()
         )
 
         # test numpy concatentate
@@ -576,7 +577,10 @@ class TestEvaluate(unittest.TestCase):
         evaluator = pybamm.EvaluatorJax(expr)
         for t, y in zip(t_tests, y_tests):
             result = evaluator.evaluate(t=t, y=y)
-            np.testing.assert_allclose(result, expr.evaluate(t=t, y=y).toarray())
+            np.testing.assert_allclose(
+                result.toarray(),
+                expr.evaluate(t=t, y=y).toarray()
+            )
 
         # test numpy concatenation
         a = pybamm.Vector(np.array([[1], [2]]))

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -650,6 +650,17 @@ class TestEvaluate(unittest.TestCase):
         evaluator = pybamm.EvaluatorJax(expr)
         evaluator.debug(y=y_test)
 
+    @unittest.skipIf(system() == "Windows", "JAX not supported on windows")
+    def test_jax_coo_matrix(self):
+        import jax
+        A = pybamm.JaxCooMatrix([0, 1], [0, 1], [1.0, 2.0], (2, 2))
+        Adense = jax.numpy.array([[1.0, 0], [0, 2.0]])
+        v = jax.numpy.array([[2.0], [1.0]])
+
+        np.testing.assert_allclose(A.toarray(), Adense)
+        np.testing.assert_allclose(A @ v, Adense @ v)
+        np.testing.assert_allclose(A.scalar_multiply(3.0).toarray(), Adense * 3.0)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -576,11 +576,19 @@ class TestEvaluate(unittest.TestCase):
                 A * pybamm.t @ pybamm.StateVector(slice(0, 2)),
                 pybamm.t * A @ pybamm.StateVector(slice(0, 2)),
         ]:
-            print('doing ',expr)
             evaluator = pybamm.EvaluatorJax(expr)
             for t, y in zip(t_tests, y_tests):
                 result = evaluator.evaluate(t=t, y=y)
                 np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
+
+        # test the sparse-scalar division
+        A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))
+        expr = A / (1 + pybamm.t) @ pybamm.StateVector(slice(0, 2))
+        evaluator = pybamm.EvaluatorJax(expr)
+        for t, y in zip(t_tests, y_tests):
+            result = evaluator.evaluate(t=t, y=y)
+            np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
+
 
         # test sparse stack
         A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate.py
@@ -578,6 +578,14 @@ class TestEvaluate(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             evaluator = pybamm.EvaluatorJax(expr)
 
+        # test sparse mat-mat mult
+        A = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[1, 0], [0, 4]])))
+        B = pybamm.Matrix(scipy.sparse.csr_matrix(np.array([[2, 0], [5, 0]])))
+        a = pybamm.StateVector(slice(0, 1))
+        expr = A @ (a * B)
+        with self.assertRaises(NotImplementedError):
+            evaluator = pybamm.EvaluatorJax(expr)
+
         # test numpy concatenation
         a = pybamm.Vector(np.array([[1], [2]]))
         b = pybamm.Vector(np.array([[3]]))


### PR DESCRIPTION
# Description

`EvaluatorJax` uses a custom COO sparse matrix class and implements mat-vec multiply, as an alternative to converting everything to dense matrices

Fixes #1235 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
