### PR TITLE
#1343 update get_termination_reason to return solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ## Bug fixes
 
+-   Fixed a bug where the event time and state were no longer returned as part of the solution ([#1344](https://github.com/pybamm-team/PyBaMM/pull/1344))
 -   Fixed a bug in `CasadiSolver` safe mode which crashed when there were extrapolation events but no termination events ([#1321](https://github.com/pybamm-team/PyBaMM/pull/1321))
 -   When an `Interpolant` is extrapolated an error is raised for `CasadiSolver` (and a warning is raised for the other solvers) ([#1315](https://github.com/pybamm-team/PyBaMM/pull/1315))
 -   Fixed `Simulation` and `model.new_copy` to fix a bug where changes to the model were overwritten ([#1278](https://github.com/pybamm-team/PyBaMM/pull/1278))

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -121,8 +121,10 @@ class TestCasadiSolver(unittest.TestCase):
         solver = pybamm.CasadiSolver(mode="safe", rtol=1e-8, atol=1e-8)
         t_eval = np.linspace(0, 5, 100)
         solution = solver.solve(model, t_eval)
-        np.testing.assert_array_less(solution.y.full()[0], 1.5)
-        np.testing.assert_array_less(solution.y.full()[-1], 2.5 + 1e-10)
+        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+        np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
         np.testing.assert_array_almost_equal(
             solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
         )
@@ -277,8 +279,12 @@ class TestCasadiSolver(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y.full()[0], 1.5)
-        np.testing.assert_array_less(step_solution.y.full()[-1], 2.5001)
+        np.testing.assert_array_less(step_solution.y.full()[0, :-1], 1.5)
+        np.testing.assert_array_less(step_solution.y.full()[-1, :-1], 2.5)
+        np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
+        np.testing.assert_array_equal(
+            step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
+        )
         np.testing.assert_array_almost_equal(
             step_solution.y.full()[0], np.exp(0.1 * step_solution.t), decimal=5
         )

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -575,10 +575,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y.full()[0:, -1], 1.5)
-        np.testing.assert_array_less(solution.y.full()[0:, -1], 1.25)
+        np.testing.assert_array_less(solution.y[0:, -1], 1.5)
+        np.testing.assert_array_less(solution.y[0:, -1], 1.25 + 1e-6)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_dae_events_casadi(self):
         # Create model
@@ -603,12 +603,10 @@ class TestScikitsSolvers(unittest.TestCase):
             solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model_disc, t_eval)
-            np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-            np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-            np.testing.assert_array_equal(
-                solution.y_event[:, 0], solution.y.full()[:, -1]
-            )
+            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 
@@ -637,16 +635,9 @@ class TestScikitsSolvers(unittest.TestCase):
                 solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model, t_eval, inputs={"rate 1": 0.1, "rate 2": 2})
-            if form == "python":
-                np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-                np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
-                np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
-            else:
-                np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-                np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
-                np.testing.assert_array_equal(
-                    solution.y_event[:, 0], solution.y.full()[:, -1]
-                )
+            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
 
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
@@ -752,11 +743,11 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y.full()[0, :-1], 1.5)
-        np.testing.assert_array_less(step_solution.y.full()[-1, :-1], 2.5)
+        np.testing.assert_array_less(step_solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(step_solution.y[-1, :-1], 2.5)
         np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
         np.testing.assert_array_equal(
-            step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
+            step_solution.y_event[:, 0], step_solution.y[:, -1]
         )
         np.testing.assert_array_almost_equal(
             step_solution.y[0], np.exp(0.1 * step_solution.t), decimal=5
@@ -797,11 +788,11 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y.full()[0, :-1], 0.55)
-        np.testing.assert_array_less(step_solution.y.full()[-1, :-1], 1.2)
+        np.testing.assert_array_less(step_solution.y[0, :-1], 0.55)
+        np.testing.assert_array_less(step_solution.y[-1, :-1], 1.2)
         np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
         np.testing.assert_array_equal(
-            step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
+            step_solution.y_event[:, 0], step_solution.y[:, -1]
         )
         var1_soln = (step_solution.t % a) ** 2 / 2 + a ** 2 / 2 * (step_solution.t // a)
         var2_soln = 2 * var1_soln
@@ -884,12 +875,10 @@ class TestScikitsSolvers(unittest.TestCase):
 
             # check solution
             for solution in [solution1, solution2]:
-                np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-                np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+                np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+                np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
                 np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-                np.testing.assert_array_equal(
-                    solution.y_event[:, 0], solution.y.full()[:, -1]
-                )
+                np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
                 var1_soln = np.exp(0.2 * solution.t)
                 y0 = np.exp(0.2 * discontinuity)
                 var1_soln[solution.t > discontinuity] = y0 * np.exp(

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -151,10 +151,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-        np.testing.assert_array_less(solution.y[0, :-1], 1.25)
+        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.25)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
 
     def test_model_solver_ode_jacobian_python(self):
         model = pybamm.BaseModel()
@@ -253,12 +253,12 @@ class TestScikitsSolvers(unittest.TestCase):
         solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 5, 100)
         solution = solver.solve(model, t_eval)
-        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-        np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
         np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
 
     def test_model_solver_dae_nonsmooth_python(self):
         model = pybamm.BaseModel()
@@ -575,10 +575,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y[0:, -1], 1.5)
-        np.testing.assert_array_less(solution.y[0:, -1], 1.25)
+        np.testing.assert_array_less(solution.y.full()[0:, -1], 1.5)
+        np.testing.assert_array_less(solution.y.full()[0:, -1], 1.25)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
 
     def test_model_solver_dae_events_casadi(self):
         # Create model
@@ -603,10 +603,12 @@ class TestScikitsSolvers(unittest.TestCase):
             solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model_disc, t_eval)
-            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+            np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+            np.testing.assert_array_equal(
+                solution.y_event[:, 0], solution.y.full()[:, -1]
+            )
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 
@@ -635,10 +637,12 @@ class TestScikitsSolvers(unittest.TestCase):
                 solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model, t_eval, inputs={"rate 1": 0.1, "rate 2": 2})
-            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+            np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+            np.testing.assert_array_equal(
+                solution.y_event[:, 0], solution.y.full()[:, -1]
+            )
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 
@@ -742,11 +746,11 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y[0, :-1], 1.5)
-        np.testing.assert_array_less(step_solution.y[-1, :-1], 2.5)
+        np.testing.assert_array_less(step_solution.y.full()[0, :-1], 1.5)
+        np.testing.assert_array_less(step_solution.y.full()[-1, :-1], 2.5)
         np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
         np.testing.assert_array_equal(
-            step_solution.y_event[:, 0], step_solution.y[:, -1]
+            step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
         )
         np.testing.assert_array_almost_equal(
             step_solution.y[0], np.exp(0.1 * step_solution.t), decimal=5
@@ -787,11 +791,11 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y[0, :-1], 0.55)
-        np.testing.assert_array_less(step_solution.y[-1, :-1], 1.2)
+        np.testing.assert_array_less(step_solution.y.full()[0, :-1], 0.55)
+        np.testing.assert_array_less(step_solution.y.full()[-1, :-1], 1.2)
         np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
         np.testing.assert_array_equal(
-            step_solution.y_event[:, 0], step_solution.y[:, -1]
+            step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
         )
         var1_soln = (step_solution.t % a) ** 2 / 2 + a ** 2 / 2 * (step_solution.t // a)
         var2_soln = 2 * var1_soln
@@ -874,10 +878,12 @@ class TestScikitsSolvers(unittest.TestCase):
 
             # check solution
             for solution in [solution1, solution2]:
-                np.testing.assert_array_less(solution.y[0, :-1], 1.5)
-                np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+                np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+                np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
                 np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-                np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+                np.testing.assert_array_equal(
+                    solution.y_event[:, 0], solution.y.full()[:, -1]
+                )
                 var1_soln = np.exp(0.2 * solution.t)
                 y0 = np.exp(0.2 * discontinuity)
                 var1_soln[solution.t > discontinuity] = y0 * np.exp(

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -151,10 +151,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.25)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.25)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_ode_jacobian_python(self):
         model = pybamm.BaseModel()
@@ -253,12 +253,12 @@ class TestScikitsSolvers(unittest.TestCase):
         solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 5, 100)
         solution = solver.solve(model, t_eval)
