### PR TITLE
Type of Driving Cycle ('A', 'V', 'W') in Experiment Class

### DIFF
--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -174,16 +174,20 @@ class Experiment:
                 end_time = self.convert_time_to_seconds(cond_list[idx + 1 :])
                 ext_drive_cycle = self.extend_drive_cycle(drive_cycles[cond_list[1]],
                                                           end_time)
-                interp = ext_drive_cycle[:, 1] # Electric Part of the Drive Cycle as Numpy Array
-                typ =  cond_list[2][1] # Find the Type of Drive Cycle ("A", "V", or "W")
+                # Electric Part of the Drive Cycle as Numpy Array
+                interp = ext_drive_cycle[:, 1]
+                # Find the Type of Drive Cycle ("A", "V", or "W")
+                typ = cond_list[2][1]
                 electric = (interp, typ)
                 time = ext_drive_cycle[:, 0][-1]
                 period = np.min(np.diff(ext_drive_cycle[:, 0]))
                 events = None
             else:
                 # e.g. Run US06
-                interp = drive_cycles[cond_list[1]][:, 1] # Electric Part of the Drive Cycle as Numpy Array
-                typ = cond_list[2][1] # Find the Type of Drive Cycle ("A", "V", or "W")
+                # Electric Part of the Drive Cycle as Numpy Array
+                interp = drive_cycles[cond_list[1]][:, 1]
+                # Find the Type of Drive Cycle ("A", "V", or "W")
+                typ = cond_list[2][1]
                 electric = (interp, typ)
                 # Set time and period to 1 second for first step and
                 # then calculate the difference in consecutive time steps

--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -18,13 +18,10 @@ examples = """
     Charge at 1 C until 4.1V,
     Hold at 4.1 V until 50 mA,
     Hold at 3V until C/50,
-    Run US06,
-    Run US06 for 20 seconds,
-    Run US06 for 45 minutes,
-    Run US06 for 2 hours,
-    Run US06 until 4.1V,
-    Run US06 until 50 mA,
-    Run US06 until C/50,
+    Run US06 (A),
+    Run US06 (A) for 20 seconds,
+    Run US06 (V) for 45 minutes,
+    Run US06 (W) for 2 hours,
     """
 
 
@@ -177,13 +174,17 @@ class Experiment:
                 end_time = self.convert_time_to_seconds(cond_list[idx + 1 :])
                 ext_drive_cycle = self.extend_drive_cycle(drive_cycles[cond_list[1]],
                                                           end_time)
-                electric = (ext_drive_cycle[:, 1], "Drive")
+                interp = ext_drive_cycle[:, 1] # Electric Part of the Drive Cycle as Numpy Array
+                typ =  cond_list[2][1] # Find the Type of Drive Cycle ("A", "V", or "W")
+                electric = (interp, typ)
                 time = ext_drive_cycle[:, 0][-1]
                 period = np.min(np.diff(ext_drive_cycle[:, 0]))
                 events = None
             else:
                 # e.g. Run US06
-                electric = (drive_cycles[cond_list[1]][:, 1], "Drive")
+                interp = drive_cycles[cond_list[1]][:, 1] # Electric Part of the Drive Cycle as Numpy Array
+                typ = cond_list[2][1] # Find the Type of Drive Cycle ("A", "V", or "W")
+                electric = (interp, typ)
                 # Set time and period to 1 second for first step and
                 # then calculate the difference in consecutive time steps
                 time = drive_cycles[cond_list[1]][:, 0][-1]

