### PR TITLE
Fix GitHub actions MacOS

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,7 +50,6 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
-#       rm -f /usr/local/bin/2to3
         brew update
         brew install graphviz
         brew install openblas

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -47,6 +47,11 @@ jobs:
         sudo apt install gfortran gcc libopenblas-dev graphviz
         sudo apt install python${{ matrix.python-version }}.dev
     
+    # Added fixes to homebrew installs:
+    # rm -f /usr/local/bin/2to3 
+    # (see https://github.com/actions/virtual-environments/issues/2322)
+    # brew unlink gcc@8 gcc@9
+    # (see https://github.com/actions/virtual-environments/issues/2391)
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,7 +50,9 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
+        rm -f /usr/local/bin/2to3
         brew update
+        brew unlink gcc@8
         brew install graphviz
         brew install openblas
         

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        rm -f /usr/local/bin/2to3
+#       rm -f /usr/local/bin/2to3
         brew update
         brew install graphviz
         brew install openblas

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -52,7 +52,7 @@ jobs:
       run: |
         rm -f /usr/local/bin/2to3
         brew update
-        brew unlink gcc@8
+        brew unlink gcc@8 gcc@9
         brew install graphviz
         brew install openblas
         


### PR DESCRIPTION
# Description

Looks like our issue with the MacOs tests evolved and now it doesn't randomly fail anymore. I have found that adding solves it 
`brew unlink gcc@8 gcc@9` (I hope it doesn't break anything down the line...).
