### PR TITLE
#1332 add more logging levels

### DIFF
--- a/examples/scripts/cycling_ageing_yang.py
+++ b/examples/scripts/cycling_ageing_yang.py
@@ -6,30 +6,40 @@ param = pb.ParameterValues(chemistry=pb.parameter_sets.Ramadass2004)
 model = pb.lithium_ion.DFN(options)
 experiment = pb.Experiment(
     [
-        "Charge at 1 C until 4.2 V",
-        "Hold at 4.2 V until C/10",
-        "Rest for 5 minutes",
-        "Discharge at 2 C until 2.8 V",
-        "Rest for 5 minutes",
+        (
+            "Charge at 1 C until 4.2 V",
+            "Hold at 4.2 V until C/10",
+            "Rest for 5 minutes",
+            "Discharge at 2 C until 2.8 V",
+            "Rest for 5 minutes",
+        ),
     ]
     * 2
     + [
-        "Charge at 1 C until 4.2 V",
-        "Hold at 4.2 V until C/20",
-        "Rest for 30 minutes",
-        "Discharge at C/3 until 2.8 V",
-        "Charge at 1 C until 4.2 V",
-        "Hold at 4.2 V until C/20",
-        "Rest for 30 minutes",
-        "Discharge at 1 C until 2.8 V",
-        "Charge at 1 C until 4.2 V",
-        "Hold at 4.2 V until C/20",
-        "Rest for 30 minutes",
-        "Discharge at 2 C until 2.8 V",
-        "Charge at 1 C until 4.2 V",
-        "Hold at 4.2 V until C/20",
-        "Rest for 30 minutes",
-        "Discharge at 3 C until 2.8 V",
+        (
+            "Charge at 1 C until 4.2 V",
+            "Hold at 4.2 V until C/20",
+            "Rest for 30 minutes",
+            "Discharge at C/3 until 2.8 V",
+        ),
+        (
+            "Charge at 1 C until 4.2 V",
+            "Hold at 4.2 V until C/20",
+            "Rest for 30 minutes",
+            "Discharge at 1 C until 2.8 V",
+        ),
+        (
+            "Charge at 1 C until 4.2 V",
+            "Hold at 4.2 V until C/20",
+            "Rest for 30 minutes",
+            "Discharge at 2 C until 2.8 V",
+        ),
+        (
+            "Charge at 1 C until 4.2 V",
+            "Hold at 4.2 V until C/20",
+            "Rest for 30 minutes",
+            "Discharge at 3 C until 2.8 V",
+        ),
     ]
 )
 sim = pb.Simulation(model, experiment=experiment, parameter_values=param)

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -158,7 +158,7 @@ class Discretisation(object):
                     )
 
         # Set the y split for variables
-        pybamm.logger.info("Set variable slices for {}".format(model.name))
+        pybamm.logger.verbose("Set variable slices for {}".format(model.name))
         self.set_variable_slices(variables)
 
         # now add extrapolated external variables to the boundary conditions
@@ -167,9 +167,13 @@ class Discretisation(object):
         self.set_external_variables(model)
 
         # set boundary conditions (only need key ids for boundary_conditions)
-        pybamm.logger.info("Discretise boundary conditions for {}".format(model.name))
+        pybamm.logger.verbose(
+            "Discretise boundary conditions for {}".format(model.name)
+        )
         self.bcs = self.process_boundary_conditions(model)
-        pybamm.logger.info("Set internal boundary conditions for {}".format(model.name))
+        pybamm.logger.verbose(
+            "Set internal boundary conditions for {}".format(model.name)
+        )
         self.set_internal_boundary_conditions(model)
 
         # set up inplace vs not inplace
@@ -188,7 +192,7 @@ class Discretisation(object):
 
         model_disc.bcs = self.bcs
 
-        pybamm.logger.info("Discretise initial conditions for {}".format(model.name))
+        pybamm.logger.verbose("Discretise initial conditions for {}".format(model.name))
         ics, concat_ics = self.process_initial_conditions(model)
         model_disc.initial_conditions = ics
         model_disc.concatenated_initial_conditions = concat_ics
@@ -196,18 +200,18 @@ class Discretisation(object):
         # Discretise variables (applying boundary conditions)
         # Note that we **do not** discretise the keys of model.rhs,
         # model.initial_conditions and model.boundary_conditions
