### PR TITLE
Solve Drive Cycle (A,V,W) in Experiment

### DIFF
--- a/examples/scripts/experiment_drive_cycle.py
+++ b/examples/scripts/experiment_drive_cycle.py
@@ -1,0 +1,87 @@
+#
+# Constant-current constant-voltage charge with US06 Drive Cycle using Experiment Class.
+#
+import pybamm
+import pandas as pd
+import os
+
+os.chdir(pybamm.__path__[0] + "/..")
+
+pybamm.set_logging_level("INFO")
+
+# import drive cycle from file
+drive_cycle_current = pd.read_csv("pybamm/input/drive_cycles/US06.csv",
+                                  comment="#",
+                                  header=None).to_numpy()
+
+
+# Map Drive Cycle
+def Map_Drive_Cycle(x, min_ip_value, max_ip_value, min_op_value, max_op_value):
+    return (x - min_ip_value) * (max_op_value - min_op_value) / (
+        max_ip_value - min_ip_value) + min_op_value
+
+
+# Map Current to Voltage
+temp_volts = np.array([])
+min_ip_value = drive_cycle_current[:, 1].min()
+max_ip_value = drive_cycle_current[:, 1].max()
+min_Voltage = 3.5
+max_Voltage = 4.1
+for I in drive_cycle_current[:, 1]:
+    temp_volts = np.append(
+        temp_volts,
+        Map_Drive_Cycle(I, min_ip_value, max_ip_value, min_Voltage,
+                        max_Voltage))
+
+drive_cycle_voltage = drive_cycle_current
+drive_cycle_voltage = np.column_stack((np.delete(drive_cycle_voltage, 1,
+                                                 1), np.array(temp_volts)))
+
+# Map Current to Power
+temp_volts = np.array([])
+min_ip_value = drive_cycle_current[:, 1].min()
+max_ip_value = drive_cycle_current[:, 1].max()
+min_Power = 2.5
+max_Power = 5.5
+for I in drive_cycle_current[:, 1]:
+    temp_volts = np.append(
+        temp_volts,
+        Map_Drive_Cycle(I, min_ip_value, max_ip_value, min_Power, max_Power))
+
+drive_cycle_power = drive_cycle_current
+drive_cycle_power = np.column_stack((np.delete(drive_cycle_power, 1,
+                                               1), np.array(temp_volts)))
+experiment = pybamm.Experiment([
+#     "Charge at 1 A until 4.1 V",
+#     "Hold at 4.1 V until 50 mA",
+#     "Rest for 1 hour",
+    "Run US06_A (A),
+#     "Rest for 1 hour",
+] 
+#     + [
+#     "Charge at 1 A until 4.1 V",
+#     "Hold at 4.1 V until 50 mA",
+#     "Rest for 1 hour",
+#     "Run US06_V (V)",
+#     "Rest for 1 hour",
+# ] + [
+#     "Charge at 1 A until 4.1 V",
+#     "Hold at 4.1 V until 50 mA",
+#     "Rest for 1 hour",
+#     "Run US06_W (W)",
+#     "Rest for 1 hour",
+# ]
+   ,drive_cycles={
+       "US06_A": drive_cycle_current,
+       "US06_V": drive_cycle_voltage,
+       "US06_W": drive_cycle_power,
+   })
+
+model = pybamm.lithium_ion.DFN()
+sim = pybamm.Simulation(model,
+                        experiment=experiment,
+                        solver=pybamm.CasadiSolver())
+sim.solve()
+
+# Show all plots
+sim.plot()

--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -233,7 +233,7 @@ class Experiment:
                         examples
                     )
                 )
-        return electric + (time,) + (period,), events
+        return electric + (time,) + (period,) + (cond,), events
 
     def extend_drive_cycle(self, drive_cycle, end_time):
         "Extends the drive cycle to enable for event"

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -171,14 +171,12 @@ class Simulation:
         self._experiment_times = []
         for op, events in zip(experiment.operating_conditions, experiment.events):
             if isinstance(op[0], np.ndarray):
-                # self.operating_mode = "drive cycle" ########!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 # If ndarray is recived from, create interpolant
                 # create interpolant
                 timescale = self._parameter_values.evaluate(model.timescale)
                 drive_cycle_interpolant = pybamm.Interpolant(
                     op[0][:, 0], op[0][:, 1], timescale * pybamm.t
                 )
-                # print(type(drive_cycle_interpolant))  #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 if op[1] == "A":
                     operating_inputs = {
                         "Current switch": 1,
@@ -193,8 +191,8 @@ class Simulation:
                         "Current switch": 0,
                         "Voltage switch": 1,
                         "Power switch": 0,
-                        "Current input [A]": 0,
-                        "Voltage input [V]": drive_cycle_interpolant,  # doesn't matter
+                        "Current input [A]": 0,  # doesn't matter
+                        "Voltage input [V]": drive_cycle_interpolant,
                         "Power input [W]": 0,  # doesn't matter
                     }
                 if op[1] == "W":
