### PR TITLE
Enable pickling of models in "python" format

### DIFF
--- a/pybamm/expression_tree/operations/evaluate.py
+++ b/pybamm/expression_tree/operations/evaluate.py
@@ -485,6 +485,7 @@ class EvaluatorPython:
         python_str = python_str + "\nself._evaluate = evaluate"
 
         self._python_str = python_str
+        self._result_var = result_var
         self._symbol = symbol
 
         # compile and run the generated python code,
@@ -506,6 +507,23 @@ class EvaluatorPython:
             return result, known_evals
         else:
             return result
+
+    def __getstate__(self):
+        # Control the state of instances of EvaluatorPython
+        # before pickling. Method "_evaluate" cannot be pickled.
+        # See https://github.com/pybamm-team/PyBaMM/issues/1283
+        state = self.__dict__.copy()
+        del state["_evaluate"]
+        return state
+
+    def __setstate__(self, state):
+        # Restore pickled attributes and
+        # compile code from "python_str"
+        # Execution of bytecode (re)adds attribute
+        # "_method"
+        self.__dict__.update(state)
+        compiled_function = compile(self._python_str, self._result_var, "exec")
+        exec(compiled_function)
 
 
 class EvaluatorJax:

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -545,12 +545,6 @@ class BaseSolver(object):
         """
         pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
-        # Cannot use multiprocessing with model in "jax" format
-        if(len(inputs) > 1) and model.convert_to_format == "jax":
-            raise pybamm.SolverError(
-                "Cannot solve list of inputs with multiprocessing "
-                "when model in format \"jax\"."
-            )
         # Make sure model isn't empty
         if len(model.rhs) == 0 and len(model.algebraic) == 0:
             if not isinstance(self, pybamm.DummySolver):
@@ -594,6 +588,13 @@ class BaseSolver(object):
             self._set_up_ext_and_inputs(model, external_variables, inputs)
             for inputs in inputs_list
         ]
+
+        # Cannot use multiprocessing with model in "jax" format
+        if(len(inputs_list) > 1) and model.convert_to_format == "jax":
+            raise pybamm.SolverError(
+                "Cannot solve list of inputs with multiprocessing "
+                "when model in format \"jax\"."
+            )
 
         # Set up
         timer = pybamm.Timer()

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -738,6 +738,8 @@ class BaseSolver(object):
                             ext_and_inputs_list,
                         ),
                     )
+                    p.close()
+                    p.join()
             # Setting the solve time for each segment.
             # pybamm.Solution.append assumes attribute
             # solve_time.

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -545,6 +545,12 @@ class BaseSolver(object):
         """
         pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
+        # Cannot use multiprocessing with model in "jax" format
+        if(len(inputs) > 1) and model.convert_to_format == "jax":
+            raise pybamm.SolverError(
+                "Cannot solve list of inputs with multiprocessing "
+                "when model in format \"jax\"."
+            )
         # Make sure model isn't empty
         if len(model.rhs) == 0 and len(model.algebraic) == 0:
             if not isinstance(self, pybamm.DummySolver):

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -200,10 +200,9 @@ class TestScipySolver(unittest.TestCase):
         var = pybamm.Variable("var", domain=domain)
         model.rhs = {var: -pybamm.InputParameter("rate") * var}
         model.initial_conditions = {var: 1}
-        model.events = [pybamm.Event("var=0.5", pybamm.min(var - 0.5))]
         # No need to set parameters; can use base discretisation (no spatial
         # operators)
-
+        model.events = [pybamm.Event("var=0.5", pybamm.min(var - 0.5))]
         # create discretisation
         mesh = get_mesh_for_testing()
         spatial_methods = {"macroscale": pybamm.FiniteVolume()}
@@ -221,15 +220,11 @@ class TestScipySolver(unittest.TestCase):
         for convert_to_format in ["python", "casadi"]:
             # Create model
             model = pybamm.BaseModel()
-            # Covert to casadi instead of python to avoid pickling of
-            # "EvaluatorPython" objects.
             model.convert_to_format = convert_to_format
             domain = ["negative electrode", "separator", "positive electrode"]
             var = pybamm.Variable("var", domain=domain)
             model.rhs = {var: -pybamm.InputParameter("rate") * var}
             model.initial_conditions = {var: 1}
-            # No need to set parameters; can use base discretisation (no spatial
-            # operators)
             # create discretisation
             mesh = get_mesh_for_testing()
             spatial_methods = {"macroscale": pybamm.FiniteVolume()}
@@ -253,15 +248,11 @@ class TestScipySolver(unittest.TestCase):
     def test_model_solver_multiple_inputs_discontinuity_error(self):
         # Create model
         model = pybamm.BaseModel()