-        pybamm.logger.info("Discretise variables for {}".format(model.name))
+        pybamm.logger.verbose("Discretise variables for {}".format(model.name))
         model_disc.variables = self.process_dict(model.variables)
 
         # Process parabolic and elliptic equations
-        pybamm.logger.info("Discretise model equations for {}".format(model.name))
+        pybamm.logger.verbose("Discretise model equations for {}".format(model.name))
         rhs, concat_rhs, alg, concat_alg = self.process_rhs_and_algebraic(model)
         model_disc.rhs, model_disc.concatenated_rhs = rhs, concat_rhs
         model_disc.algebraic, model_disc.concatenated_algebraic = alg, concat_alg
 
         # Process events
         processed_events = []
-        pybamm.logger.info("Discretise events for {}".format(model.name))
+        pybamm.logger.verbose("Discretise events for {}".format(model.name))
         for event in model.events:
             pybamm.logger.debug("Discretise event '{}'".format(event.name))
             processed_event = pybamm.Event(
@@ -222,14 +226,14 @@ class Discretisation(object):
         ]
 
         # Create mass matrix
-        pybamm.logger.info("Create mass matrix for {}".format(model.name))
+        pybamm.logger.verbose("Create mass matrix for {}".format(model.name))
         model_disc.mass_matrix, model_disc.mass_matrix_inv = self.create_mass_matrix(
             model_disc
         )
 
         # Check that resulting model makes sense
         if check_model:
-            pybamm.logger.info("Performing model checks for {}".format(model.name))
+            pybamm.logger.verbose("Performing model checks for {}".format(model.name))
             self.check_model(model_disc)
 
         pybamm.logger.info("Finish discretising {}".format(model.name))

--- a/pybamm/logger.py
+++ b/pybamm/logger.py
@@ -1,5 +1,10 @@
 #
 # Logging class for PyBaMM
+# Includes additional logging levels inspired by verboselogs
+# https://pypi.org/project/verboselogs/#overview-of-logging-levels
+#
+# Implementation from stackoverflow
+# https://stackoverflow.com/questions/2183233/how-to-add-a-custom-loglevel-to-pythons-logging-facility
 #
 import logging
 
@@ -14,6 +19,49 @@ format = (
 )
 logging.basicConfig(format=format)
 logging.Formatter(datefmt="%Y-%m-%d %H:%M:%S", fmt="%(asctime)s.%(msecs)03d")
+
+# Additional levels inspired by verboselogs
+SPAM_LEVEL_NUM = 5
+logging.addLevelName(SPAM_LEVEL_NUM, "SPAM")
+
+VERBOSE_LEVEL_NUM = 15
+logging.addLevelName(VERBOSE_LEVEL_NUM, "VERBOSE")
+
+NOTICE_LEVEL_NUM = 25
+logging.addLevelName(NOTICE_LEVEL_NUM, "NOTICE")
+
+SUCCESS_LEVEL_NUM = 35
+logging.addLevelName(SUCCESS_LEVEL_NUM, "SUCCESS")
+
+
+def spam(self, message, *args, **kws):
+    if self.isEnabledFor(SPAM_LEVEL_NUM):
+        # Yes, logger takes its '*args' as 'args'.
+        self._log(SPAM_LEVEL_NUM, message, args, **kws)
+
+
+def verbose(self, message, *args, **kws):
+    if self.isEnabledFor(VERBOSE_LEVEL_NUM):
+        # Yes, logger takes its '*args' as 'args'.
+        self._log(VERBOSE_LEVEL_NUM, message, args, **kws)
+
+
+def notice(self, message, *args, **kws):
+    if self.isEnabledFor(NOTICE_LEVEL_NUM):
+        # Yes, logger takes its '*args' as 'args'.
+        self._log(NOTICE_LEVEL_NUM, message, args, **kws)
+
+
+def success(self, message, *args, **kws):
+    if self.isEnabledFor(SUCCESS_LEVEL_NUM):
+        # Yes, logger takes its '*args' as 'args'.
+        self._log(SUCCESS_LEVEL_NUM, message, args, **kws)
+
+
+logging.Logger.spam = spam
+logging.Logger.verbose = verbose
+logging.Logger.notice = notice
+logging.Logger.success = success
 
 # Create a custom logger
 logger = logging.getLogger(__name__)

