### PR TITLE
Fixed bcs for the particle models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ## Bug fixes
 
+-   Fixed a bug on the boundary conditions of `FickianSingleParticle` and `FickianManyParticles` to ensure mass is conserved ([#1421](https://github.com/pybamm-team/PyBaMM/pull/1421))
 -   Fixed a bug where the `PolynomialSingleParticle` submodel gave incorrect results with "dimensionality" equal to 2 ([#1411](https://github.com/pybamm-team/PyBaMM/pull/1411))
 -   Fixed a bug where volume averaging in 0D gave the wrong result ([#1411](https://github.com/pybamm-team/PyBaMM/pull/1411))
 -   Fixed a sign error in the positive electrode ohmic losses ([#1407](https://github.com/pybamm-team/PyBaMM/pull/1407))

--- a/pybamm/models/submodels/interface/lithium_plating/base_plating.py
+++ b/pybamm/models/submodels/interface/lithium_plating/base_plating.py
@@ -76,7 +76,7 @@ class BasePlating(BaseInterface):
             f"{Domain} lithium plating thickness [m]": L_plated_Li * L_scale,
             f"X-averaged {domain} lithium plating thickness [m]": L_plated_Li_av
             * L_scale,
-            f"Loss of Li to {domain} lithium plating [mol]": Q_plated_Li * c_scale,
+            f"Loss of lithium to {domain} lithium plating [mol]": Q_plated_Li * c_scale,
             f"Loss of capacity to {domain} lithium plating [A.h]": Q_plated_Li
             * c_scale
             * param.F

--- a/pybamm/models/submodels/particle/fickian_many_particles.py
+++ b/pybamm/models/submodels/particle/fickian_many_particles.py
@@ -65,7 +65,6 @@ class FickianManyParticles(BaseParticle):
     def set_boundary_conditions(self, variables):
 
         c_s = variables[self.domain + " particle concentration"]
-        c_s_surf = variables[self.domain + " particle surface concentration"]
         T = pybamm.PrimaryBroadcast(
             variables[self.domain + " electrode temperature"],
             c_s.domain,
@@ -75,7 +74,11 @@ class FickianManyParticles(BaseParticle):
 
         if self.domain == "Negative":
             rbc = (
-                -self.param.C_n * j * R / self.param.a_R_n / pybamm.surf(self.param.D_n(c_s, T))
+                -self.param.C_n
+                * j
+                * R
+                / self.param.a_R_n
+                / pybamm.surf(self.param.D_n(c_s, T))
             )
 
         elif self.domain == "Positive":

--- a/pybamm/models/submodels/particle/fickian_many_particles.py
+++ b/pybamm/models/submodels/particle/fickian_many_particles.py
@@ -66,13 +66,16 @@ class FickianManyParticles(BaseParticle):
 
         c_s = variables[self.domain + " particle concentration"]
         c_s_surf = variables[self.domain + " particle surface concentration"]
-        T = variables[self.domain + " electrode temperature"]
+        T = pybamm.PrimaryBroadcast(
+            variables[self.domain + " electrode temperature"],
+            c_s.domain,
+        )
         j = variables[self.domain + " electrode interfacial current density"]
         R = variables[self.domain + " particle radius"]
 
         if self.domain == "Negative":
             rbc = (
-                -self.param.C_n * j * R / self.param.a_R_n / self.param.D_n(c_s_surf, T)
+                -self.param.C_n * j * R / self.param.a_R_n / pybamm.surf(self.param.D_n(c_s, T))
             )
 
         elif self.domain == "Positive":
@@ -82,7 +85,7 @@ class FickianManyParticles(BaseParticle):
                 * R
                 / self.param.a_R_p
                 / self.param.gamma_p
-                / self.param.D_p(c_s_surf, T)
+                / pybamm.surf(self.param.D_p(c_s, T))
             )
 
         self.boundary_conditions = {

--- a/pybamm/models/submodels/particle/fickian_single_particle.py
+++ b/pybamm/models/submodels/particle/fickian_single_particle.py
@@ -78,9 +78,10 @@ class FickianSingleParticle(BaseParticle):
         c_s_surf_xav = variables[
             "X-averaged " + self.domain.lower() + " particle surface concentration"
         ]
-        T_xav = variables[
-            "X-averaged " + self.domain.lower() + " electrode temperature"
-        ]
+        T_xav = pybamm.PrimaryBroadcast(
+            variables["X-averaged " + self.domain.lower() + " electrode temperature"],
+            c_s_xav.domain[0]
+        )
         j_xav = variables[
             "X-averaged "
             + self.domain.lower()
@@ -92,7 +93,7 @@ class FickianSingleParticle(BaseParticle):
                 -self.param.C_n
                 * j_xav
                 / self.param.a_R_n
-                / self.param.D_n(c_s_surf_xav, T_xav)
+                / pybamm.surf(self.param.D_n(c_s_xav, T_xav))
             )
 
         elif self.domain == "Positive":
@@ -101,7 +102,7 @@ class FickianSingleParticle(BaseParticle):
                 * j_xav
                 / self.param.a_R_p
                 / self.param.gamma_p
-                / self.param.D_p(c_s_surf_xav, T_xav)
+                / pybamm.surf(self.param.D_p(c_s_xav, T_xav))
             )
 
         self.boundary_conditions = {

--- a/pybamm/models/submodels/particle/fickian_single_particle.py
+++ b/pybamm/models/submodels/particle/fickian_single_particle.py
@@ -75,12 +75,9 @@ class FickianSingleParticle(BaseParticle):
         c_s_xav = variables[
             "X-averaged " + self.domain.lower() + " particle concentration"
         ]
-        c_s_surf_xav = variables[
-            "X-averaged " + self.domain.lower() + " particle surface concentration"
-        ]
         T_xav = pybamm.PrimaryBroadcast(
             variables["X-averaged " + self.domain.lower() + " electrode temperature"],
-            c_s_xav.domain[0]
+            c_s_xav.domain[0],
         )
         j_xav = variables[
             "X-averaged "

--- a/tests/integration/test_models/standard_model_tests.py
+++ b/tests/integration/test_models/standard_model_tests.py
@@ -72,7 +72,7 @@ class StandardModelTest(object):
 
         Crate = abs(
             self.parameter_values["Current function [A]"]
-            * self.parameter_values["Nominal cell capacity [A.h]"]
+            / self.parameter_values["Nominal cell capacity [A.h]"]
         )
         # don't allow zero C-rate
         if Crate == 0:

--- a/tests/integration/test_models/standard_output_tests.py
+++ b/tests/integration/test_models/standard_output_tests.py
@@ -290,18 +290,10 @@ class ParticleConcentrationTests(BaseOutputTest):
             neg_end_vs_start = self.c_s_n_rav(t[-1], x_n) - self.c_s_n_rav(t[0], x_n)
             pos_end_vs_start = self.c_s_p_rav(t[-1], x_p) - self.c_s_p_rav(t[0], x_p)
         else:
-            neg_diff = self.c_s_n(t[1:], x_n, r_n) - self.c_s_n(
-                t[:-1], x_n, r_n
-            )
-            pos_diff = self.c_s_p(t[1:], x_p, r_p) - self.c_s_p(
-                t[:-1], x_p, r_p
-            )
-            neg_end_vs_start = self.c_s_n(t[-1], x_n, r_n) - self.c_s_n(
-                t[0], x_n, r_n
-            )
-            pos_end_vs_start = self.c_s_p(t[-1], x_p, r_p) - self.c_s_p(
-                t[0], x_p, r_p
-            )
+            neg_diff = self.c_s_n(t[1:], x_n, r_n) - self.c_s_n(t[:-1], x_n, r_n)
+            pos_diff = self.c_s_p(t[1:], x_p, r_p) - self.c_s_p(t[:-1], x_p, r_p)
+            neg_end_vs_start = self.c_s_n(t[-1], x_n, r_n) - self.c_s_n(t[0], x_n, r_n)
+            pos_end_vs_start = self.c_s_p(t[-1], x_p, r_p) - self.c_s_p(t[0], x_p, r_p)
 
         if self.operating_condition == "discharge":
             np.testing.assert_array_less(neg_diff, 1e-16)
@@ -389,7 +381,7 @@ class ParticleConcentrationTests(BaseOutputTest):
                     np.testing.assert_array_less(self.N_s_p(t[1:], x_p, r_p[1:]), 1e-16)
             if self.operating_condition == "charge":
                 np.testing.assert_array_less(self.N_s_n(t[1:], x_n, r_n[1:]), 1e-16)
-                np.testing.assert_array less(-1e-16, self.N_s_p(t[1:], x_p, r_p[1:]))
+                np.testing.assert_array_less(-1e-16, self.N_s_p(t[1:], x_p, r_p[1:]))
             if self.operating_condition == "off":
                 np.testing.assert_array_almost_equal(self.N_s_n(t, x_n, r_n), 0)
                 np.testing.assert_array_almost_equal(self.N_s_p(t, x_p, r_p), 0)

--- a/tests/integration/test_models/standard_output_tests.py
+++ b/tests/integration/test_models/standard_output_tests.py
@@ -285,23 +285,37 @@ class ParticleConcentrationTests(BaseOutputTest):
             # For the assumed polynomial concentration profiles the values
             # can increase/decrease within the particle as the polynomial shifts,
             # so we just check the average instead
-            neg_end_vs_start = self.c_s_n_rav(t[1:], x_n) - self.c_s_n_rav(t[:-1], x_n)
-            pos_end_vs_start = self.c_s_p_rav(t[1:], x_p) - self.c_s_p_rav(t[:-1], x_p)
+            neg_diff = self.c_s_n_rav(t[1:], x_n) - self.c_s_n_rav(t[:-1], x_n)
+            pos_diff = self.c_s_p_rav(t[1:], x_p) - self.c_s_p_rav(t[:-1], x_p)
+            neg_end_vs_start = self.c_s_n_rav(t[-1], x_n) - self.c_s_n_rav(t[0], x_n)
+            pos_end_vs_start = self.c_s_p_rav(t[-1], x_p) - self.c_s_p_rav(t[0], x_p)
         else:
-            neg_end_vs_start = self.c_s_n(t[1:], x_n, r_n) - self.c_s_n(
+            neg_diff = self.c_s_n(t[1:], x_n, r_n) - self.c_s_n(
                 t[:-1], x_n, r_n
             )
-            pos_end_vs_start = self.c_s_p(t[1:], x_p, r_p) - self.c_s_p(
+            pos_diff = self.c_s_p(t[1:], x_p, r_p) - self.c_s_p(
                 t[:-1], x_p, r_p
+            )
+            neg_end_vs_start = self.c_s_n(t[-1], x_n, r_n) - self.c_s_n(
+                t[0], x_n, r_n
+            )
+            pos_end_vs_start = self.c_s_p(t[-1], x_p, r_p) - self.c_s_p(
+                t[0], x_p, r_p
             )
 
         if self.operating_condition == "discharge":
-            np.testing.assert_array_less(neg_end_vs_start, 1e-16)
-            np.testing.assert_array_less(-1e-16, pos_end_vs_start)
+            np.testing.assert_array_less(neg_diff, 1e-16)
+            np.testing.assert_array_less(-1e-16, pos_diff)
+            np.testing.assert_array_less(neg_end_vs_start, 0)
+            np.testing.assert_array_less(0, pos_end_vs_start)
         elif self.operating_condition == "charge":
-            np.testing.assert_array_less(-1e-16, neg_end_vs_start)
-            np.testing.assert_array_less(pos_end_vs_start, 1e-16)
+            np.testing.assert_array_less(-1e-16, neg_diff)
+            np.testing.assert_array_less(pos_diff, 1e-16)
+            np.testing.assert_array_less(0, neg_end_vs_start)
+            np.testing.assert_array_less(pos_end_vs_start, 0)
         elif self.operating_condition == "off":
+            np.testing.assert_array_almost_equal(neg_diff, 0)
+            np.testing.assert_array_almost_equal(pos_diff, 0)
             np.testing.assert_array_almost_equal(neg_end_vs_start, 0)
             np.testing.assert_array_almost_equal(pos_end_vs_start, 0)
 
@@ -374,8 +388,8 @@ class ParticleConcentrationTests(BaseOutputTest):
                     )
                     np.testing.assert_array_less(self.N_s_p(t[1:], x_p, r_p[1:]), 1e-16)
             if self.operating_condition == "charge":
-                np.testing.assert_equal(self.N_s_n(t[1:], x_n, r_n[1:]), 1e-16)
-                np.testing.assert_equal(-1e-16, self.N_s_p(t[1:], x_p, r_p[1:]))
+                np.testing.assert_array_less(self.N_s_n(t[1:], x_n, r_n[1:]), 1e-16)
+                np.testing.assert_array less(-1e-16, self.N_s_p(t[1:], x_p, r_p[1:]))
             if self.operating_condition == "off":
                 np.testing.assert_array_almost_equal(self.N_s_n(t, x_n, r_n), 0)
                 np.testing.assert_array_almost_equal(self.N_s_p(t, x_p, r_p), 0)

--- a/tests/integration/test_models/standard_output_tests.py
+++ b/tests/integration/test_models/standard_output_tests.py
@@ -370,11 +370,19 @@ class ParticleConcentrationTests(BaseOutputTest):
                     np.testing.assert_array_less(0, self.N_s_n(t[3:], x_n, r_n[1:]))
                     np.testing.assert_array_less(self.N_s_p(t[3:], x_p, r_p[1:]), 0)
                 else:
-                    np.testing.assert_equal(np.any(self.N_s_n(t[1:], x_n, r_n[1:]) >= 0), True)
-                    np.testing.assert_equal(np.any(self.N_s_p(t[1:], x_p, r_p[1:]) <= 0), True)
+                    np.testing.assert_equal(
+                        np.any(self.N_s_n(t[1:], x_n, r_n[1:]) >= 0), True
+                    )
+                    np.testing.assert_equal(
+                        np.any(self.N_s_p(t[1:], x_p, r_p[1:]) <= 0), True
+                    )
             if self.operating_condition == "charge":
-                    np.testing.assert_equal(np.any(self.N_s_n(t[1:], x_n, r_n[1:]) <= 0), True)
-                    np.testing.assert_equal(np.any(self.N_s_p(t[1:], x_p, r_p[1:]) >= 0), True)
+                np.testing.assert_equal(
+                    np.any(self.N_s_n(t[1:], x_n, r_n[1:]) <= 0), True
+                )
+                np.testing.assert_equal(
+                    np.any(self.N_s_p(t[1:], x_p, r_p[1:]) >= 0), True
+                )
             if self.operating_condition == "off":
                 np.testing.assert_array_almost_equal(self.N_s_n(t, x_n, r_n), 0)
                 np.testing.assert_array_almost_equal(self.N_s_p(t, x_p, r_p), 0)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -16,7 +16,9 @@ class TestDFN(unittest.TestCase):
         param = pybamm.ParameterValues(chemistry=pybamm.parameter_sets.Ecker2015)
         var = pybamm.standard_spatial_vars
         var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 5, var.r_p: 5}
-        modeltest = tests.StandardModelTest(model, parameter_values=param, var_pts=var_pts)
+        modeltest = tests.StandardModelTest(
+            model, parameter_values=param, var_pts=var_pts
+        )
         modeltest.test_all()
 
     def test_basic_processing_1plus1D(self):

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -12,9 +12,11 @@ class TestDFN(unittest.TestCase):
     def test_basic_processing(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lithium_ion.DFN(options)
+        # use Ecker parameters for nonlinear diffusion
+        param = pybamm.ParameterValues(chemistry=pybamm.parameter_sets.Ecker2015)
         var = pybamm.standard_spatial_vars
         var_pts = {var.x_n: 10, var.x_s: 10, var.x_p: 10, var.r_n: 5, var.r_p: 5}
-        modeltest = tests.StandardModelTest(model, var_pts=var_pts)
+        modeltest = tests.StandardModelTest(model, parameter_values=param, var_pts=var_pts)
         modeltest.test_all()
 
     def test_basic_processing_1plus1D(self):

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
@@ -12,7 +12,9 @@ class TestSPM(unittest.TestCase):
     def test_basic_processing(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lithium_ion.SPM(options)
-        modeltest = tests.StandardModelTest(model)
+        # use Ecker parameters for nonlinear diffusion
+        param = pybamm.ParameterValues(chemistry=pybamm.parameter_sets.Ecker2015)
+        modeltest = tests.StandardModelTest(model, parameter_values=param)
         modeltest.test_all()
 
     def test_basic_processing_1plus1D(self):

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
@@ -13,7 +13,9 @@ class TestSPMe(unittest.TestCase):
     def test_basic_processing(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lithium_ion.SPMe(options)
-        modeltest = tests.StandardModelTest(model)
+        # use Ecker parameters for nonlinear diffusion
+        param = pybamm.ParameterValues(chemistry=pybamm.parameter_sets.Ecker2015)
+        modeltest = tests.StandardModelTest(model, parameter_values=param)
         modeltest.test_all()
 
     def test_basic_processing_python(self):


### PR DESCRIPTION
# Description

Changed how `D` is evaluated at the boundary condition to ensure that mass is conserved. I also changed some of the `standard_output_tests` to catch when mass is not conserved (before it didn't) and fixed some others.

Fixes #1420 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/master/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
