### PR TITLE
Add to_equation in Binary and Scalar

### DIFF
--- a/docs/source/expression_tree/binary_operator.rst
+++ b/docs/source/expression_tree/binary_operator.rst
@@ -25,7 +25,7 @@ Binary Operators
 .. autoclass:: pybamm.Inner
   :members:
 
-.. autoclass:: pybamm.Heaviside
+.. autoclass:: pybamm._Heaviside
   :members:
 
 .. autoclass:: pybamm.EqualHeaviside

--- a/docs/source/expression_tree/binary_operator.rst
+++ b/docs/source/expression_tree/binary_operator.rst
@@ -25,7 +25,7 @@ Binary Operators
 .. autoclass:: pybamm.Inner
   :members:
 
-.. autoclass:: pybamm._Heaviside
+.. autoclass:: pybamm.expression_tree.binary_operators._Heaviside
   :members:
 
 .. autoclass:: pybamm.EqualHeaviside

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -2,12 +2,15 @@
 # NumpyArray class
 #
 import numpy as np
+import sympy
+from scipy.sparse import csr_matrix, issparse
+
 import pybamm
-from scipy.sparse import issparse, csr_matrix
 
 
 class Array(pybamm.Symbol):
-    """node in the expression tree that holds an tensor type variable
+    """
+    Node in the expression tree that holds an tensor type variable
     (e.g. :class:`numpy.array`)
 
     Parameters
@@ -54,12 +57,12 @@ class Array(pybamm.Symbol):
 
     @property
     def ndim(self):
-        """ returns the number of dimensions of the tensor"""
+        """returns the number of dimensions of the tensor."""
         return self._entries.ndim
 
     @property
     def shape(self):
-        """ returns the number of entries along each dimension"""
+        """returns the number of entries along each dimension."""
         return self._entries.shape
 
     @property
@@ -86,19 +89,19 @@ class Array(pybamm.Symbol):
                 self._entries_string = (entries.tobytes(),)
 
     def set_id(self):
-        """ See :meth:`pybamm.Symbol.set_id()`. """
+        """See :meth:`pybamm.Symbol.set_id()`."""
         self._id = hash(
             (self.__class__, self.name) + self.entries_string + tuple(self.domain)
         )
 
     def _jac(self, variable):
-        """ See :meth:`pybamm.Symbol._jac()`. """
+        """See :meth:`pybamm.Symbol._jac()`."""
         # Return zeros of correct size
         jac = csr_matrix((self.size, variable.evaluation_array.count(True)))
         return pybamm.Matrix(jac)
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
         return self.__class__(
             self.entries,
             self.name,
@@ -108,12 +111,17 @@ class Array(pybamm.Symbol):
         )
 
     def _base_evaluate(self, t=None, y=None, y_dot=None, inputs=None):
-        """ See :meth:`pybamm.Symbol._base_evaluate()`. """
+        """See :meth:`pybamm.Symbol._base_evaluate()`."""
         return self._entries
 
     def is_constant(self):
-        """ See :meth:`pybamm.Symbol.is_constant()`. """
+        """See :meth:`pybamm.Symbol.is_constant()`."""
         return True
+
+    def to_equation(self):
+        """Returns the value returned by the node when evaluated."""
+        entries_list = self.entries.tolist()
+        return sympy.Array(entries_list)
 
 
 def linspace(start, stop, num=50, **kwargs):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -62,7 +62,8 @@ def get_binary_children_domains(ldomain, rdomain):
 
 
 class BinaryOperator(pybamm.Symbol):
-    """A node in the expression tree representing a binary operator (e.g. `+`, `*`)
+    """
+    A node in the expression tree representing a binary operator (e.g. `+`, `*`)
 
     Derived classes will specify the particular operator
 
@@ -77,7 +78,6 @@ class BinaryOperator(pybamm.Symbol):
         lhs child node (converted to :class:`Scalar` if Number)
     right : :class:`Symbol` or :class:`Number`
         rhs child node (converted to :class:`Scalar` if Number)
