### PR TITLE
Update citations and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,21 @@ On GNU/Linux and MacOS, an optional [scikits.odes](https://scikits-odes.readthed
 
 If you use PyBaMM in your work, please cite our paper
 
-> Sulzer, V., Marquis, S. G., Timms, R., Robinson, M., & Chapman, S. J. (2020). Python Battery Mathematical Modelling (PyBaMM). _ECSarXiv. February, 7_.
+> Sulzer, V., Marquis, S. G., Timms, R., Robinson, M., & Chapman, S. J. (2021). Python Battery Mathematical Modelling (PyBaMM). _Journal of Open Research Software, 9(1)_.
 
 You can use the bibtex
 
 ```
-@article{Sulzer2021python,
-  title={Python Battery Mathematical Modelling (PyBaMM)},
-  author={Sulzer, Valentin and Marquis, Scott G and Timms, Robert and Robinson, Martin and Chapman, S Jon},
-  journal={ECSarXiv. February},
-  volume={7},
-  year={2020}
+@article{Sulzer2021,
+  title = {{Python Battery Mathematical Modelling (PyBaMM)}},
+  author = {Sulzer, Valentin and Marquis, Scott G. and Timms, Robert and Robinson, Martin and Chapman, S. Jon},
+  doi = {10.5334/jors.309},
+  journal = {Journal of Open Research Software},
+  publisher = {Software Sustainability Institute},
+  volume = {9},
+  number = {1},
+  pages = {14},
+  year = {2021}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you use PyBaMM in your work, please cite our paper
 You can use the bibtex
 
 ```
-@article{sulzer2020python,
+@article{Sulzer2021python,
   title={Python Battery Mathematical Modelling (PyBaMM)},
   author={Sulzer, Valentin and Marquis, Scott G and Timms, Robert and Robinson, Martin and Chapman, S Jon},
   journal={ECSarXiv. February},

--- a/pybamm/CITATIONS.txt
+++ b/pybamm/CITATIONS.txt
@@ -179,6 +179,8 @@
   journal = {Journal of Open Research Software},
   publisher = {Software Sustainability Institute},
   volume = {9},
+  number = {1},
+  pages = {14},
   year = {2021}
 }
 

--- a/pybamm/CITATIONS.txt
+++ b/pybamm/CITATIONS.txt
@@ -172,13 +172,14 @@
   doi = {10.1149/2.0441908jes},
 }
 
-@article{Sulzer2020,
+@article{Sulzer2021,
   title = {{Python Battery Mathematical Modelling (PyBaMM)}},
   author = {Sulzer, Valentin and Marquis, Scott G. and Timms, Robert and Robinson, Martin and Chapman, S. Jon},
-  journal = {ECSarXiv. February},
-  volume = {7},
-  year = {2020},
-  doi = {10.1149/osf.io/67ckj},
+  doi = {10.5334/jors.309},
+  journal = {Journal of Open Research Software},
+  publisher = {Software Sustainability Institute},
+  volume = {9},
+  year = {2021}
 }
 
 @article{Gustafsson2020,
@@ -228,14 +229,16 @@
   doi = {10.1016/j.electacta.2020.135862},
 }
 
-@article{Timms2020,
-title = {{Asymptotic Reduction of a Lithium-ion Pouch Cell Model}},
-journal = {Submitted for publication},
-author = {Timms, Robert and Marquis, Scott G. and Sulzer, Valentin and Please, Colin P. and Chapman, S. Jon},
-year = {2020},
-eprint = {2005.05127},
-archivePrefix = {arXiv},
-primaryClass = {physics.app-ph},
+@article{Timms2021,
+  title = {{Asymptotic Reduction of a Lithium-ion Pouch Cell Model}},
+  author = {Timms, Robert and Marquis, Scott G and Sulzer, Valentin and Please, Colin P. and Chapman, S Jonathan},
+  year = {2021},
+  journal = {SIAM Journal on Applied Mathematics},
+  publisher = {Society for Industrial and Applied Mathematics},
+  number = {3},
+  pages = {765--788},
+  volume = {81},
+  doi = {10.1137/20M1336898},
 }
 
 @article{Subramanian2005,
@@ -250,14 +253,15 @@ primaryClass = {physics.app-ph},
   doi = {10.1149/1.2032427},
 }
 
-@article{BrosaPlanella2020,
+@article{BrosaPlanella2021,
   title = {Systematic derivation and validation of a reduced thermal-electrochemical model for lithium-ion batteries using asymptotic methods},
-  journal = {Submitted for publication},
   author = {Brosa Planella, Ferran and Sheikh, Muhammad and Widanage, W. Dhammika},
-  year = {2020},
-  eprint = {2011.01611},
-  archivePrefix = {arXiv},
-  primaryClass = {physics.chem-ph},
+  year = {2021},
+  journal = {Electrochimica Acta},
+  publisher = {Elsevier},
+  pages = {138524},
+  volume = {388},
+  doi = {10.1016/j.electacta.2021.138524},
 }
 
 @article{Lain2019,
@@ -335,14 +339,14 @@ primaryClass = {physics.app-ph},
 }
 
 @article{Ren2018,
-author={Ren, Dongsheng and Smith, Kandler and Guo, Dongxu and Han, Xuebing and Feng, Xuning and Lu, Languang and Ouyang, Minggao},
-title={Investigation of Lithium Plating-Stripping Process in Li-Ion Batteries at Low Temperature Using an Electrochemical Model},
-journal={Journal of the Electrochemistry Society},
-year={2018},
-volume={165},
-pages={A2167-A2178},
-publisher={The Electrochemical Society},
-doi={10.1149/2.0661810jes}
+  author={Ren, Dongsheng and Smith, Kandler and Guo, Dongxu and Han, Xuebing and Feng, Xuning and Lu, Languang and Ouyang, Minggao},
+  title={Investigation of Lithium Plating-Stripping Process in Li-Ion Batteries at Low Temperature Using an Electrochemical Model},
+  journal={Journal of the Electrochemistry Society},
+  year={2018},
+  volume={165},
+  pages={A2167-A2178},
+  publisher={The Electrochemical Society},
+  doi={10.1149/2.0661810jes}
 }
 
 

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -18,7 +18,7 @@ class Citations:
     Examples
     --------
     >>> import pybamm
-    >>> pybamm.citations.register("Sulzer2020")
+    >>> pybamm.citations.register("Sulzer2021")
     >>> pybamm.print_citations("citations.txt")
     """
 
@@ -31,7 +31,7 @@ class Citations:
         # Initialize empty papers to cite
         self._papers_to_cite = set()
         # Register the PyBaMM paper and the numpy paper
-        self.register("Sulzer2020")
+        self.register("Sulzer2021")
         self.register("Harris2020")
 
     def read_citations(self):

--- a/pybamm/input/parameters/lithium_ion/cells/Enertech_Ai2020/parameters.csv
+++ b/pybamm/input/parameters/lithium_ion/cells/Enertech_Ai2020/parameters.csv
@@ -12,7 +12,7 @@ Electrode width [m],47E-3,Ai 2020,Not needed for 1D
 Cell cooling surface area [m2],60.484E-4,Ai 2020, pouch
 Cell volume [m3],1.5341E-5,Ai 2020, pouch
 Cell emissivity,0.95,Ai 2020,estimation
-Cell thermal expansion coefficien [m.K-1], 1.1E-6,Ai 2020,
+Cell thermal expansion coefficient [m.K-1], 1.1E-6,Ai 2020,
 ,,,
 # Current collector properties ,,,
 Negative current collector conductivity [S.m-1],58411000,CRC Handbook,copper

--- a/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
+++ b/pybamm/models/submodels/current_collector/effective_resistance_current_collector.py
@@ -51,7 +51,7 @@ class EffectiveResistance(pybamm.BaseModel):
         self.set_boundary_conditions(self.variables)
         self.set_initial_conditions(self.variables)
 
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
         # Get necessary parameters
@@ -399,7 +399,7 @@ class AlternativeEffectiveResistance2D(pybamm.BaseModel):
             {"y": var.y, "y [m]": var.y * L_y, "z": var.z, "z [m]": var.z * L_z}
         )
 
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def post_process(self, solution, param_values, V_av, I_av):
         """

--- a/pybamm/models/submodels/current_collector/potential_pair.py
+++ b/pybamm/models/submodels/current_collector/potential_pair.py
@@ -28,7 +28,7 @@ class BasePotentialPair(BaseModel):
     def __init__(self, param):
         super().__init__(param)
 
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
 

--- a/pybamm/models/submodels/electrolyte_conductivity/integrated_conductivity.py
+++ b/pybamm/models/submodels/electrolyte_conductivity/integrated_conductivity.py
@@ -31,7 +31,7 @@ class Integrated(BaseElectrolyteConductivity):
 
     def __init__(self, param, domain=None):
         super().__init__(param, domain)
-        pybamm.citations.register("BrosaPlanella2020")
+        pybamm.citations.register("BrosaPlanella2021")
 
     def _higher_order_macinnes_function(self, x):
         return pybamm.log(x)

--- a/pybamm/models/submodels/thermal/lumped.py
+++ b/pybamm/models/submodels/thermal/lumped.py
@@ -30,7 +30,7 @@ class Lumped(BaseThermal):
     def __init__(self, param, cc_dimension=0, geometry="arbitrary"):
         self.geometry = geometry
         super().__init__(param, cc_dimension)
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
 

--- a/pybamm/models/submodels/thermal/pouch_cell/pouch_cell_1D_current_collectors.py
+++ b/pybamm/models/submodels/thermal/pouch_cell/pouch_cell_1D_current_collectors.py
@@ -30,7 +30,7 @@ class CurrentCollector1D(BaseThermal):
 
     def __init__(self, param):
         super().__init__(param, cc_dimension=1)
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
 

--- a/pybamm/models/submodels/thermal/pouch_cell/pouch_cell_2D_current_collectors.py
+++ b/pybamm/models/submodels/thermal/pouch_cell/pouch_cell_2D_current_collectors.py
@@ -30,7 +30,7 @@ class CurrentCollector2D(BaseThermal):
 
     def __init__(self, param):
         super().__init__(param, cc_dimension=2)
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
 

--- a/pybamm/models/submodels/thermal/x_full.py
+++ b/pybamm/models/submodels/thermal/x_full.py
@@ -29,7 +29,7 @@ class OneDimensionalX(BaseThermal):
 
     def __init__(self, param):
         super().__init__(param)
-        pybamm.citations.register("Timms2020")
+        pybamm.citations.register("Timms2021")
 
     def get_fundamental_variables(self):
         T_n = pybamm.standard_variables.T_n

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -255,7 +255,7 @@ class LithiumIonParameters(BaseParameters):
         self.m_cr_n = pybamm.Parameter("Negative electrode Paris' law constant m")
         self.Eac_cr_n = pybamm.Parameter(
             "Negative electrode activation energy for cracking rate [kJ.mol-1]"
-        )  # noqaR
+        )  # noqa
         self.b_cr_p = pybamm.Parameter("Positive electrode Paris' law constant b")
         self.m_cr_p = pybamm.Parameter("Positive electrode Paris' law constant m")
         self.Eac_cr_p = pybamm.Parameter(

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -262,7 +262,7 @@ class LithiumIonParameters(BaseParameters):
             "Positive electrode activation energy for cracking rate [kJ.mol-1]"
         )  # noqa
         self.alpha_T_cell_dim = pybamm.Parameter(
-            "Cell thermal expansion coefficien [m.K-1]"
+            "Cell thermal expansion coefficient [m.K-1]"
         )
         self.R_const = pybamm.constants.R
         self.theta_p_dim = (

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -255,7 +255,7 @@ class LithiumIonParameters(BaseParameters):
         self.m_cr_n = pybamm.Parameter("Negative electrode Paris' law constant m")
         self.Eac_cr_n = pybamm.Parameter(
             "Negative electrode activation energy for cracking rate [kJ.mol-1]"
-        )  # noqa
+        )  # noqaR
         self.b_cr_p = pybamm.Parameter("Positive electrode Paris' law constant b")
         self.m_cr_p = pybamm.Parameter("Positive electrode Paris' law constant m")
         self.Eac_cr_p = pybamm.Parameter(

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -405,7 +405,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         **Backward integral**
 
         .. math::
-            F(x) = \\int_x^end\\!f(u)\\,du
+            F(x) = \\int_x^{end}\\!f(u)\\,du
 
         The indefinite integral must satisfy the following conditions:
 

--- a/tests/unit/test_citations.py
+++ b/tests/unit/test_citations.py
@@ -10,8 +10,8 @@ class TestCitations(unittest.TestCase):
     def test_citations(self):
         citations = pybamm.citations
         # Default papers should be in both _all_citations dict and in the papers to cite
-        self.assertIn("Sulzer2020", citations._all_citations.keys())
-        self.assertIn("Sulzer2020", citations._papers_to_cite)
+        self.assertIn("Sulzer2021", citations._all_citations.keys())
+        self.assertIn("Sulzer2021", citations._papers_to_cite)
         self.assertIn("Harris2020", citations._papers_to_cite)
         # Non-default papers should only be in the _all_citations dict
         self.assertIn("Sulzer2019physical", citations._all_citations.keys())
@@ -83,39 +83,39 @@ class TestCitations(unittest.TestCase):
         citations = pybamm.citations
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.current_collector.BasePotentialPair(param=None)
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.current_collector.EffectiveResistance()
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.current_collector.AlternativeEffectiveResistance2D()
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.thermal.pouch_cell.CurrentCollector1D(param=None)
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.thermal.pouch_cell.CurrentCollector2D(param=None)
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.thermal.Lumped(param=None)
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
         citations._reset()
-        self.assertNotIn("Timms2020", citations._papers_to_cite)
+        self.assertNotIn("Timms2021", citations._papers_to_cite)
         pybamm.thermal.OneDimensionalX(param=None)
-        self.assertIn("Timms2020", citations._papers_to_cite)
+        self.assertIn("Timms2021", citations._papers_to_cite)
 
     def test_subramanian_2005(self):
         # Test that calling relevant bits of code adds the right paper to citations
@@ -136,9 +136,9 @@ class TestCitations(unittest.TestCase):
         citations = pybamm.citations
 
         citations._reset()
-        self.assertNotIn("BrosaPlanella2020", citations._papers_to_cite)
+        self.assertNotIn("BrosaPlanella2021", citations._papers_to_cite)
         pybamm.electrolyte_conductivity.Integrated(None)
-        self.assertIn("BrosaPlanella2020", citations._papers_to_cite)
+        self.assertIn("BrosaPlanella2021", citations._papers_to_cite)
 
     def test_newman_tobias(self):
         # Test that calling relevant bits of code adds the right paper to citations


### PR DESCRIPTION
# Description

Fixed a couple of typos and updated three references that have now been published (Timms2021, Sulzer2021 and BrosaPlanella2021).

Fixes #1562

## Type of change

Very minor style fix, not included in the CHANGELOG

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.