-        np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-        np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
         np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_dae_nonsmooth_python(self):
         model = pybamm.BaseModel()
@@ -637,12 +637,18 @@ class TestScikitsSolvers(unittest.TestCase):
                 solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model, t_eval, inputs={"rate 1": 0.1, "rate 2": 2})
-            np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
-            np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+            if form == "python":
+                np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+                np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+                np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
+            else:
+                np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
+                np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
+                np.testing.assert_array_equal(
+                    solution.y_event[:, 0], solution.y.full()[:, -1]
+                )
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-            np.testing.assert_array_equal(
-                solution.y_event[:, 0], solution.y.full()[:, -1]
-            )
+
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -151,8 +151,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-        np.testing.assert_array_less(solution.y[0], 1.25 + 1e-6)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.25)
+        np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_ode_jacobian_python(self):
         model = pybamm.BaseModel()
@@ -251,10 +253,12 @@ class TestScikitsSolvers(unittest.TestCase):
         solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8, root_method="lm")
         t_eval = np.linspace(0, 5, 100)
         solution = solver.solve(model, t_eval)
-        np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-        np.testing.assert_array_less(solution.y[-1], 2.5 + 1e-6)
+        np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
         np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
+        np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_dae_nonsmooth_python(self):
         model = pybamm.BaseModel()
@@ -323,8 +327,8 @@ class TestScikitsSolvers(unittest.TestCase):
 
         # check solution
         for solution in [solution1, solution2]:
