### PR TITLE
Remove empty method

### DIFF
--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -1177,8 +1177,6 @@ class Simulation:
             and self._solver.integrator_specs != {}
         ):
             self._solver.integrator_specs = {}
-        if self.solution is not None:
-            self.solution.clear_casadi_attributes()
         with open(filename, "wb") as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -528,21 +528,11 @@ class Solution(object):
         """
         return pybamm.dynamic_plot(self, output_variables=output_variables, **kwargs)
 
-    def clear_casadi_attributes(self):
-        """Remove casadi objects for pickling, will be computed again automatically"""
-        # t_MX = None
-        # y_MX = None
-        # symbolic_inputs = None
-        # symbolic_inputs_dict = None
-        pass
-
     def save(self, filename):
         """Save the whole solution using pickle"""
         # No warning here if len(self.data)==0 as solution can be loaded
         # and used to process new variables
 
-        self.clear_casadi_attributes()
-        # Pickle
         with open(filename, "wb") as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 


### PR DESCRIPTION
The `clear_casadi_attributes()` method in the `Solution` class doesn't do anything. Apparently the method is supposed to clear Casadi objects for pickling but this is not necessary since the `Solution` object can already be pickled. So I removed the `clear_casadi_attributes()` method and references to the method.