### PR TITLE
Added 'operating mode' to the doc string of BaseBatteryModel class

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -79,13 +79,13 @@ class BaseBatteryModel(pybamm.BaseModel):
                 - "none": :class:`pybamm.sei.NoSEI` (no SEI growth)
                 - "constant": :class:`pybamm.sei.Constant` (constant SEI thickness)
                 - "reaction limited": :class:`pybamm.sei.ReactionLimited`
-                - "solvent-diffusion limited":
+                - "solvent-diffusion limited":\
                     :class:`pybamm.sei.SolventDiffusionLimited`
-                - "electron-migration limited":
+                - "electron-migration limited": \
                     :class:`pybamm.sei.ElectronMigrationLimited`
-                - "interstitial-diffusion limited":
+                - "interstitial-diffusion limited": \
                     :class:`pybamm.sei.InterstitialDiffusionLimited`
-                - "ec reaction limited":
+                - "ec reaction limited": \
                     :class:`pybamm.sei.EcReactionLimited`
             * "sei film resistance" : str
                 Set the submodel for additional term in the overpotential due to SEI.
@@ -105,8 +105,8 @@ class BaseBatteryModel(pybamm.BaseModel):
                         \\eta_r = \\frac{F}{RT}
                         * (\\phi_s - \\phi_e - U - R_{sei} * L_{sei} * j)
 
-                - "average": constant additional resistance term (approximation to the
-                    true model). This model can give similar results to the
+                - "average": constant additional resistance term (approximation to the \
+                    true model). This model can give similar results to the \
                     "distributed" case without needing to make j an algebraic state\
 
                     .. math::

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -79,13 +79,13 @@ class BaseBatteryModel(pybamm.BaseModel):
                 - "none": :class:`pybamm.sei.NoSEI` (no SEI growth)
                 - "constant": :class:`pybamm.sei.Constant` (constant SEI thickness)
                 - "reaction limited": :class:`pybamm.sei.ReactionLimited`
-                - "solvent-diffusion limited": \
+                - "solvent-diffusion limited":
                     :class:`pybamm.sei.SolventDiffusionLimited`
-                - "electron-migration limited": \
+                - "electron-migration limited":
                     :class:`pybamm.sei.ElectronMigrationLimited`
-                - "interstitial-diffusion limited": \
+                - "interstitial-diffusion limited":
                     :class:`pybamm.sei.InterstitialDiffusionLimited`
-                - "ec reaction limited": \
+                - "ec reaction limited":
                     :class:`pybamm.sei.EcReactionLimited`
             * "sei film resistance" : str
                 Set the submodel for additional term in the overpotential due to SEI.
@@ -105,8 +105,8 @@ class BaseBatteryModel(pybamm.BaseModel):
                         \\eta_r = \\frac{F}{RT}
                         * (\\phi_s - \\phi_e - U - R_{sei} * L_{sei} * j)
 
-                - "average": constant additional resistance term (approximation to the \
-                    true model). This model can give similar results to the \
+                - "average": constant additional resistance term (approximation to the
+                    true model). This model can give similar results to the
                     "distributed" case without needing to make j an algebraic state\
 
                     .. math::
@@ -130,6 +130,13 @@ class BaseBatteryModel(pybamm.BaseModel):
                 solve an algebraic equation for it. Default is "false", unless "sei film
                 resistance" is distributed in which case it is automatically set to
                 "true".
+            * "operating mode" : str
+                Sets the operating mode for the model. Can be "current" (default),
+                "voltage" or "power". Alternatively, the operating mode can be
+                controlled with an arbitrary function by passing the function directly
+                as the option. In this case the function must define the residual of
+                an algebraic equation. The applied current will be solved for such
+                that the algebraic constraint is satisfied.
 
     **Extends:** :class:`pybamm.BaseModel`
     """


### PR DESCRIPTION
# Description

1. Added description for 'operating mode' parameter in BaseBatteryModel class.
2. Deleted '\\' from some lines to format the displayed output. With '\\', the output was behaving weirdly as displayed in the screenshot below (The line, where "average"  is described, was breaking up with huge spaces in between).
![image](https://user-images.githubusercontent.com/74055102/109320922-979c2980-7876-11eb-99ef-770f40f56dad.png)

Please let me know if you want any changes or additions in the PR. Thanks!


Fixes #1388 

## Type of change

Doc string addition

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues
- [x] All tests pass
- [x] The documentation builds


## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
