### PR TITLE
Add to_equation for SPM

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -374,8 +374,8 @@ class MatrixMultiplication(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        right = sympy.Matrix(right)
         left = sympy.Matrix(left)
+        right = sympy.Matrix(right)
         return left * right
 
 

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -166,7 +166,9 @@ class BinaryOperator(pybamm.Symbol):
 
     def _binary_evaluate(self, left, right):
         """Perform binary operation on nodes 'left' and 'right'."""
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"{self.__class__} does not implement _binary_evaluate."
+        )
 
     def _evaluates_on_edges(self, dimension):
         """See :meth:`pybamm.Symbol._evaluates_on_edges()`."""
@@ -372,8 +374,8 @@ class MatrixMultiplication(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        left = sympy.Matrix(left)
         right = sympy.Matrix(right)
+        left = sympy.Matrix(left)
         return left * right
 
 

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -2,13 +2,17 @@
 # Parameter classes
 #
 import numbers
-import numpy as np
-import pybamm
 import sys
+
+import numpy as np
+import sympy
+
+import pybamm
 
 
 class Parameter(pybamm.Symbol):
-    """A node in the expression tree representing a parameter
+    """
+    A node in the expression tree representing a parameter.
 
     This node will be replaced by a :class:`.Scalar` node
 
@@ -19,14 +23,13 @@ class Parameter(pybamm.Symbol):
         name of the node
     domain : iterable of str, optional
         list of domains the parameter is valid over, defaults to empty list
-
     """
 
     def __init__(self, name, domain=[]):
         super().__init__(name, domain=domain)
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
         return Parameter(self.name, self.domain)
 
     def _evaluate_for_shape(self):
@@ -37,13 +40,14 @@ class Parameter(pybamm.Symbol):
         return np.nan
 
     def is_constant(self):
-        """ See :meth:`pybamm.Symbol.is_constant()`. """
+        """See :meth:`pybamm.Symbol.is_constant()`."""
         # Parameter is not constant since it can become an InputParameter
         return False
 
 
 class FunctionParameter(pybamm.Symbol):
-    """A node in the expression tree representing a function parameter
+    """
+    A node in the expression tree representing a function parameter.
 
     This node will be replaced by a :class:`pybamm.Function` node if a callable function
     is passed to the parameter values, and otherwise (in some rarer cases, such as
@@ -142,7 +146,7 @@ class FunctionParameter(pybamm.Symbol):
         self._input_names = inp
 
     def set_id(self):
-        """See :meth:`pybamm.Symbol.set_id` """
+        """See :meth:`pybamm.Symbol.set_id`"""
         self._id = hash(
             (self.__class__, self.name, self.diff_variable)
             + tuple([child.id for child in self.children])
@@ -150,8 +154,10 @@ class FunctionParameter(pybamm.Symbol):
         )
 
     def get_children_domains(self, children_list):
-        """Obtains the unique domain of the children. If the
-        children have different domains then raise an error"""
+        """
+        Obtains the unique domain of the children.
+        If the children have different domains then raise an error
+        """
         domains = [child.domain for child in children_list if child.domain != []]
 
         # check that there is one common domain amongst children
@@ -169,7 +175,7 @@ class FunctionParameter(pybamm.Symbol):
         return domain
 
     def diff(self, variable):
-        """ See :meth:`pybamm.Symbol.diff()`. """
+        """See :meth:`pybamm.Symbol.diff()`."""
         # return a new FunctionParameter, that knows it will need to be differentiated
         # when the parameters are set
         children_list = self.orphans
@@ -180,7 +186,7 @@ class FunctionParameter(pybamm.Symbol):
         return FunctionParameter(self.name, input_dict, diff_variable=variable)
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
         out = self._function_parameter_new_copy(
             self._input_names, self.orphans, print_name=self.print_name
         )
@@ -189,7 +195,8 @@ class FunctionParameter(pybamm.Symbol):
     def _function_parameter_new_copy(
         self, input_names, children, print_name="calculate"
     ):
-        """Returns a new copy of the function parameter.
+        """
+        Returns a new copy of the function parameter.
 
         Inputs
         ------
@@ -219,3 +226,7 @@ class FunctionParameter(pybamm.Symbol):
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
         return sum(child.evaluate_for_shape() for child in self.children)
+
+    def to_equation(self):
+        """Convert the node and its subtree into a SymPy equation."""
+        return sympy.symbols(self.print_name)

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -959,3 +959,6 @@ class Symbol(anytree.NodeMixin):
             self.shape_for_testing
         except ValueError as e:
             raise pybamm.ShapeError("Cannot find shape (original error: {})".format(e))
+
+    def to_equation(self):
+        return self.name

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -1,13 +1,17 @@
 #
 # Variable class
 #
-import pybamm
 import numbers
+
 import numpy as np
+import sympy
+
+import pybamm
 
 
 class VariableBase(pybamm.Symbol):
-    """A node in the expression tree represending a dependent variable
+    """
+    A node in the expression tree represending a dependent variable.
 
     This node will be discretised by :class:`.Discretisation` and converted
     to a :class:`pybamm.StateVector` node.
@@ -50,7 +54,7 @@ class VariableBase(pybamm.Symbol):
         self.print_name = None
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
 
         out = self.__class__(
             self.name, self.domain, self.auxiliary_domains, self.bounds
@@ -59,14 +63,22 @@ class VariableBase(pybamm.Symbol):
         return out
 
     def _evaluate_for_shape(self):
-        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
+        """See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()`"""
         return pybamm.evaluate_for_shape_using_domain(
             self.domain, self.auxiliary_domains
         )
 
+    def to_equation(self):
+        """Convert the node and its subtree into a SymPy equation."""
+        if getattr(self, "print_name", None):
+            return sympy.symbols(self.print_name)
+        else:
+            return self.name
+
 
 class Variable(VariableBase):
-    """A node in the expression tree represending a dependent variable
+    """
+    A node in the expression tree represending a dependent variable.
 
     This node will be discretised by :class:`.Discretisation` and converted
     to a :class:`pybamm.StateVector` node.
@@ -145,7 +157,6 @@ class VariableDot(VariableBase):
 
         Note: Variable._jac adds a dash to the name of the corresponding VariableDot, so
         we remove this here
-
         """
         return Variable(
             self.name[:-1], domain=self.domain, auxiliary_domains=self.auxiliary_domains
@@ -161,7 +172,8 @@ class VariableDot(VariableBase):
 
 
 class ExternalVariable(Variable):
-    """A node in the expression tree representing an external variable variable
+    """
+    A node in the expression tree representing an external variable variable.
 
     This node will be discretised by :class:`.Discretisation` and converted
     to a :class:`.Vector` node.
@@ -193,13 +205,13 @@ class ExternalVariable(Variable):
         return self._size
 
     def new_copy(self):
-        """ See :meth:`pybamm.Symbol.new_copy()`. """
+        """See :meth:`pybamm.Symbol.new_copy()`."""
         return ExternalVariable(
             self.name, self.size, self.domain, self.auxiliary_domains
         )
 
     def _evaluate_for_shape(self):
-        """ See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()` """
+        """See :meth:`pybamm.Symbol.evaluate_for_shape_using_domain()`"""
         return np.nan * np.ones((self.size, 1))
 
     def _base_evaluate(self, t=None, y=None, y_dot=None, inputs=None):

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -2,8 +2,11 @@
 # Tests for the Parameter class
 #
 import numbers
-import pybamm
 import unittest
+
+import sympy
+
+import pybamm
 
 
 class TestParameter(unittest.TestCase):
@@ -92,6 +95,11 @@ class TestFunctionParameter(unittest.TestCase):
         self.assertEqual(myfun_dim(x).print_name, "myfun")
         self.assertEqual(myfun_dimensional(x).print_name, "myfun")
         self.assertEqual(_myfun(x).print_name, None)
+
+    def test_to_equation(self):
+        func = pybamm.FunctionParameter("test", {"x": pybamm.Scalar(1)})
+        func.print_name = "test"
+        self.assertEqual(func.to_equation(), sympy.symbols("test"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -489,6 +489,9 @@ class TestSymbol(unittest.TestCase):
         with self.assertRaises(pybamm.ShapeError):
             (y1 + y2).test_shape()
 
+    def test_to_equation(self):
+        self.assertEqual(pybamm.Symbol("test").to_equation(), "test")
+
 
 class TestIsZero(unittest.TestCase):
     def test_is_scalar_zero(self):

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -1,11 +1,13 @@
 #
 # Tests for the Unary Operator classes
 #
-import pybamm
-
 import unittest
+
 import numpy as np
+import sympy
 from scipy.sparse import diags
+
+import pybamm
 
 
 class TestUnaryOperators(unittest.TestCase):
@@ -560,11 +562,7 @@ class TestUnaryOperators(unittest.TestCase):
         self.assertEqual(average_conc_broad.auxiliary_domains, {"secondary": ["test"]})
 
         # x-average of broadcast
-        for domain in [
-            ["negative electrode"],
-            ["separator"],
-            ["positive electrode"],
-        ]:
+        for domain in [["negative electrode"], ["separator"], ["positive electrode"]]:
             a = pybamm.Variable("a", domain=domain)
             x = pybamm.SpatialVariable("x", domain)
             av_a = pybamm.x_average(a)
@@ -740,6 +738,17 @@ class TestUnaryOperators(unittest.TestCase):
         self.assertEqual(a.jac(pybamm.StateVector(slice(0, 1))).evaluate(), 0)
         self.assertFalse(a.is_constant())
         self.assertFalse((2 * a).is_constant())
+
+    def test_to_equation(self):
+        # Test print_name
+        pybamm.Floor.print_name = "test"
+        self.assertEqual(pybamm.Floor(-2.5).to_equation(), sympy.symbols("test"))
+
+        # Test Negate
+        self.assertEqual(pybamm.Negate(4).to_equation(), -4.0)
+
+        # Test AbsoluteValue
+        self.assertEqual(pybamm.AbsoluteValue(-4).to_equation(), 4.0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -6,6 +6,8 @@ import unittest
 import numpy as np
 import sympy
 from scipy.sparse import diags
+from sympy.vector.operators import Divergence as sympy_Divergence
+from sympy.vector.operators import Gradient as sympy_Gradient
 
 import pybamm
 
@@ -749,6 +751,16 @@ class TestUnaryOperators(unittest.TestCase):
 
         # Test AbsoluteValue
         self.assertEqual(pybamm.AbsoluteValue(-4).to_equation(), 4.0)
+
+        # Test Gradient
+        a = pybamm.Symbol("a", domain="test")
+        self.assertEqual(pybamm.Gradient(a).to_equation(), sympy_Gradient("a"))
+
+        # Test Divergence
+        self.assertEqual(
+            pybamm.Divergence(pybamm.Gradient(a)).to_equation(),
+            sympy_Divergence(sympy_Gradient(a)),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_variable.py
+++ b/tests/unit/test_expression_tree/test_variable.py
@@ -1,10 +1,12 @@
 #
 # Tests for the Variable class
 #
-import pybamm
-import numpy as np
-
 import unittest
+
+import numpy as np
+import sympy
+
+import pybamm
 
 
 class TestVariable(unittest.TestCase):
@@ -44,6 +46,15 @@ class TestVariable(unittest.TestCase):
             pybamm.Variable("var", bounds=(1, 0))
         with self.assertRaisesRegex(ValueError, "Invalid bounds"):
             pybamm.Variable("var", bounds=(1, 1))
+
+    def test_to_equation(self):
+        # Test print_name
+        func = pybamm.Variable("test_string")
+        func.print_name = "test"
+        self.assertEqual(func.to_equation(), sympy.symbols("test"))
+
+        # Test name
+        self.assertEqual(pybamm.Variable("name").to_equation(), "name")
 
 
 class TestVariableDot(unittest.TestCase):


### PR DESCRIPTION
# Description

- Add to_equation in FunctionParameter, Symbol, UnaryOperator, Gradient, Divergence and Variable
- Make to_equation SPM compatible
- Add tests

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
