### PR TITLE
#1406 fixed bug with positive electrode ohmic losses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ## Bug fixes
 
+-   Fixed a sign error in the positive electrode ohmic losses ([#1407](https://github.com/pybamm-team/PyBaMM/pull/1407))
 -   Simulations now stop when an experiment becomes infeasible ([#1395](https://github.com/pybamm-team/PyBaMM/pull/1395))
 -   Added a check for domains in `Concatenation` ([#1368](https://github.com/pybamm-team/PyBaMM/pull/1368))
 -   Differentiation now works even when the differentiation variable is a constant ([#1294](https://github.com/pybamm-team/PyBaMM/pull/1294))

--- a/pybamm/models/submodels/electrode/base_electrode.py
+++ b/pybamm/models/submodels/electrode/base_electrode.py
@@ -53,7 +53,7 @@ class BaseElectrode(pybamm.BaseSubModel):
             phi_s_av_dim = param.U_p_ref - param.U_n_ref + pot * phi_s_av
 
             v = pybamm.boundary_value(phi_s, "right")
-            delta_phi_s = phi_s - v
+            delta_phi_s = v - phi_s
         delta_phi_s_av = pybamm.x_average(delta_phi_s)
         delta_phi_s_dim = delta_phi_s * pot
         delta_phi_s_av_dim = delta_phi_s_av * pot


### PR DESCRIPTION
# Description

Fixed the sign in the definition of positive electrode overpotential.

Fixes #1406

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
