### PR TITLE
#1414 fix bug in set_initial_conditions_from

### DIFF
--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -384,8 +384,6 @@ class BaseModel(object):
 
         if isinstance(solution, pybamm.Solution):
             solution = solution.last_state
-        else:
-            solution = pybamm.FuzzyDict(solution)
         for var, equation in model.initial_conditions.items():
             if isinstance(var, pybamm.Variable):
                 try:
@@ -404,7 +402,7 @@ class BaseModel(object):
                 elif final_state.ndim == 2:
                     final_state_eval = final_state[:, -1]
                 elif final_state.ndim == 3:
-                    final_state_eval = final_state[:, :, -1].flatten()
+                    final_state_eval = final_state[:, :, -1].flatten(order="F")
                 else:
                     raise NotImplementedError("Variable must be 0D, 1D, or 2D")
                 model.initial_conditions[var] = pybamm.Vector(final_state_eval)

--- a/pybamm/solvers/casadi_algebraic_solver.py
+++ b/pybamm/solvers/casadi_algebraic_solver.py
@@ -220,6 +220,8 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
         y_diff = casadi.horzcat(*[y0_diff] * len(t_eval))
         y_sol = casadi.vertcat(y_diff, y_alg)
         # Return solution object (no events, so pass None to t_event, y_event)
-        sol = pybamm.Solution(t_eval, y_sol, model, inputs_dict, termination="success")
+        sol = pybamm.Solution(
+            [t_eval], y_sol, model, inputs_dict, termination="success"
+        )
         sol.integration_time = integration_time
         return sol


### PR DESCRIPTION
# Description

Fix a bug in the function to update a model from initial conditions (wrong order for a 2D variable)

Fixes #1414 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
