### PR TITLE
#1329 reformat Solution to avoid concatenating y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 ## Optimizations
 
--   If solver method `solve()` is passed a list of inputs as the `inputs` keyword argument, the resolution of the model for each input set is spread acrosss several Python processes, usually running in parallel on different processors. The default number of processes is the number of processors available. `solve()` takes a new keyword argument `nproc` which can be used to set this number a manually.
+-   The `Solution` class now only creates the concatenated `y` when the user asks for it. This is an optimization step as the concatenation can be slow, especially with larger experiments ([#1331](https://github.com/pybamm-team/PyBaMM/pull/1331))
+-   If solver method `solve()` is passed a list of inputs as the `inputs` keyword argument, the resolution of the model for each input set is spread across several Python processes, usually running in parallel on different processors. The default number of processes is the number of processors available. `solve()` takes a new keyword argument `nproc` which can be used to set this number a manually.
 -   Variables are now post-processed using CasADi ([#1316](https://github.com/pybamm-team/PyBaMM/pull/1316))
 -   Operations such as `1*x` and `0+x` now directly return `x` ([#1252](https://github.com/pybamm-team/PyBaMM/pull/1252))
 

--- a/docs/source/solvers/solution.rst
+++ b/docs/source/solvers/solution.rst
@@ -1,8 +1,5 @@
 Solutions
 =========
 
-.. autoclass:: pybamm._BaseSolution
-  :members:
-
 .. autoclass:: pybamm.Solution
   :members:

--- a/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
@@ -22,6 +22,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\u001b[33mWARNING: You are using pip version 20.2.4; however, version 20.3.3 is available.\n",
+      "You should consider upgrading via the '/Users/vsulzer/Documents/Energy_storage/PyBaMM/.tox/dev/bin/python -m pip install --upgrade pip' command.\u001b[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
@@ -64,13 +66,13 @@
     {
      "data": {
       "text/plain": [
-       "{SpatialVariable(0x62eb5d16885394c9, x_n, children=[], domain=['negative electrode'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
-       " SpatialVariable(-0x14459c29151bda45, x_s, children=[], domain=['separator'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
-       " SpatialVariable(-0x4a38fdaaecee173f, x_p, children=[], domain=['positive electrode'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
-       " SpatialVariable(-0xf387938c410c357, r_n, children=[], domain=['negative particle'], auxiliary_domains={'secondary': \"['negative electrode']\", 'tertiary': \"['current collector']\"}): 30,\n",
-       " SpatialVariable(0x2f93da3e03d4dcbe, r_p, children=[], domain=['positive particle'], auxiliary_domains={'secondary': \"['positive electrode']\", 'tertiary': \"['current collector']\"}): 30,\n",
-       " SpatialVariable(0x14b0200ccfc1f5cc, y, children=[], domain=['current collector'], auxiliary_domains={}): 10,\n",
-       " SpatialVariable(-0x4938b510c47f7708, z, children=[], domain=['current collector'], auxiliary_domains={}): 10}"
+       "{SpatialVariable(0x3452d5d06e5d6beb, x_n, children=[], domain=['negative electrode'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
+       " SpatialVariable(-0x561e00d7cc14367b, x_s, children=[], domain=['separator'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
+       " SpatialVariable(-0x71763e2ccac3ade7, x_p, children=[], domain=['positive electrode'], auxiliary_domains={'secondary': \"['current collector']\"}): 20,\n",
+       " SpatialVariable(-0x19c83c2dfa4ac578, r_n, children=[], domain=['negative particle'], auxiliary_domains={'secondary': \"['negative electrode']\", 'tertiary': \"['current collector']\"}): 30,\n",
+       " SpatialVariable(0x5c2de4f3839b67be, r_p, children=[], domain=['positive particle'], auxiliary_domains={'secondary': \"['positive electrode']\", 'tertiary': \"['current collector']\"}): 30,\n",
+       " SpatialVariable(-0x5746d0678b95cd9a, y, children=[], domain=['current collector'], auxiliary_domains={}): 10,\n",
+       " SpatialVariable(-0x7e1ee8ded1c165e8, z, children=[], domain=['current collector'], auxiliary_domains={}): 10}"
       ]
      },
      "execution_count": 3,
@@ -123,7 +125,7 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.solvers.solution.Solution at 0x7f8beed56e80>"
+       "<pybamm.solvers.solution.Solution at 0x1453f6880>"
       ]
      },
      "execution_count": 5,
@@ -151,7 +153,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0613bdd52da440c9925d1dcb26558e71",
+       "model_id": "fbd0fd9401444435940b9933716cb07d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -238,7 +240,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99cad0a3137b4ee1ba353ae02b02b43f",
+       "model_id": "1ef54c1f3c1941f988d9ce0459149078",
        "version_major": 2,
        "version_minor": 0
       },
@@ -252,7 +254,7 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x7f8beb334e80>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x146458400>"
       ]
      },
      "execution_count": 9,
@@ -288,7 +290,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/pouch-cell-model.ipynb
+++ b/examples/notebooks/models/pouch-cell-model.ipynb
@@ -353,11 +353,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "comsol_solution = pybamm.Solution(solutions[\"1+1D DFN\"].t, solutions[\"1+1D DFN\"].y)\n",
     "comsol_model.timescale = simulations[\"1+1D DFN\"].model.timescale\n",
     "comsol_model.length_scales = simulations[\"1+1D DFN\"].model.length_scales\n",
-    "comsol_solution.model = comsol_model\n",
-    "comsol_solution.inputs = {}"
+    "comsol_solution = pybamm.Solution(solutions[\"1+1D DFN\"].t, solutions[\"1+1D DFN\"].y, comsol_model, {})"
    ]
   },
   {

--- a/examples/scripts/compare_comsol/compare_comsol_DFN.py
+++ b/examples/scripts/compare_comsol/compare_comsol_DFN.py
@@ -123,11 +123,12 @@ comsol_model.variables = {
 }
 
 # Make new solution with same t and y
-comsol_solution = pybamm.Solution(pybamm_solution.t, pybamm_solution.y)
 # Update solution scales to match the pybamm model
 comsol_model.timescale_eval = pybamm_model.timescale_eval
 comsol_model.length_scales_eval = pybamm_model.length_scales_eval
-comsol_solution.model = comsol_model
+comsol_solution = pybamm.Solution(
+    pybamm_solution.t, pybamm_solution.y, comsol_model, {}
+)
 
 # plot
 output_variables = [

--- a/examples/scripts/experimental_protocols/cccv.py
+++ b/examples/scripts/experimental_protocols/cccv.py
@@ -8,7 +8,7 @@ pybamm.set_logging_level("INFO")
 experiment = pybamm.Experiment(
     [
         (
-            "Discharge at C/10 for 10 hours or until 3.3 V",
+            "Discharge at C/5 for 10 hours or until 3.3 V",
             "Rest for 1 hour",
             "Charge at 1 A until 4.1 V",
             "Hold at 4.1 V until 50 mA",
@@ -25,7 +25,7 @@ sim.solve()
 fig, ax = plt.subplots()
 for i in range(3):
     # Extract sub solutions
-    sol = sim.solution.cycles[i][0]
+    sol = sim.solution.cycles[i]
     # Extract variables
     t = sol["Time [h]"].entries
     V = sol["Terminal voltage [V]"].entries
@@ -33,8 +33,8 @@ for i in range(3):
     ax.plot(t - t[0], V, label="Discharge {}".format(i + 1))
     ax.set_xlabel("Time [h]")
     ax.set_ylabel("Voltage [V]")
-    ax.set_xlim([0, 13])
-ax.legend()
+    ax.set_xlim([0, 10])
+ax.legend(loc="lower left")
 
 # Save time, voltage, current, discharge capacity, temperature, and electrolyte
 # concentration to csv and matlab formats

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -214,7 +214,7 @@ from .spatial_methods.scikit_finite_element import ScikitFiniteElement
 #
 # Solver classes
 #
-from .solvers.solution import Solution, _BaseSolution
+from .solvers.solution import Solution
 from .solvers.processed_variable import ProcessedVariable
 from .solvers.processed_symbolic_variable import ProcessedSymbolicVariable
 from .solvers.base_solver import BaseSolver

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -565,14 +565,14 @@ class ParameterValues:
                 self.parameter_events.append(
                     pybamm.Event(
                         "Interpolant {} lower bound".format(name),
-                        new_children[0] - min(data[:, 0]),
+                        pybamm.min(new_children[0] - min(data[:, 0])),
                         pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
                     )
                 )
                 self.parameter_events.append(
                     pybamm.Event(
                         "Interpolant {} upper bound".format(name),
-                        max(data[:, 0]) - new_children[0],
+                        pybamm.min(max(data[:, 0]) - new_children[0]),
                         pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
                     )
                 )

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -432,8 +432,7 @@ class QuickPlot(object):
                 var_min is not None
                 and var_max is not None
                 and (np.isnan(var_min) or np.isnan(var_max))
-            ):
-                variable_lists[0][0]._interpolation_function(0, 0)
+            ):  # pragma: no cover
                 raise ValueError(f"Axis limits cannot be NaN for variables '{key}'")
 
     def plot(self, t):

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -428,6 +428,13 @@ class QuickPlot(object):
                 self.axis_limits[key] = [x_min, x_max, var_min, var_max]
             else:
                 self.variable_limits[key] = (var_min, var_max)
+            if (
+                var_min is not None
+                and var_max is not None
+                and (np.isnan(var_min) or np.isnan(var_max))
+            ):
+                variable_lists[0][0]._interpolation_function(0, 0)
+                raise ValueError(f"Axis limits cannot be NaN for variables '{key}'")
 
     def plot(self, t):
         """Produces a quick plot with the internal states at time t.
@@ -676,7 +683,7 @@ class QuickPlot(object):
                         var = variable(
                             time_in_seconds,
                             **self.spatial_variable_dict[key],
-                            warn=False
+                            warn=False,
                         )
                         plot[i][j].set_ydata(var)
                         var_min = min(var_min, np.nanmin(var))

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -455,11 +455,11 @@ class Simulation:
                 self.step(dt, solver=solver, npts=npts, **kwargs)
 
                 # Extract the new parts of the solution to construct the entire "phase"
-                new_num_subsolutions = len(self.solution.sub_solutions)
+                sol = self.solution
+                new_num_subsolutions = len(sol.sub_solutions)
                 diff_num_subsolutions = new_num_subsolutions - previous_num_subsolutions
                 previous_num_subsolutions = new_num_subsolutions
 
-                sol = self.solution
                 phase_solution = pybamm.Solution(
                     sol.all_ts[-diff_num_subsolutions:],
                     sol.all_ys[-diff_num_subsolutions:],
@@ -496,6 +496,9 @@ class Simulation:
                 cycle_solution = phases[cycle_start_idx]
                 for idx in range(cycle_length - 1):
                     cycle_solution = cycle_solution + phases[cycle_start_idx + idx + 1]
+                cycle_solution.phases = phases[
+                    cycle_start_idx : cycle_start_idx + cycle_length
+                ]
                 self.solution.cycles.append(cycle_solution)
             pybamm.logger.info(
                 "Finish experiment simulation, took {}".format(timer.time())

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -428,7 +428,6 @@ class Simulation:
                         )
 
             self._solution = solver.solve(self.built_model, t_eval, **kwargs)
-            self.t_eval = self._solution.t * self._solution.timescale_eval
 
         elif self.operating_mode == "with experiment":
             if t_eval is not None:
@@ -438,10 +437,13 @@ class Simulation:
             # Re-initialize solution, e.g. for solving multiple times with different
             # inputs without having to build the simulation again
             self._solution = None
+            previous_num_subsolutions = 0
             # Step through all experimental conditions
             inputs = kwargs.get("inputs", {})
             pybamm.logger.info("Start running experiment")
             timer = pybamm.Timer()
+
+            phases = []
             for idx, (exp_inputs, dt) in enumerate(
                 zip(self._experiment_inputs, self._experiment_times)
             ):
@@ -451,6 +453,25 @@ class Simulation:
                 # Make sure we take at least 2 timesteps
                 npts = max(int(round(dt / exp_inputs["period"])) + 1, 2)
                 self.step(dt, solver=solver, npts=npts, **kwargs)
+
+                # Extract the new parts of the solution to construct the entire "phase"
+                new_num_subsolutions = len(self.solution.sub_solutions)
+                diff_num_subsolutions = new_num_subsolutions - previous_num_subsolutions
+                previous_num_subsolutions = new_num_subsolutions
+
+                sol = self.solution
+                phase_solution = pybamm.Solution(
+                    sol.all_ts[-diff_num_subsolutions:],
+                    sol.all_ys[-diff_num_subsolutions:],
+                    sol.model,
+                    sol.all_inputs[-diff_num_subsolutions:],
+                    sol.t_event,
+                    sol.y_event,
+                    sol.termination,
+                )
+                phase_solution.solve_time = 0
+                phase_solution.integration_time = 0
+                phases.append(phase_solution)
                 # Only allow events specified by experiment
                 if not (
                     self._solution.termination == "final time"
@@ -467,19 +488,15 @@ class Simulation:
                         "or reducing the period.\n\n"
                     )
                     break
-            if hasattr(self.solution, "_sub_solutions"):
-                # Construct solution.cycles (a list of tuples) from sub_solutions
-                self.solution.cycles = []
-                for cycle_num, cycle_length in enumerate(self.experiment.cycle_lengths):
-                    cycle_start_idx = sum(self.experiment.cycle_lengths[0:cycle_num])
-                    self.solution.cycles.append(
-                        tuple(
-                            [
-                                self.solution.sub_solutions[cycle_start_idx + idx]
-                                for idx in range(cycle_length)
-                            ]
-                        )
-                    )
+            # Construct solution.cycles (a list of solutions corresponding to
+            # cycles) from sub_solutions
+            self.solution.cycles = []
+            for cycle_num, cycle_length in enumerate(self.experiment.cycle_lengths):
+                cycle_start_idx = sum(self.experiment.cycle_lengths[0:cycle_num])
+                cycle_solution = phases[cycle_start_idx]
+                for idx in range(cycle_length - 1):
+                    cycle_solution = cycle_solution + phases[cycle_start_idx + idx + 1]
+                self.solution.cycles.append(cycle_solution)
             pybamm.logger.info(
                 "Finish experiment simulation, took {}".format(timer.time())
             )

--- a/pybamm/solvers/algebraic_solver.py
+++ b/pybamm/solvers/algebraic_solver.py
@@ -46,7 +46,7 @@ class AlgebraicSolver(pybamm.BaseSolver):
     def tol(self, value):
         self._tol = value
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Calculate the solution of the algebraic equations through root-finding
 
@@ -56,12 +56,14 @@ class AlgebraicSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : :class:`numpy.array`, size (k,)
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
         """
-        inputs = inputs or {}
+        inputs_dict = inputs_dict or {}
         if model.convert_to_format == "casadi":
-            inputs = casadi.vertcat(*[x for x in inputs.values()])
+            inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+        else:
+            inputs = inputs_dict
 
         y0 = model.y0
         if isinstance(y0, casadi.DM):
@@ -218,6 +220,6 @@ class AlgebraicSolver(pybamm.BaseSolver):
         y_diff = np.r_[[y0_diff] * len(t_eval)].T
         y_sol = np.r_[y_diff, y_alg]
         # Return solution object (no events, so pass None to t_event, y_event)
-        sol = pybamm.Solution(t_eval, y_sol, termination="success")
+        sol = pybamm.Solution(t_eval, y_sol, model, inputs_dict, termination="success")
         sol.integration_time = integration_time
         return sol

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -495,7 +495,7 @@ class BaseSolver(object):
             of the algebraic equations). If self.root_method == None then returns
             model.y0.
         """
-        pybamm.logger.info("Start calculating consistent states")
+        pybamm.logger.debug("Start calculating consistent states")
         if self.root_method is None:
             return model.y0
         try:
@@ -504,7 +504,7 @@ class BaseSolver(object):
             raise pybamm.SolverError(
                 "Could not find consistent states: {}".format(e.args[0])
             )
-        pybamm.logger.info("Found consistent states")
+        pybamm.logger.debug("Found consistent states")
         y0 = root_sol.all_ys[0]
         if isinstance(y0, np.ndarray):
             y0 = y0.flatten()
@@ -945,7 +945,12 @@ class BaseSolver(object):
 
         # Step
         t_eval = np.linspace(t, t + dt_dimensionless, npts)
-        pybamm.logger.info("Calling solver")
+        pybamm.logger.info(
+            "Stepping for {:.0f} < t < {:.0f}".format(
+                t * model.timescale_eval,
+                (t + dt_dimensionless) * model.timescale_eval,
+            )
+        )
         timer.reset()
         solution = self._integrate(model, t_eval, ext_and_inputs)
 
@@ -966,8 +971,8 @@ class BaseSolver(object):
         # Identify the event that caused termination
         termination = self.get_termination_reason(solution, model.events)
 
-        pybamm.logger.debug("Finish stepping {} ({})".format(model.name, termination))
-        pybamm.logger.debug(
+        pybamm.logger.info("Finish stepping {} ({})".format(model.name, termination))
+        pybamm.logger.info(
             (
                 "Set-up time: {}, Step time: {} (of which integration time: {}), "
                 "Total time: {}"
@@ -1032,6 +1037,8 @@ class BaseSolver(object):
                 event_sol.solve_time = 0
                 event_sol.integration_time = 0
                 solution = solution + event_sol
+
+            return solution.termination
 
     def check_extrapolation(self, solution, events):
         """

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1058,12 +1058,10 @@ class BaseSolver(object):
                 # events extrapolate
                 extrap_events[event.name] = False
                 # This might be a little bit slow but is ok for now
-                for outer_idx in range(len(solution.all_ts)):
-                    ts = solution.all_ts[outer_idx]
-                    ys = solution.all_ys[outer_idx]
-                    inputs = solution.all_inputs[outer_idx]
-                    for inner_idx in range(len(ts)):
-                        t = ts[inner_idx]
+                for ts, ys, inputs in zip(
+                    solution.all_ts, solution.all_ys, solution.all_inputs
+                ):
+                    for inner_idx, t in enumerate(ts):
                         y = ys[:, inner_idx]
                         if isinstance(y, casadi.DM):
                             y = y.full()

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1019,22 +1019,19 @@ class BaseSolver(object):
             # Update t, y and inputs to include event time and state
             # Note: if the final entry of t is equal to the event time we skip
             # this (having duplicate entries causes an error later in ProcessedVariable)
-            try:
-                if solution.t_event != solution.all_ts[-1][-1]:
-                    event_sol = pybamm.Solution(
-                        solution.t_event,
-                        solution.y_event,
-                        solution.model,
-                        solution.all_inputs[-1],
-                        solution.t_event,
-                        solution.y_event,
-                        solution.termination,
-                    )
-                    event_sol.solve_time = 0
-                    event_sol.integration_time = 0
-                    solution = solution + event_sol
-            except:
-                n = 1
+            if solution.t_event != solution.all_ts[-1][-1]:
+                event_sol = pybamm.Solution(
+                    solution.t_event,
+                    solution.y_event,
+                    solution.model,
+                    solution.all_inputs[-1],
+                    solution.t_event,
+                    solution.y_event,
+                    solution.termination,
+                )
+                event_sol.solve_time = 0
+                event_sol.integration_time = 0
+                solution = solution + event_sol
 
     def check_extrapolation(self, solution, events):
         """

--- a/pybamm/solvers/casadi_algebraic_solver.py
+++ b/pybamm/solvers/casadi_algebraic_solver.py
@@ -39,7 +39,7 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
     def tol(self, value):
         self._tol = value
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Calculate the solution of the algebraic equations through root-finding
 
@@ -49,21 +49,23 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : :class:`numpy.array`, size (k,)
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving. If any input
             parameters that are present in the model are missing from "inputs", then
             the solution will consist of `ProcessedSymbolicVariable` objects, which must
             be provided with inputs to obtain their value.
         """
         # Record whether there are any symbolic inputs
-        inputs = inputs or {}
-        has_symbolic_inputs = any(isinstance(v, casadi.MX) for v in inputs.values())
+        inputs_dict = inputs_dict or {}
+        has_symbolic_inputs = any(
+            isinstance(v, casadi.MX) for v in inputs_dict.values()
+        )
         symbolic_inputs = casadi.vertcat(
-            *[v for v in inputs.values() if isinstance(v, casadi.MX)]
+            *[v for v in inputs_dict.values() if isinstance(v, casadi.MX)]
         )
 
         # Create casadi objects for the root-finder
-        inputs = casadi.vertcat(*[v for v in inputs.values()])
+        inputs = casadi.vertcat(*[v for v in inputs_dict.values()])
 
         y0 = model.y0
 
@@ -73,7 +75,9 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
             for t in t_eval
         ):
             pybamm.logger.debug("Keeping same solution at all times")
-            return pybamm.Solution(t_eval, y0, termination="success")
+            return pybamm.Solution(
+                t_eval, y0, model, inputs_dict, termination="success"
+            )
 
         # The casadi algebraic solver can read rhs equations, but leaves them unchanged
         # i.e. the part of the solution vector that corresponds to the differential
@@ -189,6 +193,6 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
         y_diff = casadi.horzcat(*[y0_diff] * len(t_eval))
         y_sol = casadi.vertcat(y_diff, y_alg)
         # Return solution object (no events, so pass None to t_event, y_event)
-        sol = pybamm.Solution(t_eval, y_sol, termination="success")
+        sol = pybamm.Solution(t_eval, y_sol, model, inputs_dict, termination="success")
         sol.integration_time = integration_time
         return sol

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -185,7 +185,9 @@ class CasadiSolver(pybamm.BaseSolver):
                             "outside these bounds.".format(extrap_event_names)
                         )
 
-            pybamm.logger.info("Start solving {} with {}".format(model.name, self.name))
+            pybamm.logger.debug(
+                "Start solving {} with {}".format(model.name, self.name)
+            )
 
             if self.mode == "safe without grid":
                 # in "safe without grid" mode,

--- a/pybamm/solvers/dummy_solver.py
+++ b/pybamm/solvers/dummy_solver.py
@@ -12,7 +12,7 @@ class DummySolver(pybamm.BaseSolver):
         super().__init__()
         self.name = "Dummy solver"
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve an empty model.
 
@@ -22,17 +22,19 @@ class DummySolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : :class:`numpy.array`, size (k,)
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
 
         Returns
         -------
-        object
-            An object containing the times and values of the solution, as well as
-            various diagnostic messages.
+        :class:`pybamm.Solution`
+            A Solution object containing the times and values of the solution,
+            as well as various diagnostic messages.
 
         """
         y_sol = np.zeros((1, t_eval.size))
-        sol = pybamm.Solution(t_eval, y_sol, termination="final time")
+        sol = pybamm.Solution(
+            t_eval, y_sol, model, inputs_dict, termination="final time"
+        )
         sol.integration_time = 0
         return sol

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -148,7 +148,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
         return atol
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve a DAE model defined by residuals with initial conditions y0.
 
@@ -158,10 +158,14 @@ class IDAKLUSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : numeric type
             The times at which to compute the solution
+        inputs_dict : dict, optional
+            Any external variables or input parameters to pass to the model when solving
         """
         if model.rhs_eval.form == "casadi":
             # stack inputs
-            inputs = casadi.vertcat(*[x for x in inputs.values()])
+            inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+        else:
+            inputs = inputs_dict
 
         if model.jacobian_eval is None:
             raise pybamm.SolverError("KLU requires the Jacobian to be provided")
@@ -276,6 +280,8 @@ class IDAKLUSolver(pybamm.BaseSolver):
             sol = pybamm.Solution(
                 sol.t,
                 np.transpose(y_out),
+                model,
+                inputs_dict,
                 t[-1],
                 np.transpose(y_out[-1])[:, np.newaxis],
                 termination,

--- a/pybamm/solvers/jax_solver.py
+++ b/pybamm/solvers/jax_solver.py
@@ -179,7 +179,7 @@ class JaxSolver(pybamm.BaseSolver):
         else:
             return jax.jit(solve_model_bdf)
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -189,7 +189,7 @@ class JaxSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : :class:`numpy.array`, size (k,)
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
 
         Returns
@@ -203,7 +203,7 @@ class JaxSolver(pybamm.BaseSolver):
         if model not in self._cached_solves:
             self._cached_solves[model] = self.create_solve(model, t_eval)
 
-        y = self._cached_solves[model](inputs).block_until_ready()
+        y = self._cached_solves[model](inputs_dict).block_until_ready()
         integration_time = timer.time()
 
         # convert to a normal numpy array
@@ -212,6 +212,8 @@ class JaxSolver(pybamm.BaseSolver):
         termination = "final time"
         t_event = None
         y_event = onp.array(None)
-        sol = pybamm.Solution(t_eval, y, t_event, y_event, termination)
+        sol = pybamm.Solution(
+            t_eval, y, model, inputs_dict, t_event, y_event, termination
+        )
         sol.integration_time = integration_time
         return sol

--- a/pybamm/solvers/processed_symbolic_variable.py
+++ b/pybamm/solvers/processed_symbolic_variable.py
@@ -100,11 +100,8 @@ class ProcessedSymbolicVariable(object):
         "Create a 0D variable"
         # Evaluate the base_variable index-by-index
         idx = 0
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 next_entries = self.base_variable(t, y, inputs)
@@ -124,11 +121,8 @@ class ProcessedSymbolicVariable(object):
 
         # Evaluate the base_variable index-by-index
         idx = 0
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 next_entries = self.base_variable(t, y, inputs)

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -512,7 +512,7 @@ class ProcessedVariable(object):
             else:
                 return self.length_scales[domain]
         except KeyError:
-            if self.warn:
+            if self.warn:  # pragma: no cover
                 pybamm.logger.warning(
                     "No length scale set for {}. "
                     "Using default of 1 [m].".format(domain)

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -1,7 +1,6 @@
 #
 # Processed Variable class
 #
-import casadi
 import numbers
 import numpy as np
 import pybamm
@@ -53,26 +52,27 @@ class ProcessedVariable(object):
     def __init__(self, base_variable, base_variable_casadi, solution, warn=True):
         self.base_variable = base_variable
         self.base_variable_casadi = base_variable_casadi
-        self.t_sol = solution.t
-        self.u_sol = solution.y
+
+        self.all_ts = solution.all_ts
+        self.all_ys = solution.all_ys
+        self.all_inputs_casadi = solution.all_inputs_casadi
+
         self.mesh = base_variable.mesh
-        self.inputs = solution.inputs
         self.domain = base_variable.domain
         self.auxiliary_domains = base_variable.auxiliary_domains
         self.warn = warn
 
         # Set timescale
         self.timescale = solution.timescale_eval
-        self.t_pts = self.t_sol * self.timescale
+        self.t_pts = solution.t * self.timescale
 
         # Store length scales
         if solution.model:
             self.length_scales = solution.length_scales_eval
 
         # Evaluate base variable at initial time
-        inputs = casadi.vertcat(*[inp[:, 0] for inp in self.inputs.values()])
         self.base_eval = self.base_variable_casadi(
-            solution.t[0], solution.y[:, 0], inputs
+            self.all_ts[0][0], self.all_ys[0][:, 0], self.all_inputs_casadi[0]
         ).full()
 
         # handle 2D (in space) finite element variables differently
@@ -116,16 +116,21 @@ class ProcessedVariable(object):
 
     def initialise_0D(self):
         # initialise empty array of the correct size
-        entries = np.empty(len(self.t_sol))
+        entries = np.empty(len(self.t_pts))
+        idx = 0
         # Evaluate the base_variable index-by-index
-        for idx in range(len(self.t_sol)):
-            t = self.t_sol[idx]
-            u = self.u_sol[:, idx]
-            inputs = casadi.vertcat(*[inp[:, idx] for inp in self.inputs.values()])
-            entries[idx] = self.base_variable_casadi(t, u, inputs).full()[0, 0]
+        for outer_idx in range(len(self.all_ts)):
+            ts = self.all_ts[outer_idx]
+            ys = self.all_ys[outer_idx]
+            inputs = self.all_inputs_casadi[outer_idx]
+            for inner_idx in range(len(ts)):
+                t = ts[inner_idx]
+                y = ys[:, inner_idx]
+                entries[idx] = self.base_variable_casadi(t, y, inputs).full()[0, 0]
+                idx += 1
 
         # set up interpolation
-        if len(self.t_sol) == 1:
+        if len(self.t_pts) == 1:
             # Variable is just a scalar value, but we need to create a callable
             # function to be consitent with other processed variables
             def fun(t):
@@ -146,14 +151,19 @@ class ProcessedVariable(object):
 
     def initialise_1D(self, fixed_t=False):
         len_space = self.base_eval.shape[0]
-        entries = np.empty((len_space, len(self.t_sol)))
+        entries = np.empty((len_space, len(self.t_pts)))
 
         # Evaluate the base_variable index-by-index
-        for idx in range(len(self.t_sol)):
-            t = self.t_sol[idx]
-            u = self.u_sol[:, idx]
-            inputs = casadi.vertcat(*[inp[:, idx] for inp in self.inputs.values()])
-            entries[:, idx] = self.base_variable_casadi(t, u, inputs).full()[:, 0]
+        idx = 0
+        for outer_idx in range(len(self.all_ts)):
+            ts = self.all_ts[outer_idx]
+            ys = self.all_ys[outer_idx]
+            inputs = self.all_inputs_casadi[outer_idx]
+            for inner_idx in range(len(ts)):
+                t = ts[inner_idx]
+                y = ys[:, inner_idx]
+                entries[:, idx] = self.base_variable_casadi(t, y, inputs).full()[:, 0]
+                idx += 1
 
         # Get node and edge values
         nodes = self.mesh.nodes
@@ -204,7 +214,7 @@ class ProcessedVariable(object):
         self.first_dim_pts = edges * length_scale
 
         # set up interpolation
-        if len(self.t_sol) == 1:
+        if len(self.t_pts) == 1:
             # function of space only
             interpolant = interp.interp1d(
                 pts_for_interp,
@@ -249,18 +259,23 @@ class ProcessedVariable(object):
         second_dim_pts = second_dim_nodes
         first_dim_size = len(first_dim_pts)
         second_dim_size = len(second_dim_pts)
-        entries = np.empty((first_dim_size, second_dim_size, len(self.t_sol)))
+        entries = np.empty((first_dim_size, second_dim_size, len(self.t_pts)))
 
         # Evaluate the base_variable index-by-index
-        for idx in range(len(self.t_sol)):
-            t = self.t_sol[idx]
-            u = self.u_sol[:, idx]
-            inputs = casadi.vertcat(*[inp[:, idx] for inp in self.inputs.values()])
-            entries[:, :, idx] = np.reshape(
-                self.base_variable_casadi(t, u, inputs).full(),
-                [first_dim_size, second_dim_size],
-                order="F",
-            )
+        idx = 0
+        for outer_idx in range(len(self.all_ts)):
+            ts = self.all_ts[outer_idx]
+            ys = self.all_ys[outer_idx]
+            inputs = self.all_inputs_casadi[outer_idx]
+            for inner_idx in range(len(ts)):
+                t = ts[inner_idx]
+                y = ys[:, inner_idx]
+                entries[:, :, idx] = np.reshape(
+                    self.base_variable_casadi(t, y, inputs).full(),
+                    [first_dim_size, second_dim_size],
+                    order="F",
+                )
+                idx += 1
 
         # add points outside first dimension domain for extrapolation to
         # boundaries
@@ -323,11 +338,15 @@ class ProcessedVariable(object):
             self.second_dimension = "x"
             self.r_sol = first_dim_pts
             self.x_sol = second_dim_pts
-        elif self.domain[0] in [
-            "negative electrode",
-            "separator",
-            "positive electrode",
-        ] and self.auxiliary_domains["secondary"] == ["current collector"]:
+        elif (
+            self.domain[0]
+            in [
+                "negative electrode",
+                "separator",
+                "positive electrode",
+            ]
+            and self.auxiliary_domains["secondary"] == ["current collector"]
+        ):
             self.first_dimension = "x"
             self.second_dimension = "z"
             self.x_sol = first_dim_pts
@@ -356,7 +375,7 @@ class ProcessedVariable(object):
         self.second_dim_pts = second_dim_edges * second_length_scale
 
         # set up interpolation
-        if len(self.t_sol) == 1:
+        if len(self.t_pts) == 1:
             # function of space only. Note the order of the points is the reverse
             # of what you'd expect
             interpolant = interp.interp2d(
@@ -387,19 +406,23 @@ class ProcessedVariable(object):
         len_y = len(y_sol)
         z_sol = self.mesh.edges["z"]
         len_z = len(z_sol)
-        entries = np.empty((len_y, len_z, len(self.t_sol)))
+        entries = np.empty((len_y, len_z, len(self.t_pts)))
 
         # Evaluate the base_variable index-by-index
-        for idx in range(len(self.t_sol)):
-            t = self.t_sol[idx]
-            u = self.u_sol[:, idx]
-            inputs = casadi.vertcat(*[inp[:, idx] for inp in self.inputs.values()])
-
-            entries[:, :, idx] = np.reshape(
-                self.base_variable_casadi(t, u, inputs).full(),
-                [len_y, len_z],
-                order="F",
-            )
+        idx = 0
+        for outer_idx in range(len(self.all_ts)):
+            ts = self.all_ts[outer_idx]
+            ys = self.all_ys[outer_idx]
+            inputs = self.all_inputs_casadi[outer_idx]
+            for inner_idx in range(len(ts)):
+                t = ts[inner_idx]
+                y = ys[:, inner_idx]
+                entries[:, :, idx] = np.reshape(
+                    self.base_variable_casadi(t, y, inputs).full(),
+                    [len_y, len_z],
+                    order="F",
+                )
+                idx += 1
 
         # assign attributes for reference
         self.entries = entries
@@ -412,7 +435,7 @@ class ProcessedVariable(object):
         self.second_dim_pts = z_sol * self.get_spatial_scale("z", "current collector")
 
         # set up interpolation
-        if len(self.t_sol) == 1:
+        if len(self.t_pts) == 1:
             # function of space only. Note the order of the points is the reverse
             # of what you'd expect
             interpolant = interp.interp2d(

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -119,11 +119,8 @@ class ProcessedVariable(object):
         entries = np.empty(len(self.t_pts))
         idx = 0
         # Evaluate the base_variable index-by-index
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 entries[idx] = self.base_variable_casadi(t, y, inputs).full()[0, 0]
@@ -155,11 +152,8 @@ class ProcessedVariable(object):
 
         # Evaluate the base_variable index-by-index
         idx = 0
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 entries[:, idx] = self.base_variable_casadi(t, y, inputs).full()[:, 0]
@@ -263,11 +257,8 @@ class ProcessedVariable(object):
 
         # Evaluate the base_variable index-by-index
         idx = 0
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 entries[:, :, idx] = np.reshape(
@@ -410,11 +401,8 @@ class ProcessedVariable(object):
 
         # Evaluate the base_variable index-by-index
         idx = 0
-        for outer_idx in range(len(self.all_ts)):
-            ts = self.all_ts[outer_idx]
-            ys = self.all_ys[outer_idx]
-            inputs = self.all_inputs_casadi[outer_idx]
-            for inner_idx in range(len(ts)):
+        for ts, ys, inputs in zip(self.all_ts, self.all_ys, self.all_inputs_casadi):
+            for inner_idx, t in enumerate(ts):
                 t = ts[inner_idx]
                 y = ys[:, inner_idx]
                 entries[:, :, idx] = np.reshape(

--- a/pybamm/solvers/scikits_dae_solver.py
+++ b/pybamm/solvers/scikits_dae_solver.py
@@ -72,7 +72,7 @@ class ScikitsDaeSolver(pybamm.BaseSolver):
         pybamm.citations.register("hindmarsh2000pvode")
         pybamm.citations.register("hindmarsh2005sundials")
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -82,12 +82,15 @@ class ScikitsDaeSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : numeric type
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
 
         """
+        inputs_dict = inputs_dict or {}
         if model.convert_to_format == "casadi":
-            inputs = casadi.vertcat(*[x for x in inputs.values()])
+            inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+        else:
+            inputs = inputs_dict
 
         y0 = model.y0
         if isinstance(y0, casadi.DM):
@@ -154,6 +157,8 @@ class ScikitsDaeSolver(pybamm.BaseSolver):
             sol = pybamm.Solution(
                 sol.values.t,
                 np.transpose(sol.values.y),
+                model,
+                inputs_dict,
                 t_root,
                 np.transpose(sol.roots.y),
                 termination,

--- a/pybamm/solvers/scikits_ode_solver.py
+++ b/pybamm/solvers/scikits_ode_solver.py
@@ -69,7 +69,7 @@ class ScikitsOdeSolver(pybamm.BaseSolver):
         pybamm.citations.register("hindmarsh2000pvode")
         pybamm.citations.register("hindmarsh2005sundials")
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -79,12 +79,14 @@ class ScikitsOdeSolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : numeric type
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
 
         """
         if model.rhs_eval.form == "casadi":
-            inputs = casadi.vertcat(*[x for x in inputs.values()])
+            inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+        else:
+            inputs = inputs_dict
 
         y0 = model.y0
         if isinstance(y0, casadi.DM):
@@ -169,6 +171,8 @@ class ScikitsOdeSolver(pybamm.BaseSolver):
             sol = pybamm.Solution(
                 sol.values.t,
                 np.transpose(sol.values.y),
+                model,
+                inputs_dict,
                 t_root,
                 np.transpose(sol.roots.y),
                 termination,

--- a/pybamm/solvers/scipy_solver.py
+++ b/pybamm/solvers/scipy_solver.py
@@ -36,7 +36,7 @@ class ScipySolver(pybamm.BaseSolver):
         self.name = "Scipy solver ({})".format(method)
         pybamm.citations.register("virtanen2020scipy")
 
-    def _integrate(self, model, t_eval, inputs=None):
+    def _integrate(self, model, t_eval, inputs_dict=None):
         """
         Solve a model defined by dydt with initial conditions y0.
 
@@ -46,7 +46,7 @@ class ScipySolver(pybamm.BaseSolver):
             The model whose solution to calculate.
         t_eval : :class:`numpy.array`, size (k,)
             The times at which to compute the solution
-        inputs : dict, optional
+        inputs_dict : dict, optional
             Any input parameters to pass to the model when solving
 
         Returns
@@ -57,7 +57,9 @@ class ScipySolver(pybamm.BaseSolver):
 
         """
         if model.convert_to_format == "casadi":
-            inputs = casadi.vertcat(*[x for x in inputs.values()])
+            inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+        else:
+            inputs = inputs_dict
 
         extra_options = {**self.extra_options, "rtol": self.rtol, "atol": self.atol}
 
@@ -113,7 +115,9 @@ class ScipySolver(pybamm.BaseSolver):
                 termination = "final time"
                 t_event = None
                 y_event = np.array(None)
-            sol = pybamm.Solution(sol.t, sol.y, t_event, y_event, termination)
+            sol = pybamm.Solution(
+                sol.t, sol.y, model, inputs_dict, t_event, y_event, termination
+            )
             sol.integration_time = integration_time
             return sol
         else:

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -12,9 +12,8 @@ from scipy.io import savemat
 
 class Solution(object):
     """
-    (Semi-private) class containing the solution of, and various attributes associated
-    with, a PyBaMM model. This class is automatically created by the `Solution` class,
-    and should never be called from outside the `Solution` class.
+    Class containing the solution of, and various attributes associated with, a PyBaMM
+    model.
 
     Parameters
     ----------

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -446,6 +446,7 @@ class Solution(object):
             self.termination,
         )
         new_sol._all_inputs_casadi = self.all_inputs_casadi
+        new_sol._sub_solutions = self.sub_solutions
 
         new_sol.solve_time = self.solve_time
         new_sol.integration_time = self.integration_time

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -112,10 +112,13 @@ class Solution(object):
         try:
             return self._t
         except AttributeError:
-            self._t = np.concatenate(self.all_ts)
-            if any(np.diff(self._t) <= 0):
-                raise ValueError("Solution time vector must be strictly increasing")
+            self.set_t()
             return self._t
+
+    def set_t(self):
+        self._t = np.concatenate(self.all_ts)
+        if any(np.diff(self._t) <= 0):
+            raise ValueError("Solution time vector must be strictly increasing")
 
     @property
     def y(self):
@@ -123,11 +126,14 @@ class Solution(object):
         try:
             return self._y
         except AttributeError:
-            if isinstance(self.all_ys[0], (casadi.DM, casadi.MX)):
-                self._y = casadi.horzcat(*self.all_ys)
-            else:
-                self._y = np.hstack(self.all_ys)
+            self.set_y()
             return self._y
+
+    def set_y(self):
+        if isinstance(self.all_ys[0], (casadi.DM, casadi.MX)):
+            self._y = casadi.horzcat(*self.all_ys)
+        else:
+            self._y = np.hstack(self.all_ys)
 
     @property
     def model(self):

--- a/tests/integration/test_solvers/test_solution.py
+++ b/tests/integration/test_solvers/test_solution.py
@@ -93,23 +93,20 @@ class TestSolution(unittest.TestCase):
                 sol_step, model, dt, external_variables=external_variables
             )
         np.testing.assert_array_equal(
-            sol_step.inputs["Volume-averaged cell temperature"],
-            np.zeros((1, len(sol_step.t))),
+            sol_step.all_inputs[0]["Volume-averaged cell temperature"], 0
         )
         np.testing.assert_array_equal(
-            sol_step.inputs["X-averaged negative particle concentration"],
-            np.ones((mesh["negative particle"].npts, len(sol_step.t))) * 0.6,
+            sol_step.all_inputs[0]["X-averaged negative particle concentration"], 0.6
         )
 
         # Solve
         t_eval = np.linspace(0, 3600)
         sol = solver.solve(model, t_eval, external_variables=external_variables)
         np.testing.assert_array_equal(
-            sol.inputs["Volume-averaged cell temperature"], np.zeros((1, len(sol.t)))
+            sol.all_inputs[0]["Volume-averaged cell temperature"], 0
         )
         np.testing.assert_array_equal(
-            sol.inputs["X-averaged negative particle concentration"],
-            np.ones((mesh["negative particle"].npts, len(sol.t))) * 0.6,
+            sol.all_inputs[0]["X-averaged negative particle concentration"], 0.6
         )
 
 

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -109,11 +109,11 @@ class TestSimulationExperiment(unittest.TestCase):
         # Solve a first time
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         sim.solve(inputs={"Dsn": 1})
-        np.testing.assert_array_equal(sim.solution.inputs["Dsn"], 1)
+        np.testing.assert_array_equal(sim.solution.all_inputs[0]["Dsn"], 1)
 
         # Solve again, input should change
         sim.solve(inputs={"Dsn": 2})
-        np.testing.assert_array_equal(sim.solution.inputs["Dsn"], 2)
+        np.testing.assert_array_equal(sim.solution.all_inputs[0]["Dsn"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -683,9 +683,7 @@ class TestBaseModel(unittest.TestCase):
         model_disc = disc.process_model(model, inplace=False)
         t = np.linspace(0, 1)
         y = np.tile(3 * t, (1 + 30 + 50, 1))
-        sol = pybamm.Solution(t, y)
-        sol.model = model_disc
-        sol.inputs = {}
+        sol = pybamm.Solution(t, y, model_disc, {})
 
         # Update out-of-place first, since otherwise we'll have already modified the
         # model

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -198,7 +198,9 @@ class TestSimulation(unittest.TestCase):
         param.update({"Current function [A]": "[input]"})
         sim = pybamm.Simulation(model, parameter_values=param)
         sim.solve(t_eval=[0, 600], inputs={"Current function [A]": 1})
-        np.testing.assert_array_equal(sim.solution.inputs["Current function [A]"], 1)
+        np.testing.assert_array_equal(
+            sim.solution.all_inputs[0]["Current function [A]"], 1
+        )
 
     def test_step_with_inputs(self):
         dt = 0.001
@@ -214,7 +216,9 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(sim.solution.y.full()[0, :].size, 2)
         self.assertEqual(sim.solution.t[0], 0)
         self.assertEqual(sim.solution.t[1], dt / tau)
-        np.testing.assert_array_equal(sim.solution.inputs["Current function [A]"], 1)
+        np.testing.assert_array_equal(
+            sim.solution.all_inputs[0]["Current function [A]"], 1
+        )
         sim.step(
             dt, inputs={"Current function [A]": 2}
         )  # automatically append the next step
@@ -224,7 +228,7 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(sim.solution.t[1], dt / tau)
         self.assertEqual(sim.solution.t[2], 2 * dt / tau)
         np.testing.assert_array_equal(
-            sim.solution.inputs["Current function [A]"], np.array([[1, 1, 2]])
+            sim.solution.all_inputs[1]["Current function [A]"], 2
         )
 
     def test_save_load(self):
@@ -381,7 +385,9 @@ class TestSimulation(unittest.TestCase):
 
         # tets list gets turned into np.linspace(t0, tf, 100)
         sim.solve(t_eval=[0, 10])
-        np.testing.assert_array_almost_equal(sim.t_eval, np.linspace(0, 10, 100))
+        np.testing.assert_array_almost_equal(
+            sim.solution.t * sim.solution.timescale_eval, np.linspace(0, 10, 100)
+        )
 
     def test_battery_model_with_input_height(self):
         # load model

--- a/tests/unit/test_solvers/test_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_algebraic_solver.py
@@ -42,6 +42,7 @@ class TestAlgebraicSolver(unittest.TestCase):
             y0 = np.array([2])
             rhs = {}
             timescale_eval = 1
+            length_scales = {}
             jac_algebraic_eval = None
             convert_to_format = "python"
 
@@ -64,6 +65,7 @@ class TestAlgebraicSolver(unittest.TestCase):
             y0 = np.array([2])
             rhs = {}
             timescale_eval = 1
+            length_scales = {}
             jac_algebraic_eval = None
             convert_to_format = "casadi"
 
@@ -94,6 +96,7 @@ class TestAlgebraicSolver(unittest.TestCase):
             y0 = np.zeros(2)
             rhs = {}
             timescale_eval = 1
+            length_scales = {}
             convert_to_format = "python"
 
             def algebraic_eval(self, t, y, inputs):

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -116,6 +116,7 @@ class TestBaseSolver(unittest.TestCase):
                 self.rhs = {}
                 self.jac_algebraic_eval = None
                 self.timescale_eval = 1
+                self.length_scales = {}
                 t = casadi.MX.sym("t")
                 y = casadi.MX.sym("y")
                 p = casadi.MX.sym("p")
@@ -151,6 +152,7 @@ class TestBaseSolver(unittest.TestCase):
                 self.concatenated_rhs = np.array([1])
                 self.jac_algebraic_eval = None
                 self.timescale_eval = 1
+                self.length_scales = {}
                 t = casadi.MX.sym("t")
                 y = casadi.MX.sym("y", vec.size)
                 p = casadi.MX.sym("p")
@@ -198,6 +200,7 @@ class TestBaseSolver(unittest.TestCase):
                 self.rhs = {}
                 self.jac_algebraic_eval = None
                 self.timescale_eval = 1
+                self.length_scales = {}
                 t = casadi.MX.sym("t")
                 y = casadi.MX.sym("y")
                 p = casadi.MX.sym("p")
@@ -295,12 +298,16 @@ class TestBaseSolver(unittest.TestCase):
         model.initial_conditions = {v: 1}
         model.events.append(
             pybamm.Event(
-                "Triggered event", v - 0.5, pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
+                "Triggered event",
+                v - 0.5,
+                pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
             )
         )
         model.events.append(
             pybamm.Event(
-                "Ignored event", v + 10, pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
+                "Ignored event",
+                v + 10,
+                pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
             )
         )
         solver = pybamm.ScipySolver()

--- a/tests/unit/test_solvers/test_casadi_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_casadi_algebraic_solver.py
@@ -56,6 +56,7 @@ class TestCasadiAlgebraicSolver(unittest.TestCase):
             t = casadi.MX.sym("t")
             y = casadi.MX.sym("y")
             p = casadi.MX.sym("p")
+            length_scales = {}
             rhs = {}
             casadi_algebraic = casadi.Function("alg", [t, y, p], [y ** 2 + 1])
             bounds = (np.array([-np.inf]), np.array([np.inf]))

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -247,8 +247,8 @@ class TestCasadiSolver(unittest.TestCase):
             step_sol_2.y.full()[0],
             np.concatenate(
                 [
-                    np.exp(0.1 * step_sol.t[:5]),
-                    np.exp(0.1 * step_sol.t[4]) * np.exp(-(step_sol.t[5:] - dt)),
+                    np.exp(0.1 * step_sol_2.t[:5]),
+                    np.exp(0.1 * step_sol_2.t[4]) * np.exp(-(step_sol_2.t[5:] - dt)),
                 ]
             ),
         )
@@ -474,12 +474,16 @@ class TestCasadiSolver(unittest.TestCase):
         model.initial_conditions = {v: 1}
         model.events.append(
             pybamm.Event(
-                "Triggered event", v - 0.5, pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
+                "Triggered event",
+                v - 0.5,
+                pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
             )
         )
         model.events.append(
             pybamm.Event(
-                "Ignored event", v + 10, pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
+                "Ignored event",
+                v + 10,
+                pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
             )
         )
         solver = pybamm.CasadiSolver(mode="safe")
@@ -646,6 +650,7 @@ class TestCasadiSolverSensitivity(unittest.TestCase):
         solver = pybamm.CasadiSolver(atol=1e-10, rtol=1e-10)
         t_eval = np.linspace(0, 1)
         solution = solver.solve(model, t_eval)
+        solution["var"]
         np.testing.assert_array_almost_equal(
             solution["var"].value({"param": 7}), 7 * np.exp(-t_eval)[np.newaxis, :]
         )

--- a/tests/unit/test_solvers/test_processed_symbolic_variable.py
+++ b/tests/unit/test_solvers/test_processed_symbolic_variable.py
@@ -18,7 +18,7 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
 
         t_sol = np.linspace(0, 1)
         y_sol = np.array([np.linspace(0, 5)])
-        solution = pybamm.Solution(t_sol, y_sol)
+        solution = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         processed_var = pybamm.ProcessedSymbolicVariable(var, solution)
         np.testing.assert_array_equal(processed_var.value(), 2 * y_sol)
 
@@ -36,8 +36,12 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
 
         t_sol = np.linspace(0, 1)
         y_sol = np.array([np.linspace(0, 5)])
-        solution = pybamm.Solution(t_sol, y_sol)
-        solution.inputs = {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")}
+        solution = pybamm.Solution(
+            t_sol,
+            y_sol,
+            pybamm.BaseModel(),
+            {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")},
+        )
         processed_var = pybamm.ProcessedSymbolicVariable(var, solution)
         np.testing.assert_array_equal(
             processed_var.value({"p": 3, "q": 4}).full(), 3 * y_sol + 4
@@ -70,8 +74,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
 
         t_sol = np.linspace(0, 1)
         y_sol = np.array([np.linspace(0, 5)])
-        solution = pybamm.Solution(t_sol, y_sol)
-        solution.inputs = {"p": casadi.MX.sym("p"), "q": 2}
+        solution = pybamm.Solution(
+            t_sol, y_sol, pybamm.BaseModel(), {"p": casadi.MX.sym("p"), "q": 2}
+        )
         processed_var = pybamm.ProcessedSymbolicVariable(var, solution)
         np.testing.assert_array_equal(
             processed_var.value({"p": 3}).full(), 3 * y_sol - 2
@@ -92,9 +97,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         eqn_sol = disc.process_symbol(eqn)
 
         # With scalar t_sol
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         processed_eqn = pybamm.ProcessedSymbolicVariable(eqn_sol, sol)
         np.testing.assert_array_equal(
             processed_eqn.value(), y_sol + x_sol[:, np.newaxis]
@@ -103,7 +108,7 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         # With vector t_sol
         t_sol = np.linspace(0, 1)
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * np.linspace(0, 5)
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         processed_eqn = pybamm.ProcessedSymbolicVariable(eqn_sol, sol)
         np.testing.assert_array_equal(
             processed_eqn.value(), (y_sol + x_sol[:, np.newaxis]).T.reshape(-1, 1)
@@ -123,11 +128,15 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         eqn_sol = disc.process_symbol(eqn)
 
         # Scalar t
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * 5
 
-        sol = pybamm.Solution(t_sol, y_sol)
-        sol.inputs = {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")}
+        sol = pybamm.Solution(
+            t_sol,
+            y_sol,
+            pybamm.BaseModel(),
+            {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")},
+        )
         processed_eqn = pybamm.ProcessedSymbolicVariable(eqn_sol, sol)
 
         # Test values
@@ -146,8 +155,12 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         t_sol = np.linspace(0, 1)
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * np.linspace(0, 5)
 
-        sol = pybamm.Solution(t_sol, y_sol)
-        sol.inputs = {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")}
+        sol = pybamm.Solution(
+            t_sol,
+            y_sol,
+            pybamm.BaseModel(),
+            {"p": casadi.MX.sym("p"), "q": casadi.MX.sym("q")},
+        )
         processed_eqn = pybamm.ProcessedSymbolicVariable(eqn_sol, sol)
 
         # Test values
@@ -176,10 +189,14 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         eqn_sol = disc.process_symbol(eqn)
 
         # Scalar t
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
-        sol.inputs = {"p": casadi.MX.sym("p", n), "q": casadi.MX.sym("q")}
+        sol = pybamm.Solution(
+            t_sol,
+            y_sol,
+            pybamm.BaseModel(),
+            {"p": casadi.MX.sym("p", n), "q": casadi.MX.sym("q")},
+        )
         processed_eqn = pybamm.ProcessedSymbolicVariable(eqn_sol, sol)
 
         # Test values - constant p
@@ -223,9 +240,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         x_sol = disc.process_symbol(x).entries[:, 0]
         var_sol = disc.process_symbol(var)
 
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         pybamm.ProcessedSymbolicVariable(var_sol, sol)
 
         # Particle domain
@@ -237,9 +254,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         r_sol = disc.process_symbol(r).entries[:, 0]
         var_sol = disc.process_symbol(var)
 
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(r_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         pybamm.ProcessedSymbolicVariable(var_sol, sol)
 
         # Current collector domain
@@ -251,9 +268,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         z_sol = disc.process_symbol(z).entries[:, 0]
         var_sol = disc.process_symbol(var)
 
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(z_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         pybamm.ProcessedSymbolicVariable(var_sol, sol)
 
         # Other domain
@@ -271,9 +288,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         x_sol = disc.process_symbol(x).entries[:, 0]
         var_sol = disc.process_symbol(var)
 
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(x_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         pybamm.ProcessedSymbolicVariable(var_sol, sol)
 
         # 2D fails
@@ -293,9 +310,9 @@ class TestProcessedSymbolicVariable(unittest.TestCase):
         r_sol = disc.process_symbol(r).entries[:, 0]
         var_sol = disc.process_symbol(var)
 
-        t_sol = [0]
+        t_sol = np.array([0])
         y_sol = np.ones_like(r_sol)[:, np.newaxis] * 5
-        sol = pybamm.Solution(t_sol, y_sol)
+        sol = pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {})
         with self.assertRaisesRegex(NotImplementedError, "Shape not recognized"):
             pybamm.ProcessedSymbolicVariable(var_sol, sol)
 

--- a/tests/unit/test_solvers/test_processed_variable.py
+++ b/tests/unit/test_solvers/test_processed_variable.py
@@ -37,7 +37,10 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.array([np.linspace(0, 5)])
         var_casadi = to_casadi(var, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(processed_var.entries, t_sol * y_sol[0])
 
@@ -48,7 +51,10 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.array([1])[:, np.newaxis]
         var_casadi = to_casadi(var, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(processed_var.entries, y_sol[0])
 
@@ -69,13 +75,19 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(processed_var.entries, y_sol)
         np.testing.assert_array_equal(processed_var(t_sol, x_sol), y_sol)
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_eqn = pybamm.ProcessedVariable(
-            eqn_sol, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn_sol,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_eqn(t_sol, x_sol), t_sol * y_sol + x_sol[:, np.newaxis]
@@ -92,7 +104,10 @@ class TestProcessedVariable(unittest.TestCase):
         x_s_edge.mesh = disc.mesh["separator"]
         x_s_casadi = to_casadi(x_s_edge, y_sol)
         processed_x_s_edge = pybamm.ProcessedVariable(
-            x_s_edge, x_s_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            x_s_edge,
+            x_s_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             x_s_edge.entries[:, 0], processed_x_s_edge.entries[:, 0]
@@ -105,7 +120,10 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.ones_like(x_sol)[:, np.newaxis]
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_eqn2 = pybamm.ProcessedVariable(
-            eqn_sol, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn_sol,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_eqn2.entries, y_sol + x_sol[:, np.newaxis]
@@ -127,6 +145,8 @@ class TestProcessedVariable(unittest.TestCase):
         solution = pybamm.Solution(
             np.linspace(0, 1, nt),
             y_sol,
+            pybamm.BaseModel(),
+            {},
             np.linspace(0, 1, 1),
             np.zeros((var_pts[x])),
             "test",
@@ -162,7 +182,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_var.entries,
@@ -194,7 +217,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_var.entries,
@@ -211,7 +237,10 @@ class TestProcessedVariable(unittest.TestCase):
         x_s_edge.secondary_mesh = disc.mesh["current collector"]
         x_s_casadi = to_casadi(x_s_edge, y_sol)
         processed_x_s_edge = pybamm.ProcessedVariable(
-            x_s_edge, x_s_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            x_s_edge,
+            x_s_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             x_s_edge.entries.flatten(), processed_x_s_edge.entries[:, :, 0].T.flatten()
@@ -242,7 +271,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_var.entries,
@@ -263,7 +295,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, u_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, u_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, u_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_var.entries, np.reshape(u_sol, [len(y), len(z), len(t_sol)])
@@ -283,7 +318,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, u_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, u_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, u_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(
             processed_var.entries, np.reshape(u_sol, [len(y), len(z), len(t_sol)])
@@ -302,7 +340,10 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.array([np.linspace(0, 5, 1000)])
         var_casadi = to_casadi(var, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # vector
         np.testing.assert_array_equal(processed_var(t_sol), y_sol[0])
@@ -312,7 +353,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         eqn_casadi = to_casadi(eqn, y_sol)
         processed_eqn = pybamm.ProcessedVariable(
-            eqn, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(processed_eqn(t_sol), t_sol * y_sol[0])
         np.testing.assert_array_almost_equal(processed_eqn(0.5), 0.5 * 2.5)
@@ -333,7 +377,10 @@ class TestProcessedVariable(unittest.TestCase):
         y_sol = np.array([[100]])
         eqn_casadi = to_casadi(eqn, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            eqn, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
 
         np.testing.assert_array_equal(processed_var(), 200)
@@ -354,7 +401,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 2 vectors
         np.testing.assert_array_almost_equal(processed_var(t_sol, x_sol), y_sol)
@@ -371,7 +421,10 @@ class TestProcessedVariable(unittest.TestCase):
         )
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_eqn = pybamm.ProcessedVariable(
-            eqn_sol, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn_sol,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 2 vectors
         np.testing.assert_array_almost_equal(
@@ -388,7 +441,10 @@ class TestProcessedVariable(unittest.TestCase):
         x_casadi = to_casadi(x_disc, y_sol)
 
         processed_x = pybamm.ProcessedVariable(
-            x_disc, x_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            x_disc,
+            x_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_almost_equal(processed_x(x=x_sol), x_sol[:, np.newaxis])
 
@@ -399,7 +455,10 @@ class TestProcessedVariable(unittest.TestCase):
         r_n.mesh = disc.mesh["negative particle"]
         r_n_casadi = to_casadi(r_n, y_sol)
         processed_r_n = pybamm.ProcessedVariable(
-            r_n, r_n_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            r_n,
+            r_n_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         np.testing.assert_array_equal(r_n.entries[:, 0], processed_r_n.entries[:, 0])
         np.testing.assert_array_almost_equal(
@@ -420,7 +479,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            eqn_sol, eqn_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            eqn_sol,
+            eqn_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
 
         # vector
@@ -455,7 +517,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 3 vectors
         np.testing.assert_array_equal(
@@ -500,7 +565,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 3 vectors
         np.testing.assert_array_equal(
@@ -532,7 +600,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 2 vectors
         np.testing.assert_array_equal(processed_var(x=x_sol, r=r_sol).shape, (10, 40))
@@ -558,7 +629,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 3 vectors
         np.testing.assert_array_equal(
@@ -594,7 +668,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 3 vectors
         np.testing.assert_array_equal(
@@ -615,7 +692,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, u_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, u_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, u_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 3 vectors
         np.testing.assert_array_equal(
@@ -656,7 +736,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, u_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, u_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, u_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         # 2 vectors
         np.testing.assert_array_equal(processed_var(y=y_sol, z=z_sol).shape, (15, 15))
@@ -682,6 +765,11 @@ class TestProcessedVariable(unittest.TestCase):
         # set up and solve model
         whole_cell = ["negative electrode", "separator", "positive electrode"]
         model = pybamm.BaseBatteryModel()
+        model.length_scales = {
+            "negative electrode": pybamm.Scalar(1),
+            "separator": pybamm.Scalar(1),
+            "positive electrode": pybamm.Scalar(1),
+        }
         c = pybamm.Variable("conc", domain=whole_cell)
         c_s = pybamm.Variable(
             "particle conc",
@@ -725,7 +813,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         with self.assertRaisesRegex(ValueError, "x cannot be None"):
             processed_var(0)
@@ -745,7 +836,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         var_casadi = to_casadi(var_sol, y_sol)
         processed_var = pybamm.ProcessedVariable(
-            var_sol, var_casadi, pybamm.Solution(t_sol, y_sol), warn=False
+            var_sol,
+            var_casadi,
+            pybamm.Solution(t_sol, y_sol, pybamm.BaseModel(), {}),
+            warn=False,
         )
         with self.assertRaisesRegex(ValueError, "r cannot be None"):
             processed_var(0)
@@ -772,7 +866,10 @@ class TestProcessedVariable(unittest.TestCase):
 
         with self.assertRaisesRegex(NotImplementedError, "Shape not recognized"):
             pybamm.ProcessedVariable(
-                var_sol, var_casadi, pybamm.Solution(t_sol, u_sol), warn=False
+                var_sol,
+                var_casadi,
+                pybamm.Solution(t_sol, u_sol, pybamm.BaseModel(), {}),
+                warn=False,
             )
 
 

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -46,6 +46,7 @@ class TestScikitsSolvers(unittest.TestCase):
             y0 = np.array([0.0, 1.0])
             terminate_events_eval = []
             timescale_eval = 1
+            length_scales = {}
             convert_to_format = "python"
 
             def residuals_eval(self, t, y, ydot, inputs):
@@ -96,6 +97,7 @@ class TestScikitsSolvers(unittest.TestCase):
             y0 = np.array([0.0, 0.0])
             terminate_events_eval = []
             timescale_eval = 1
+            length_scales = {}
             convert_to_format = "python"
 
             def residuals_eval(self, t, y, ydot, inputs):

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -30,7 +30,7 @@ class TestSolution(unittest.TestCase):
         with self.assertRaisesRegex(
             ValueError, "Solution time vector must be strictly increasing"
         ):
-            sol.t
+            sol.set_t()
 
     def test_add_solutions(self):
         # Set up first solution

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -13,64 +13,61 @@ class TestSolution(unittest.TestCase):
     def test_init(self):
         t = np.linspace(0, 1)
         y = np.tile(t, (20, 1))
-        sol = pybamm.Solution(t, y)
+        sol = pybamm.Solution(t, y, pybamm.BaseModel(), {})
         np.testing.assert_array_equal(sol.t, t)
         np.testing.assert_array_equal(sol.y, y)
         self.assertEqual(sol.t_event, None)
         self.assertEqual(sol.y_event, None)
         self.assertEqual(sol.termination, "final time")
-        self.assertEqual(sol.inputs, {})
+        self.assertEqual(sol.all_inputs, [{}])
         self.assertIsInstance(sol.model, pybamm.BaseModel)
 
-        with self.assertRaisesRegex(AttributeError, "sub solutions"):
-            print(sol.sub_solutions)
+    def test_errors(self):
+        bad_ts = [np.array([1, 2, 3]), np.array([3, 4, 5])]
+        sol = pybamm.Solution(
+            bad_ts, [np.ones((1, 3)), np.ones((1, 3))], pybamm.BaseModel(), {}
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Solution time vector must be strictly increasing"
+        ):
+            sol.t
 
-    def test_append(self):
+    def test_add_solutions(self):
         # Set up first solution
         t1 = np.linspace(0, 1)
         y1 = np.tile(t1, (20, 1))
-        sol1 = pybamm.Solution(t1, y1)
+        sol1 = pybamm.Solution(t1, y1, pybamm.BaseModel(), {"a": 1})
         sol1.solve_time = 1.5
         sol1.integration_time = 0.3
-        sol1.model = pybamm.BaseModel()
-        sol1.inputs = {"a": 1}
 
         # Set up second solution
         t2 = np.linspace(1, 2)
         y2 = np.tile(t2, (20, 1))
-        sol2 = pybamm.Solution(t2, y2)
+        sol2 = pybamm.Solution(t2, y2, pybamm.BaseModel(), {"a": 2})
         sol2.solve_time = 1
         sol2.integration_time = 0.5
-        sol2.inputs = {"a": 2}
-        sol1.append(sol2, create_sub_solutions=True)
+        sol_sum = sol1 + sol2
 
         # Test
-        self.assertEqual(sol1.solve_time, 2.5)
-        self.assertEqual(sol1.integration_time, 0.8)
-        np.testing.assert_array_equal(sol1.t, np.concatenate([t1, t2[1:]]))
-        np.testing.assert_array_equal(sol1.y, np.concatenate([y1, y2[:, 1:]], axis=1))
+        self.assertEqual(sol_sum.solve_time, 2.5)
+        self.assertEqual(sol_sum.integration_time, 0.8)
+        np.testing.assert_array_equal(sol_sum.t, np.concatenate([t1, t2[1:]]))
         np.testing.assert_array_equal(
-            sol1.inputs["a"],
-            np.concatenate([1 * np.ones_like(t1), 2 * np.ones_like(t2[1:])])[
-                np.newaxis, :
-            ],
+            sol_sum.y, np.concatenate([y1, y2[:, 1:]], axis=1)
         )
+        np.testing.assert_array_equal(sol_sum.all_inputs, [{"a": 1}, {"a": 2}])
 
         # Test sub-solutions
-        self.assertEqual(len(sol1.sub_solutions), 2)
-        np.testing.assert_array_equal(sol1.sub_solutions[0].t, t1)
-        np.testing.assert_array_equal(sol1.sub_solutions[1].t, t2)
-        self.assertEqual(sol1.sub_solutions[0].model, sol1.model)
-        np.testing.assert_array_equal(
-            sol1.sub_solutions[0].inputs["a"], 1 * np.ones_like(t1)[np.newaxis, :]
-        )
-        self.assertEqual(sol1.sub_solutions[1].model, sol2.model)
-        np.testing.assert_array_equal(
-            sol1.sub_solutions[1].inputs["a"], 2 * np.ones_like(t2)[np.newaxis, :]
-        )
+        self.assertEqual(len(sol_sum.sub_solutions), 2)
+        np.testing.assert_array_equal(sol_sum.sub_solutions[0].t, t1)
+        np.testing.assert_array_equal(sol_sum.sub_solutions[1].t, t2)
+        self.assertEqual(sol_sum.sub_solutions[0].model, sol_sum.model)
+        np.testing.assert_array_equal(sol_sum.sub_solutions[0].all_inputs[0]["a"], 1)
+        self.assertEqual(sol_sum.sub_solutions[1].model, sol2.model)
+        np.testing.assert_array_equal(sol_sum.sub_solutions[1].all_inputs[0]["a"], 2)
 
     def test_cycles(self):
-        model = pybamm.lithium_ion.DFN()
+        model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment(
             [
                 ("Discharge at C/20 for 0.5 hours", "Charge at C/20 for 15 minutes"),
@@ -78,16 +75,20 @@ class TestSolution(unittest.TestCase):
             ]
         )
         sim = pybamm.Simulation(model, experiment=experiment)
-        sim.solve()
-        num_cycles = len(experiment.cycle_lengths)
-        for idx, sub_solution in enumerate(sim.solution.sub_solutions):
-            cycle_sub_solution = sim.solution.cycles[idx // num_cycles][
-                idx % num_cycles
-            ]
-            self.assertEqual(cycle_sub_solution, sub_solution)
+        sol = sim.solve()
+        self.assertEqual(len(sol.cycles), 2)
+        len_cycle_1 = len(sol.cycles[0].t)
+
+        self.assertIsInstance(sol.cycles[0], pybamm.Solution)
+        np.testing.assert_array_equal(sol.cycles[0].t, sol.t[:len_cycle_1])
+        np.testing.assert_array_equal(sol.cycles[0].y, sol.y[:, :len_cycle_1])
+
+        self.assertIsInstance(sol.cycles[1], pybamm.Solution)
+        np.testing.assert_array_equal(sol.cycles[1].t, sol.t[len_cycle_1:])
+        np.testing.assert_array_equal(sol.cycles[1].y, sol.y[:, len_cycle_1:])
 
     def test_total_time(self):
-        sol = pybamm.Solution(np.array([0]), np.array([[1, 2]]))
+        sol = pybamm.Solution(np.array([0]), np.array([[1, 2]]), pybamm.BaseModel(), {})
         sol.set_up_time = 0.5
         sol.solve_time = 1.2
         self.assertEqual(sol.total_time, 1.7)


### PR DESCRIPTION
# Description

Reformat `Solution` to avoid concatenating `y` (for performance)

Fixes #1329 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
