### PR TITLE
Replaced all occurrences of 'Binder' with 'Google Colab'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -482,15 +482,9 @@ tox.ini
 
 Documentation is built using https://readthedocs.org/ and published on http://pybamm.readthedocs.io/.
 
-### Binder
+### Google Colab
 
-Editable notebooks are made available using [Binder](mybinder.readthedocs.io) at https://mybinder.org/v2/gh/pybamm-team/PyBaMM/master.
-
-Configuration files:
-
-```
-postBuild
-```
+Editable notebooks are made available using [Google Colab](https://colab.research.google.com/notebooks/intro.ipynb) [here](https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/master/).
 
 ### GitHub
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Examples
 Detailed examples can be viewed on the
 `GitHub examples page <https://github.com/pybamm-team/PyBaMM/tree/master/examples/notebooks>`_,
 and run locally using ``jupyter notebook``, or online through
-`Binder <https://mybinder.org/v2/gh/pybamm-team/PyBaMM/master?filepath=examples%2Fnotebooks>`_.
+`Google Colab <https://colab.research.google.com/github/pybamm-team/PyBaMM/blob/master/>`_.
 
 Contributing
 ============


### PR DESCRIPTION
# Description

A simple documentation fix replacing ```Binder``` with ```Google Colab```. I searched in the documentation and there were only 2 such occurrences I could find. I could not find any configuration files for Google Colab, if there is one or if any changes are required in this PR, please let me know. Thank you! 

Fixes #1390 

## Type of change

Changed Docs ( CONTRIBUTING.md and docs/index.rst )

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
