### PR TITLE
fixed downloading of wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: wheels
+          path: wheels
 
       - name: Publish wheels on PyPI
         if: |


### PR DESCRIPTION
# Description

This should make the workflow to publish the wheels work as before (see details [here](https://github.com/actions/download-artifact/tree/v2#compatibility-between-v1-and-v2)).