-
     """
 
     def __init__(self, name, left, right):
@@ -95,7 +95,7 @@ class BinaryOperator(pybamm.Symbol):
         self.right = self.children[1]
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         # Possibly add brackets for clarity
         if isinstance(self.left, pybamm.BinaryOperator) and not (
             (self.left.name == self.name)
@@ -115,7 +115,7 @@ class BinaryOperator(pybamm.Symbol):
         return "{} {} {}".format(left_str, self.name, right_str)
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
 
         # process children
         new_left = self.left.new_copy()
@@ -136,7 +136,7 @@ class BinaryOperator(pybamm.Symbol):
         return self._binary_evaluate(left, right)
 
     def evaluate(self, t=None, y=None, y_dot=None, inputs=None, known_evals=None):
-        """ See :meth:`pybamm.Symbol.evaluate()`. """
+        """See :meth:`pybamm.Symbol.evaluate()`."""
         if known_evals is not None:
             id = self.id
             try:
@@ -155,35 +155,35 @@ class BinaryOperator(pybamm.Symbol):
             return self._binary_evaluate(left, right)
 
     def _evaluate_for_shape(self):
-        """ See :meth:`pybamm.Symbol.evaluate_for_shape()`. """
+        """See :meth:`pybamm.Symbol.evaluate_for_shape()`."""
         left = self.children[0].evaluate_for_shape()
         right = self.children[1].evaluate_for_shape()
         return self._binary_evaluate(left, right)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ Calculate the jacobian of a binary operator. """
+        """Calculate the jacobian of a binary operator."""
         raise NotImplementedError
 
     def _binary_evaluate(self, left, right):
-        """ Perform binary operation on nodes 'left' and 'right'. """
+        """Perform binary operation on nodes 'left' and 'right'."""
         raise NotImplementedError
 
     def _evaluates_on_edges(self, dimension):
-        """ See :meth:`pybamm.Symbol._evaluates_on_edges()`. """
+        """See :meth:`pybamm.Symbol._evaluates_on_edges()`."""
         return self.left.evaluates_on_edges(dimension) or self.right.evaluates_on_edges(
             dimension
         )
 
     def is_constant(self):
-        """ See :meth:`pybamm.Symbol.is_constant()`. """
+        """See :meth:`pybamm.Symbol.is_constant()`."""
         return self.left.is_constant() and self.right.is_constant()
 
     def _sympy_operator(self, left, right):
-        """Apply appropriate SymPy operators"""
+        """Apply appropriate SymPy operators."""
         return self._binary_evaluate(left, right)
 
     def to_equation(self):
-        """Convert the node and its subtree into a SymPy equation"""
+        """Convert the node and its subtree into a SymPy equation."""
         if getattr(self, "print_name", None):
             return sympy.symbols(self.print_name)
         else:
@@ -194,17 +194,18 @@ class BinaryOperator(pybamm.Symbol):
 
 
 class Power(BinaryOperator):
-    """A node in the expression tree representing a `**` power operator
+    """
+    A node in the expression tree representing a `**` power operator.
 
     **Extends:** :class:`BinaryOperator`
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("**", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         # apply chain rule and power rule
         base, exponent = self.orphans
         # derivative if variable is in the base
@@ -216,7 +217,7 @@ class Power(BinaryOperator):
         return diff
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # apply chain rule and power rule
         left, right = self.orphans
         if right.evaluates_to_constant_number():
@@ -229,56 +230,58 @@ class Power(BinaryOperator):
             )
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         # don't raise RuntimeWarning for NaNs
         with np.errstate(invalid="ignore"):
             return left ** right
 
 
 class Addition(BinaryOperator):