--- a/pybamm/logger.py
+++ b/pybamm/logger.py
@@ -36,25 +36,21 @@ logging.addLevelName(SUCCESS_LEVEL_NUM, "SUCCESS")
 
 def spam(self, message, *args, **kws):
     if self.isEnabledFor(SPAM_LEVEL_NUM):
-        # Yes, logger takes its '*args' as 'args'.
         self._log(SPAM_LEVEL_NUM, message, args, **kws)
 
 
 def verbose(self, message, *args, **kws):
     if self.isEnabledFor(VERBOSE_LEVEL_NUM):
-        # Yes, logger takes its '*args' as 'args'.
         self._log(VERBOSE_LEVEL_NUM, message, args, **kws)
 
 
 def notice(self, message, *args, **kws):
     if self.isEnabledFor(NOTICE_LEVEL_NUM):
-        # Yes, logger takes its '*args' as 'args'.
         self._log(NOTICE_LEVEL_NUM, message, args, **kws)
 
 
 def success(self, message, *args, **kws):
     if self.isEnabledFor(SUCCESS_LEVEL_NUM):
-        # Yes, logger takes its '*args' as 'args'.
         self._log(SUCCESS_LEVEL_NUM, message, args, **kws)
 
 

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -629,7 +629,7 @@ class BaseBatteryModel(pybamm.BaseModel):
                 `model.update` instead."""
             )
 
-        pybamm.logger.info("Building {}".format(self.name))
+        pybamm.logger.info("Start building {}".format(self.name))
 
         if self._built_fundamental_and_external is False:
             self.build_fundamental_and_external()
@@ -656,6 +656,7 @@ class BaseBatteryModel(pybamm.BaseModel):
                 self.variables.update(var)
 
         self._built = True
+        pybamm.logger.info("Finish building {}".format(self.name))
 
     def new_empty_copy(self):
         "See :meth:`pybamm.BaseModel.new_empty_copy()`"

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -371,13 +371,15 @@ class ParameterValues:
 
         new_rhs = {}
         for variable, equation in unprocessed_model.rhs.items():
-            pybamm.logger.debug("Processing parameters for {!r} (rhs)".format(variable))
+            pybamm.logger.verbose(
+                "Processing parameters for {!r} (rhs)".format(variable)
+            )
             new_rhs[variable] = self.process_symbol(equation)
         model.rhs = new_rhs
 
         new_algebraic = {}
         for variable, equation in unprocessed_model.algebraic.items():
-            pybamm.logger.debug(
+            pybamm.logger.verbose(
                 "Processing parameters for {!r} (algebraic)".format(variable)
             )
             new_algebraic[variable] = self.process_symbol(equation)
@@ -385,7 +387,7 @@ class ParameterValues:
 
         new_initial_conditions = {}
         for variable, equation in unprocessed_model.initial_conditions.items():
-            pybamm.logger.debug(
+            pybamm.logger.verbose(
                 "Processing parameters for {!r} (initial conditions)".format(variable)
             )
             new_initial_conditions[variable] = self.process_symbol(equation)
@@ -395,7 +397,7 @@ class ParameterValues:
 
         new_variables = {}
         for variable, equation in unprocessed_model.variables.items():
-            pybamm.logger.debug(
+            pybamm.logger.verbose(
                 "Processing parameters for {!r} (variables)".format(variable)
             )
             new_variables[variable] = self.process_symbol(equation)
@@ -403,7 +405,7 @@ class ParameterValues:
 
         new_events = []
         for event in unprocessed_model.events:
-            pybamm.logger.debug(
+            pybamm.logger.verbose(
                 "Processing parameters for event '{}''".format(event.name)
             )
             new_events.append(
@@ -413,7 +415,7 @@ class ParameterValues:
             )
 
         for event in self.parameter_events:
-            pybamm.logger.debug(
+            pybamm.logger.verbose(
                 "Processing parameters for event '{}''".format(event.name)
             )
             new_events.append(
@@ -458,7 +460,7 @@ class ParameterValues:
             for side in sides:
                 try:
                     bc, typ = bcs[side]
-                    pybamm.logger.debug(
+                    pybamm.logger.verbose(
                         "Processing parameters for {!r} ({} bc)".format(variable, side)
                     )
                     processed_bc = (self.process_symbol(bc), typ)

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -467,7 +467,8 @@ class Simulation:
                     npts = max(int(round(dt / exp_inputs["period"])) + 1, 2)
                     self.step(dt, solver=solver, npts=npts, **kwargs)
 
-                    # Extract the new parts of the solution to construct the entire "step"
+                    # Extract the new parts of the solution
+                    # to construct the entire "step"
                     sol = self.solution
                     new_num_subsolutions = len(sol.sub_solutions)
                     diff_num_subsolutions = (

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -443,64 +443,84 @@ class Simulation:
             pybamm.logger.info("Start running experiment")
             timer = pybamm.Timer()
 
-            steps = []
-            for idx, (exp_inputs, dt) in enumerate(
-                zip(self._experiment_inputs, self._experiment_times)
-            ):
-                pybamm.logger.info(self.experiment.operating_conditions_strings[idx])
-                inputs.update(exp_inputs)
-                kwargs["inputs"] = inputs
-                # Make sure we take at least 2 timesteps
-                npts = max(int(round(dt / exp_inputs["period"])) + 1, 2)
-                self.step(dt, solver=solver, npts=npts, **kwargs)
+            all_cycle_solutions = []
 
-                # Extract the new parts of the solution to construct the entire "step"
-                sol = self.solution
-                new_num_subsolutions = len(sol.sub_solutions)
-                diff_num_subsolutions = new_num_subsolutions - previous_num_subsolutions
-                previous_num_subsolutions = new_num_subsolutions
-
-                step_solution = pybamm.Solution(
-                    sol.all_ts[-diff_num_subsolutions:],
-                    sol.all_ys[-diff_num_subsolutions:],
-                    sol.model,
-                    sol.all_inputs[-diff_num_subsolutions:],
-                    sol.t_event,
-                    sol.y_event,
-                    sol.termination,
-                )
-                step_solution.solve_time = 0
-                step_solution.integration_time = 0
-                steps.append(step_solution)
-                # Only allow events specified by experiment
-                if not (
-                    self._solution.termination == "final time"
-                    or "[experiment]" in self._solution.termination
-                ):
-                    pybamm.logger.warning(
-                        "\n\n\tExperiment is infeasible: '{}' ".format(
-                            self._solution.termination
-                        )
-                        + "was triggered during '{}'. ".format(
-                            self.experiment.operating_conditions_strings[idx]
-                        )
-                        + "Try reducing current, shortening the time interval, "
-                        "or reducing the period.\n\n"
-                    )
-                    break
-            # Construct solution.cycles (a list of solutions corresponding to
-            # cycles) from sub_solutions
-            self.solution.cycles = []
+            idx = 0
             for cycle_num, cycle_length in enumerate(self.experiment.cycle_lengths):
-                cycle_start_idx = sum(self.experiment.cycle_lengths[0:cycle_num])
-                cycle_solution = steps[cycle_start_idx]
-                for idx in range(cycle_length - 1):
-                    cycle_solution = cycle_solution + steps[cycle_start_idx + idx + 1]
-                cycle_solution.steps = steps[
-                    cycle_start_idx : cycle_start_idx + cycle_length
-                ]
-                self.solution.cycles.append(cycle_solution)
-            pybamm.logger.info(
+                pybamm.logger.info(
+                    f"Cycle {cycle_num+1} ---------------------------------------------"
+                )
+                steps = []
+                cycle_solution = None
+                for step_num in range(cycle_length):
+                    exp_inputs = self._experiment_inputs[idx]
+                    dt = self._experiment_times[idx]
+                    # Use 1-indexing for printing cycle number as it is more
+                    # human-intuitive
+                    pybamm.logger.info(
+                        f"Cycle {cycle_num+1}, step {step_num+1}: "
+                        f"{self.experiment.operating_conditions_strings[idx]}"
+                    )
+                    inputs.update(exp_inputs)
+                    kwargs["inputs"] = inputs
+                    # Make sure we take at least 2 timesteps
+                    npts = max(int(round(dt / exp_inputs["period"])) + 1, 2)
+                    self.step(dt, solver=solver, npts=npts, **kwargs)
+
+                    # Extract the new parts of the solution to construct the entire "step"
+                    sol = self.solution
+                    new_num_subsolutions = len(sol.sub_solutions)
+                    diff_num_subsolutions = (
+                        new_num_subsolutions - previous_num_subsolutions
+                    )
+                    previous_num_subsolutions = new_num_subsolutions
+
+                    step_solution = pybamm.Solution(
+                        sol.all_ts[-diff_num_subsolutions:],
+                        sol.all_ys[-diff_num_subsolutions:],
+                        sol.model,
+                        sol.all_inputs[-diff_num_subsolutions:],
+                        sol.t_event,
+                        sol.y_event,
+                        sol.termination,
+                    )
+                    step_solution.solve_time = 0
+                    step_solution.integration_time = 0
+                    steps.append(step_solution)
+                    # Only allow events specified by experiment
+                    if not (
+                        self._solution.termination == "final time"
+                        or "[experiment]" in self._solution.termination
+                    ):
+                        pybamm.logger.warning(
+                            "\n\n\tExperiment is infeasible: '{}' ".format(
+                                self._solution.termination
+                            )
+                            + "was triggered during '{}'. ".format(
+                                self.experiment.operating_conditions_strings[idx]
+                            )
+                            + "Try reducing current, shortening the time interval, "
+                            "or reducing the period.\n\n"
+                        )
+                        break
+
+                    # Construct cycle solutions (a list of solutions corresponding to
+                    # cycles) from sub_solutions
+                    if step_num == 0:
+                        cycle_solution = step_solution
+                    else:
+                        cycle_solution = cycle_solution + step_solution
+
+                    # Increment index for next iteration
+                    idx += 1
+
+                # At the final step of the inner loop we save the cycle
+                cycle_solution.steps = steps
+                all_cycle_solutions.append(cycle_solution)
+
+            self.solution.cycles = all_cycle_solutions
+
+            pybamm.logger.notice(
                 "Finish experiment simulation, took {}".format(timer.time())
             )
 

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -446,9 +446,11 @@ class Simulation:
             all_cycle_solutions = []
 
             idx = 0
+            num_cycles = len(self.experiment.cycle_lengths)
             for cycle_num, cycle_length in enumerate(self.experiment.cycle_lengths):
                 pybamm.logger.info(
-                    f"Cycle {cycle_num+1} ---------------------------------------------"
+                    f"Cycle {cycle_num+1}/{num_cycles} ({timer.time()} elapsed) "
+                    + "-" * 20
                 )
                 steps = []
                 cycle_solution = None
@@ -458,7 +460,8 @@ class Simulation:
                     # Use 1-indexing for printing cycle number as it is more
                     # human-intuitive
                     pybamm.logger.info(
-                        f"Cycle {cycle_num+1}, step {step_num+1}: "
+                        f"Cycle {cycle_num+1}/{num_cycles}, "
+                        f"step {step_num+1}/{cycle_length}: "
                         f"{self.experiment.operating_conditions_strings[idx]}"
                     )
                     inputs.update(exp_inputs)

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -491,6 +491,14 @@ class Simulation:
                     step_solution.solve_time = 0
                     step_solution.integration_time = 0
                     steps.append(step_solution)
+
+                    # Construct cycle solutions (a list of solutions corresponding to
+                    # cycles) from sub_solutions
+                    if step_num == 0:
+                        cycle_solution = step_solution
+                    else:
+                        cycle_solution = cycle_solution + step_solution
+
                     # Only allow events specified by experiment
                     if not (
                         self._solution.termination == "final time"
@@ -507,13 +515,6 @@ class Simulation:
                             "or reducing the period.\n\n"
                         )
                         break
-
-                    # Construct cycle solutions (a list of solutions corresponding to
-                    # cycles) from sub_solutions
-                    if step_num == 0:
-                        cycle_solution = step_solution
-                    else:
-                        cycle_solution = cycle_solution + step_solution
 
                     # Increment index for next iteration
                     idx += 1

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -137,6 +137,7 @@ class BaseSolver(object):
             The times (in seconds) at which to compute the solution
 
         """
