### PR TITLE
add gjo for funding finding

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -242,7 +242,8 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/18349157?v=4",
       "profile": "https://github.com/gjo97",
       "contributions": [
-        "ideas"
+        "ideas",
+        "fundingFinding"
       ]
     },
     {


### PR DESCRIPTION
# Description

Add gjo for funding finding (bot didn't want to add it). The README will be updated once we ask the bot to add the contributions for the tutorials.