-    """A node in the expression tree representing an addition operator
+    """
+    A node in the expression tree representing an addition operator.
 
     **Extends:** :class:`BinaryOperator`
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("+", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         return self.left.diff(variable) + self.right.diff(variable)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         return left_jac + right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         return left + right
 
 
 class Subtraction(BinaryOperator):
-    """A node in the expression tree representing a subtraction operator
+    """
+    A node in the expression tree representing a subtraction operator.
 
     **Extends:** :class:`BinaryOperator`
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
 
         super().__init__("-", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         return self.left.diff(variable) - self.right.diff(variable)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         return left_jac - right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         return left - right
 
 
@@ -292,18 +295,18 @@ class Multiplication(BinaryOperator):
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
 
         super().__init__("*", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         # apply product rule
         left, right = self.orphans
         return left.diff(variable) * right + left * right.diff(variable)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # apply product rule
         left, right = self.orphans
         if left.evaluates_to_constant_number():
@@ -314,7 +317,7 @@ class Multiplication(BinaryOperator):
             return right * left_jac + left * right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
 
         if issparse(left):
             return csr_matrix(left.multiply(right))
@@ -326,24 +329,25 @@ class Multiplication(BinaryOperator):
 
 
 class MatrixMultiplication(BinaryOperator):
-    """A node in the expression tree representing a matrix multiplication operator
+    """
+    A node in the expression tree representing a matrix multiplication operator.
 
     **Extends:** :class:`BinaryOperator`
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("@", left, right)
 
     def diff(self, variable):
-        """ See :meth:`pybamm.Symbol.diff()`. """
+        """See :meth:`pybamm.Symbol.diff()`."""
         # We shouldn't need this
         raise NotImplementedError(
             "diff not implemented for symbol of type 'MatrixMultiplication'"
         )
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # We only need the case where left is an array and right
         # is a (slice of a) state vector, e.g. for discretised spatial
         # operators of the form D @ u (also catch cases of (-D) @ u)
@@ -363,7 +367,7 @@ class MatrixMultiplication(BinaryOperator):
             )
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         return left @ right
 
     def _sympy_operator(self, left, right):
@@ -372,23 +376,24 @@ class MatrixMultiplication(BinaryOperator):
 
 
 class Division(BinaryOperator):
-    """A node in the expression tree representing a division operator
+    """
+    A node in the expression tree representing a division operator.
 
     **Extends:** :class:`BinaryOperator`
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("/", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         # apply quotient rule
         top, bottom = self.orphans
         return (top.diff(variable) * bottom - top * bottom.diff(variable)) / bottom ** 2
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # apply quotient rule
         left, right = self.orphans
         if left.evaluates_to_constant_number():
@@ -399,7 +404,7 @@ class Division(BinaryOperator):
             return (right * left_jac - left * right_jac) / right ** 2
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
 
         if issparse(left):
             return csr_matrix(left.multiply(1 / right))
@@ -431,17 +436,17 @@ class Inner(BinaryOperator):
     """
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("inner product", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         # apply product rule
         left, right = self.orphans
         return left.diff(variable) * right + left * right.diff(variable)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # apply product rule
         left, right = self.orphans
         if left.evaluates_to_constant_number():
@@ -452,7 +457,7 @@ class Inner(BinaryOperator):
             return right * left_jac + left * right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
 
         if issparse(left):
             return left.multiply(right)
@@ -463,11 +468,11 @@ class Inner(BinaryOperator):
             return left * right
 
     def _binary_new_copy(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_new_copy()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_new_copy()`."""
         return pybamm.inner(left, right)
 
     def _evaluates_on_edges(self, dimension):
-        """ See :meth:`pybamm.Symbol._evaluates_on_edges()`. """
+        """See :meth:`pybamm.Symbol._evaluates_on_edges()`."""
         return False
 
 
@@ -494,7 +499,8 @@ def inner(left, right):
 
 
 class Heaviside(BinaryOperator):
-    """A node in the expression tree representing a heaviside step function.
+    """
+    A node in the expression tree representing a heaviside step function.
 
     Adding this operation to the rhs or algebraic equations in a model can often cause a
     discontinuity in the solution. For the specific cases listed below, this will be
@@ -510,39 +516,39 @@ class Heaviside(BinaryOperator):
     """
 
     def __init__(self, name, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__(name, left, right)
 
     def diff(self, variable):
-        """ See :meth:`pybamm.Symbol.diff()`. """
+        """See :meth:`pybamm.Symbol.diff()`."""
         # Heaviside should always be multiplied by something else so hopefully don't
         # need to worry about shape
         return pybamm.Scalar(0)
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # Heaviside should always be multiplied by something else so hopefully don't
         # need to worry about shape
         return pybamm.Scalar(0)
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        return sympy.Heaviside(left,right)
+        return sympy.Heaviside(left, right)
 
 
 class EqualHeaviside(Heaviside):
     """A heaviside function with equality (return 1 when left = right)"""
 
     def __init__(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator.__init__()`. """
+        """See :meth:`pybamm.BinaryOperator.__init__()`."""
         super().__init__("<=", left, right)
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         return "{!s} <= {!s}".format(self.left, self.right)
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         # don't raise RuntimeWarning for NaNs
         with np.errstate(invalid="ignore"):
             return left <= right
@@ -555,11 +561,11 @@ class NotEqualHeaviside(Heaviside):
         super().__init__("<", left, right)
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         return "{!s} < {!s}".format(self.left, self.right)
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         # don't raise RuntimeWarning for NaNs
         with np.errstate(invalid="ignore"):
             return left < right
@@ -572,7 +578,7 @@ class Modulo(BinaryOperator):
         super().__init__("%", left, right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         # apply chain rule and power rule
         left, right = self.orphans
         # derivative if variable is in the base
@@ -584,7 +590,7 @@ class Modulo(BinaryOperator):
         return diff
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         # apply chain rule and power rule
         left, right = self.orphans
         if right.evaluates_to_constant_number():
@@ -595,11 +601,11 @@ class Modulo(BinaryOperator):
             return left_jac - right_jac * pybamm.Floor(left / right)
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         return "{!s} mod {!s}".format(self.left, self.right)
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         return left % right
 
 
@@ -610,28 +616,28 @@ class Minimum(BinaryOperator):
         super().__init__("minimum", left, right)
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         return "minimum({!s}, {!s})".format(self.left, self.right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         left, right = self.orphans
         return (left <= right) * left.diff(variable) + (left > right) * right.diff(
             variable
         )
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         left, right = self.orphans
         return (left <= right) * left_jac + (left > right) * right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         # don't raise RuntimeWarning for NaNs
         return np.minimum(left, right)
 
     def _binary_new_copy(self, left, right):
-        "See :meth:`pybamm.BinaryOperator._binary_new_copy()`. "
+        """See :meth:`pybamm.BinaryOperator._binary_new_copy()`."""
         return pybamm.minimum(left, right)
 
 
@@ -642,28 +648,28 @@ class Maximum(BinaryOperator):
         super().__init__("maximum", left, right)
 
     def __str__(self):
-        """ See :meth:`pybamm.Symbol.__str__()`. """
+        """See :meth:`pybamm.Symbol.__str__()`."""
         return "maximum({!s}, {!s})".format(self.left, self.right)
 
     def _diff(self, variable):
-        """ See :meth:`pybamm.Symbol._diff()`. """
+        """See :meth:`pybamm.Symbol._diff()`."""
         left, right = self.orphans
         return (left >= right) * left.diff(variable) + (left < right) * right.diff(
             variable
         )
 
     def _binary_jac(self, left_jac, right_jac):
-        """ See :meth:`pybamm.BinaryOperator._binary_jac()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
         left, right = self.orphans
         return (left >= right) * left_jac + (left < right) * right_jac
 
     def _binary_evaluate(self, left, right):
-        """ See :meth:`pybamm.BinaryOperator._binary_evaluate()`. """
+        """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
         # don't raise RuntimeWarning for NaNs
         return np.maximum(left, right)
 
     def _binary_new_copy(self, left, right):
-        "See :meth:`pybamm.BinaryOperator._binary_new_copy()`. "
+        """See :meth:`pybamm.BinaryOperator._binary_new_copy()`."""
         return pybamm.maximum(left, right)
 
 
@@ -1333,7 +1339,6 @@ def source(left, right, boundary=False):
         corresponding to a source term which only acts on the boundary of the
         domain. If False (default), the matrix is assembled over the entire domain,
         corresponding to a source term in the bulk.
-
     """
     # Broadcast if left is number
     if isinstance(left, numbers.Number):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -503,6 +503,8 @@ def inner(left, right):
 class _Heaviside(BinaryOperator):
     """
     A node in the expression tree representing a heaviside step function.
+    This class is semi-private and should not be called directly, use `EqualHeaviside`
+    or `NotEqualHeaviside` instead, or `<` or `<=`.
 
     Adding this operation to the rhs or algebraic equations in a model can often cause a
     discontinuity in the solution. For the specific cases listed below, this will be

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -372,6 +372,8 @@ class MatrixMultiplication(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
+        left = sympy.Matrix(left)
+        right = sympy.Matrix(right)
         return left * right
 
 

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -500,7 +500,7 @@ def inner(left, right):
     return pybamm.simplify_if_constant(pybamm.Inner(left, right))
 
 
-class Heaviside(BinaryOperator):
+class _Heaviside(BinaryOperator):
     """
     A node in the expression tree representing a heaviside step function.
 
@@ -533,12 +533,8 @@ class Heaviside(BinaryOperator):
         # need to worry about shape
         return pybamm.Scalar(0)
 
-    def _sympy_operator(self, left, right):
-        """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        return sympy.Heaviside(left, right)
 
-
-class EqualHeaviside(Heaviside):
+class EqualHeaviside(_Heaviside):
     """A heaviside function with equality (return 1 when left = right)"""
 
     def __init__(self, left, right):
@@ -556,7 +552,7 @@ class EqualHeaviside(Heaviside):
             return left <= right
 
 
-class NotEqualHeaviside(Heaviside):
+class NotEqualHeaviside(_Heaviside):
     """A heaviside function without equality (return 0 when left = right)"""
 
     def __init__(self, left, right):

--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -1,8 +1,10 @@
 #
 # Scalar class
 #
-import pybamm
 import numpy as np
+import sympy
+
+import pybamm
 
 
 class Scalar(pybamm.Symbol):
@@ -20,7 +22,6 @@ class Scalar(pybamm.Symbol):
         if not provided
     domain : iterable of str, optional
         list of domains the parameter is valid over, defaults to empty list
-
     """
 
     def __init__(self, value, name=None, domain=[]):
@@ -66,3 +67,7 @@ class Scalar(pybamm.Symbol):
     def is_constant(self):
         """ See :meth:`pybamm.Symbol.is_constant()`. """
         return True
+
+    def to_equation(self):
+        """Returns the value returned by the node when evaluated"""
+        return self.value

--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -2,13 +2,13 @@
 # Scalar class
 #
 import numpy as np
-import sympy
 
 import pybamm
 
 
 class Scalar(pybamm.Symbol):
-    """A node in the expression tree representing a scalar value
+    """
+    A node in the expression tree representing a scalar value.
 
     **Extends:** :class:`Symbol`
 
@@ -37,7 +37,7 @@ class Scalar(pybamm.Symbol):
 
     @property
     def value(self):
-        """the value returned by the node when evaluated"""
+        """The value returned by the node when evaluated."""
         return self._value
 
     @value.setter
@@ -45,7 +45,7 @@ class Scalar(pybamm.Symbol):
         self._value = np.float64(value)
 
     def set_id(self):
-        """ See :meth:`pybamm.Symbol.set_id()`. """
+        """See :meth:`pybamm.Symbol.set_id()`."""
         # We must include the value in the hash, since different scalars can be
         # indistinguishable by class, name and domain alone
         self._id = hash(
@@ -53,21 +53,21 @@ class Scalar(pybamm.Symbol):
         )
 
     def _base_evaluate(self, t=None, y=None, y_dot=None, inputs=None):
-        """ See :meth:`pybamm.Symbol._base_evaluate()`. """
+        """See :meth:`pybamm.Symbol._base_evaluate()`."""
         return self._value
 
     def _jac(self, variable):
-        """ See :meth:`pybamm.Symbol._jac()`. """
+        """See :meth:`pybamm.Symbol._jac()`."""
         return pybamm.Scalar(0)
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
         return Scalar(self.value, self.name, self.domain)
 
     def is_constant(self):
-        """ See :meth:`pybamm.Symbol.is_constant()`. """
+        """See :meth:`pybamm.Symbol.is_constant()`."""
         return True
 
     def to_equation(self):
-        """Returns the value returned by the node when evaluated"""
+        """Returns the value returned by the node when evaluated."""
         return self.value

--- a/pybamm/parameters/base_parameters.py
+++ b/pybamm/parameters/base_parameters.py
@@ -1,9 +1,12 @@
+#
+# Base parameters class
+#
 import pybamm
 
 
 class BaseParameters:
     """
-    Overload the `__setattr__` method to record what the variable was called
+    Overload the `__setattr__` method to record what the variable was called.
     """
 
     def __setattr__(self, name, value):

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -301,7 +301,7 @@ class BaseSolver(object):
                     model.concatenated_rhs.pre_order(),
                     model.concatenated_algebraic.pre_order(),
                 ):
-                    if isinstance(symbol, pybamm.Heaviside):
+                    if isinstance(symbol, pybamm._Heaviside):
                         found_t = False
                         # Dimensionless
                         if symbol.right.id == pybamm.t.id:

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1,15 +1,18 @@
 #
 # Base solver class
 #
-import casadi
 import copy
-import pybamm
-import numbers
-import numpy as np
-import sys
 import itertools
 import multiprocessing as mp
+import numbers
+import sys
 import warnings
+
+import casadi
+import numpy as np
+
+import pybamm
+from pybamm.expression_tree.binary_operators import _Heaviside
 
 
 class BaseSolver(object):
@@ -301,7 +304,7 @@ class BaseSolver(object):
                     model.concatenated_rhs.pre_order(),
                     model.concatenated_algebraic.pre_order(),
                 ):
-                    if isinstance(symbol, pybamm._Heaviside):
+                    if isinstance(symbol, _Heaviside):
                         found_t = False
                         # Dimensionless
                         if symbol.right.id == pybamm.t.id:

--- a/tests/unit/test_expression_tree/test_array.py
+++ b/tests/unit/test_expression_tree/test_array.py
@@ -4,6 +4,7 @@
 import unittest
 
 import numpy as np
+import sympy
 
 import pybamm
 
@@ -36,8 +37,7 @@ class TestArray(unittest.TestCase):
 
     def test_to_equation(self):
         self.assertEqual(
-            str(pybamm.Array([1, 2]).to_equation()),
-            "[[1.00000000000000], [2.00000000000000]]",
+            pybamm.Array([1, 2]).to_equation(), sympy.Array([[1.0], [2.0]])
         )
 
 

--- a/tests/unit/test_expression_tree/test_array.py
+++ b/tests/unit/test_expression_tree/test_array.py
@@ -1,10 +1,11 @@
 #
 # Tests for the Array class
 #
-import pybamm
+import unittest
+
 import numpy as np
 
-import unittest
+import pybamm
 
 
 class TestArray(unittest.TestCase):
@@ -32,6 +33,12 @@ class TestArray(unittest.TestCase):
         C, D = pybamm.meshgrid(c, d)
         np.testing.assert_array_equal(A, C.entries)
         np.testing.assert_array_equal(B, D.entries)
+
+    def test_to_equation(self):
+        self.assertEqual(
+            str(pybamm.Array([1, 2]).to_equation()),
+            "[[1.00000000000000], [2.00000000000000]]",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -667,6 +667,24 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(pybamm.inner(a3, a2).evaluate(), 3)
         self.assertEqual(pybamm.inner(a3, a3).evaluate(), 9)
 
+    def test_to_equation(self):
+        # Test Power
+        self.assertEqual(pybamm.Power(7, 2).to_equation(), 49)
+
+        # Test Division
+        self.assertEqual(pybamm.Division(10, 2).to_equation(), 5)
+
+        # Test Matrix Multiplication
+        arr1 = pybamm.Array([[1, 0], [0, 1]])
+        arr2 = pybamm.Array([[4, 1], [2, 2]])
+        self.assertEqual(
+            pybamm.MatrixMultiplication(arr1, arr2).to_equation(),
+            "Matrix([[4.0, 1.0], [2.0, 2.0]])",
+        )
+
+        # Test Heaviside
+        self.assertEqual(pybamm.Heaviside("test", 4, 2).to_equation(), 1)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -4,6 +4,7 @@
 import unittest
 
 import numpy as np
+import sympy
 from scipy.sparse.coo import coo_matrix
 
 import pybamm
@@ -679,7 +680,7 @@ class TestBinaryOperators(unittest.TestCase):
         arr2 = pybamm.Array([[4, 1], [2, 2]])
         self.assertEqual(
             pybamm.MatrixMultiplication(arr1, arr2).to_equation(),
-            "Matrix([[4.0, 1.0], [2.0, 2.0]])",
+            sympy.Matrix([[4.0, 1.0], [2.0, 2.0]]),
         )
 
         # Test Heaviside

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -683,6 +683,12 @@ class TestBinaryOperators(unittest.TestCase):
             sympy.Matrix([[4.0, 1.0], [2.0, 2.0]]),
         )
 
+        # Test EqualHeaviside
+        self.assertEqual(pybamm.EqualHeaviside(1, 0).to_equation(), False)
+
+        # Test NotEqualHeaviside
+        self.assertEqual(pybamm.NotEqualHeaviside(2, 4).to_equation(), True)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -1,11 +1,12 @@
 #
 # Tests for the Binary Operator classes
 #
-import pybamm
+import unittest
 
 import numpy as np
-import unittest
 from scipy.sparse.coo import coo_matrix
+
+import pybamm
 
 
 class TestBinaryOperators(unittest.TestCase):
@@ -370,16 +371,14 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertAlmostEqual(minimum.evaluate(y=np.array([2]))[0, 0], 1)
         self.assertAlmostEqual(minimum.evaluate(y=np.array([0]))[0, 0], 0)
         self.assertEqual(
-            str(minimum),
-            "log(1.9287498479639178e-22 + exp(-50.0 * y[0:1])) / -50.0",
+            str(minimum), "log(1.9287498479639178e-22 + exp(-50.0 * y[0:1])) / -50.0"
         )
 
         maximum = pybamm.softplus(a, b, 50)
         self.assertAlmostEqual(maximum.evaluate(y=np.array([2]))[0, 0], 2)
         self.assertAlmostEqual(maximum.evaluate(y=np.array([0]))[0, 0], 1)
         self.assertEqual(
-            str(maximum),
-            "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0",
+            str(maximum), "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"
         )
 
         # Test that smooth min/max are used when the setting is changed

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -683,9 +683,6 @@ class TestBinaryOperators(unittest.TestCase):
             sympy.Matrix([[4.0, 1.0], [2.0, 2.0]]),
         )
 
-        # Test Heaviside
-        self.assertEqual(pybamm.Heaviside("test", 4, 2).to_equation(), 1)
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -669,6 +669,10 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(pybamm.inner(a3, a3).evaluate(), 9)
 
     def test_to_equation(self):
+        # Test print_name
+        pybamm.Addition.print_name = "test"
+        self.assertEqual(pybamm.Addition(1, 2).to_equation(), sympy.symbols("test"))
+
         # Test Power
         self.assertEqual(pybamm.Power(7, 2).to_equation(), 49)
 

--- a/tests/unit/test_expression_tree/test_scalar.py
+++ b/tests/unit/test_expression_tree/test_scalar.py
@@ -1,9 +1,9 @@
 #
 # Tests for the Scalar class
 #
-import pybamm
-
 import unittest
+
+import pybamm
 
 
 class TestScalar(unittest.TestCase):
@@ -31,6 +31,10 @@ class TestScalar(unittest.TestCase):
         self.assertEqual(a1.id, a2.id)
         a3 = pybamm.Scalar(5)
         self.assertNotEqual(a1.id, a3.id)
+
+    def test_to_equation(self):
+        a = pybamm.Scalar(3)
+        self.assertEqual(str(a.to_equation()), "3.0")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -107,10 +107,10 @@ class TestSymbol(unittest.TestCase):
         self.assertIsInstance(a @ b, pybamm.MatrixMultiplication)
         self.assertIsInstance(a / b, pybamm.Division)
         self.assertIsInstance(a ** b, pybamm.Power)
-        self.assertIsInstance(a < b, pybamm.Heaviside)
-        self.assertIsInstance(a <= b, pybamm.Heaviside)
-        self.assertIsInstance(a > b, pybamm.Heaviside)
-        self.assertIsInstance(a >= b, pybamm.Heaviside)
+        self.assertIsInstance(a < b, pybamm._Heaviside)
+        self.assertIsInstance(a <= b, pybamm._Heaviside)
+        self.assertIsInstance(a > b, pybamm._Heaviside)
+        self.assertIsInstance(a >= b, pybamm._Heaviside)
         self.assertIsInstance(a % b, pybamm.Modulo)
 
         # binary - symbol and number

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -1,12 +1,14 @@
 #
 # Test for the Symbol class
 #
-import pybamm
-
-import unittest
-import numpy as np
 import os
+import unittest
+
+import numpy as np
 from scipy.sparse import coo_matrix
+
+import pybamm
+from pybamm.expression_tree.binary_operators import _Heaviside
 
 
 class TestSymbol(unittest.TestCase):
@@ -107,10 +109,10 @@ class TestSymbol(unittest.TestCase):
         self.assertIsInstance(a @ b, pybamm.MatrixMultiplication)
         self.assertIsInstance(a / b, pybamm.Division)
         self.assertIsInstance(a ** b, pybamm.Power)
-        self.assertIsInstance(a < b, pybamm._Heaviside)
-        self.assertIsInstance(a <= b, pybamm._Heaviside)
-        self.assertIsInstance(a > b, pybamm._Heaviside)
-        self.assertIsInstance(a >= b, pybamm._Heaviside)
+        self.assertIsInstance(a < b, _Heaviside)
+        self.assertIsInstance(a <= b, _Heaviside)
+        self.assertIsInstance(a > b, _Heaviside)
+        self.assertIsInstance(a >= b, _Heaviside)
         self.assertIsInstance(a % b, pybamm.Modulo)
 
         # binary - symbol and number


### PR DESCRIPTION
# Description

- Add `to_equation` in Scalar, Binary Operators and Array
- Change `Heaviside` to `_Heaviside`
- Add tests

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