+        pybamm.logger.info("Start solver set-up")
 
         # Check model.algebraic for ode solvers
         if self.ode_solver is True and len(model.algebraic) > 0:
@@ -221,7 +222,7 @@ class BaseSolver(object):
             def report(string):
                 # don't log event conversion
                 if "event" not in string:
-                    pybamm.logger.info(string)
+                    pybamm.logger.verbose(string)
 
             if use_jacobian is None:
                 use_jacobian = model.use_jacobian
@@ -691,7 +692,7 @@ class BaseSolver(object):
         discontinuities = [v for v in discontinuities if v < t_eval_dimensionless[-1]]
 
         if len(discontinuities) > 0:
-            pybamm.logger.info(
+            pybamm.logger.verbose(
                 "Discontinuity events found at t = {}".format(discontinuities)
             )
             if isinstance(inputs, list):
@@ -700,7 +701,7 @@ class BaseSolver(object):
                     " sets with discontinuities"
                 )
         else:
-            pybamm.logger.info("No discontinuity events found")
+            pybamm.logger.verbose("No discontinuity events found")
 
         # insert time points around discontinuities in t_eval
         # keep track of sub sections to integrate by storing start and end indices
@@ -728,7 +729,7 @@ class BaseSolver(object):
         old_y0 = model.y0
         solutions = None
         for start_index, end_index in zip(start_indices, end_indices):
