### PR TITLE
make sure citations file closed after read

### DIFF
--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -42,22 +42,23 @@ class Citations:
         citation = ""
         start = True
 
-        for line in open(citations_file):
-            # if start is true, we need to find the key
-            if start is True:
-                # match everything between { and , in the first line to get the key
-                brace_idx = line.find("{")
-                comma_idx = line.find(",")
-                key = line[brace_idx + 1 : comma_idx]
-                # turn off start as we now have the right key
-                start = False
-            citation += line
-            # blank line means next block, add citation to dictionary and
-            # reset everything
-            if line == "\n":
-                self._all_citations[key] = citation
-                citation = ""
-                start = True
+        with open(citations_file) as f:
+            for line in f:
+                # if start is true, we need to find the key
+                if start is True:
+                    # match everything between { and , in the first line to get the key
+                    brace_idx = line.find("{")
+                    comma_idx = line.find(",")
+                    key = line[brace_idx + 1 : comma_idx]
+                    # turn off start as we now have the right key
+                    start = False
+                citation += line
+                # blank line means next block, add citation to dictionary and
+                # reset everything
+                if line == "\n":
+                    self._all_citations[key] = citation
+                    citation = ""
+                    start = True
 
         # add the final citation
         self._all_citations[key] = citation

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -60,8 +60,8 @@ class Citations:
                     citation = ""
                     start = True
 
-        # add the final citation
-        self._all_citations[key] = citation
+            # add the final citation
+            self._all_citations[key] = citation
 
     def register(self, key):
         """Register a paper to be cited. The intended use is that :meth:`register`


### PR DESCRIPTION
# Description

citations file not closed in pybamm.citations.Citations.read_citations which causes pytest failed if import pybamm:

_pytest/unraisableexception.py:78: in unraisable_exception_runtest_hook
    warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E   pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
E   
E   Traceback (most recent call last):
E     File "pybamm/citations.py", line 45, in read_citations
E       for line in open(citations_file):
E   ResourceWarning: unclosed file <_io.TextIOWrapper name='pybamm/CITATIONS.txt' mode='r' encoding='UTF-8'>


Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
