### PR TITLE
Issue 1504 half cell simulation

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -690,7 +690,7 @@ class BaseBatteryModel(pybamm.BaseModel):
 
     def new_empty_copy(self):
         """ See :meth:`pybamm.BaseModel.new_empty_copy()` """
-        new_model = self.__class__(name=self.name, options=self.options, build=False)
+        new_model = self.__class__(name=self.name, options=self.options)
         new_model.use_jacobian = self.use_jacobian
         new_model.convert_to_format = self.convert_to_format
         new_model.timescale = self.timescale

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -13,7 +13,7 @@ class BasicDFNHalfCell(BaseModel):
 
     This class differs from the :class:`pybamm.lithium_ion.BasicDFN` model class in
     that it is for a cell with a lithium counter electrode (half cell). This is a
-    feature under development (for example, it cannot be used with the Simulation class
+    feature under development (for example, it cannot be used with the Experiment class
     for the moment) and in the future it will be incorporated as a standard model with
     the full functionality.
 

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -97,6 +97,10 @@ class Simulation:
     ):
         self.parameter_values = parameter_values or model.default_parameter_values
 
+        if isinstance(model, pybamm.lithium_ion.BasicDFNHalfCell):
+            if experiment is not None:
+                raise NotImplementedError("BasicDFNHalfCell is not compatible with experiment simulations yet.")
+
         if experiment is None:
             # Check to see if the current is provided as data (i.e. drive cycle)
             current = self._parameter_values.get("Current function [A]")

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -97,11 +97,6 @@ class Simulation:
     ):
         self.parameter_values = parameter_values or model.default_parameter_values
 
-        if isinstance(model, pybamm.lithium_ion.BasicDFNHalfCell):
-            raise NotImplementedError(
-                "BasicDFNHalfCell is not compatible with Simulations yet."
-            )
-
         if experiment is None:
             # Check to see if the current is provided as data (i.e. drive cycle)
             current = self._parameter_values.get("Current function [A]")

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -99,7 +99,9 @@ class Simulation:
 
         if isinstance(model, pybamm.lithium_ion.BasicDFNHalfCell):
             if experiment is not None:
-                raise NotImplementedError("BasicDFNHalfCell is not compatible with experiment simulations yet.")
+                raise NotImplementedError(
+                    "BasicDFNHalfCell is not compatible "
+                    "with experiment simulations yet.")
 
         if experiment is None:
             # Check to see if the current is provided as data (i.e. drive cycle)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -39,22 +39,25 @@ class TestBasicModels(unittest.TestCase):
     def test_dfn_half_cell_simulation_with_experiment_error(self):
         options = {"working electrode": "negative"}
         model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)
-        experiment = pybamm.Experiment([("Discharge at C/10 for 10 hours or until 3.5 V")])
+        experiment = pybamm.Experiment([
+            ("Discharge at C/10 for 10 hours or until 3.5 V")])
         with self.assertRaisesRegex(
-            NotImplementedError, "BasicDFNHalfCell is not compatible with experiment simulations yet."):
+                NotImplementedError,
+                "BasicDFNHalfCell is not compatible with experiment simulations yet."):
             pybamm.Simulation(model, experiment=experiment)
 
     def basic_dfn_half_cell_simulation(self):
-        model = pybamm.lithium_ion.BasicDFNHalfCell(options={"working electrode": "positive"})
+        model = pybamm.lithium_ion.BasicDFNHalfCell(
+            options={"working electrode": "positive"})
         chemistry = pybamm.parameter_sets.Chen2020
         param = pybamm.ParameterValues(chemistry=chemistry)
-        param.update({
-        "Lithium counter electrode exchange-current density [A.m-2]": 12.6,
-        "Lithium counter electrode conductivity [S.m-1]": 1.0776e7,
-        "Lithium counter electrode thickness [m]": 250e-6,
-        },
-        check_already_exists=False,
-        )
+        param.update(
+            {
+                "Lithium counter electrode exchange-current density [A.m-2]": 12.6,
+                "Lithium counter electrode conductivity [S.m-1]": 1.0776e7,
+                "Lithium counter electrode thickness [m]": 250e-6,
+            },
+            check_already_exists=False, )
         param["Initial concentration in negative electrode [mol.m-3]"] = 1000
         param["Current function [A]"] = 2.5
         sim = pybamm.Simulation(model=model, parameter_values=param)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -36,14 +36,6 @@ class TestBasicModels(unittest.TestCase):
         copy = model.new_copy()
         copy.check_well_posedness()
 
-    def test_dfn_half_cell_simulation_error(self):
-        options = {"working electrode": "negative"}
-        model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)
-        with self.assertRaisesRegex(
-            NotImplementedError, "not compatible with Simulations yet."
-        ):
-            pybamm.Simulation(model)
-
     def test_dfn_half_cell_defaults(self):
         # test default geometry
         var = half_cell_spatial_vars

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -36,6 +36,19 @@ class TestBasicModels(unittest.TestCase):
         copy = model.new_copy()
         copy.check_well_posedness()
 
+    def test_dfn_half_cell_simulation_with_experiment_error(self):
+        options = {"working electrode": "negative"}
+        model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)
+        experiment = pybamm.Experiment([("Discharge at C/10 for 10 hours or until 3.5 V")])
+        with self.assertRaisesRegex(
+            NotImplementedError, "BasicDFNHalfCell is not compatible with experiment simulations yet."):
+            pybamm.Simulation(model, experiment=experiment)
+
+    def basic_dfn_half_cell_simulation(self):
+        model = pybamm.lithium_ion.BasicDFNHalfCell(options={"working electrode": "positive"})
+        sim = pybamm.Simulation(model=model)
+        sim.solve([0, 3600])
+
     def test_dfn_half_cell_defaults(self):
         # test default geometry
         var = half_cell_spatial_vars

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -46,8 +46,22 @@ class TestBasicModels(unittest.TestCase):
 
     def basic_dfn_half_cell_simulation(self):
         model = pybamm.lithium_ion.BasicDFNHalfCell(options={"working electrode": "positive"})
-        sim = pybamm.Simulation(model=model)
-        sim.solve([0, 3600])
+        chemistry = pybamm.parameter_sets.Chen2020
+        param = pybamm.ParameterValues(chemistry=chemistry)
+        param.update({
+        "Lithium counter electrode exchange-current density [A.m-2]": 12.6,
+        "Lithium counter electrode conductivity [S.m-1]": 1.0776e7,
+        "Lithium counter electrode thickness [m]": 250e-6,
+        },
+        check_already_exists=False,
+        )
+        param["Initial concentration in negative electrode [mol.m-3]"] = 1000
+        param["Current function [A]"] = 2.5
+        sim = pybamm.Simulation(model=model, parameter_values=param)
+        sim.solve([0, 100])
+        self.assertTrue(
+            isinstance(sim.solution, pybamm.solvers.solution.Solution)
+        )
 
     def test_dfn_half_cell_defaults(self):
         # test default geometry


### PR DESCRIPTION
# Description

Allows BasicDFNHalfCell to work with the Simulation class, and fixes a bug where an option `build` is no longer supported in the base_battery_model.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
