### PR TITLE
update logging info for solutions list

### DIFF
--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -821,14 +821,10 @@ class BaseSolver(object):
         else:
             pybamm.logger.info("Finish solving {} for all inputs".format(model.name))
             pybamm.logger.info(
-                (
-                    "Set-up time: {}, Solve time: {} (of which integration time: {}), "
-                    "Total time: {}"
-                ).format(
+                ("Set-up time: {}, Solve time: {}, Total time: {}").format(
                     solutions[0].set_up_time,
-                    sum([sol.solve_time for sol in solutions]),
-                    sum([sol.integration_time for sol in solutions]),
-                    sum([sol.total_time for sol in solutions]),
+                    solutions[0].solve_time,
+                    solutions[0].total_time,
                 )
             )
 


### PR DESCRIPTION
# Description

I previously updated the logger info so that when calling `solve` for a list of inputs it didn't print the termination reason (since it may be different for each set of inputs). At the same time I changed it so that it returned the sum of the integration, solve and total times. This was the wrong thing to do as it gives the impression that the call to `solve` to ~N times as long as it actually did (for a list on N inputs). I've reverted it back to just print a single set up, solve and total time (note all solutions get given the same solve time, see https://github.com/pybamm-team/PyBaMM/pull/1261). I also removed the integration time info from the logger in this case since it is also different for each set of inputs. Users can still access the integration time for each solution in the list of solutions if they want to.

The logger info when returning a single solution remains unchanged. 
