### PR TITLE
Bump versions and format whitespaces

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: wheels
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,4 +17,4 @@ matplotlib >= 2.0
 #
 guzzle-sphinx-theme
 sphinx>4.0
-sympy==1.8
+sympy==1.9

--- a/pybamm/CITATIONS.txt
+++ b/pybamm/CITATIONS.txt
@@ -192,17 +192,17 @@
 }
 
 @article{Kirk2021,
-	author = {Toby L. Kirk and Colin P. Please and S. Jon Chapman},
-	title = {Physical Modelling of the Slow Voltage Relaxation Phenomenon in Lithium-Ion Batteries},
-	journal = {Journal of The Electrochemical Society},
-	year = 2021,
-	month = {jun},
-	publisher = {The Electrochemical Society},
-	volume = {168},
-	number = {6},
-	pages = {060554},
-	doi = {10.1149/1945-7111/ac0bf7},
-	url = {https://doi.org/10.1149/1945-7111/ac0bf7},
+  author = {Toby L. Kirk and Colin P. Please and S. Jon Chapman},
+  title = {Physical Modelling of the Slow Voltage Relaxation Phenomenon in Lithium-Ion Batteries},
+  journal = {Journal of The Electrochemical Society},
+  year = 2021,
+  month = {jun},
+  publisher = {The Electrochemical Society},
+  volume = {168},
+  number = {6},
+  pages = {060554},
+  doi = {10.1149/1945-7111/ac0bf7},
+  url = {https://doi.org/10.1149/1945-7111/ac0bf7},
 }
 
 @article{Lain2019,
@@ -283,17 +283,17 @@
 }
 
 @article{OKane2020,
-	doi = {10.1149/1945-7111/ab90ac},
-	url = {https://doi.org/10.1149/1945-7111/ab90ac},
-	year = {2020},
-	month = {may},
-	publisher = {The Electrochemical Society},
-	volume = {167},
-	number = {9},
-	pages = {090540},
-	author = {Simon E. J. O'Kane and Ian D. Campbell and Mohamed W. J. Marzook and Gregory J. Offer and Monica Marinescu},
-	title = {Physical Origin of the Differential Voltage Minimum Associated with Lithium Plating in Li-Ion Batteries},
-	journal = {Journal of The Electrochemical Society}
+  doi = {10.1149/1945-7111/ab90ac},
+  url = {https://doi.org/10.1149/1945-7111/ab90ac},
+  year = {2020},
+  month = {may},
+  publisher = {The Electrochemical Society},
+  volume = {167},
+  number = {9},
+  pages = {090540},
+  author = {Simon E. J. O'Kane and Ian D. Campbell and Mohamed W. J. Marzook and Gregory J. Offer and Monica Marinescu},
+  title = {Physical Origin of the Differential Voltage Minimum Associated with Lithium Plating in Li-Ion Batteries},
+  journal = {Journal of The Electrochemical Society}
 }
 
 @article{ORegan2021,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ casadi >= 3.5.0
 imageio>=2.9.0
 jupyter  # For example notebooks
 pybtex
-sympy==1.8
+sympy==1.9
 # Note: Matplotlib is loaded for debug plots but to ensure pybamm runs
 # on systems without an attached display it should never be imported
 # outside of plot() methods.

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ setup(
         "imageio>=2.9.0",
         "jupyter",  # For example notebooks
         "pybtex",
-        "sympy==1.8",
+        "sympy==1.9",
         # Note: Matplotlib is loaded for debug plots, but to ensure pybamm runs
         # on systems without an attached display, it should never be imported
         # outside of plot() methods.

--- a/tox.ini
+++ b/tox.ini
@@ -19,13 +19,13 @@ deps =
      !windows-!mac: scikits.odes
 
 commands =
-      tests-!windows-!mac: sh -c "pybamm_install_jax"  # install jax, jaxlib for ubuntu
-	 tests: python run-tests.py --unit --folder all
-	 quick: python run-tests.py --unit
-         integration: python run-tests.py --unit --folder integration
-	 examples: python run-tests.py --examples
-	 dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
-	 doctests: python run-tests.py --doctest
+     tests-!windows-!mac: sh -c "pybamm_install_jax"  # install jax, jaxlib for ubuntu
+     tests: python run-tests.py --unit --folder all
+     quick: python run-tests.py --unit
+     integration: python run-tests.py --unit --folder integration
+     examples: python run-tests.py --examples
+     dev-!windows-!mac: sh -c "echo export LD_LIBRARY_PATH={env:LD_LIBRARY_PATH} >> {envbindir}/activate"
+     doctests: python run-tests.py --doctest
 
 [testenv:pybamm-requires]
 platform = [linux,darwin]
@@ -37,7 +37,7 @@ deps =
      cmake
 commands =
          python {toxinidir}/scripts/install_KLU_Sundials.py
-	 - git clone https://github.com/pybind/pybind11.git {toxinidir}/pybind11
+      - git clone https://github.com/pybind/pybind11.git {toxinidir}/pybind11
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
# Description

- Bump sympy version and format whitespaces by replacing tab with spaces

In github
<img width="691" alt="github" src="https://user-images.githubusercontent.com/64051212/141233322-9f89d389-521f-48e1-b376-d845c6a523e1.png">

versus in vscode
<img width="601" alt="vscode" src="https://user-images.githubusercontent.com/64051212/141233335-6e8fad23-06e6-4c65-a9f1-eb96e0d1afd7.png">

https://github.com/github/VisualStudio/issues/1524#issuecomment-437797198
https://github.com/Microsoft/vscode/issues/62935#issuecomment-437795366