### PR TITLE
Run tests once using coverage on `ubuntu-latest` with Python 3.9

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run integration tests for GNU/Linux
       if: matrix.os == 'ubuntu-latest'
-      run: python -m tox -e tests --folder integration
+      run: python -m tox -e integration-tests
 
     - name: Run unit tests for Windows and MacOS
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -2,7 +2,7 @@ name: PyBaMM
 
 on:
   push:
-    
+
   pull_request:
 
   # everyday at 3 am UTC
@@ -10,7 +10,7 @@ on:
     - cron:  '0 3 * * *'
 
 jobs:
-  
+
   style:
     runs-on: ubuntu-latest
     steps:
@@ -40,14 +40,14 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-  
+
     - name: Install Linux system dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
         sudo apt install gfortran gcc libopenblas-dev graphviz
         sudo apt install texlive-full
-    
+
     # Added fixes to homebrew installs:
     # rm -f /usr/local/bin/2to3 
     # (see https://github.com/actions/virtual-environments/issues/2322)
@@ -62,7 +62,7 @@ jobs:
     - name: Install Windows system dependencies
       if: matrix.os == 'windows-latest'
       run: choco install graphviz --version=2.38.0.20190211
-    
+
     - name: Install standard python dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools
@@ -76,6 +76,10 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
       run: python -m tox -e quick
 
+    - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
+      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)
+      run: tox -e coverage
+
     - name: Run integration tests for GNU/Linux
       if: matrix.os == 'ubuntu-latest'
       run: python -m tox -e integration
@@ -87,16 +91,11 @@ jobs:
     - name: Install docs dependencies and run doctests
       if: matrix.os == 'ubuntu-latest'
       run: tox -e doctests
-    
+
     - name: Install dev dependencies and run example tests
       if: matrix.os == 'ubuntu-latest'
       run: tox -e examples
-        
-    - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)
-      run: tox -e coverage
 
     - name: Upload coverage report
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
       uses: codecov/codecov-action@v1
-

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -73,7 +73,7 @@ jobs:
       run: tox -e pybamm-requires
 
     - name: Run unit tests for GNU/Linux
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
       run: python -m tox -e tests
 
     - name: Run unit tests for Windows and MacOS

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -72,7 +72,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: tox -e pybamm-requires
 
-    - name: Run unit tests for GNU/Linux
+    - name: Run unit tests for GNU/Linux with Python 3.7 and 3.8
       if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
       run: python -m tox -e tests
 
@@ -88,7 +88,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: tox -e examples
         
-    - name: Install and run coverage
+    - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
       if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)
       run: tox -e coverage
 

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -74,7 +74,11 @@ jobs:
 
     - name: Run unit tests for GNU/Linux with Python 3.7 and 3.8
       if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
-      run: python -m tox -e tests
+      run: python -m tox -e quick
+
+    - name: Run integration tests for GNU/Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: python -m tox -e tests --folder integration
 
     - name: Run unit tests for Windows and MacOS
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -78,7 +78,7 @@ jobs:
 
     - name: Run integration tests for GNU/Linux
       if: matrix.os == 'ubuntu-latest'
-      run: python -m tox -e integration-tests
+      run: python -m tox -e integration
 
     - name: Run unit tests for Windows and MacOS
       if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -77,7 +77,7 @@ jobs:
       run: python -m tox -e quick
 
     - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
