### PR TITLE
Spectral volume reference

### DIFF
--- a/pybamm/CITATIONS.txt
+++ b/pybamm/CITATIONS.txt
@@ -309,3 +309,15 @@ primaryClass = {physics.app-ph},
   publisher = {The Electrochemical Society},
   doi = {10.1149/2.0281914jes},
 }
+
+@article{Wang2002,
+  title = {Spectral (Finite) Volume Method for Conservation Laws on Unstructured Grids},
+  author = {Wang, Z. J.},
+  journal = {Journal of Computational Physics},
+  volume = {178},
+  number = {1},
+  pages = {210--251},
+  year = {2002},
+  publisher = {Elsevier Science (USA)},
+  doi = {doi:10.1006/jcph.2002.7041},
+}

--- a/pybamm/CITATIONS.txt
+++ b/pybamm/CITATIONS.txt
@@ -319,5 +319,5 @@ primaryClass = {physics.app-ph},
   pages = {210--251},
   year = {2002},
   publisher = {Elsevier Science (USA)},
-  doi = {doi:10.1006/jcph.2002.7041},
+  doi = {10.1006/jcph.2002.7041},
 }

--- a/pybamm/spatial_methods/spectral_volume.py
+++ b/pybamm/spatial_methods/spectral_volume.py
@@ -39,12 +39,21 @@ class SpectralVolume(pybamm.FiniteVolume):
     mesh : :class:`pybamm.Mesh`
         Contains all the submeshes for discretisation
 
+    References
+    ----------
+    .. [2] Z. J. Wang.
+           “Spectral (Finite) Volume Method for Conservation Laws
+           on Unstructured Grids”.
+           Journal of Computational Physics,
+           178:210–251, 2002
+
     **Extends:"": :class:`pybamm.FiniteVolume`
     """
 
     def __init__(self, options=None, order=2):
         self.order = order
         super().__init__(options)
+        pybamm.citations.register("Wang2002")
 
     def chebyshev_collocation_points(self, noe, a=-1.0, b=1.0):
         """

--- a/pybamm/spatial_methods/spectral_volume.py
+++ b/pybamm/spatial_methods/spectral_volume.py
@@ -39,14 +39,6 @@ class SpectralVolume(pybamm.FiniteVolume):
     mesh : :class:`pybamm.Mesh`
         Contains all the submeshes for discretisation
 
-    References
-    ----------
-    .. [2] Z. J. Wang.
-           “Spectral (Finite) Volume Method for Conservation Laws
-           on Unstructured Grids”.
-           Journal of Computational Physics,
-           178:210–251, 2002
-
     **Extends:"": :class:`pybamm.FiniteVolume`
     """
 


### PR DESCRIPTION
# Description

Added the automated reference for Spectral Volumes to CITATIONS.txt. I'm sorry for just realizing now that I forgot it initially.

Should have been part of the merge for issue #900.

## Type of change

Minor (no entry in CHANGELOG.md necessary).
