### PR TITLE
run black and flake8

### DIFF
--- a/examples/scripts/custom_model.py
+++ b/examples/scripts/custom_model.py
@@ -59,12 +59,12 @@ model.submodels[
 ] = pybamm.electrolyte_conductivity.LeadingOrder(model.param)
 model.submodels["negative sei"] = pybamm.sei.NoSEI(model.param, "Negative")
 model.submodels["positive sei"] = pybamm.sei.NoSEI(model.param, "Positive")
-model.submodels[
-    "negative lithium plating"
-] = pybamm.lithium_plating.NoPlating(model.param, "Negative")
-model.submodels[
-    "positive lithium plating"
-] = pybamm.lithium_plating.NoPlating(model.param, "Positive")
+model.submodels["negative lithium plating"] = pybamm.lithium_plating.NoPlating(
+    model.param, "Negative"
+)
+model.submodels["positive lithium plating"] = pybamm.lithium_plating.NoPlating(
+    model.param, "Positive"
+)
 
 # build model
 model.build_model()

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -99,9 +99,7 @@ class Citations:
         else:
             raise pybamm.OptionError(
                 "Output format {} not recognised."
-                "It should be 'text' or 'bibtex'.".format(
-                    output_format
-                )
+                "It should be 'text' or 'bibtex'.".format(output_format)
             )
 
         if filename is None:

--- a/pybamm/geometry/half_cell_geometry.py
+++ b/pybamm/geometry/half_cell_geometry.py
@@ -47,9 +47,7 @@ def half_cell_geometry(
     }
     # Add particle domains
     if include_particles is True:
-        geometry.update(
-            {"working particle": {var.r_w: {"min": 0, "max": 1}}}
-        )
+        geometry.update({"working particle": {var.r_w: {"min": 0, "max": 1}}})
 
     if current_collector_dimension == 0:
         geometry["current collector"] = {var.z: {"position": 1}}

