### PR TITLE
Make `PyBaMM` importable in `Linux` systems if `jax` is already installed

### DIFF
--- a/.github/release_checklist.md
+++ b/.github/release_checklist.md
@@ -4,4 +4,4 @@
   - `CITATION.cff`
   - `vcpkg.json`
 - Update CHANGELOG.md with a summary of the release
-- Update jax and jaxlib to latest version in `pybamm.util.install_jax` and fix any bugs that arise
+- Update jax and jaxlib to latest version in `pybamm.util.install_jax` and `pybamm.util.is_jax_compatible`, and fix any bugs that arise

--- a/.github/release_checklist.md
+++ b/.github/release_checklist.md
@@ -4,4 +4,4 @@
   - `CITATION.cff`
   - `vcpkg.json`
 - Update CHANGELOG.md with a summary of the release
-- Update jax and jaxlib to latest version in `pybamm.util.install_jax` and `pybamm.util.is_jax_compatible`, and fix any bugs that arise
+- Update jax and jaxlib to latest version in `pybamm.util` and fix any bugs that arise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+-   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))
 -   Solid tortuosity is now correctly calculated with Bruggeman coefficient of the respective electrode ([#1773](https://github.com/pybamm-team/PyBaMM/pull/1773))
@@ -37,7 +38,7 @@
 -   The `chemistry` keyword argument in `ParameterValues` has been deprecated. Use `ParameterValues(chem)` instead of `ParameterValues(chemistry=chem)` ([#1822](https://github.com/pybamm-team/PyBaMM/pull/1822))
 -   Raise error when trying to convert an `Interpolant` with the "pchip" interpolator to CasADI ([#1791](https://github.com/pybamm-team/PyBaMM/pull/1791))
 -   Raise error if `Concatenation` is used directly with `Variable` objects (`concatenation` should be used instead) ([#1789](https://github.com/pybamm-team/PyBaMM/pull/1789))
--   Made jax, jaxlib and the PyBaMM JaxSolver optional ([#1767](https://github.com/pybamm-team/PyBaMM/pull/1767))
+-   Made jax, jaxlib and the PyBaMM JaxSolver optional ([#1767](https://github.com/pybamm-team/PyBaMM/pull/1767), [#1803](https://github.com/pybamm-team/PyBaMM/pull/1803))
 
 # [v21.10](https://github.com/pybamm-team/PyBaMM/tree/v21.10) - 2021-10-31
 

--- a/examples/notebooks/Creating Models/1-an-ode-model.ipynb
+++ b/examples/notebooks/Creating Models/1-an-ode-model.ipynb
@@ -37,7 +37,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/1-an-ode-model.ipynb
+++ b/examples/notebooks/Creating Models/1-an-ode-model.ipynb
@@ -37,6 +37,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -296,7 +297,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -310,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Creating Models/1-an-ode-model.ipynb
+++ b/examples/notebooks/Creating Models/1-an-ode-model.ipynb
@@ -37,7 +37,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/2-a-pde-model.ipynb
+++ b/examples/notebooks/Creating Models/2-a-pde-model.ipynb
@@ -39,7 +39,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/2-a-pde-model.ipynb
+++ b/examples/notebooks/Creating Models/2-a-pde-model.ipynb
@@ -39,6 +39,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -340,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Creating Models/2-a-pde-model.ipynb
+++ b/examples/notebooks/Creating Models/2-a-pde-model.ipynb
@@ -39,7 +39,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
+++ b/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
@@ -62,7 +62,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
+++ b/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
@@ -62,6 +62,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -362,7 +363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
+++ b/examples/notebooks/Creating Models/3-negative-particle-problem.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
+++ b/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
@@ -57,7 +57,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
+++ b/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
@@ -57,6 +57,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -422,7 +423,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
+++ b/examples/notebooks/Creating Models/4-comparing-full-and-reduced-order-models.ipynb
@@ -57,7 +57,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/5-half-cell-model.ipynb
+++ b/examples/notebooks/Creating Models/5-half-cell-model.ipynb
@@ -68,7 +68,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/5-half-cell-model.ipynb
+++ b/examples/notebooks/Creating Models/5-half-cell-model.ipynb
@@ -68,6 +68,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -648,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Creating Models/5-half-cell-model.ipynb
+++ b/examples/notebooks/Creating Models/5-half-cell-model.ipynb
@@ -68,7 +68,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
+++ b/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
@@ -188,6 +188,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -728,7 +729,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -742,7 +743,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
+++ b/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
@@ -188,7 +188,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
+++ b/examples/notebooks/Creating Models/6-a-simple-SEI-model.ipynb
@@ -188,7 +188,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
@@ -32,7 +32,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 1 - How to run a model.ipynb
@@ -32,6 +32,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -264,7 +265,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -278,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -158,7 +159,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -172,7 +173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 2 - Compare models.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
@@ -47,7 +47,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
@@ -47,6 +47,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
@@ -1072,7 +1073,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 3 - Basic plotting.ipynb
@@ -47,7 +47,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -28,7 +28,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 4 - Setting parameter values.ipynb
@@ -28,6 +28,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -728,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
@@ -28,6 +28,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -213,7 +214,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -227,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 5 - Run experiments.ipynb
@@ -28,7 +28,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
@@ -40,7 +40,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "model = pybamm.lithium_ion.SPMe()\n",

--- a/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
@@ -40,7 +40,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "model = pybamm.lithium_ion.SPMe()\n",

--- a/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 6 - Managing simulation outputs.ipynb
@@ -40,6 +40,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "model = pybamm.lithium_ion.SPMe()\n",
@@ -436,7 +437,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -450,7 +451,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
@@ -23,7 +23,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
@@ -23,6 +23,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -149,7 +150,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -163,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 7 - Model options.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
@@ -27,7 +27,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
@@ -27,6 +27,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -149,7 +150,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -163,7 +164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 8 - Solver options.ipynb
@@ -27,7 +27,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
@@ -27,6 +27,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -325,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
@@ -27,7 +27,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
+++ b/examples/notebooks/Getting Started/Tutorial 9 - Changing the mesh.ipynb
@@ -27,7 +27,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/batch_study.ipynb
+++ b/examples/notebooks/batch_study.ipynb
@@ -31,6 +31,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
@@ -639,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/batch_study.ipynb
+++ b/examples/notebooks/batch_study.ipynb
@@ -31,7 +31,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",

--- a/examples/notebooks/batch_study.ipynb
+++ b/examples/notebooks/batch_study.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",

--- a/examples/notebooks/change-settings.ipynb
+++ b/examples/notebooks/change-settings.ipynb
@@ -39,6 +39,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -671,7 +672,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -685,7 +686,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/change-settings.ipynb
+++ b/examples/notebooks/change-settings.ipynb
@@ -39,7 +39,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/change-settings.ipynb
+++ b/examples/notebooks/change-settings.ipynb
@@ -39,7 +39,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/customize-quick-plot.ipynb
+++ b/examples/notebooks/customize-quick-plot.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",

--- a/examples/notebooks/customize-quick-plot.ipynb
+++ b/examples/notebooks/customize-quick-plot.ipynb
@@ -31,7 +31,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",

--- a/examples/notebooks/customize-quick-plot.ipynb
+++ b/examples/notebooks/customize-quick-plot.ipynb
@@ -31,7 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install pybamm -q\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
     "models = [pybamm.lithium_ion.SPM(), pybamm.lithium_ion.SPMe(), pybamm.lithium_ion.DFN()]\n",
@@ -228,7 +229,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -242,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/expression_tree/broadcasts.ipynb
+++ b/examples/notebooks/expression_tree/broadcasts.ipynb
@@ -24,7 +24,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"

--- a/examples/notebooks/expression_tree/broadcasts.ipynb
+++ b/examples/notebooks/expression_tree/broadcasts.ipynb
@@ -24,7 +24,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"

--- a/examples/notebooks/expression_tree/broadcasts.ipynb
+++ b/examples/notebooks/expression_tree/broadcasts.ipynb
@@ -24,6 +24,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"
@@ -290,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/expression_tree/expression-tree.ipynb
+++ b/examples/notebooks/expression_tree/expression-tree.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/expression_tree/expression-tree.ipynb
+++ b/examples/notebooks/expression_tree/expression-tree.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/expression_tree/expression-tree.ipynb
+++ b/examples/notebooks/expression_tree/expression-tree.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -255,9 +256,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PyBaMM development (env)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "pybamm-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -269,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/initialize-model-with-solution.ipynb
+++ b/examples/notebooks/initialize-model-with-solution.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "\n",
     "import pybamm\n",

--- a/examples/notebooks/initialize-model-with-solution.ipynb
+++ b/examples/notebooks/initialize-model-with-solution.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "\n",
     "import pybamm\n",

--- a/examples/notebooks/initialize-model-with-solution.ipynb
+++ b/examples/notebooks/initialize-model-with-solution.ipynb
@@ -30,7 +30,8 @@
     }
    ],
    "source": [
-    "%pip install pybamm -q\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "\n",
     "import pybamm\n",
     "import pandas as pd\n",
@@ -312,7 +313,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -326,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
+++ b/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
@@ -39,7 +39,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
+++ b/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
@@ -39,7 +39,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
+++ b/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
@@ -39,6 +39,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -487,7 +488,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/DFN.ipynb
+++ b/examples/notebooks/models/DFN.ipynb
@@ -120,7 +120,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"

--- a/examples/notebooks/models/DFN.ipynb
+++ b/examples/notebooks/models/DFN.ipynb
@@ -120,7 +120,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"

--- a/examples/notebooks/models/DFN.ipynb
+++ b/examples/notebooks/models/DFN.ipynb
@@ -120,6 +120,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"
@@ -283,7 +284,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -297,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/MPM.ipynb
+++ b/examples/notebooks/models/MPM.ipynb
@@ -102,7 +102,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/MPM.ipynb
+++ b/examples/notebooks/models/MPM.ipynb
@@ -102,6 +102,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -973,7 +974,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/MPM.ipynb
+++ b/examples/notebooks/models/MPM.ipynb
@@ -102,7 +102,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -67,7 +67,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -67,7 +67,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/SPM.ipynb
+++ b/examples/notebooks/models/SPM.ipynb
@@ -67,6 +67,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -1199,7 +1200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/SPMe.ipynb
+++ b/examples/notebooks/models/SPMe.ipynb
@@ -116,6 +116,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -258,7 +259,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -272,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/SPMe.ipynb
+++ b/examples/notebooks/models/SPMe.ipynb
@@ -116,7 +116,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/SPMe.ipynb
+++ b/examples/notebooks/models/SPMe.ipynb
@@ -116,7 +116,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
+++ b/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
@@ -22,6 +22,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -337,7 +338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
+++ b/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
@@ -22,7 +22,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
+++ b/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
@@ -22,7 +22,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
+++ b/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
@@ -35,7 +35,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
+++ b/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
@@ -35,7 +35,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
+++ b/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
@@ -35,6 +35,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -245,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/compare-ecker-data.ipynb
+++ b/examples/notebooks/models/compare-ecker-data.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-ecker-data.ipynb
+++ b/examples/notebooks/models/compare-ecker-data.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-ecker-data.ipynb
+++ b/examples/notebooks/models/compare-ecker-data.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -262,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/compare-lithium-ion.ipynb
+++ b/examples/notebooks/models/compare-lithium-ion.ipynb
@@ -46,6 +46,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -453,7 +454,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -467,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/compare-lithium-ion.ipynb
+++ b/examples/notebooks/models/compare-lithium-ion.ipynb
@@ -46,7 +46,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-lithium-ion.ipynb
+++ b/examples/notebooks/models/compare-lithium-ion.ipynb
@@ -46,7 +46,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-particle-diffusion-models.ipynb
+++ b/examples/notebooks/models/compare-particle-diffusion-models.ipynb
@@ -33,7 +33,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-particle-diffusion-models.ipynb
+++ b/examples/notebooks/models/compare-particle-diffusion-models.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/compare-particle-diffusion-models.ipynb
+++ b/examples/notebooks/models/compare-particle-diffusion-models.ipynb
@@ -33,8 +33,8 @@
     }
    ],
    "source": [
-    "# install PyBaMM if it is not installed\n",
-    "%pip install pybamm -q\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import numpy as np\n",
@@ -337,7 +337,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -351,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/electrode-state-of-health.ipynb
+++ b/examples/notebooks/models/electrode-state-of-health.ipynb
@@ -30,7 +30,8 @@
     }
    ],
    "source": [
-    "%pip install pybamm -q\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -353,7 +354,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/electrode-state-of-health.ipynb
+++ b/examples/notebooks/models/electrode-state-of-health.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/models/electrode-state-of-health.ipynb
+++ b/examples/notebooks/models/electrode-state-of-health.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/models/jelly-roll-model.ipynb
+++ b/examples/notebooks/models/jelly-roll-model.ipynb
@@ -51,7 +51,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np \n",

--- a/examples/notebooks/models/jelly-roll-model.ipynb
+++ b/examples/notebooks/models/jelly-roll-model.ipynb
@@ -51,6 +51,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np \n",
@@ -394,7 +395,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -408,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/jelly-roll-model.ipynb
+++ b/examples/notebooks/models/jelly-roll-model.ipynb
@@ -51,7 +51,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np \n",

--- a/examples/notebooks/models/latexify.ipynb
+++ b/examples/notebooks/models/latexify.ipynb
@@ -29,6 +29,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -306,7 +307,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -546,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/latexify.ipynb
+++ b/examples/notebooks/models/latexify.ipynb
@@ -29,7 +29,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/latexify.ipynb
+++ b/examples/notebooks/models/latexify.ipynb
@@ -29,7 +29,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/lead-acid.ipynb
+++ b/examples/notebooks/models/lead-acid.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/lead-acid.ipynb
+++ b/examples/notebooks/models/lead-acid.ipynb
@@ -28,7 +28,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/lead-acid.ipynb
+++ b/examples/notebooks/models/lead-acid.ipynb
@@ -28,6 +28,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -440,7 +441,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -454,7 +455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/lithium-plating.ipynb
+++ b/examples/notebooks/models/lithium-plating.ipynb
@@ -25,6 +25,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -554,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/lithium-plating.ipynb
+++ b/examples/notebooks/models/lithium-plating.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/lithium-plating.ipynb
+++ b/examples/notebooks/models/lithium-plating.ipynb
@@ -25,7 +25,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/pouch-cell-model.ipynb
+++ b/examples/notebooks/models/pouch-cell-model.ipynb
@@ -50,7 +50,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import sys\n",

--- a/examples/notebooks/models/pouch-cell-model.ipynb
+++ b/examples/notebooks/models/pouch-cell-model.ipynb
@@ -50,7 +50,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import sys\n",

--- a/examples/notebooks/models/pouch-cell-model.ipynb
+++ b/examples/notebooks/models/pouch-cell-model.ipynb
@@ -50,6 +50,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import sys\n",
@@ -816,7 +817,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -830,7 +831,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/rate-capability.ipynb
+++ b/examples/notebooks/models/rate-capability.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/rate-capability.ipynb
+++ b/examples/notebooks/models/rate-capability.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/rate-capability.ipynb
+++ b/examples/notebooks/models/rate-capability.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -163,7 +164,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -177,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
+++ b/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
@@ -25,7 +25,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
+++ b/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
+++ b/examples/notebooks/models/simulating-ORegan-2021-parameter-set.ipynb
@@ -25,6 +25,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -177,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
+++ b/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
@@ -22,6 +22,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -273,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
+++ b/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
@@ -22,7 +22,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
+++ b/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
@@ -22,7 +22,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
+++ b/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
@@ -22,6 +22,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -418,7 +419,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
+++ b/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
@@ -22,7 +22,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
+++ b/examples/notebooks/models/submodel_loss_of_active_materials.ipynb
@@ -22,7 +22,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/thermal-models.ipynb
+++ b/examples/notebooks/models/thermal-models.ipynb
@@ -25,7 +25,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/thermal-models.ipynb
+++ b/examples/notebooks/models/thermal-models.ipynb
@@ -25,6 +25,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -491,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/thermal-models.ipynb
+++ b/examples/notebooks/models/thermal-models.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/unsteady-heat-equation.ipynb
+++ b/examples/notebooks/models/unsteady-heat-equation.ipynb
@@ -45,7 +45,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/unsteady-heat-equation.ipynb
+++ b/examples/notebooks/models/unsteady-heat-equation.ipynb
@@ -45,6 +45,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -447,7 +448,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -461,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/models/unsteady-heat-equation.ipynb
+++ b/examples/notebooks/models/unsteady-heat-equation.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/models/using-model-options_thermal-example.ipynb
+++ b/examples/notebooks/models/using-model-options_thermal-example.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
@@ -210,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/using-model-options_thermal-example.ipynb
+++ b/examples/notebooks/models/using-model-options_thermal-example.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/using-model-options_thermal-example.ipynb
+++ b/examples/notebooks/models/using-model-options_thermal-example.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",

--- a/examples/notebooks/models/using-submodels.ipynb
+++ b/examples/notebooks/models/using-submodels.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/models/using-submodels.ipynb
+++ b/examples/notebooks/models/using-submodels.ipynb
@@ -32,6 +32,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -606,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/models/using-submodels.ipynb
+++ b/examples/notebooks/models/using-submodels.ipynb
@@ -32,7 +32,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/parameterization/change-input-current.ipynb
+++ b/examples/notebooks/parameterization/change-input-current.ipynb
@@ -39,7 +39,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/parameterization/change-input-current.ipynb
+++ b/examples/notebooks/parameterization/change-input-current.ipynb
@@ -39,7 +39,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/parameterization/change-input-current.ipynb
+++ b/examples/notebooks/parameterization/change-input-current.ipynb
@@ -39,6 +39,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -337,7 +338,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -351,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/parameterization/parameter-management.ipynb
+++ b/examples/notebooks/parameterization/parameter-management.ipynb
@@ -74,7 +74,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "pybamm.PARAMETER_PATH"

--- a/examples/notebooks/parameterization/parameter-management.ipynb
+++ b/examples/notebooks/parameterization/parameter-management.ipynb
@@ -74,7 +74,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "pybamm.PARAMETER_PATH"

--- a/examples/notebooks/parameterization/parameter-management.ipynb
+++ b/examples/notebooks/parameterization/parameter-management.ipynb
@@ -74,6 +74,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "pybamm.PARAMETER_PATH"
@@ -414,7 +415,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -428,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/parameterization/parameter-values.ipynb
+++ b/examples/notebooks/parameterization/parameter-values.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/parameterization/parameter-values.ipynb
+++ b/examples/notebooks/parameterization/parameter-values.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",
@@ -526,7 +527,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/parameterization/parameter-values.ipynb
+++ b/examples/notebooks/parameterization/parameter-values.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/parameterization/parameterization.ipynb
+++ b/examples/notebooks/parameterization/parameterization.ipynb
@@ -41,6 +41,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -2474,7 +2475,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/parameterization/parameterization.ipynb
+++ b/examples/notebooks/parameterization/parameterization.ipynb
@@ -41,7 +41,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/parameterization/parameterization.ipynb
+++ b/examples/notebooks/parameterization/parameterization.ipynb
@@ -41,7 +41,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/simulating-long-experiments.ipynb
+++ b/examples/notebooks/simulating-long-experiments.ipynb
@@ -31,7 +31,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/simulating-long-experiments.ipynb
+++ b/examples/notebooks/simulating-long-experiments.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/simulating-long-experiments.ipynb
+++ b/examples/notebooks/simulating-long-experiments.ipynb
@@ -31,7 +31,8 @@
     }
    ],
    "source": [
-    "%pip install pybamm -q\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"
@@ -2481,7 +2482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/simulation-class.ipynb
+++ b/examples/notebooks/simulation-class.ipynb
@@ -16,7 +16,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/simulation-class.ipynb
+++ b/examples/notebooks/simulation-class.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]

--- a/examples/notebooks/simulation-class.ipynb
+++ b/examples/notebooks/simulation-class.ipynb
@@ -16,6 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
@@ -357,7 +358,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/examples/notebooks/solution-data-and-processed-variables.ipynb
+++ b/examples/notebooks/solution-data-and-processed-variables.ipynb
@@ -42,7 +42,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/solution-data-and-processed-variables.ipynb
+++ b/examples/notebooks/solution-data-and-processed-variables.ipynb
@@ -42,6 +42,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -514,7 +515,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -528,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/solution-data-and-processed-variables.ipynb
+++ b/examples/notebooks/solution-data-and-processed-variables.ipynb
@@ -42,7 +42,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/solvers/dae-solver.ipynb
+++ b/examples/notebooks/solvers/dae-solver.ipynb
@@ -23,7 +23,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/solvers/dae-solver.ipynb
+++ b/examples/notebooks/solvers/dae-solver.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/solvers/dae-solver.ipynb
+++ b/examples/notebooks/solvers/dae-solver.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "# Setup\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",
@@ -329,7 +329,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -343,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/solvers/ode-solver.ipynb
+++ b/examples/notebooks/solvers/ode-solver.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "# Setup\n",
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",
@@ -301,7 +301,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -315,7 +315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/solvers/ode-solver.ipynb
+++ b/examples/notebooks/solvers/ode-solver.ipynb
@@ -23,7 +23,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/solvers/ode-solver.ipynb
+++ b/examples/notebooks/solvers/ode-solver.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import tests\n",

--- a/examples/notebooks/solvers/speed-up-solver.ipynb
+++ b/examples/notebooks/solvers/speed-up-solver.ipynb
@@ -30,6 +30,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
@@ -1036,7 +1037,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1050,7 +1051,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/solvers/speed-up-solver.ipynb
+++ b/examples/notebooks/solvers/speed-up-solver.ipynb
@@ -30,7 +30,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/solvers/speed-up-solver.ipynb
+++ b/examples/notebooks/solvers/speed-up-solver.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",

--- a/examples/notebooks/spatial_methods/finite-volumes.ipynb
+++ b/examples/notebooks/spatial_methods/finite-volumes.ipynb
@@ -62,7 +62,6 @@
     }
    ],
    "source": [
-    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/examples/notebooks/spatial_methods/finite-volumes.ipynb
+++ b/examples/notebooks/spatial_methods/finite-volumes.ipynb
@@ -62,6 +62,7 @@
     }
    ],
    "source": [
+    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
@@ -1306,7 +1307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/notebooks/spatial_methods/finite-volumes.ipynb
+++ b/examples/notebooks/spatial_methods/finite-volumes.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "%pip uninstall jax        # uninstall jax if it is installed (Google Colab)\n",
+    "%pip uninstall --yes jax  # uninstall jax if it is installed (Google Colab)\n",
     "%pip install pybamm -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -66,7 +66,7 @@ PARAMETER_PATH = [
 #
 from .util import Timer, TimerTime, FuzzyDict
 from .util import root_dir, load_function, rmse, get_infinite_nested_dict, load
-from .util import get_parameters_filepath, have_jax, install_jax
+from .util import get_parameters_filepath, have_jax, install_jax, is_jax_compatible
 from .logger import logger, set_logging_level
 from .settings import settings
 from .citations import Citations, citations, print_citations

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -370,8 +370,7 @@ def install_jax():
     elif importlib.util.find_spec("jax") is not None:
         if not is_jax_compatible():
             raise ValueError(
-                "Jax is already installed",
-                "but the installed version of jax or jaxlib is not supported by PyBaMM",
+                "Jax is already installed but the installed version of jax or jaxlib is not supported by PyBaMM",  # noqa: E501
             )
     else:
         subprocess.check_call(

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -21,6 +21,10 @@ import numpy as np
 
 import pybamm
 
+# versions of jax and jaxlib compatible with PyBaMM
+JAX_VERSION = "0.2.12"
+JAXLIB_VERSION = "0.1.70"
+
 
 def root_dir():
     """return the root directory of the PyBaMM install directory"""
@@ -355,16 +359,13 @@ def have_jax():
 def is_jax_compatible():
     """Check if the available version of jax and jaxlib are compatible with PyBaMM"""
     return (
-        pkg_resources.get_distribution("jax").version == "0.2.12"
-        and pkg_resources.get_distribution("jaxlib").version == "0.1.70"
+        pkg_resources.get_distribution("jax").version == JAX_VERSION
+        and pkg_resources.get_distribution("jaxlib").version == JAXLIB_VERSION
     )
 
 
 def install_jax():
     """Install jax, jaxlib"""
-    jax_version = "jax==0.2.12"
-    jaxlib_version = "jaxlib==0.1.70"
-
     if system() == "Windows":
         raise NotImplementedError("Jax is not available on Windows")
     elif importlib.util.find_spec("jax") is not None:
@@ -374,5 +375,12 @@ def install_jax():
             )
     else:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", jax_version, jaxlib_version]
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                f"jax=={JAX_VERSION}",
+                f"jaxlib=={JAXLIB_VERSION}",
+            ]
         )

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -348,11 +348,11 @@ def have_jax():
     return (
         (importlib.util.find_spec("jax") is not None)
         and (importlib.util.find_spec("jaxlib") is not None)
-        and jax_compatible_with_pybamm()
+        and is_jax_compatible()
     )
 
 
-def jax_compatible_with_pybamm():
+def is_jax_compatible():
     """Check if the available version of jax and jaxlib are compatible with PyBaMM"""
     return (
         pkg_resources.get_distribution("jax").version == "0.2.12"
@@ -368,7 +368,7 @@ def install_jax():
     if system() == "Windows":
         raise NotImplementedError("Jax is not available on Windows")
     elif importlib.util.find_spec("jax") is not None:
-        if not jax_compatible_with_pybamm():
+        if not is_jax_compatible():
             raise ValueError(
                 "Jax is already installed", 
                 "but the installed version of jax or jaxlib is not supported by PyBaMM"

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -370,7 +370,8 @@ def install_jax():
     elif importlib.util.find_spec("jax") is not None:
         if not jax_compatible_with_pybamm():
             raise ValueError(
-                "The installed version of jax or jaxlib is not supported by PyBaMM"
+                "Jax is already installed", 
+                "but the installed version of jax or jaxlib is not supported by PyBaMM"
             )
     else:
         subprocess.check_call(

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -370,8 +370,8 @@ def install_jax():
     elif importlib.util.find_spec("jax") is not None:
         if not is_jax_compatible():
             raise ValueError(
-                "Jax is already installed", 
-                "but the installed version of jax or jaxlib is not supported by PyBaMM"
+                "Jax is already installed",
+                "but the installed version of jax or jaxlib is not supported by PyBaMM",
             )
     else:
         subprocess.check_call(

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -364,7 +364,7 @@ def is_jax_compatible():
     )
 
 
-def install_jax():
+def install_jax():  # pragma: no cover
     """Install jax, jaxlib"""
     if system() == "Windows":
         raise NotImplementedError("Jax is not available on Windows")

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -128,6 +128,10 @@ class TestUtil(unittest.TestCase):
         path = os.path.join(package_dir, tempfile_obj.name)
         self.assertTrue(pybamm.get_parameters_filepath(tempfile_obj.name) == path)
 
+    def test_is_jax_compatible(self):
+        compatible = pybamm.is_jax_compatible()
+        self.assertTrue(compatible)
+
 
 class TestSearch(unittest.TestCase):
     def test_url_gets_to_stdout(self):

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -129,8 +129,9 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(pybamm.get_parameters_filepath(tempfile_obj.name) == path)
 
     def test_is_jax_compatible(self):
-        compatible = pybamm.is_jax_compatible()
-        self.assertTrue(compatible)
+        if pybamm.have_jax():
+            compatible = pybamm.is_jax_compatible()
+            self.assertTrue(compatible)
 
 
 class TestSearch(unittest.TestCase):


### PR DESCRIPTION
# Description

- Check for the version of `jax` in `have_jax()`
- Give an error in `install_jax()` if `jax` is already available with a different version

Additionally, the cell with `pybamm.print_citations()` gives an error which is described here - https://github.com/pybamm-team/BattBot/issues/47 - and is most probably an error within the `pybtex` library.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
