### PR TITLE
Issue 1063 tplus temperature dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+-   Added temperature dependence to the transference number (`t_plus`) ([1317](https://github.com/pybamm-team/PyBaMM/pull/1317))
 -   Added new functionality for `Interpolant` ([#1312](https://github.com/pybamm-team/PyBaMM/pull/1312))
 -   Added option to express experiments (and extract solutions) in terms of cycles of operating condition ([#1309](https://github.com/pybamm-team/PyBaMM/pull/1309))
 -   The event time and state are now returned as part of `Solution.t` and `Solution.y` so that the event is accurately captured in the returned solution ([#1300](https://github.com/pybamm-team/PyBaMM/pull/1300))

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_DMC_1_1_Landesfeind2019/electrolyte_TDF_EC_DMC_1_1_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_DMC_1_1_Landesfeind2019/electrolyte_TDF_EC_DMC_1_1_Landesfeind2019.py
@@ -2,7 +2,7 @@ from electrolyte_base_Landesfeind2019 import electrolyte_TDF_base_Landesfeind201
 import numpy as np
 
 
-def electrolyte_TDF_EC_DMC_1_1_Landesfeind2019(c_e, T=298.15):
+def electrolyte_TDF_EC_DMC_1_1_Landesfeind2019(c_e, T):
     """
     Thermodynamic factor (TDF) of LiPF6 in EC:DMC (1:1 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_DMC_1_1_Landesfeind2019/electrolyte_transference_number_EC_DMC_1_1_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_DMC_1_1_Landesfeind2019/electrolyte_transference_number_EC_DMC_1_1_Landesfeind2019.py
@@ -4,7 +4,7 @@ from electrolyte_base_Landesfeind2019 import (
 import numpy as np
 
 
-def electrolyte_transference_number_EC_DMC_1_1_Landesfeind2019(c_e, T=298.15):
+def electrolyte_transference_number_EC_DMC_1_1_Landesfeind2019(c_e, T):
     """
     Transference number of LiPF6 in EC:DMC (1:1 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_EMC_3_7_Landesfeind2019/electrolyte_TDF_EC_EMC_3_7_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_EMC_3_7_Landesfeind2019/electrolyte_TDF_EC_EMC_3_7_Landesfeind2019.py
@@ -2,7 +2,7 @@ from electrolyte_base_Landesfeind2019 import electrolyte_TDF_base_Landesfeind201
 import numpy as np
 
 
-def electrolyte_TDF_EC_EMC_3_7_Landesfeind2019(c_e, T=298.15):
+def electrolyte_TDF_EC_EMC_3_7_Landesfeind2019(c_e, T):
     """
     Thermodynamic factor (TDF) of LiPF6 in EC:EMC (3:7 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_EMC_3_7_Landesfeind2019/electrolyte_transference_number_EC_EMC_3_7_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EC_EMC_3_7_Landesfeind2019/electrolyte_transference_number_EC_EMC_3_7_Landesfeind2019.py
@@ -4,7 +4,7 @@ from electrolyte_base_Landesfeind2019 import (
 import numpy as np
 
 
-def electrolyte_transference_number_EC_EMC_3_7_Landesfeind2019(c_e, T=298.15):
+def electrolyte_transference_number_EC_EMC_3_7_Landesfeind2019(c_e, T):
     """
     Transference number of LiPF6 in EC:EMC (3:7 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EMC_FEC_19_1_Landesfeind2019/electrolyte_TDF_EMC_FEC_19_1_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EMC_FEC_19_1_Landesfeind2019/electrolyte_TDF_EMC_FEC_19_1_Landesfeind2019.py
@@ -2,7 +2,7 @@ from electrolyte_base_Landesfeind2019 import electrolyte_TDF_base_Landesfeind201
 import numpy as np
 
 
-def electrolyte_TDF_EMC_FEC_19_1_Landesfeind2019(c_e, T=298.15):
+def electrolyte_TDF_EMC_FEC_19_1_Landesfeind2019(c_e, T):
     """
     Thermodyamic factor (TDF) of LiPF6 in EMC:FEC (19:1 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EMC_FEC_19_1_Landesfeind2019/electrolyte_transference_number_EMC_FEC_19_1_Landesfeind2019.py
+++ b/pybamm/input/parameters/lithium-ion/electrolytes/lipf6_EMC_FEC_19_1_Landesfeind2019/electrolyte_transference_number_EMC_FEC_19_1_Landesfeind2019.py
@@ -4,7 +4,7 @@ from electrolyte_base_Landesfeind2019 import (
 import numpy as np
 
 
-def electrolyte_transference_number_EMC_FEC_19_1_Landesfeind2019(c_e, T=298.15):
+def electrolyte_transference_number_EMC_FEC_19_1_Landesfeind2019(c_e, T):
     """
     Transference number of LiPF6 in EMC:FEC (19:1 w:w) as a function of ion
     concentration and temperature. The data comes from [1].

--- a/pybamm/models/full_battery_models/lead_acid/basic_full.py
+++ b/pybamm/models/full_battery_models/lead_acid/basic_full.py
@@ -244,7 +244,7 @@ class BasicFull(BaseModel):
         ######################
         N_e = (
             -tor * param.D_e(c_e, T) * pybamm.grad(c_e)
-            + param.C_e * param.t_plus(c_e) * i_e / param.gamma_e
+            + param.C_e * param.t_plus(c_e, T) * i_e / param.gamma_e
             + param.C_e * c_e * v
         )
         s = pybamm.Concatenation(

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
@@ -258,7 +258,8 @@ class BasicDFN(BaseModel):
         ######################
         N_e = -tor * param.D_e(c_e, T) * pybamm.grad(c_e)
         self.rhs[c_e] = (1 / eps) * (
-            -pybamm.div(N_e) / param.C_e + (1 - param.t_plus(c_e)) * j / param.gamma_e
+            -pybamm.div(N_e) / param.C_e
+            + (1 - param.t_plus(c_e, T)) * j / param.gamma_e
         )
         self.boundary_conditions[c_e] = {
             "left": (pybamm.Scalar(0), "Neumann"),

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -265,10 +265,11 @@ class BasicDFNHalfCell(BaseModel):
         ######################
         N_e = -tor * param.D_e(c_e, T) * pybamm.grad(c_e)
         self.rhs[c_e] = (1 / eps) * (
-            -pybamm.div(N_e) / param.C_e + (1 - param.t_plus(c_e)) * j / param.gamma_e
+            -pybamm.div(N_e) / param.C_e
+            + (1 - param.t_plus(c_e, T)) * j / param.gamma_e
         )
         dce_dx = (
-            -(1 - param.t_plus(c_e))
+            -(1 - param.t_plus(c_e, T))
             * i_cell
             * param.C_e
             / (tor * param.gamma_e * param.D_e(c_e, T))

--- a/pybamm/models/submodels/electrolyte_diffusion/composite_diffusion.py
+++ b/pybamm/models/submodels/electrolyte_diffusion/composite_diffusion.py
@@ -46,7 +46,7 @@ class Composite(BaseElectrolyteDiffusion):
         param = self.param
 
         N_e_diffusion = -tor_0 * param.D_e(c_e_0_av, T_0) * pybamm.grad(c_e)
-        N_e_migration = param.C_e * param.t_plus(c_e) * i_e / param.gamma_e
+        N_e_migration = param.C_e * param.t_plus(c_e, T_0) * i_e / param.gamma_e
         N_e_convection = param.C_e * c_e_0_av * v_box_0
 
         N_e = N_e_diffusion + N_e_migration + N_e_convection

--- a/pybamm/models/submodels/electrolyte_diffusion/first_order_diffusion.py
+++ b/pybamm/models/submodels/electrolyte_diffusion/first_order_diffusion.py
@@ -74,12 +74,12 @@ class FirstOrder(BaseElectrolyteDiffusion):
         ]
         rhs_n = (
             d_epsc_n_0_dt
-            - (sum_s_j_n_0 - param.t_plus(c_e_0) * sum_j_n_0) / param.gamma_e
+            - (sum_s_j_n_0 - param.t_plus(c_e_0, T_0) * sum_j_n_0) / param.gamma_e
         )
         rhs_s = d_epsc_s_0_dt
         rhs_p = (
             d_epsc_p_0_dt
-            - (sum_s_j_p_0 - param.t_plus(c_e_0) * sum_j_p_0) / param.gamma_e
+            - (sum_s_j_p_0 - param.t_plus(c_e_0, T_0) * sum_j_p_0) / param.gamma_e
         )
 
         # Diffusivities

--- a/pybamm/models/submodels/electrolyte_diffusion/full_diffusion.py
+++ b/pybamm/models/submodels/electrolyte_diffusion/full_diffusion.py
@@ -43,7 +43,7 @@ class Full(BaseElectrolyteDiffusion):
         param = self.param
 
         N_e_diffusion = -tor * param.D_e(c_e, T) * pybamm.grad(c_e)
-        N_e_migration = param.C_e * param.t_plus(c_e) * i_e / param.gamma_e
+        N_e_migration = param.C_e * param.t_plus(c_e, T) * i_e / param.gamma_e
         N_e_convection = param.C_e * c_e * v_box
 
         N_e = N_e_diffusion + N_e_migration + N_e_convection

--- a/pybamm/models/submodels/electrolyte_diffusion/leading_order_diffusion.py
+++ b/pybamm/models/submodels/electrolyte_diffusion/leading_order_diffusion.py
@@ -60,6 +60,8 @@ class LeadingOrder(BaseElectrolyteDiffusion):
 
         c_e_av = variables["X-averaged electrolyte concentration"]
 
+        T_av = variables["X-averaged cell temperature"]
+
         eps_n_av = variables["X-averaged negative electrode porosity"]
         eps_s_av = variables["X-averaged separator porosity"]
         eps_p_av = variables["X-averaged positive electrode porosity"]
@@ -84,8 +86,8 @@ class LeadingOrder(BaseElectrolyteDiffusion):
             "Sum of x-averaged positive electrode electrolyte reaction source terms"
         ]
         source_terms = (
-            param.l_n * (sum_s_j_n_0 - param.t_plus(c_e_av) * sum_j_n_0)
-            + param.l_p * (sum_s_j_p_0 - param.t_plus(c_e_av) * sum_j_p_0)
+            param.l_n * (sum_s_j_n_0 - param.t_plus(c_e_av, T_av) * sum_j_n_0)
+            + param.l_p * (sum_s_j_p_0 - param.t_plus(c_e_av, T_av) * sum_j_p_0)
         ) / param.gamma_e
 
         self.rhs = {

--- a/pybamm/parameters/lead_acid_parameters.py
+++ b/pybamm/parameters/lead_acid_parameters.py
@@ -225,7 +225,7 @@ class LeadAcidParameters:
         self.R_sei_dimensional = pybamm.Scalar(0)
         self.beta_sei_n = pybamm.Scalar(0)
 
-    def t_plus(self, c_e):
+    def t_plus(self, c_e, T):
         "Dimensionless transference number (i.e. c_e is dimensionless)"
         inputs = {"Electrolyte concentration [mol.m-3]": c_e * self.c_e_typ}
         return pybamm.FunctionParameter("Cation transference number", inputs)
@@ -440,7 +440,7 @@ class LeadAcidParameters:
             self.c_e_typ
             * self.M_e
             / self.rho_typ
-            * (self.t_plus(1) + self.M_minus / self.M_e)
+            * (self.t_plus(1, self.T_ref) + self.M_minus / self.M_e)
         )
         # Migrative kinematic relationship coefficient (electrolyte)
         self.omega_c_e = (
@@ -700,7 +700,7 @@ class LeadAcidParameters:
         "Thermodynamic factor"
         return (
             self.chi_dimensional(self.c_e_typ * c_e)
-            * (2 * (1 - self.t_plus(c_e)))
+            * (2 * (1 - self.t_plus(c_e, T)))
             / (
                 self.V_w
                 * self.c_T(self.c_e_typ * c_e, self.c_e_typ * c_ox, self.c_e_typ * c_hy)

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -733,14 +733,18 @@ class LithiumIonParameters:
             2*(1-t_plus) for Stefan-Maxwell,
         see Bizeray et al (2016) "Resolving a discrepancy ...".
         """
-        return (2 * (1 - self.t_plus(c_e))) * (self.one_plus_dlnf_dlnc(c_e, T))
+        return (2 * (1 - self.t_plus(c_e, T))) * (self.one_plus_dlnf_dlnc(c_e, T))
 
-    def t_plus(self, c_e):
-        "Dimensionless transference number (i.e. c_e is dimensionless)"
-        inputs = {"Electrolyte concentration [mol.m-3]": c_e * self.c_e_typ}
+    def t_plus(self, c_e, T):
+        "Cation transference number (dimensionless)"
+        inputs = {
+            "Electrolyte concentration [mol.m-3]": c_e * self.c_e_typ,
+            "Temperature [K]": self.Delta_T * T + self.T_ref,
+        }
         return pybamm.FunctionParameter("Cation transference number", inputs)
 
     def one_plus_dlnf_dlnc(self, c_e, T):
+        "Thermodynamic factor (dimensionless)"
         inputs = {
             "Electrolyte concentration [mol.m-3]": c_e * self.c_e_typ,
             "Temperature [K]": self.Delta_T * T + self.T_ref,

--- a/tests/unit/test_models/test_submodels/test_electrolyte_diffusion/test_leading_order_diffusion.py
+++ b/tests/unit/test_models/test_submodels/test_electrolyte_diffusion/test_leading_order_diffusion.py
@@ -24,6 +24,7 @@ class TestLeadingOrder(unittest.TestCase):
             "Sum of x-averaged negative electrode electrolyte reaction source terms": a,
             "Sum of x-averaged positive electrode electrolyte reaction source terms": a,
             "X-averaged separator transverse volume-averaged acceleration": a,
+            "X-averaged cell temperature": a,
         }
         submodel = pybamm.electrolyte_diffusion.LeadingOrder(param)
         std_tests = tests.StandardSubModelTests(submodel, variables)


### PR DESCRIPTION
# Description

The transference number `t_plus` is now a function of both electrolyte concentration and temperature. For lead-acid, the temperature dependence is ignored, as it happened with the other parameters.

Fixes #1063 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