--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -170,7 +170,7 @@ class Experiment:
             dc_types = ["(A)", "(V)", "(W)"]
             if all(x not in cond for x in dc_types):
                 raise ValueError(
-                    """Type of diving cycle must be
+                    """Type of drive cycle must be
                     specified using '(A)', '(V)' or '(W)'.
                     For example: {}""".format(
                         examples

--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -167,28 +167,37 @@ class Experiment:
                         examples
                     )
                 )
-                # Check for Events
+            dc_types = ["(A)", "(V)", "(W)"]
+            if all(x not in cond for x in dc_types):
+                raise ValueError(
+                    """Type of diving cycle must be
+                    specified using '(A)', '(V)' or '(W)'.
+                    For example: {}""".format(
+                        examples
+                    )
+                )
+            # Check for Events
             elif "for" in cond:
                 # e.g. for 3 hours
                 idx = cond_list.index("for")
                 end_time = self.convert_time_to_seconds(cond_list[idx + 1 :])
                 ext_drive_cycle = self.extend_drive_cycle(drive_cycles[cond_list[1]],
                                                           end_time)
-                # Electric Part of the Drive Cycle as Numpy Array
-                interp = ext_drive_cycle[:, 1]
-                # Find the Type of Drive Cycle ("A", "V", or "W")
+                # Drive cycle as numpy array
+                dc_data = ext_drive_cycle
+                # Find the type of drive cycle ("A", "V", or "W")
                 typ = cond_list[2][1]
-                electric = (interp, typ)
+                electric = (dc_data, typ)
                 time = ext_drive_cycle[:, 0][-1]
                 period = np.min(np.diff(ext_drive_cycle[:, 0]))
                 events = None
             else:
                 # e.g. Run US06
-                # Electric Part of the Drive Cycle as Numpy Array
-                interp = drive_cycles[cond_list[1]][:, 1]
-                # Find the Type of Drive Cycle ("A", "V", or "W")
+                # Drive cycle as numpy array
+                dc_data = drive_cycles[cond_list[1]]
+                # Find the type of drive cycle ("A", "V", or "W")
                 typ = cond_list[2][1]
-                electric = (interp, typ)
+                electric = (dc_data, typ)
                 # Set time and period to 1 second for first step and
                 # then calculate the difference in consecutive time steps
                 time = drive_cycles[cond_list[1]][:, 0][-1]
@@ -282,7 +291,7 @@ class Experiment:
                     sign = -1
                 else:
                     raise ValueError(
-                        """instruction must be 'discharge', 'charge', 'rest', 'hold' or 'Run'.
+                        """Instruction must be 'discharge', 'charge', 'rest', 'hold' or 'Run'.
                         For example: {}""".format(
                             examples
                         )

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -27,7 +27,7 @@ class TestExperiment(unittest.TestCase):
                 "Discharge at 1 A for 0.5 hours",
                 "Charge at 200 mA for 45 minutes (1 minute period)",
                 "Discharge at 1W for 0.5 hours",
-                "Charge at 200 mW for 45 minutes",
+                "Charge at 200mW for 45 minutes",
                 "Rest for 10 minutes (5 minute period)",
                 "Hold at 1V for 20 seconds",
                 "Charge at 1 C until 4.1V",
@@ -74,15 +74,15 @@ class TestExperiment(unittest.TestCase):
         )
         # Check drive cycle operating conditions
         self.assertTrue(
-            ((experiment.operating_conditions[-3][0] == drive_cycle[:, 1]).all() & (
+            ((experiment.operating_conditions[-3][0] == drive_cycle).all() & (
                 experiment.operating_conditions[-3][1] == "A") & (
                 experiment.operating_conditions[-3][2] == time_0).all() & (
                 experiment.operating_conditions[-3][3] == period_0).all() & (
-                experiment.operating_conditions[-2][0] == drive_cycle_1[:, 1]).all() & (
+                experiment.operating_conditions[-2][0] == drive_cycle_1).all() & (
                 experiment.operating_conditions[-2][1] == "V") & (
                 experiment.operating_conditions[-2][2] == time_1).all() & (
                 experiment.operating_conditions[-2][3] == period_1).all() & (
-                experiment.operating_conditions[-1][0] == drive_cycle_2[:, 1]).all() & (
+                experiment.operating_conditions[-1][0] == drive_cycle_2).all() & (
                 experiment.operating_conditions[-1][1] == "W") & (
                 experiment.operating_conditions[-1][2] == time_2).all() & (
                 experiment.operating_conditions[-1][3] == period_2).all())
@@ -174,6 +174,14 @@ class TestExperiment(unittest.TestCase):
             ValueError, "Instruction must be"
         ):
             pybamm.Experiment(["Run at at 1 A for 2 hours"])
+        with self.assertRaisesRegex(
+            ValueError, "Instruction must be"
+        ):
+            pybamm.Experiment(["Play at 1 A for 2 hours"])
+        with self.assertRaisesRegex(
+            ValueError, "Instruction"
+        ):
+            pybamm.Experiment(["Cell Charge at 1 A for 2 hours"])
         with self.assertRaisesRegex(ValueError, "units must be"):
             pybamm.Experiment(["Discharge at 1 B for 2 hours"])
         with self.assertRaisesRegex(ValueError, "time units must be"):

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -171,6 +171,10 @@ class TestExperiment(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Instruction must be"):
             pybamm.Experiment(["Run at 1 A for 2 hours"])
         with self.assertRaisesRegex(
+            ValueError, "Type of drive cycle must be"
+        ):
+            pybamm.Experiment(["Run US06 for 2 hours"])
+        with self.assertRaisesRegex(
             ValueError, "Instruction must be"
         ):
             pybamm.Experiment(["Run at at 1 A for 2 hours"])

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -34,9 +34,9 @@ class TestExperiment(unittest.TestCase):
                 "Hold at 4.1 V until 50mA",
                 "Hold at 3V until C/50",
                 "Discharge at C/3 for 2 hours or until 2.5 V",
-                "Run US06",
-                "Run US06 for 5 minutes",
-                "Run US06 for 0.5 hours",
+                "Run US06 (A)",
+                "Run US06 (V) for 5 minutes",
+                "Run US06 (W) for 0.5 hours",
             ],
             {"test": "test"}, drive_cycles={"US06": drive_cycle},
             period="20 seconds",
@@ -75,15 +75,15 @@ class TestExperiment(unittest.TestCase):
         # Check drive cycle operating conditions
         self.assertTrue(
             ((experiment.operating_conditions[-3][0] == drive_cycle[:, 1]).all() & (
-                experiment.operating_conditions[-3][1] == "Drive") & (
+                experiment.operating_conditions[-3][1] == "A") & (
                 experiment.operating_conditions[-3][2] == time_0).all() & (
                 experiment.operating_conditions[-3][3] == period_0).all() & (
                 experiment.operating_conditions[-2][0] == drive_cycle_1[:, 1]).all() & (
-                experiment.operating_conditions[-2][1] == "Drive") & (
+                experiment.operating_conditions[-2][1] == "V") & (
                 experiment.operating_conditions[-2][2] == time_1).all() & (
                 experiment.operating_conditions[-2][3] == period_1).all() & (
                 experiment.operating_conditions[-1][0] == drive_cycle_2[:, 1]).all() & (
-                experiment.operating_conditions[-1][1] == "Drive") & (
+                experiment.operating_conditions[-1][1] == "W") & (
                 experiment.operating_conditions[-1][2] == time_2).all() & (
                 experiment.operating_conditions[-1][3] == period_2).all())
         )


### PR DESCRIPTION
# Description

The experiment.py file is modified to read the operating conditions string which includes the type of driving cycle ('A', 'V', 'W').
This change is suggested by @tinosulzer in #1193. 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