-      if: success() && (matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9)
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
       run: tox -e coverage
 
     - name: Run integration tests for GNU/Linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ Major PyBaMM features are showcased in [Jupyter notebooks](https://jupyter.org/)
 
 All example notebooks should be listed in [examples/README.md](https://github.com/pybamm-team/PyBaMM/blob/develop/examples/notebooks/README.md). Please follow the (naming and writing) style of existing notebooks where possible.
 
-Where possible, notebooks are tested daily. A list of slow notebooks (which time-out and fail tests) is maintained in `.slow-books`, these notebooks will be excluded from daily testing.
+All the notebooks are tested daily.
 
 ## Citations
 

--- a/run-tests.py
+++ b/run-tests.py
@@ -104,35 +104,20 @@ def run_doc_tests():
         sys.exit(ret)
 
 
-def run_notebook_and_scripts(skip_slow_books=False, executable="python"):
+def run_notebook_and_scripts(executable="python"):
     """
     Runs Jupyter notebook tests. Exits if they fail.
     """
-    # Ignore slow books?
-    ignore_list = []
-    if skip_slow_books and os.path.isfile(".slow-books"):
-        with open(".slow-books", "r") as f:
-            for line in f.readlines():
-                line = line.strip()
-                if not line or line[:1] == "#":
-                    continue
-                if not line.startswith("examples/"):
-                    line = "examples/" + line
-                if not line.endswith(".ipynb"):
-                    line = line + ".ipynb"
-                if not os.path.isfile(line):
-                    raise Exception("Slow notebook note found: " + line)
-                ignore_list.append(line)
 
     # Scan and run
     print("Testing notebooks and scripts with executable `" + str(executable) + "`")
-    if not scan_for_nb_and_scripts("examples", True, executable, ignore_list):
+    if not scan_for_nb_and_scripts("examples", True, executable):
         print("\nErrors encountered in notebooks")
         sys.exit(1)
     print("\nOK")
 
 
-def scan_for_nb_and_scripts(root, recursive=True, executable="python", ignore_list=[]):
+def scan_for_nb_and_scripts(root, recursive=True, executable="python"):
     """
     Scans for, and tests, all notebooks and scripts in a directory.
     """
@@ -142,9 +127,6 @@ def scan_for_nb_and_scripts(root, recursive=True, executable="python", ignore_li
     # Scan path
     for filename in os.listdir(root):
         path = os.path.join(root, filename)
-        if path in ignore_list:
-            print("Skipping slow book: " + path)
-            continue
 
         # Recurse into subdirectories
         if recursive and os.path.isdir(path):
@@ -354,11 +336,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--examples",
         action="store_true",
-        help="Test only the fast Jupyter notebooks and scripts in `examples`.",
-    )
-    parser.add_argument(
-        "--allexamples",
-        action="store_true",
         help="Test all Jupyter notebooks and scripts in `examples`.",
     )
     parser.add_argument(
@@ -416,12 +393,9 @@ if __name__ == "__main__":
         has_run = True
         run_doc_tests()
     # Notebook tests
-    if args.allexamples:
-        has_run = True
-        run_notebook_and_scripts(executable=interpreter)
     elif args.examples:
         has_run = True
-        run_notebook_and_scripts(True, interpreter)
+        run_notebook_and_scripts(interpreter)
     if args.debook:
         has_run = True
         export_notebook(*args.debook)

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
 	 tests: python run-tests.py --unit --folder all
 	 quick: python run-tests.py --unit
-         integration-tests: python run-tests.py --nosub --folder integration
+         integration: python run-tests.py --nosub --folder integration
 	 examples: python run-tests.py --examples
 	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
 	 doctests: python run-tests.py --doctest

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
 	 tests: python run-tests.py --unit --folder all
 	 quick: python run-tests.py --unit
-      integration-tests: python run-tests.py --unit --folder integration
+         integration-tests: python run-tests.py --nosub --folder integration
 	 examples: python run-tests.py --examples
 	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
 	 doctests: python run-tests.py --doctest

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
 	 tests: python run-tests.py --unit --folder all
 	 quick: python run-tests.py --unit
-         integration: python run-tests.py --nosub --folder integration
+         integration: python run-tests.py --unit --folder integration
 	 examples: python run-tests.py --examples
 	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
 	 doctests: python run-tests.py --doctest

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
 commands =
 	 tests: python run-tests.py --unit --folder all
 	 quick: python run-tests.py --unit
+      integration-tests: python run-tests.py --unit --folder integration
 	 examples: python run-tests.py --examples
 	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
 	 doctests: python run-tests.py --doctest


### PR DESCRIPTION
# Description

- Removed the code for "slow books"
- Speed up the CI by running unit tests only once (using coverage) on `ubuntu-latest` with Python `3.9`
- Run integration and unit tests separately on `ubuntu-latest`

Speeds up the CI by 15-30 mins!

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
