### PR TITLE
Fix typo in FindSuiteSparse.cmake

### DIFF
--- a/FindSuiteSparse.cmake
+++ b/FindSuiteSparse.cmake
@@ -64,7 +64,7 @@ find_library(SUITESPARSE_CONFIG_LIB
   PATH_SUFFIXES "lib" "lib32" "lib64" "Lib"
   NO_DEFAULT_PATH
 )
-# now also include the deafult paths
+# now also include the default paths
 find_library(SUITESPARSE_CONFIG_LIB
   NAMES "suitesparseconfig"
   PATH_SUFFIXES "lib" "lib32" "lib64" "Lib"
@@ -93,7 +93,7 @@ foreach(_component ${SUITESPARSE_COMPONENTS})
     PATH_SUFFIXES "lib" "lib32" "lib64" "${_component}" "${_component}/Lib"
     NO_DEFAULT_PATH
   )
-  #now  also include the deafult paths
+  #now  also include the default paths
   find_library(${_component}_LIBRARY
     NAMES "${_componentLower}"
     PATH_SUFFIXES "lib" "lib32" "lib64" "${_component}" "${_component}/Lib"


### PR DESCRIPTION


# Description

Fixed typo.
```
deafult -> default
```


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
