### PR TITLE
Added warning for 'casadi' format

### DIFF
--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -152,6 +152,13 @@ class IDAKLUSolver(pybamm.BaseSolver):
         if model.rhs_eval.form == "casadi":
             # stack inputs
             inputs = casadi.vertcat(*[x for x in inputs_dict.values()])
+            # raise warning about casadi format being slow
+            pybamm.logger.warning(
+                "Using casadi form for the IDA KLU solver is slow. "
+                "Set `model.convert_to_format='python'` for better performance. "
+                "For DAE models, this may also require changing the root method to "
+                "'lm'."
+            )
         else:
             inputs = inputs_dict
 


### PR DESCRIPTION
# Description

Added warning to Idaklu solver if the model is converted to the format "casadi". 

A question - should I add
```py
if self.root_method != "CasadiAlgebraicSolver":
```
condition before adding the warning?

I also looked in the unit tests directory but couldn't find a suitable place for adding any sort of test for this warning (Please let me know where to put the test, if it is required)

Fixes #887 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
