### PR TITLE
Issue 1320 casadi error extrap events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## Bug fixes
 
+-   Fixed a bug in `CasadiSolver` safe mode which crashed when there were extrapolation events but no termination events ([#1321](https://github.com/pybamm-team/PyBaMM/pull/1321))
 -   When an `Interpolant` is extrapolated an error is raised for `CasadiSolver` (and a warning is raised for the other solvers) ([#1315](https://github.com/pybamm-team/PyBaMM/pull/1315))
 -   Fixed `Simulation` and `model.new_copy` to fix a bug where changes to the model were overwritten ([#1278](https://github.com/pybamm-team/PyBaMM/pull/1278))
 

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -142,37 +142,42 @@ class CasadiSolver(pybamm.BaseSolver):
             # Step-and-check
             t = t_eval[0]
             t_f = t_eval[-1]
-            init_event_signs = np.sign(
-                np.concatenate(
-                    [event(t, y0, inputs) for event in model.terminate_events_eval]
-                )
-            )
-
-            extrap_event = [
-                event(t, y0, inputs)
-                for event in model.interpolant_extrapolation_events_eval
-            ]
-
-            if extrap_event:
-                if (np.concatenate(extrap_event) < self.extrap_tol).any():
-                    extrap_event_names = []
-                    for event in model.events:
-                        if (
-                            event.event_type
-                            == pybamm.EventType.INTERPOLANT_EXTRAPOLATION
-                            and (
-                                event.expression.evaluate(t, y0.full(), inputs=inputs,)
-                                < self.extrap_tol
-                            ).any()
-                        ):
-                            extrap_event_names.append(event.name[12:])
-
-                    raise pybamm.SolverError(
-                        "CasADI solver failed because the following interpolation "
-                        "bounds were exceeded at the initial conditions: {}. "
-                        "You may need to provide additional interpolation points "
-                        "outside these bounds.".format(extrap_event_names)
+            if model.terminate_events_eval:
+                init_event_signs = np.sign(
+                    np.concatenate(
+                        [event(t, y0, inputs) for event in model.terminate_events_eval]
                     )
+                )
+            else:
+                init_event_signs = np.sign([])
+
+            if model.interpolant_extrapolation_events_eval:
+                extrap_event = [
+                    event(t, y0, inputs)
+                    for event in model.interpolant_extrapolation_events_eval
+                ]
+                if extrap_event:
+                    if (np.concatenate(extrap_event) < self.extrap_tol).any():
+                        extrap_event_names = []
+                        for event in model.events:
+                            if (
+                                event.event_type
+                                == pybamm.EventType.INTERPOLANT_EXTRAPOLATION
+                                and (
+                                    event.expression.evaluate(
+                                        t, y0.full(), inputs=inputs,
+                                    )
+                                    < self.extrap_tol
+                                ).any()
+                            ):
+                                extrap_event_names.append(event.name[12:])
+
+                        raise pybamm.SolverError(
+                            "CasADI solver failed because the following interpolation "
+                            "bounds were exceeded at the initial conditions: {}. "
+                            "You may need to provide additional interpolation points "
+                            "outside these bounds.".format(extrap_event_names)
+                        )
 
             pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
 
@@ -240,44 +245,48 @@ class CasadiSolver(pybamm.BaseSolver):
                             )
                         )
                 # Check most recent y to see if any events have been crossed
-                new_event_signs = np.sign(
-                    np.concatenate(
-                        [
-                            event(t, current_step_sol.y[:, -1], inputs)
-                            for event in model.terminate_events_eval
-                        ]
-                    )
-                )
-
-                extrap_event = [
-                    event(t, current_step_sol.y[:, -1], inputs=inputs)
-                    for event in model.interpolant_extrapolation_events_eval
-                ]
-
-                if extrap_event:
-                    if (np.concatenate(extrap_event) < self.extrap_tol).any():
-                        extrap_event_names = []
-                        for event in model.events:
-                            if (
-                                event.event_type
-                                == pybamm.EventType.INTERPOLANT_EXTRAPOLATION
-                                and (
-                                    event.expression.evaluate(
-                                        t,
-                                        current_step_sol.y[:, -1].full(),
-                                        inputs=inputs,
-                                    )
-                                    < self.extrap_tol
-                                ).any()
-                            ):
-                                extrap_event_names.append(event.name[12:])
-
-                        raise pybamm.SolverError(
-                            "CasADI solver failed because the following interpolation "
-                            "bounds were exceeded: {}. You may need to provide "
-                            "additional interpolation points outside these "
-                            "bounds.".format(extrap_event_names)
+                if model.terminate_events_eval:
+                    new_event_signs = np.sign(
+                        np.concatenate(
+                            [
+                                event(t, current_step_sol.y[:, -1], inputs)
+                                for event in model.terminate_events_eval
+                            ]
                         )
+                    )
+                else:
+                    new_event_signs = np.sign([])
+
+                if model.interpolant_extrapolation_events_eval:
+                    extrap_event = [
+                        event(t, current_step_sol.y[:, -1], inputs=inputs)
+                        for event in model.interpolant_extrapolation_events_eval
+                    ]
+
+                    if extrap_event:
+                        if (np.concatenate(extrap_event) < self.extrap_tol).any():
+                            extrap_event_names = []
+                            for event in model.events:
+                                if (
+                                    event.event_type
+                                    == pybamm.EventType.INTERPOLANT_EXTRAPOLATION
+                                    and (
+                                        event.expression.evaluate(
+                                            t,
+                                            current_step_sol.y[:, -1].full(),
+                                            inputs=inputs,
+                                        )
+                                        < self.extrap_tol
+                                    ).any()
+                                ):
+                                    extrap_event_names.append(event.name[12:])
+
+                            raise pybamm.SolverError(
+                                "CasADI solver failed because the following "
+                                "interpolation bounds were exceeded: {}. You may need "
+                                "to provide additional interpolation points outside "
+                                "these bounds.".format(extrap_event_names)
+                            )
 
                 # Exit loop if the sign of an event changes
                 # Locate the event time using a root finding algorithm and


### PR DESCRIPTION
# Description

Added a check before running `np.concatenate` to avoid the error.

Fixes #1320 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
