### PR TITLE
Update contibuting guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,7 +360,7 @@ wherever code is called that uses that citation (for example, in functions or in
 
 ## Benchmarks
 
-A benchmark suite is located in the `benchmarks` directory at the root of the PyBaMM project. These benchamrks can be run using [airspeed velocity](https://asv.readthedocs.io/en/stable/)
+A benchmark suite is located in the `benchmarks` directory at the root of the PyBaMM project. These benchmarks can be run using [airspeed velocity](https://asv.readthedocs.io/en/stable/) (`asv`).
 
 ### Running the benchmarks
 First of all, you'll need `asv` installed:
@@ -372,27 +372,26 @@ To run the benchmarks for the latest commit on the `develop` branch, simply ente
 ```shell
 asv run
 ```
-If it's the first time you run `asv`, you will be prompted for information about your machine (e.g. its name, operating system, architecture...).
+If it is the first time you run `asv`, you will be prompted for information about your machine (e.g. its name, operating system, architecture...).
 
 Running the benchmarks can take a while, as all benchmarks are repeated several times to ensure statistically significant results. If accuracy isn't an issue, use the `--quick` option to avoid repeating each benchmark multiple times.
 ```shell
 asv run --quick
 ```
 
-Benchmarks can also be run over a range of commits. For instance, the following runs the benchmark suite over every commit between version `0.3` and the tip of the
-`develop` branch:
+Benchmarks can also be run over a range of commits. For instance, the following command runs the benchmark suite over every commit between version `0.3` and the tip of the `develop` branch:
 ```shell
 asv run v0.3..develop
 ```
 Further information on how to run benchmarks with `asv` can be found in the documentation at [Using airspeed velocity](https://asv.readthedocs.io/en/stable/using.html).
 
-The benchmark configuration file is named `asv.conf.json` and can be found at the root of the PyBaMM project, see the [asv reference](https://asv.readthedocs.io/en/stable/reference.html) for details on available settings and options.
+`asv` is configured using a file `asv.conf.json` located at the root of the PyBaMM repository. See the [asv reference](https://asv.readthedocs.io/en/stable/reference.html) for details on available settings and options.
 
 Benchmark results are stored in a directory `results/` at the location of the configuration file. There is one result file per commit, per machine.
 
 ### Visualising benchmark results
 
-`asv` is able to generate a static website with a visualisation of the benchmarks results, i.e. the benchmark duration as a function of the commit hash.
+`asv` is able to generate a static website with a visualisation of the benchmarks results, i.e. the benchmark's duration as a function of the commit hash.
 To generate the website, use
 ```shell
 asv publish
@@ -436,10 +435,9 @@ class TimeSPM:
 
 Similarly, a `teardown` method will be run after the benchmark. Note that, unless the `--quick` option is used, benchmarks are executed several times for accuracy, and both the `setup` and `teardown` function are executed before/after each repetition.
 
-Running benchmarks can take a while, and by default encountered exceptions will not
-be shown. When developing benchmarks, it is often convenient to use the following command instead of `asv run`:
+Running benchmarks can take a while, and by default encountered exceptions will not be shown. When developing benchmarks, it is often convenient to use the following command instead of `asv run`:
 ```shell
-as dev
+asv dev
 ```
 
 `asv dev` implies options `--quick`, `--show-stderr`, and `--dry-run` (to avoid updating the `results` directory).
@@ -462,9 +460,9 @@ Note that this file must be kept in sync with the version number in [pybamm/__in
 
 Each change pushed to the PyBaMM GitHub repository will trigger the test and benchmark suites to be run, using [GitHub actions](https://github.com/features/actions).
 
-Tests are run for different operating systems, and for all python versions officially supported by PyBaMM. If you opened a Pull Request, feedback is directly available on your PR's page. If all tests pass, a green tick will be displayed next to the corresponding test run. If one or more test(s) fail, a red cross will be displayed instead.
+Tests are run for different operating systems, and for all python versions officially supported by PyBaMM. If you opened a Pull Request, feedback is directly available on the corresponding page. If all tests pass, a green tick will be displayed next to the corresponding test run. If one or more test(s) fail, a red cross will be displayed instead.
 
-Similarly, the benchmark suite is automatically run for the most recently pushed commit. Benchmarks results are compared to the results available for the latest commit on the `develop` branch. Should any significant performance regression be found, a red cross will be displayed next to the benchmark run.
+Similarly, the benchmark suite is automatically run for the most recently pushed commit. Benchmark results are compared to the results available for the latest commit on the `develop` branch. Should any significant performance regression be found, a red cross will be displayed next to the benchmark run.
 
 In all cases, more details can be obtained by clicking on a specific run.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -458,23 +458,17 @@ setup.py
 
 Note that this file must be kept in sync with the version number in [pybamm/__init__.py](pybamm/__init__.py).
 
-### Travis CI
+### Continuous Integration using GitHub actions
 
-All committed code is tested using [Travis CI](https://travis-ci.org/), tests are published on https://travis-ci.org/pybamm-team/PyBaMM.
+Each change pushed to the PyBaMM GitHub repository will trigger the test and benchmark suites to be run, using [GitHub actions](https://github.com/features/actions).
 
-Configuration files:
+Tests are run for different operating systems, and for all python versions officially supported by PyBaMM. If you opened a Pull Request, feedback is directly available on your PR's page. If all tests pass, a green tick will be displayed next to the corresponding test run. If one or more test(s) fail, a red cross will be displayed instead.
 
-```
-.travis.yaml
-```
+Similarly, the benchmark suite is automatically run for the most recently pushed commit. Benchmarks results are compared to the results available for the latest commit on the `develop` branch. Should any significant performance regression be found, a red cross will be displayed next to the benchmark run.
 
-For every commit, Travis runs unit tests, integration tests, doc tests, flake8 and notebook tests.
-<!-- Unit tests and flake8 testing is done for every commit. A nightly cronjob also tests the notebooks. Notebooks listed in `.slow-books` are excluded from these tests. -->
+In all cases, more details can be obtained by clicking on a specific run.
 
-<!-- ### Appveyor
-
- -->
-
+Configuration files for various GitHub actions workflow can be found in `.github/worklfows`.
 
 ### Codecov
 
@@ -483,7 +477,7 @@ Code coverage (how much of our code is actually seen by the (linux) unit tests) 
 Configuration files:
 
 ```
-.coveragerc
+tox.ini
 ```
 
 ### Read the Docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -358,6 +358,92 @@ pybamm.citations.register("your_paper_bibtex_identifier")
 
 wherever code is called that uses that citation (for example, in functions or in the `__init__` method of a class such as a model or solver).
 
+## Benchmarks
+
+A benchmark suite is located in the `benchmarks` directory at the root of the PyBaMM project. These benchamrks can be run using [airspeed velocity](https://asv.readthedocs.io/en/stable/)
+
+### Running the benchmarks
+First of all, you'll need `asv` installed:
+```shell
+pip install asv
+```
+
+To run the benchmarks for the latest commit on the `develop` branch, simply enter the following command:
+```shell
+asv run
+```
+If it's the first time you run `asv`, you will be prompted for information about your machine (e.g. its name, operating system, architecture...).
+
+Running the benchmarks can take a while, as all benchmarks are repeated several times to ensure statistically significant results. If accuracy isn't an issue, use the `--quick` option to avoid repeating each benchmark multiple times.
+```shell
+asv run --quick
+```
+
+Benchmarks can also be run over a range of commits. For instance, the following runs the benchmark suite over every commit between version `0.3` and the tip of the
+`develop` branch:
+```shell
+asv run v0.3..develop
+```
+Further information on how to run benchmarks with `asv` can be found in the documentation at [Using airspeed velocity](https://asv.readthedocs.io/en/stable/using.html).
+
+The benchmark configuration file is named `asv.conf.json` and can be found at the root of the PyBaMM project, see the [asv reference](https://asv.readthedocs.io/en/stable/reference.html) for details on available settings and options.
+
+Benchmark results are stored in a directory `results/` at the location of the configuration file. There is one result file per commit, per machine.
+
+### Visualising benchmark results
+
+`asv` is able to generate a static website with a visualisation of the benchmarks results, i.e. the benchmark duration as a function of the commit hash.
+To generate the website, use
+```shell
+asv publish
+```
+then, to view the website:
+```shell
+asv preview
+```
+
+Current benchmarks over PyBaMM's history can be viewed at https://pybamm-team.github.io/pybamm-bench/
+
+### Adding benchmarks
+
+To contribute benchmarks to PyBaMM, add a new benchmark function in one of the files in the `benchmarks/` directory.
+Benchmarks are distributed across multiple files, grouped by theme. You're welcome to add a new file if none of your benchmarks fit into one of the already existing files.
+Inside a benchmark file (e.g. `benchmarks/benchmarks.py`) benchmarks functions are grouped within classes.
+
+Note that benchmark functions _must_ start with the prefix `time_`, for instance
+```python3
+def time_solve_SPM_ScipySolver(self):
+        solver = pb.ScipySolver()
+        solver.solve(self.model, [0, 3600])
+```
+
+In the case where some setup is necessary, but should not be timed, a `setup` function
+can be defined as a method of the relevant class. For example:
+```python3
+class TimeSPM:
+    def setup(self):
+        model = pb.lithium_ion.SPM()
+        geometry = model.default_geometry
+
+	    # ...
+
+        self.model = model
+
+    def time_solve_SPM_ScipySolver(self):
+        solver = pb.ScipySolver()
+        solver.solve(self.model, [0, 3600])
+```
+
+Similarly, a `teardown` method will be run after the benchmark. Note that, unless the `--quick` option is used, benchmarks are executed several times for accuracy, and both the `setup` and `teardown` function are executed before/after each repetition.
+
+Running benchmarks can take a while, and by default encountered exceptions will not
+be shown. When developing benchmarks, it is often convenient to use the following command instead of `asv run`:
+```shell
+as dev
+```
+
+`asv dev` implies options `--quick`, `--show-stderr`, and `--dry-run` (to avoid updating the `results` directory).
+
 ## Infrastructure
 
 ### Setuptools


### PR DESCRIPTION
Add a section about running benchmarks with `asv` as well as adding new benchmarks.

Update the section on CI to mention GitHub actions instead of Travis CI
