### PR TITLE
Check for any performance regression on pull request

### DIFF
--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -1,0 +1,33 @@
+name: Run benchmarks on PR
+on:
+  pull_request:
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install asv
+        run: pip install -U pip virtualenv asv
+      - name: Fetch base branch
+        run: |
+          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
+          git fetch origin $GITHUB_HEAD_REF:$GITHUB_HEAD_REF
+      - name: Run benchmarks
+        run: |
+          asv machine --machine "GitHubRunner"
+          # Get IDs of branch and PR commits
+          BRANCH_COMMIT_SHA=$(git rev-parse $GITHUB_BASE_REF)
+          echo $BRANCH_COMMIT_SHA | tee -a commits_to_compare.txt
+          echo $GITHUB_SHA | tee -a commit_to_compare.txt
+          asv run HASHFILE:commit_to_compare.txt --m "GitHubRunner" --show-stderr
+      - name: Compare commits' benchmark results
+        run: |
+          BRANCH_COMMIT_SHA=$(head -1 commits_to_compare.txt)
+          asv compare $BRANCH_COMMIT_SHA $GITHUB_SHA
+
+    

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -32,7 +32,7 @@ jobs:
           HEAD_COMMIT=$(tail -1 commits_to_compare.txt)
           echo "SUMMARY OF CHANGES"
           echo "=================="
-          asv compare --only-changed $BASE_COMMIT $HEAD_COMMIT | tee compare_result.txt
+          asv compare $BASE_COMMIT $HEAD_COMMIT | tee compare_result.txt
           REGRESSIONS=$(grep "+" compare_result.txt)
           if [ ! -z "$REGRESSIONS" ]; \
           then \
@@ -43,6 +43,4 @@ jobs:
           printf "Found %d regression(s)\n" $(echo "$REGRESSIONS" | wc -l); \
           exit 1; \
           fi
-
-
     

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -21,13 +21,17 @@ jobs:
         run: |
           asv machine --machine "GitHubRunner"
           # Get IDs of branch and PR commits
-          BRANCH_COMMIT_SHA=$(git rev-parse $GITHUB_BASE_REF)
-          echo $BRANCH_COMMIT_SHA | tee -a commits_to_compare.txt
-          echo $GITHUB_SHA | tee -a commit_to_compare.txt
-          asv run HASHFILE:commit_to_compare.txt --m "GitHubRunner" --show-stderr
+          BASE_COMMIT=$(git rev-parse $GITHUB_BASE_REF)
+          HEAD_COMMIT=$(git rev-parse $GITHUB_HEAD_REF)
+          echo $BASE_COMMIT | tee commits_to_compare.txt
+          echo $HEAD_COMMIT | tee -a commits_to_compare.txt
+          asv run HASHFILE:commits_to_compare.txt --m "GitHubRunner" --show-stderr
       - name: Compare commits' benchmark results
         run: |
-          BRANCH_COMMIT_SHA=$(head -1 commits_to_compare.txt)
-          asv compare $BRANCH_COMMIT_SHA $GITHUB_SHA
+          cat commits_to_compare.txt
+          BASE_COMMIT=$(head -1 commits_to_compare.txt)
+          HEAD_COMMIT=$(tail -1 commits_to_compare.txt)
+          asv compare $BASE_COMMIT $HEAD_COMMIT
+
 
     

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -28,10 +28,21 @@ jobs:
           asv run HASHFILE:commits_to_compare.txt --m "GitHubRunner" --show-stderr
       - name: Compare commits' benchmark results
         run: |
-          cat commits_to_compare.txt
           BASE_COMMIT=$(head -1 commits_to_compare.txt)
           HEAD_COMMIT=$(tail -1 commits_to_compare.txt)
-          asv compare $BASE_COMMIT $HEAD_COMMIT
+          echo "SUMMARY OF CHANGES"
+          echo "=================="
+          asv compare --only-changed $BASE_COMMIT $HEAD_COMMIT | tee compare_result.txt
+          REGRESSIONS=$(grep "+" compare_result.txt)
+          if [ ! -z "$REGRESSIONS" ]; \
+          then \
+          echo "REGRESSIONS FOUND"; \
+          echo "================="; \
+          echo "$REGRESSIONS"; \
+          echo "================="; \
+          printf "Found %d regression(s)\n" $(echo "$REGRESSIONS" | wc -l); \
+          exit 1; \
+          fi
 
 
     

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -33,7 +33,9 @@ jobs:
           echo "SUMMARY OF CHANGES"
           echo "=================="
           asv compare $BASE_COMMIT $HEAD_COMMIT | tee compare_result.txt
-          REGRESSIONS=$(grep "+" compare_result.txt)
+          # Make sure grep returns error code 0 even if code 1 is
+          # returned because no match is found
+          REGRESSIONS=$({ grep "+" compare_result.txt || test $? = 1; })
           if [ ! -z "$REGRESSIONS" ]; \
           then \
           echo "REGRESSIONS FOUND"; \
@@ -43,4 +45,3 @@ jobs:
           printf "Found %d regression(s)\n" $(echo "$REGRESSIONS" | wc -l); \
           exit 1; \
           fi
-    


### PR DESCRIPTION
# Description
_This comes on top of #1334 (Nightly benchmarks with asv).
Better to first review and merge #1334 then review this PR._

This adds a new GitHub action workflow `Run benchmarks on PR` (`benchmark_on_PR.yml`) that runs each time a pull request is opened and reports any performance regression compared to the tip of the base branch of the PR.
This workflow uses [airspeed velocity](https://asv.readthedocs.io/en/stable/) to run the benchmark suite for both the new commit and the tip of the base branch for the PR. If any of the benchmark run results in a performance regression of more than 10% compared to the base commit, the workflow reports a failure. Here "performance" means wall-clock time. The value of 10% for the regression ratio is arbitrary, and can be tuned at will.

I manually tested this feature on my fork, see for instance [this CI log](https://github.com/tlestang/PyBaMM/runs/1748192484?check_suite_focus=true). In  this case I introduced the Scipy Solver sleep for 2 seconds, in order to simulate a regression.
However I'm not sure how to automatically test that behaviour, so it might take a couple of PRs to get this right.

One **known issue** is that the workflow will fail if the pull request is opened from a fork.  This is because both base and feature branches must be fetched for asv to be able to run the benchmarks. I'm not sure how to fetch the feature branch from a fork from a github workflow running on the base repo.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`
