### PR TITLE
Disable compilation of sundials and scikits.odes on mac

### DIFF
--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -21,8 +21,8 @@ jobs:
         run: |
           asv machine --machine "GitHubRunner"
           # Get IDs of branch and PR commits
-          BASE_COMMIT=$(git rev-parse $GITHUB_BASE_REF)
-          HEAD_COMMIT=$(git rev-parse $GITHUB_HEAD_REF)
+          BASE_COMMIT=$(git rev-parse develop)
+          HEAD_COMMIT=$(git rev-parse HEAD)
           echo $BASE_COMMIT | tee commits_to_compare.txt
           echo $HEAD_COMMIT | tee -a commits_to_compare.txt
           asv run HASHFILE:commits_to_compare.txt --m "GitHubRunner" --show-stderr

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -1,6 +1,6 @@
 name: Run benchmarks on PR
 on:
-  pull_request:
+  push:
 
 jobs:
   benchmarks:

--- a/.github/workflows/benchmark_on_PR.yml
+++ b/.github/workflows/benchmark_on_PR.yml
@@ -1,4 +1,4 @@
-name: Run benchmarks on PR
+name: Run benchmarks on push
 on:
   push:
 

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -47,17 +47,10 @@ jobs:
         sudo apt install gfortran gcc libopenblas-dev graphviz
         sudo apt install python${{ matrix.python-version }}.dev
     
-    # Added fixes to homebrew installs:
-    # rm -f /usr/local/bin/2to3 
-    # (see https://github.com/actions/virtual-environments/issues/2322)
-    # brew unlink gcc@8 gcc@9
-    # (see https://github.com/actions/virtual-environments/issues/2391)
     - name: Install MacOS system dependencies
       if: matrix.os == 'macos-latest'
       run: |
-        rm -f /usr/local/bin/2to3
         brew update
-        brew unlink gcc@8 gcc@9
         brew install graphviz
         brew install openblas
         

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -64,23 +64,23 @@ jobs:
         python -m pip install tox
 
     - name: Install SuiteSparse and Sundials
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: tox -e pybamm-requires
 
-    - name: Run unit tests for GNU/Linux and MacOS
-      if: matrix.os != 'windows-latest'
+    - name: Run unit tests for GNU/Linux
+      if: matrix.os == 'ubuntu-latest'
       run: python -m tox -e tests
 
-    - name: Run unit tests for Windows
-      if: matrix.os == 'windows-latest'
-      run: python -m tox -e windows-tests
+    - name: Run unit tests for Windows and MacOS
+      if: matrix.os != 'ubuntu-latest'
+      run: python -m tox -e mac-windows-tests
 
     - name: Install docs dependencies and run doctests
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: tox -e doctests
     
     - name: Install dev dependencies and run example tests
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-latest'
       run: tox -e examples
         
     - name: Install and run coverage

--- a/tox.ini
+++ b/tox.ini
@@ -2,29 +2,27 @@
 envlist = {windows}-{tests,quick,dev},tests,quick,dev
 
 [testenv]
-platform = !windows: [linux,darwin]
-           windows: win32
 skipsdist = true
 skip_install = flake8: true	     
 usedevelop = true
-passenv = !windows: SUNDIALS_INST
-whitelist_externals = !windows: sh
+passenv = !windows-!mac: SUNDIALS_INST
+whitelist_externals = !windows-!mac: sh
 setenv =
-       !windows: SUNDIALS_INST = {env:SUNDIALS_INST:{homedir}/.local}
-       !windows: LD_LIBRARY_PATH = {homedir}/.local/lib{:}{env:LD_LIBRARY_PATH:}
+       !windows-!mac: SUNDIALS_INST = {env:SUNDIALS_INST:{homedir}/.local}
+       !windows-!mac: LD_LIBRARY_PATH = {homedir}/.local/lib{:}{env:LD_LIBRARY_PATH:}
 deps =
-     dev-!windows: cmake
+     dev-!windows-!mac: cmake
      dev: black
      dev: flake8
      dev,doctests: sphinx>=1.5
      dev,doctests: guzzle-sphinx-theme
-     !windows: scikits.odes
+     !windows-!mac: scikits.odes
      
 commands =
 	 tests: python run-tests.py --unit --folder all
 	 quick: python run-tests.py --unit
 	 examples: python run-tests.py --examples
-	 dev-!windows: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
+	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
 	 doctests: python run-tests.py --doctest
 
 [testenv:pybamm-requires]


### PR DESCRIPTION
# Description
Since 03/02/2021 the scheduled "PyBaMM" workflow fails on mac for all python versions.
See https://github.com/pybamm-team/PyBaMM/actions/runs/532703527
The logs indicate that CMake cannot find the fortran compiler, and therefore Sundials isn't compiled... and the installation of scikits.odes fails.

Until a solution is found, this disables the compilation of sundials, as well as the installation of scikits.odes, on macos.
