### PR TITLE
Make benchmark_on_push pass for merge commits on develop

### DIFF
--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -15,7 +15,13 @@ jobs:
         run: pip install -U pip virtualenv asv
       - name: Fetch base branch
         run: |
-          git fetch origin develop:develop
+          # This workflow also runs for merge commits
+          # on develop. In this case, we don't want to be
+          # fetching the develop branch.
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          if [ $current_branch != "develop" ]; then
+              git fetch origin develop:develop
+          fi
       - name: Run benchmarks
         run: |
           asv machine --machine "GitHubRunner"


### PR DESCRIPTION
Merges are also push events and therefore the benchmark_on_push workflow also runs for merge commits.
So needed to add a condition to avoid fetching the develop branch when workflow runs for a merge commit on develop.