### PR TITLE
#1507 remove algebraic equation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## Bug fixes
 
+-   Removed the overly-restrictive check "each variable in the algebraic eqn keys must appear in the eqn" ([#1510](https://github.com/pybamm-team/PyBaMM/pull/1510))
 -   Made parameters importable through pybamm ([#1475](https://github.com/pybamm-team/PyBaMM/pull/1475))
 
 ## Breaking changes

--- a/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
+++ b/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
@@ -350,7 +350,7 @@ class AlternativeEffectiveResistance2D(pybamm.BaseModel):
             f_p: pybamm.laplacian(f_p)
             - pybamm.source(1, f_p)
             + c * pybamm.DefiniteIntegralVector(f_p, vector_type="column"),
-            c: pybamm.yz_average(f_p) + pybamm.NotConstant(0) * c,
+            c: pybamm.yz_average(f_p),
         }
 
         # Boundary conditons

--- a/pybamm/models/submodels/current_collector/quite_conductive_potential_pair.py
+++ b/pybamm/models/submodels/current_collector/quite_conductive_potential_pair.py
@@ -67,9 +67,7 @@ class BaseQuiteConductivePotentialPair(BasePotentialPair):
             * pybamm.laplacian(phi_s_cp)
             + pybamm.source(i_boundary_cc_0, phi_s_cp)
             + c * pybamm.PrimaryBroadcast(cc_area, "current collector"),
-            c: pybamm.Integral(i_boundary_cc, z)
-            - applied_current / cc_area
-            + pybamm.Multiplication(0, c),
+            c: pybamm.Integral(i_boundary_cc, z) - applied_current / cc_area,
         }
 
     def set_initial_conditions(self, variables):

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -342,18 +342,6 @@ class TestBaseModel(unittest.TestCase):
         with self.assertRaisesRegex(pybamm.ModelError, "extra algebraic keys"):
             model.check_well_posedness()
 
-        # before discretisation, fail if the algebraic eqn keys don't appear in the eqns
-        model = pybamm.BaseModel()
-        model.algebraic = {c: d - 2, d: d - c}
-        with self.assertRaisesRegex(
-            pybamm.ModelError,
-            "each variable in the algebraic eqn keys must appear in the eqn",
-        ):
-            model.check_well_posedness()
-        # passes when we switch the equations around
-        model.algebraic = {c: d - c, d: d - 2}
-        model.check_well_posedness()
-
         # after discretisation, algebraic equation without a StateVector fails
         model = pybamm.BaseModel()
         model.algebraic = {


### PR DESCRIPTION
# Description
Remove the check "each variable in the algebraic eqn keys must appear in the eqn"

Fixes #1507 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
