### PR TITLE
Get initial_soc working as simulation solve argument with experiments

### DIFF
--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -626,6 +626,17 @@ class Simulation:
                     * c_p_max,
                 }
             )
+            # For experiments also update the following
+            if hasattr(self, 'op_conds_to_model_and_param'):
+                for key, (model, param) in self.op_conds_to_model_and_param.items():
+                    param.update(
+                        {
+                            "Initial concentration in negative electrode [mol.m-3]": x
+                            * c_n_max,
+                            "Initial concentration in positive electrode [mol.m-3]": y
+                            * c_p_max,
+                        }
+                    )
             # Save solved initial SOC in case we need to re-build the model
             self._built_initial_soc = initial_soc
 

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -223,6 +223,10 @@ class TestSimulation(unittest.TestCase):
         self.assertEqual(sim._built_initial_soc, 1)
         sim.solve(t_eval=[0, 600], initial_soc=0.5)
         self.assertEqual(sim._built_initial_soc, 0.5)
+        exp = pybamm.Experiment(['Discharge at 1C until 3.6V (1 minute period)'])
+        sim = pybamm.Simulation(model, parameter_values=param, experiment=exp)
+        sim.solve(initial_soc=0.8)
+        self.assertEqual(sim._built_initial_soc, 0.8)
 
     def test_solve_with_inputs(self):
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Update the stored parameter_values dicts on the simulation when running experiments to set the initial soc

Fixes #1561

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
