### PR TITLE
Update Tutorial 4 - Setting parameter values.ipynb

### DIFF
--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -887,7 +887,7 @@
     "\n",
     "# Create interpolant\n",
     "timescale = parameter_values.evaluate(model.timescale)\n",
-    "current_interpolant = pybamm.Interpolant(drive_cycle[:, 0], drive_cycle[:, 1], timescale * pybamm.t)\n",
+    "current_interpolant = pybamm.Interpolant(drive_cycle, timescale * pybamm.t)\n",
     "\n",
     "# Set drive cycle\n",
     "parameter_values[\"Current function [A]\"] = current_interpolant"


### PR DESCRIPTION
Fix bugs in the use of pybamm.Interpolant
------------------------------------------------------------
The init function in interpolant.py is  __init__(self, data, child, name, interpolator, extrapolate, entries_string). So "current_interpolant = pybamm.Interpolant(drive_cycle[:, 0], drive_cycle[:, 1], timescale * pybamm.t)" cause an error showed below. The correct usage should be "current_interpolant = pybamm.Interpolant(drive_cycle,timescale*pybamm.t)".
  
ValueError                 Traceback (most recent call last)
<ipython-input-11-e54986b193b4> in <module>
      6 # Create interpolant
      7 timescale = parameter_values.evaluate(model.timescale)
----> 8 current_interpolant = pybamm.Interpolant(drive_cycle[:, 0], drive_cycle[:, 1], timescale * pybamm.t)
      9 
     10 # Set drive cycle

~/anaconda3/envs/taichi/lib/python3.8/site-packages/pybamm/expression_tree/interpolant.py in __init__(self, data, child, name, interpolator, extrapolate, entries_string)
     41     ):
     42         if data.ndim != 2 or data.shape[1] != 2:
---> 43             raise ValueError(
     44                 """
     45                 data should have exactly two columns (x and y) but has shape {}

ValueError: 
                data should have exactly two columns (x and y) but has shape (601,)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [* ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