-            np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-            np.testing.assert_array_less(solution.y[-1], 2.5 + 1e-6)
+            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
             var1_soln = np.exp(0.2 * solution.t)
             y0 = np.exp(0.2 * discontinuity)
             var1_soln[solution.t > discontinuity] = y0 * np.exp(
@@ -390,8 +394,8 @@ class TestScikitsSolvers(unittest.TestCase):
 
         # check solution
         for solution in [solution1, solution2]:
-            np.testing.assert_array_less(solution.y[0], 0.55 + 1e-6)
-            np.testing.assert_array_less(solution.y[-1], 1.2 + 1e-6)
+            np.testing.assert_array_less(solution.y[0, :-1], 0.55)
+            np.testing.assert_array_less(solution.y[-1, :-1], 1.2)
             var1_soln = (solution.t % a) ** 2 / 2 + a ** 2 / 2 * (solution.t // a)
             var2_soln = 2 * var1_soln
             np.testing.assert_allclose(solution.y[0], var1_soln, rtol=1e-06)
@@ -571,8 +575,10 @@ class TestScikitsSolvers(unittest.TestCase):
         t_eval = np.linspace(0, 10, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
-        np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-        np.testing.assert_array_less(solution.y[0], 1.25 + 1e-6)
+        np.testing.assert_array_less(solution.y[0:, -1], 1.5)
+        np.testing.assert_array_less(solution.y[0:, -1], 1.25)
+        np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_dae_events_casadi(self):
         # Create model
@@ -597,8 +603,10 @@ class TestScikitsSolvers(unittest.TestCase):
             solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model_disc, t_eval)
-            np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-            np.testing.assert_array_less(solution.y[-1], 2.5 + 1e-6)
+            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+            np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 
@@ -627,8 +635,10 @@ class TestScikitsSolvers(unittest.TestCase):
                 solver = pybamm.ScikitsDaeSolver(rtol=1e-8, atol=1e-8)
             t_eval = np.linspace(0, 5, 100)
             solution = solver.solve(model, t_eval, inputs={"rate 1": 0.1, "rate 2": 2})
-            np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-            np.testing.assert_array_less(solution.y[-1], 2.5 + 1e-6)
+            np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+            np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+            np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+            np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
             np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
             np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
 
@@ -732,8 +742,12 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y[0], 1.5 + 1e-6)
-        np.testing.assert_array_less(step_solution.y[-1], 2.5 + 1e-6)
+        np.testing.assert_array_less(step_solution.y[0, :-1], 1.5)
+        np.testing.assert_array_less(step_solution.y[-1, :-1], 2.5)
+        np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
+        np.testing.assert_array_equal(
+            step_solution.y_event[:, 0], step_solution.y[:, -1]
+        )
         np.testing.assert_array_almost_equal(
             step_solution.y[0], np.exp(0.1 * step_solution.t), decimal=5
         )
@@ -773,8 +787,12 @@ class TestScikitsSolvers(unittest.TestCase):
         while time < end_time:
             step_solution = step_solver.step(step_solution, model, dt=dt, npts=10)
             time += dt
-        np.testing.assert_array_less(step_solution.y[0], 0.55 + 1e-6)
-        np.testing.assert_array_less(step_solution.y[-1], 1.2 + 1e-6)
+        np.testing.assert_array_less(step_solution.y[0, :-1], 0.55)
+        np.testing.assert_array_less(step_solution.y[-1, :-1], 1.2)
+        np.testing.assert_equal(step_solution.t_event[0], step_solution.t[-1])
+        np.testing.assert_array_equal(
+            step_solution.y_event[:, 0], step_solution.y[:, -1]
+        )
         var1_soln = (step_solution.t % a) ** 2 / 2 + a ** 2 / 2 * (step_solution.t // a)
         var2_soln = 2 * var1_soln
         np.testing.assert_array_almost_equal(step_solution.y[0], var1_soln, decimal=5)
@@ -856,8 +874,10 @@ class TestScikitsSolvers(unittest.TestCase):
 
             # check solution
             for solution in [solution1, solution2]:
-                np.testing.assert_array_less(solution.y[0], 1.5 + 1e-6)
-                np.testing.assert_array_less(solution.y[-1], 2.5 + 1e-6)
+                np.testing.assert_array_less(solution.y[0, :-1], 1.5)
+                np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
+                np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+                np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
                 var1_soln = np.exp(0.2 * solution.t)
                 y0 = np.exp(0.2 * discontinuity)
                 var1_soln[solution.t > discontinuity] = y0 * np.exp(

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -101,6 +101,8 @@ class TestScipySolver(unittest.TestCase):
         self.assertLess(len(solution.t), len(t_eval))
         np.testing.assert_array_equal(solution.t[:-1], t_eval[: len(solution.t) - 1])
         np.testing.assert_allclose(solution.y[0], np.exp(-0.1 * solution.t))
+        np.testing.assert_equal(solution.t_event[0], solution.t[-1])
+        np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
 
     def test_model_solver_ode_with_jacobian_python(self):
         # Create model


### PR DESCRIPTION
# Description
Return the solution as well as the termination reason in `get_termination_reason`. This is so that the updated solution (`solution = solution + event_sol`) which includes the event state gets returned by the solver.

Fixes #1343 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