@@ -202,12 +200,11 @@ class Simulation:
                         "Current switch": 0,
                         "Voltage switch": 0,
                         "Power switch": 1,
-                        "Current input [A]": 0,
+                        "Current input [A]": 0,  # doesn't matter
                         "Voltage input [V]": 0,  # doesn't matter
-                        "Power input [W]": drive_cycle_interpolant,  # doesn't matter
+                        "Power input [W]": drive_cycle_interpolant,
                     }
             else:
-                # self.operating_mode = "experiment" ########!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!        
                 if op[1] in ["A", "C"]:
                     # Update inputs for constant current
                     if op[1] == "A":
@@ -460,7 +457,8 @@ class Simulation:
                     for event in new_model.events
                     if event.name not in ["Minimum voltage", "Maximum voltage"]
                 ]
-
+# Make Interpolant Here
+                print("OK GEE")
                 # Update parameter values
                 new_parameter_values = self.parameter_values.copy()
                 if op_inputs["Current switch"] == 1:
@@ -731,8 +729,6 @@ class Simulation:
                     dt = self._experiment_times[idx]
                     op_conds_str = self.experiment.operating_conditions_strings[idx]
                     op_conds_elec = self.experiment.operating_conditions[idx][:2]
-                    # print('Operating Conditions', op_conds_elec)
-                    # model = self.op_conds_to_built_models[op_conds_elec]
                     model = self.op_conds_to_built_models[op_conds_str]
                     # Use 1-indexing for printing cycle number as it is more
                     # human-intuitive
@@ -754,9 +750,7 @@ class Simulation:
                     )
                     steps.append(step_solution)
                     current_solution = step_solution
-
                     cycle_solution = cycle_solution + step_solution
-
                     # Only allow events specified by experiment
                     if not (
                         cycle_solution is None

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -907,7 +907,15 @@ class BaseSolver(object):
         # Set up external variables and inputs
         external_variables = external_variables or {}
         inputs = inputs or {}
+        if isinstance(inputs['Current input [A]'], pybamm.Interpolant):
+            del inputs['Current input [A]']
+        elif isinstance(inputs['Voltage input [V]'], pybamm.Interpolant):
+            del inputs['Voltage input [V]']
+        elif isinstance(inputs['Power input [W]'], pybamm.Interpolant):
+            del inputs['Power input [W]']
+        print("First Inputs",inputs)
         ext_and_inputs = {**external_variables, **inputs}
+        print("First EXT and Inputs",ext_and_inputs)
 
         # Check that any inputs that may affect the scaling have not changed
         # Set model timescale
@@ -1199,6 +1207,7 @@ class InitialConditions(SolverCallable):
     def __call__(self, inputs):
         if self.form == "casadi":
             if isinstance(inputs, dict):
+                print(inputs) #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 inputs = casadi.vertcat(*[x for x in inputs.values()])
             return self._function(0, self.y_dummy, inputs)
         else:

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -913,9 +913,7 @@ class BaseSolver(object):
             del inputs['Voltage input [V]']
         elif isinstance(inputs['Power input [W]'], pybamm.Interpolant):
             del inputs['Power input [W]']
-        print("First Inputs",inputs)
         ext_and_inputs = {**external_variables, **inputs}
-        print("First EXT and Inputs",ext_and_inputs)
 
         # Check that any inputs that may affect the scaling have not changed
         # Set model timescale
@@ -1207,7 +1205,6 @@ class InitialConditions(SolverCallable):
     def __call__(self, inputs):
         if self.form == "casadi":
             if isinstance(inputs, dict):
-                print(inputs) #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 inputs = casadi.vertcat(*[x for x in inputs.values()])
             return self._function(0, self.y_dummy, inputs)
         else:


### PR DESCRIPTION
# Description

PR Status: (Work in Progress)

This PR provides the functionality of solving the drive cycle using the experiment only if the first input of the experiment is the drive cycle. 

Issues in PR:

- When two consecutive drive cycles are given in the experiment, only the first one solves but the second one only returns 0 current. 

- If the drive cycle is not the first input of the experiment, the drive cycle part only returns 0 current. 

Possible Cause of this Issue: 

The driving cycles are given to the solver as interpolant. I think there is an issue with the timing of the interpolant which I am unable to overcome. For example, The US06 Drive cycle data have time range [0:600], When the drive cycle is the first input of the experiment is drive cycle (solution start time = 0), the cycle is solved successfully, but when the same cycle is repeated, (solution time > 600), the interpolant returns 0 A.

@tinosulzer and @Saransh-cpp suggestions on overcoming this issue are highly appreciated. 

Fixes # (issue)
#1279 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
