### PR TITLE
Remove OCV from ECM resistance definition

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -901,14 +901,8 @@ class BaseBatteryModel(pybamm.BaseModel):
         i_cc = self.variables["Current collector current density"]
         i_cc_dim = self.variables["Current collector current density [A.m-2]"]
         # Gather all overpotentials
-        v_ecm = -(eta_ocv + eta_r_av + eta_c_av + eta_e_av + delta_phi_s_av)
-        v_ecm_dim = -(
-            eta_ocv_dim
-            + eta_r_av_dim
-            + eta_c_av_dim
-            + eta_e_av_dim
-            + delta_phi_s_av_dim
-        )
+        v_ecm = -(eta_r_av + eta_c_av + eta_e_av + delta_phi_s_av)
+        v_ecm_dim = -(eta_r_av_dim + eta_c_av_dim + eta_e_av_dim + delta_phi_s_av_dim)
         # Current collector area for turning resistivity into resistance
         A_cc = self.param.A_cc
 

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -861,9 +861,8 @@ class BaseBatteryModel(pybamm.BaseModel):
         )
 
         # Battery-wide variables
+        V = self.variables["Terminal voltage"]
         V_dim = self.variables["Terminal voltage [V]"]
-        eta_e_av = self.variables["X-averaged electrolyte ohmic losses"]
-        eta_c_av = self.variables["X-averaged concentration overpotential"]
         eta_e_av_dim = self.variables["X-averaged electrolyte ohmic losses [V]"]
         eta_c_av_dim = self.variables["X-averaged concentration overpotential [V]"]
         num_cells = pybamm.Parameter(
@@ -900,9 +899,9 @@ class BaseBatteryModel(pybamm.BaseModel):
         # based on Ohm's Law
         i_cc = self.variables["Current collector current density"]
         i_cc_dim = self.variables["Current collector current density [A.m-2]"]
-        # Gather all overpotentials
-        v_ecm = -(eta_r_av + eta_c_av + eta_e_av + delta_phi_s_av)
-        v_ecm_dim = -(eta_r_av_dim + eta_c_av_dim + eta_e_av_dim + delta_phi_s_av_dim)
+        # ECM overvoltage is OCV minus terminal voltage
+        v_ecm = ocv - V
+        v_ecm_dim = ocv_dim - V_dim
         # Current collector area for turning resistivity into resistance
         A_cc = self.param.A_cc
 
@@ -928,18 +927,17 @@ class BaseBatteryModel(pybamm.BaseModel):
         )
 
         # Cut-off voltage
-        voltage = self.variables["Terminal voltage"]
         self.events.append(
             pybamm.Event(
                 "Minimum voltage",
-                voltage - self.param.voltage_low_cut,
+                V - self.param.voltage_low_cut,
                 pybamm.EventType.TERMINATION,
             )
         )
         self.events.append(
             pybamm.Event(
                 "Maximum voltage",
-                voltage - self.param.voltage_high_cut,
+                V - self.param.voltage_high_cut,
                 pybamm.EventType.TERMINATION,
             )
         )


### PR DESCRIPTION
# Description

To address #1377, this removes the OCV (difference between current OCV and initial OCV) from the definition of the `Local ECM resistance`. The `Change in measured open circuit voltage` variable is left untouched.

Fixes #1377

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works

## TO DO

- [ ] Add to changelog

## Screenshot

Same plot as in #1377, after change:

<img width="581" alt="grafik" src="https://user-images.githubusercontent.com/10965193/107689293-f07d9680-6ca8-11eb-9043-fc8b84ae5a92.png">