-            pybamm.logger.info(
+            pybamm.logger.verbose(
                 "Calling solver for {} < t < {}".format(
                     t_eval_dimensionless[start_index] * model.timescale_eval,
                     t_eval_dimensionless[end_index - 1] * model.timescale_eval,
@@ -926,7 +927,7 @@ class BaseSolver(object):
                     )
         # Run set up on first step
         if old_solution is None:
-            pybamm.logger.info(
+            pybamm.logger.verbose(
                 "Start stepping {} with {}".format(model.name, self.name)
             )
             self.set_up(model, ext_and_inputs)
@@ -945,7 +946,7 @@ class BaseSolver(object):
 
         # Step
         t_eval = np.linspace(t, t + dt_dimensionless, npts)
-        pybamm.logger.info(
+        pybamm.logger.verbose(
             "Stepping for {:.0f} < t < {:.0f}".format(
                 t * model.timescale_eval,
                 (t + dt_dimensionless) * model.timescale_eval,
@@ -971,8 +972,8 @@ class BaseSolver(object):
         # Identify the event that caused termination
         termination = self.get_termination_reason(solution, model.events)
 
-        pybamm.logger.info("Finish stepping {} ({})".format(model.name, termination))
-        pybamm.logger.info(
+        pybamm.logger.verbose("Finish stepping {} ({})".format(model.name, termination))
+        pybamm.logger.verbose(
             (
                 "Set-up time: {}, Step time: {} (of which integration time: {}), "
                 "Total time: {}"

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -13,14 +13,19 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(logger.level, 20)
         pybamm.set_logging_level("ERROR")
         self.assertEqual(logger.level, 40)
-        pybamm.set_logging_level("SPAM")
-        self.assertEqual(logger.level, 5)
         pybamm.set_logging_level("VERBOSE")
         self.assertEqual(logger.level, 15)
         pybamm.set_logging_level("NOTICE")
         self.assertEqual(logger.level, 25)
         pybamm.set_logging_level("SUCCESS")
         self.assertEqual(logger.level, 35)
+
+        pybamm.set_logging_level("SPAM")
+        self.assertEqual(logger.level, 5)
+        pybamm.logger.spam("Test spam level")
+        pybamm.logger.verbose("Test verbose level")
+        pybamm.logger.notice("Test notice level")
+        pybamm.logger.success("Test success level")
 
         # reset
         pybamm.set_logging_level("WARNING")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -13,6 +13,17 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(logger.level, 20)
         pybamm.set_logging_level("ERROR")
         self.assertEqual(logger.level, 40)
+        pybamm.set_logging_level("SPAM")
+        self.assertEqual(logger.level, 5)
+        pybamm.set_logging_level("VERBOSE")
+        self.assertEqual(logger.level, 15)
+        pybamm.set_logging_level("NOTICE")
+        self.assertEqual(logger.level, 25)
+        pybamm.set_logging_level("SUCCESS")
+        self.assertEqual(logger.level, 35)
+
+        # reset
+        pybamm.set_logging_level("WARNING")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Add new logging levels and make the logging cleaner for when running an experiment. The output now looks like this:
```
2021-01-23 18:30:48,697 - [INFO] base_battery_model.build_model(632): Start building Doyle-Fuller-Newman model
2021-01-23 18:30:48,771 - [INFO] base_battery_model.build_model(659): Finish building Doyle-Fuller-Newman model
2021-01-23 18:30:48,791 - [INFO] replace_symbols.process_model(39): Start replacing symbols in Doyle-Fuller-Newman model
2021-01-23 18:30:48,844 - [INFO] replace_symbols.process_model(110): Finish replacing symbols in Doyle-Fuller-Newman model
2021-01-23 18:30:48,845 - [INFO] parameter_values.process_model(352): Start setting parameters for Doyle-Fuller-Newman model
2021-01-23 18:30:48,937 - [INFO] parameter_values.process_model(443): Finish setting parameters for Doyle-Fuller-Newman model
2021-01-23 18:30:48,938 - [INFO] discretisation.process_model(137): Start discretising Doyle-Fuller-Newman model
2021-01-23 18:30:49,497 - [INFO] discretisation.process_model(239): Finish discretising Doyle-Fuller-Newman model
2021-01-23 18:30:49,497 - [INFO] simulation.solve(443): Start running experiment
2021-01-23 18:30:49,497 - [INFO] simulation.solve(451): Cycle 1/3 (4.280 us elapsed) --------------------
2021-01-23 18:30:49,497 - [INFO] simulation.solve(462): Cycle 1/3, step 1/5: Discharge at C/5 for 10 hours or until 3.3 V
2021-01-23 18:30:49,497 - [INFO] base_solver.set_up(140): Start solver set-up
2021-01-23 18:30:49,637 - [INFO] base_solver.set_up(433): Finish solver set-up
2021-01-23 18:30:51,595 - [INFO] simulation.solve(462): Cycle 1/3, step 2/5: Rest for 1 hour
2021-01-23 18:30:51,958 - [INFO] simulation.solve(462): Cycle 1/3, step 3/5: Charge at 1 A until 4.1 V
2021-01-23 18:30:52,403 - [INFO] simulation.solve(462): Cycle 1/3, step 4/5: Hold at 4.1 V until 50 mA
2021-01-23 18:30:52,586 - [INFO] simulation.solve(462): Cycle 1/3, step 5/5: Rest for 1 hour
2021-01-23 18:30:52,943 - [INFO] simulation.solve(451): Cycle 2/3 (3.446 s elapsed) --------------------
2021-01-23 18:30:52,943 - [INFO] simulation.solve(462): Cycle 2/3, step 1/5: Discharge at C/5 for 10 hours or until 3.3 V
2021-01-23 18:30:55,404 - [INFO] simulation.solve(462): Cycle 2/3, step 2/5: Rest for 1 hour
2021-01-23 18:30:55,779 - [INFO] simulation.solve(462): Cycle 2/3, step 3/5: Charge at 1 A until 4.1 V
2021-01-23 18:30:56,173 - [INFO] simulation.solve(462): Cycle 2/3, step 4/5: Hold at 4.1 V until 50 mA
2021-01-23 18:30:56,362 - [INFO] simulation.solve(462): Cycle 2/3, step 5/5: Rest for 1 hour
2021-01-23 18:30:56,709 - [INFO] simulation.solve(451): Cycle 3/3 (7.211 s elapsed) --------------------
2021-01-23 18:30:56,709 - [INFO] simulation.solve(462): Cycle 3/3, step 1/5: Discharge at C/5 for 10 hours or until 3.3 V
2021-01-23 18:30:59,132 - [INFO] simulation.solve(462): Cycle 3/3, step 2/5: Rest for 1 hour
2021-01-23 18:30:59,553 - [INFO] simulation.solve(462): Cycle 3/3, step 3/5: Charge at 1 A until 4.1 V
2021-01-23 18:30:59,952 - [INFO] simulation.solve(462): Cycle 3/3, step 4/5: Hold at 4.1 V until 50 mA
2021-01-23 18:31:00,139 - [INFO] simulation.solve(462): Cycle 3/3, step 5/5: Rest for 1 hour
2021-01-23 18:31:00,497 - [NOTICE] simulation.solve(527): Finish experiment simulation, took 10.999 s
```


We could use "notice" to add some things between "warning" and "info" but I haven't done this in this PR.

Fixes #1332 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
