### PR TITLE
Issue 1363 length scale bug

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -302,7 +302,7 @@
         "code",
         "example",
         "doc",
-        "test",
+        "test"
       ]
     },
     {

--- a/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
+++ b/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
@@ -30,7 +30,7 @@ class BaseModel(pybamm.BaseBatteryModel):
             "negative electrode": self.param.L_x,
             "separator": self.param.L_x,
             "positive electrode": self.param.L_x,
-            "current collector y": self.param.L_y,
+            "current collector y": self.param.L_z,
             "current collector z": self.param.L_z,
         }
 

--- a/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -27,7 +27,7 @@ class BaseModel(pybamm.BaseBatteryModel):
             "positive electrode": self.param.L_x,
             "negative particle": self.param.R_n_typ,
             "positive particle": self.param.R_p_typ,
-            "current collector y": self.param.L_y,
+            "current collector y": self.param.L_z,
             "current collector z": self.param.L_z,
         }
         self.set_standard_output_variables()

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -62,7 +62,7 @@ class BasicDFNHalfCell(BaseModel):
             "working electrode": param.L_x,
             "separator": param.L_x,
             "working particle": R_w_typ,
-            "current collector y": param.L_y,
+            "current collector y": param.L_z,
             "current collector z": param.L_z,
         }
 
@@ -222,7 +222,7 @@ class BasicDFNHalfCell(BaseModel):
         # derivatives
         self.boundary_conditions[c_s_w] = {
             "left": (pybamm.Scalar(0), "Neumann"),
-            "right": (-C_w * j_w / a_R_w / gamma_w / D_w(c_s_surf_w, T), "Neumann",),
+            "right": (-C_w * j_w / a_R_w / gamma_w / D_w(c_s_surf_w, T), "Neumann"),
         }
 
         # c_w_init can in general be a function of x
@@ -249,10 +249,7 @@ class BasicDFNHalfCell(BaseModel):
         i_s_w = -sigma_eff_w * pybamm.grad(phi_s_w)
         self.boundary_conditions[phi_s_w] = {
             "left": (pybamm.Scalar(0), "Neumann"),
-            "right": (
-                i_cell / pybamm.boundary_value(-sigma_eff_w, "right"),
-                "Neumann",
-            ),
+            "right": (i_cell / pybamm.boundary_value(-sigma_eff_w, "right"), "Neumann"),
         }
         self.algebraic[phi_s_w] = pybamm.div(i_s_w) + j_w
         # Initial conditions must also be provided for algebraic equations, as an

--- a/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
+++ b/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
@@ -42,7 +42,7 @@ class EffectiveResistance(pybamm.BaseModel):
 
         # Set default length scales
         self.length_scales = {
-            "current collector y": self.param.L_y,
+            "current collector y": self.param.L_z,
             "current collector z": self.param.L_z,
         }
 
@@ -318,7 +318,7 @@ class AlternativeEffectiveResistance2D(pybamm.BaseModel):
 
         # Set default length scales
         self.length_scales = {
-            "current collector y": self.param.L_y,
+            "current collector y": self.param.L_z,
             "current collector z": self.param.L_z,
         }
 


### PR DESCRIPTION
# Description

Changes the "current collector y" length scale from `L_y` to `L_z`. This is because both the y- and z-directions should be scaled with `L_z` when non-dimensionalising (otherwise there is an awkward extra factor of `L_y/L_z` in the 2D Laplacian for the current collector problem).

Fixes #1363 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
