### PR TITLE
Skip print_name setter

### DIFF
--- a/pybamm/expression_tree/printing/print_name.py
+++ b/pybamm/expression_tree/printing/print_name.py
@@ -41,6 +41,10 @@ GREEK_LETTERS = [
 def prettify_print_name(name):
     """Prettify print_name using regex"""
 
+    # Skip prettify_print_name() for cases like `new_copy()`
+    if "{" in name:
+        return name
+
     # Return print_name if name exists in the dictionary
     if name in PRINT_NAME_OVERRIDES:
         return PRINT_NAME_OVERRIDES[name]

--- a/tests/unit/test_expression_tree/test_printing/test_print_name.py
+++ b/tests/unit/test_expression_tree/test_printing/test_print_name.py
@@ -29,6 +29,12 @@ class TestPrintName(unittest.TestCase):
         # Test greek letters
         self.assertEqual(param1.delta_phi_n.print_name, r"\delta_\phi_n")
 
+        # Test new_copy()
+        param2 = pybamm.LeadAcidParameters()
+        x_n = pybamm.standard_spatial_vars.x_n
+        a_n = param2.a_n(x_n)
+        a_n_new = a_n.new_copy()
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_printing/test_print_name.py
+++ b/tests/unit/test_expression_tree/test_printing/test_print_name.py
@@ -33,7 +33,7 @@ class TestPrintName(unittest.TestCase):
         param2 = pybamm.LeadAcidParameters()
         x_n = pybamm.standard_spatial_vars.x_n
         a_n = param2.a_n(x_n)
-        a_n_new = a_n.new_copy()
+        a_n.new_copy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Skip print_name setter for `new_copy`

Fixes #1540 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
