### PR TITLE
Issue 1673 import parameters chemistry error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ example notebook ([#1602](https://github.com/pybamm-team/PyBaMM/pull/1602))
 
 ## Bug fixes
 
+-   Fixed bug with `load_function` ([#1675](https://github.com/pybamm-team/PyBaMM/pull/1675))
 -   Updated documentation to include some previously missing functions, such as `erf` and `tanh` ([#1628](https://github.com/pybamm-team/PyBaMM/pull/1628))
 -   Fixed reading citation file without closing ([#1620](https://github.com/pybamm-team/PyBaMM/pull/1620))
 -   Porosity variation for SEI and plating models is calculated from the film thickness rather than from a separate ODE ([#1617](https://github.com/pybamm-team/PyBaMM/pull/1617))

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -273,9 +273,12 @@ def load_function(filename):
     # Assign path to _ and filename to tail
     _, tail = os.path.split(filename)
 
-    # Strip absolute path to pybamm/input/exapmle.py
+    # Strip absolute path to pybamm/input/example.py
     if "pybamm" in filename:
         root_path = filename[filename.rfind("pybamm") :]
+    elif os.getcwd() in filename:
+        root_path = filename.replace(os.getcwd(), "")
+        root_path = root_path[1:]
     else:
         root_path = filename
 

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -4,6 +4,7 @@
 
 import os
 import tempfile
+import subprocess
 import unittest
 
 import numpy as np
@@ -70,6 +71,18 @@ class TestParameterValues(unittest.TestCase):
         # incomplete chemistry
         with self.assertRaisesRegex(KeyError, "must provide 'cell' parameters"):
             pybamm.ParameterValues(chemistry={"chemistry": "lithium_ion"})
+
+    def test_update_from_chemistry_local(self):
+        # Copy parameters
+        cmd = ["pybamm_edit_parameter", "-f", "lithium_ion"]
+        subprocess.run(cmd)
+
+        # Import parameters from chemistry
+        pybamm.ParameterValues(chemistry=pybamm.parameter_sets.Chen2020)
+
+        # Clean up parameter files
+        cmd = ["rm", "-r", "lithium_ion"]
+        subprocess.run(cmd)
 
     def test_update(self):
         # converts to dict if not


### PR DESCRIPTION
# Description

This allows importing parameters via chemistry that is in the local directory. I don't think this fixes importing parameters from other folders via chemistry. This is a much more complicated issue (I believe), but this fix should be enough for the workshop.

Fixes #1673 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
