### PR TITLE
#1393 end simulation when experiment infeasible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Bug fixes
 
+-   Simulations now stop when an experiment becomes infeasible ([#1395](https://github.com/pybamm-team/PyBaMM/pull/1395))
 -   Added a check for domains in `Concatenation` ([#1368](https://github.com/pybamm-team/PyBaMM/pull/1368))
 -   Differentiation now works even when the differentiation variable is a constant ([#1294](https://github.com/pybamm-team/PyBaMM/pull/1294))
 -   Fixed a bug where the event time and state were no longer returned as part of the solution ([#1344](https://github.com/pybamm-team/PyBaMM/pull/1344))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ If you want to check integration tests as well as unit tests, type
 ```bash
 tox -e tests # (GNU/Linux and MacOS)
 #
-python -m tox -e windows-tests (Windows)
+python -m tox -e windows-tests # (Windows)
 ```
 
 When you commit anything to PyBaMM, these checks will also be run automatically (see [infrastructure](#infrastructure)).
@@ -216,7 +216,7 @@ To test all example scripts and notebooks, type
 ```bash
 tox -e examples # (GNU/Linux and MacOS)
 #
-python -m tox -e windows-examples (Windows)
+python -m tox -e windows-examples # (Windows)
 ```
 
 If notebooks fail because of changes to pybamm, it can be a bit of a hassle to debug. In these cases, you can create a temporary export of a notebook's Python content using
@@ -340,7 +340,7 @@ Where possible, notebooks are tested daily. A list of slow notebooks (which time
 
 ## Citations
 
-We aim to recognize all contributions by automatically generating citations to the relevant papers on which different parts of the code are built. 
+We aim to recognize all contributions by automatically generating citations to the relevant papers on which different parts of the code are built.
 These will change depending on what models and solvers you use.
 Adding the command
 

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -68,6 +68,22 @@ class TestExperiments(unittest.TestCase):
             [cap / 20] * 11 + [0] * 10 + ([cap / 20] * 10 + [0] * 10) * 9,
         )
 
+    def test_infeasible(self):
+        experiment = pybamm.Experiment(
+            [
+                ("Discharge at 1C for 0.5 hours",),
+            ]
+            * 4
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model, experiment=experiment, solver=pybamm.CasadiSolver()
+        )
+        sol = sim.solve()
+        # this experiment fails during the third cycle (i.e. is infeasible)
+        # so we should just return the successful cycles (2 in this case)
+        self.assertEqual(len(sol.cycles), 2)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description
Makes it so that simulations stop when an experiment becomes infeasible 

Fixes #1393 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