-        # Covert to casadi instead of python to avoid pickling of
-        # "EvaluatorPython" objects.
         model.convert_to_format = "casadi"
         domain = ["negative electrode", "separator", "positive electrode"]
         var = pybamm.Variable("var", domain=domain)
         model.rhs = {var: -pybamm.InputParameter("rate") * var}
         model.initial_conditions = {var: 1}
-        # No need to set parameters; can use base discretisation (no spatial
-        # operators)
         # create discretisation
         mesh = get_mesh_for_testing()
         spatial_methods = {"macroscale": pybamm.FiniteVolume()}
@@ -292,15 +283,11 @@ class TestScipySolver(unittest.TestCase):
     def test_model_solver_multiple_inputs_initial_conditions_error(self):
         # Create model
         model = pybamm.BaseModel()
-        # Covert to casadi instead of python to avoid pickling of
-        # "EvaluatorPython" objects.
         model.convert_to_format = "casadi"
         domain = ["negative electrode", "separator", "positive electrode"]
         var = pybamm.Variable("var", domain=domain)
         model.rhs = {var: -pybamm.InputParameter("rate") * var}
         model.initial_conditions = {var: 2 * pybamm.InputParameter("rate")}
-        # No need to set parameters; can use base discretisation (no spatial
-        # operators)
         # create discretisation
         mesh = get_mesh_for_testing()
         spatial_methods = {"macroscale": pybamm.FiniteVolume()}
@@ -321,8 +308,6 @@ class TestScipySolver(unittest.TestCase):
     def test_model_solver_multiple_inputs_jax_format_error(self):
         # Create model
         model = pybamm.BaseModel()
-        # Covert to casadi instead of python to avoid pickling of
-        # "EvaluatorPython" objects.
         model.convert_to_format = "jax"
         domain = ["negative electrode", "separator", "positive electrode"]
         var = pybamm.Variable("var", domain=domain)

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -318,6 +318,38 @@ class TestScipySolver(unittest.TestCase):
         ):
             solver.solve(model, t_eval, inputs=inputs_list, nproc=2)
 
+    def test_model_solver_multiple_inputs_jax_format_error(self):
+        # Create model
+        model = pybamm.BaseModel()
+        # Covert to casadi instead of python to avoid pickling of
+        # "EvaluatorPython" objects.
+        model.convert_to_format = "jax"
+        domain = ["negative electrode", "separator", "positive electrode"]
+        var = pybamm.Variable("var", domain=domain)
+        model.rhs = {var: -pybamm.InputParameter("rate") * var}
+        model.initial_conditions = {var: 2 * pybamm.InputParameter("rate")}
+        # No need to set parameters; can use base discretisation (no spatial
+        # operators)
+        # create discretisation
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(model)
+
+        solver = pybamm.ScipySolver(rtol=1e-8, atol=1e-8, method="RK45")
+        t_eval = np.linspace(0, 10, 100)
+        ninputs = 8
+        inputs_list = [{"rate": 0.01 * (i + 1)} for i in range(ninputs)]
+
+        with self.assertRaisesRegex(
+            pybamm.SolverError,
+            (
+                "Cannot solve list of inputs with multiprocessing "
+                'when model in format "jax".'
+            ),
+        ):
+            solver.solve(model, t_eval, inputs=inputs_list, nproc=2)
+
     def test_model_solver_with_external(self):
         # Create model
         model = pybamm.BaseModel()

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,11 @@ deps =
      scikits.odes
 commands = 
      coverage run run-tests.py --nosub
+     # Some tests make use of multiple processes through
+     # multiprocessing. Coverage data is then generated for each
+     # process separately and data must then be combined into one
+     # single coverage data file.
+     coverage combine
      coverage xml
 
 [testenv:docs]
@@ -115,3 +120,6 @@ ignore=
 
 [coverage:run]
 source = pybamm
+# By default coverage data isn't collected in forked processes, see
+# https://coverage.readthedocs.io/en/coverage-5.3.1/subprocess.html
+concurrency = multiprocessing


### PR DESCRIPTION
# Description

This defines the two methods `__getstate__` and `__setstate__` that can be used to control what is pickled when pickling a class
instance, as well as what happens when the object in unpickled.

In this case this is useful to avoid pickling the `_evaluate` attribute, which is a reference to a function that cannot be pickled.
This attribute is restored when unpicking by re-compiling the definition of the function `evaluate`. 

Note that this does _not_ make it possible to pickle model in "jax" format.

Fixes #1283 #734 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