--- a/pybamm/input/parameters/lithium-ion/negative_electrodes/graphite_Chen2020_plating/graphite_LGM50_diffusivity_Chen2020.py
+++ b/pybamm/input/parameters/lithium-ion/negative_electrodes/graphite_Chen2020_plating/graphite_LGM50_diffusivity_Chen2020.py
@@ -3,28 +3,28 @@ from pybamm import exp, constants
 
 def graphite_LGM50_diffusivity_Chen2020(sto, T):
     """
-      LG M50 Graphite diffusivity as a function of stochiometry, in this case the
-      diffusivity is taken to be a constant. The value is taken from [1].
+    LG M50 Graphite diffusivity as a function of stochiometry, in this case the
+    diffusivity is taken to be a constant. The value is taken from [1].
 
-      References
-      ----------
-      .. [1] Chang-Hui Chen, Ferran Brosa Planella, Kieran O’Regan, Dominika Gastol, W.
-      Dhammika Widanage, and Emma Kendrick. "Development of Experimental Techniques for
-      Parameterization of Multi-scale Lithium-ion Battery Models." Journal of the
-      Electrochemical Society 167 (2020): 080534.
+    References
+    ----------
+    .. [1] Chang-Hui Chen, Ferran Brosa Planella, Kieran O’Regan, Dominika Gastol, W.
+    Dhammika Widanage, and Emma Kendrick. "Development of Experimental Techniques for
+    Parameterization of Multi-scale Lithium-ion Battery Models." Journal of the
+    Electrochemical Society 167 (2020): 080534.
 
-      Parameters
-      ----------
-      sto: :class:`pybamm.Symbol`
-         Electrode stochiometry
-      T: :class:`pybamm.Symbol`
-         Dimensional temperature
+    Parameters
+    ----------
+    sto: :class:`pybamm.Symbol`
+       Electrode stochiometry
+    T: :class:`pybamm.Symbol`
+       Dimensional temperature
 
-      Returns
-      -------
-      :class:`pybamm.Symbol`
-         Solid diffusivity
-   """
+    Returns
+    -------
+    :class:`pybamm.Symbol`
+       Solid diffusivity
+    """
 
     D_ref = 3.3e-14
     E_D_s = 3.03e4

--- a/pybamm/models/submodels/interface/lithium_plating/base_plating.py
+++ b/pybamm/models/submodels/interface/lithium_plating/base_plating.py
@@ -78,7 +78,9 @@ class BasePlating(BaseInterface):
             * L_scale,
             f"Loss of Li to {domain} lithium plating [mol]": Q_plated_Li * c_scale,
             f"Loss of capacity to {domain} lithium plating [A.h]": Q_plated_Li
-            * c_scale * param.F / 3600,
+            * c_scale
+            * param.F
+            / 3600,
         }
 
         return variables

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -739,9 +739,9 @@ class LithiumIonParameters:
         self.c_plated_Li_0 = self.c_plated_Li_0_dim / self.c_e_typ
 
         # ratio of lithium plating reaction scaled to intercalation reaction
-        self.Gamma_plating = (
-            self.a_n_typ * self.j_scale_n * self.tau_discharge
-        ) / (self.F * self.c_e_typ)
+        self.Gamma_plating = (self.a_n_typ * self.j_scale_n * self.tau_discharge) / (
+            self.F * self.c_e_typ
+        )
 
         # Initial conditions
         self.epsilon_n_init = pybamm.Parameter("Negative electrode porosity")

--- a/pybamm/parameters/parameter_sets.py
+++ b/pybamm/parameters/parameter_sets.py
@@ -175,6 +175,7 @@ Ai2020 = {
 #
 # Lead-acid
 #
+
 Sulzer2019 = {
     "chemistry": "lead-acid",
     "cell": "BBOXX_Sulzer2019",

--- a/pybamm/solvers/jax_bdf_solver.py
+++ b/pybamm/solvers/jax_bdf_solver.py
@@ -715,7 +715,10 @@ def block_diag(lst):
             return Ai
         else:
             return onp.zeros(
-                (Ai.shape[0] if Ai.ndim > 1 else 1, Aj.shape[1] if Aj.ndim > 1 else 1,),
+                (
+                    Ai.shape[0] if Ai.ndim > 1 else 1,
+                    Aj.shape[1] if Aj.ndim > 1 else 1,
+                ),
                 dtype=Ai.dtype,
             )
 

--- a/tests/integration/test_models/standard_model_tests.py
+++ b/tests/integration/test_models/standard_model_tests.py
@@ -128,9 +128,7 @@ class OptimisationsTest(object):
 
         self.model = model
 
-    def evaluate_model(
-        self, use_known_evals=False, to_python=False, to_jax=False
-    ):
+    def evaluate_model(self, use_known_evals=False, to_python=False, to_jax=False):
         result = np.empty((0, 1))
         for eqn in [self.model.concatenated_rhs, self.model.concatenated_algebraic]:
 

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -294,7 +294,7 @@ class TestSymbol(unittest.TestCase):
 
     def test_simplify(self):
         a = pybamm.Parameter("A")
-        #test error
+        # test error
         with self.assertRaisesRegex(
             pybamm.ModelError, "simplify is deprecated as it now has no effect"
         ):

--- a/tests/unit/test_parameters/test_lead_acid_parameters.py
+++ b/tests/unit/test_parameters/test_lead_acid_parameters.py
@@ -100,7 +100,7 @@ class TestStandardParametersLeadAcid(unittest.TestCase):
     def test_thermal_parameters(self):
         values = pybamm.lead_acid.BaseModel().default_parameter_values
         param = pybamm.LeadAcidParameters()
-        T = 1   # dummy temperature as the values are constant
+        T = 1  # dummy temperature as the values are constant
 
         # Density
         self.assertAlmostEqual(values.evaluate(param.rho_cn(T)), 0.8810, places=2)

--- a/tests/unit/test_parameters/test_lithium_ion_parameters.py
+++ b/tests/unit/test_parameters/test_lithium_ion_parameters.py
@@ -167,7 +167,7 @@ class TestDimensionlessParameterValues(unittest.TestCase):
         values = pybamm.lithium_ion.BaseModel().default_parameter_values
         param = pybamm.LithiumIonParameters()
         c_rate = param.i_typ / 24
-        T = 1   # dummy temperature as the values are constant
+        T = 1  # dummy temperature as the values are constant
 
         # Density
         np.testing.assert_almost_equal(values.evaluate(param.rho_cn(T)), 1.9019, 2)

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -95,8 +95,9 @@ class TestParameterValues(unittest.TestCase):
     def test_check_parameter_values(self):
         # Cell capacity [A.h] deprecated
         with self.assertRaisesRegex(ValueError, "Cell capacity"):
-            pybamm.ParameterValues({"Cell capacity [A.h]": 1,
-                                    "Nominal cell capacity [A.h]": 1})
+            pybamm.ParameterValues(
+                {"Cell capacity [A.h]": 1, "Nominal cell capacity [A.h]": 1}
+            )
         with self.assertWarnsRegex(DeprecationWarning, "Cell capacity"):
             pybamm.ParameterValues({"Cell capacity [A.h]": 1})
         # Can't provide a current density of 0, as this will cause a ZeroDivision error


### PR DESCRIPTION
# Description

I found various formatting and styling mistakes so I ran `black .` and `flake8`


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
