### PR TITLE
Wrong argument type in `ParameterValues.update`

### DIFF
--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -79,7 +79,7 @@ class ParameterValues:
                 path = os.path.split(file_path)[0]
                 values = self.read_parameters_csv(file_path)
             else:
-                path = None
+                path = ""
             # Don't check parameter already exists when first creating it
             self.update(values, check_already_exists=False, path=path)
 


### PR DESCRIPTION
# Description

I didn't open an issue since this is such a tiny change: in the constructor of `ParameterValues`, if the `values` argument is neither `None` nor a string, the `path` argument that is fed to `ParameterValues.update` is set to `None`. However this is incorrect as that method expects it to be a string; passing `None` will lead to a `ValueError` in `os.path.join`.

This happened to me when creating a dictionary of parameter values where one value was `[function]/absolute/path/to/function`. With this fix, it works.

