### PR TITLE
Update vcpkg configuration

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,10 +1,14 @@
 {
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "c26477297ce1a9d67844e86bf0cda0e7741bd169"
+  },
   "registries": [
     {
       "kind": "git",
       "repository": "https://github.com/pybamm-team/sundials-vcpkg-registry.git",
-      "baseline": "3cdbafc061c4cdda2377c77c86aeb72cfcfbada6",
-      "packages": [ "sundials" ]
+      "packages": [ "sundials" ],
+      "baseline": "c19f72020d323811c5a5adf96235b961ec4ef89a"
     }
   ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "c26477297ce1a9d67844e86bf0cda0e7741bd169"
+    "baseline": "642d1ccb276ce13d8a8521b1ef2856f5f7bc9cdd"
   },
   "registries": [
     {


### PR DESCRIPTION
# Description

The current `vcpkg-configuration.json` file causes the vcpkg install to fail. `vcpkg` looks for `sundials` inside the builtin registry instead of the alternative registry at [sundials-vcpkg-registry ](https://github.com/pybamm-team/sundials-vcpkg-registry).

Explicitly specifying the builtin registry to act as the default seems to fix this. In my explorations I also updated the sundials registry, particularly the version keyword used in the various configuration files for the registry and sundials port. See

- [8269dd7b755268e4e0a8e01eb32bb1f140c643d6](https://github.com/pybamm-team/sundials-vcpkg-registry/commit/8269dd7b755268e4e0a8e01eb32bb1f140c643d6)
- [4285b3a438da55e7ee081b5dbdd56a736dd41330](https://github.com/pybamm-team/sundials-vcpkg-registry/tree/4285b3a438da55e7ee081b5dbdd56a736dd41330)
- [c19f72020d323811c5a5adf96235b961ec4ef89a](https://github.com/pybamm-team/sundials-vcpkg-registry/tree/c19f72020d323811c5a5adf96235b961ec4ef89a)

Fixes #1656 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

_I will merge this set of changes to `main` once it is approved - which should trigger the release of 21.08 for windows._
