### PR TITLE
add lines to remove 'tests' from site-packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import subprocess
 from pathlib import Path
 from platform import system
 import wheel.bdist_wheel as orig
+import site
+import shutil
 
 try:
     from setuptools import setup, find_packages, Extension
@@ -221,3 +223,9 @@ setup(
         ]
     },
 )
+
+# pybtex adds a folder "tests" to the site packages, so we manually remove this
+path_to_sitepackages = site.getsitepackages()[0]
+path_to_tests_dir = os.path.join(path_to_sitepackages, "tests")
+if os.path.exists(path_to_tests_dir):
+    shutil.rmtree(path_to_tests_dir)


### PR DESCRIPTION
# Description

`pip install pybtex` installs an unnecessary `tests` directory which messes up running some of the tests in pybamm individually.
This change removes that directory when it is installed via setup.py
