### PR TITLE
default stress-induced diffusion 

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -243,9 +243,15 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         # provided
 
         # Change the default for stress-induced diffusion based on which particle
-        # mechanics option is provided
+        # mechanics option is provided. If the user doesn't supply a particle mechanics
+        # option set the default stress-induced diffusion option based on the default
+        # particle mechanics option which may change depending on other options
+        # (e.g. for stress-driven LAM the default mechanics option is "swelling only")
         mechanics_option = extra_options.get("particle mechanics", "none")
-        if mechanics_option == "none":
+        if (
+            mechanics_option == "none"
+            and default_options["particle mechanics"] == "none"
+        ):
             default_options["stress-induced diffusion"] = "false"
         else:
             default_options["stress-induced diffusion"] = "true"

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -33,7 +33,7 @@ PRINT_OPTIONS_OUTPUT = """\
 'SEI': 'none' (possible: ['none', 'constant', 'reaction limited', 'solvent-diffusion limited', 'electron-migration limited', 'interstitial-diffusion limited', 'ec reaction limited'])
 'SEI film resistance': 'none' (possible: ['none', 'distributed', 'average'])
 'SEI porosity change': 'false' (possible: ['false', 'true'])
-'stress-induced diffusion': 'false' (possible: ['false', 'true'])
+'stress-induced diffusion': 'true' (possible: ['false', 'true'])
 'surface form': 'differential' (possible: ['false', 'differential', 'algebraic'])
 'thermal': 'x-full' (possible: ['isothermal', 'lumped', 'x-lumped', 'x-full'])
 'total interfacial current density as a state': 'false' (possible: ['false', 'true'])
@@ -250,6 +250,10 @@ class TestBaseBatteryModel(unittest.TestCase):
                     )
                 }
             )
+        # check default options change
+        model = pybamm.BaseBatteryModel({"loss of active material": "stress-driven"})
+        self.assertEqual(model.options["particle mechanics"], "swelling only")
+        self.assertEqual(model.options["stress-induced diffusion"], "true")
 
         # crack model
         with self.assertRaisesRegex(pybamm.OptionError, "particle mechanics"):


### PR DESCRIPTION
# Description

If no option is provided for "particle mechanics" or "stress-induced diffusion" then the default stress-induced diffusion option is set based on the default particle mechanics option. For example, if the user sets up a model with stress-driven LAM
```python3
model = pybamm.lithium_ion.SPM({"loss of active material": "stress-driven"})
```
then the default particle mechanics option is automatically changed to "swelling only". In <= v21.10 stress-induced diffusion was hardcoded, so was automatically included with particle mechanics. As of v21.11 "stress-induced diffusion" is a separate option, so wasn't included in the above example. After this PR stress-induced diffusion _will_ be included in the above model since the default mechanics option has changed to "swelling only".

In summary the default options for the above model will be:

- <= v21.10: `{"particle mechanics": "swelling only"}` (stress-induced diffusion included since it is hardcoded)
- v21.11:  `{"particle mechanics": "swelling only", "stress-induced diffusion": "false"}`
- After this PR: `{"particle mechanics": "swelling only", "stress-induced diffusion": "true"}` (i.e. same behaviour as in <= v21.10)

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
