### PR TITLE
#1785 override sympy operators exp and atan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Unreleased](https://github.com/pybamm-team/PyBaMM/)
+
+## Bug fixes
+
+-   Fixed `sympy` operators for `Arctan` and `Exponential` ([#1786](https://github.com/pybamm-team/PyBaMM/pull/1786))
+
 # [v21.10](https://github.com/pybamm-team/PyBaMM/tree/v21.9) - 2021-10-31
 
 ## Features

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -321,6 +321,10 @@ class Arctan(SpecificFunction):
         """See :meth:`pybamm.Function._function_diff()`."""
         return 1 / (children[0] ** 2 + 1)
 
+    def _sympy_operator(self, child):
+        """Override :meth:`pybamm.Function._sympy_operator`"""
+        return sympy.atan(child)
+
 
 def arctan(child):
     """Returns hyperbolic tan function of child."""
@@ -389,6 +393,10 @@ class Exponential(SpecificFunction):
     def _function_diff(self, children, idx):
         """See :meth:`pybamm.Function._function_diff()`."""
         return Exponential(children[0])
+
+    def _sympy_operator(self, child):
+        """Override :meth:`pybamm.Function._sympy_operator`"""
+        return sympy.exp(child)
 
 
 def exp(child):

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -140,6 +140,12 @@ class TestFunction(unittest.TestCase):
         # Test Arcsinh
         self.assertEqual(pybamm.Arcsinh(a).to_equation(), sympy.asinh(a))
 
+        # Test Arctan
+        self.assertEqual(pybamm.Arctan(a).to_equation(), sympy.atan(a))
+
+        # Test Exponential
+        self.assertEqual(pybamm.Exponential(a).to_equation(), sympy.exp(a))
+
         # Test log
         self.assertEqual(pybamm.Log(54.0).to_equation(), sympy.log(54.0))
 


### PR DESCRIPTION
# Description

Overrode the `sympy` operator for `Exponential` and `Arctan`. I think the only left are `Max` and `Min` but not sure if we want to override them by the `Max` and `Min` from `sympy`.

Fixes #1785

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
