### PR TITLE
[>master] Switch to manylinux2014

### DIFF
--- a/build_manylinux_wheels/Dockerfile
+++ b/build_manylinux_wheels/Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/pypa/manylinux2010_x86_64:2020-05-29-c06f15c
 
 ENV PLAT manylinux2010_x86_64
 
+RUN yum -y update
 RUN yum -y remove cmake
 RUN yum -y install wget openblas-devel
 RUN /opt/python/cp37-cp37m/bin/pip install --upgrade pip cmake

--- a/build_manylinux_wheels/Dockerfile
+++ b/build_manylinux_wheels/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux2010_x86_64:2020-05-29-c06f15c
+FROM quay.io/pypa/manylinux2014_x86_64:2020-11-11-bc8ce45
 
-ENV PLAT manylinux2010_x86_64
+ENV PLAT manylinux2014_x86_64
 
 RUN yum -y update
 RUN yum -y remove cmake


### PR DESCRIPTION
Building of manylinux wheels inside the manylinux2010 image breaks because the package repos are off following CentOS 6 reaching its end of life on November, 30th. See https://github.com/pypa/manylinux/issues/836

This updates the Dockerfile, to use the manylinux2014 image instead, based on CentOS 7.