### PR TITLE
fix typo in initial conditions

### DIFF
--- a/examples/notebooks/models/thermal-models.ipynb
+++ b/examples/notebooks/models/thermal-models.ipynb
@@ -26,8 +26,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33mWARNING: You are using pip version 20.2.2; however, version 20.2.4 is available.\n",
-      "You should consider upgrading via the '/home/user/Documents/PyBaMM/env/bin/python3 -m pip install --upgrade pip' command.\u001b[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
@@ -169,7 +167,7 @@
     "\n",
     "and initial condition\n",
     "\n",
-    "$$ \\frac{\\partial T}{\\partial t}\\bigg|_{t=0} = T_0.$$\n",
+    "$$ T\\big|_{t=0} = T_0.$$\n",
     "\n",
     "Here $\\lambda_k$ is the thermal conductivity of component $k$, and the heat transfer coefficients $h_{cn}$ and $h_{cp}$ correspond to heat transfer at the large surface of the pouch on the side of the negative current collector, heat transfer at the large surface of the pouch on the side of the positive current collector, respectively. The heat source term $Q$ is as described in the section on lumped models. Note: the 1D model neglects any cooling from the tabs or edges of the cell -- it assumes a pouch cell geometry and _only_ accounts for cooling from the two large surfaces of the pouch. \n",
     "\n",
@@ -203,7 +201,7 @@
     "$$ -\\lambda_{eff} \\nabla_\\perp T \\cdot \\boldsymbol{n} = \\frac{(L_{cn}+L_n+L_s+L_p)h_{edge}+L_{cp}h_{cp}}{L_{cn}+L_n+L_s+L_p+L_{cp}}(T-T_\\infty),$$  \n",
     "at the positive tab, and\n",
     "$$ -\\lambda_{eff} \\nabla_\\perp T \\cdot \\boldsymbol{n} = h_{edge}(T-T_\\infty),$$  \n",
-    "elsewhere.\n",
+    "elsewhere. Again, an initial temperature $T_0$ must be prescribed.\n",
     "\n",
     "Here the heat source term is averaged in the x direction so that $\\bar{Q}=\\bar{Q}(y,z)$. The parameter $\\lambda_{eff}$ is the effective thermal conductivity, computed as \n",
     "\n",
@@ -391,7 +389,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "096b55724e5d4e4c9a02ccef80c6a341",
+       "model_id": "f452cfe20acd4e5b8950c303ce562255",
        "version_major": 2,
        "version_minor": 0
       },
@@ -405,7 +403,7 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x7f23363a2e80>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x7feb1a363a58>"
       ]
      },
      "execution_count": 11,


### PR DESCRIPTION
# Description
initial conditions in the text were written as prescribing the time derivative of the temperature instead of the temperature...

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
