### PR TITLE
#1889 fix some parameter bugs and add timescale option

### DIFF
--- a/pybamm/expression_tree/operations/replace_symbols.py
+++ b/pybamm/expression_tree/operations/replace_symbols.py
@@ -110,13 +110,13 @@ class SymbolReplacer(object):
         ]
 
         # Process timescale
-        model.timescale = self.process_symbol(unprocessed_model.timescale)
+        model._timescale = self.process_symbol(unprocessed_model.timescale)
 
         # Process length scales
         new_length_scales = {}
         for domain, scale in unprocessed_model.length_scales.items():
             new_length_scales[domain] = self.process_symbol(scale)
-        model.length_scales = new_length_scales
+        model._length_scales = new_length_scales
 
         pybamm.logger.info("Finish replacing symbols in {}".format(model.name))
 

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -285,6 +285,8 @@ class BaseModel:
     @timescale.setter
     def timescale(self, value):
         """Set the timescale"""
+        if not isinstance(value, (numbers.Number, pybamm.Scalar)):
+            raise ValueError("model.timescale must be a scalar")
         self._timescale = value
 
     @property

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -285,8 +285,6 @@ class BaseModel:
     @timescale.setter
     def timescale(self, value):
         """Set the timescale"""
-        if not isinstance(value, (numbers.Number, pybamm.Scalar)):
-            raise ValueError("model.timescale must be a scalar")
         self._timescale = value
 
     @property

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -119,8 +119,8 @@ class BaseModel:
         self.y_slices = None
 
         # Default timescale is 1 second
-        self.timescale = pybamm.Scalar(1)
-        self.length_scales = {}
+        self._timescale = pybamm.Scalar(1)
+        self._length_scales = {}
 
     @property
     def name(self):
@@ -290,7 +290,7 @@ class BaseModel:
     @property
     def length_scales(self):
         "Length scales of model"
-        return self._length_scale
+        return self._length_scales
 
     @length_scales.setter
     def length_scales(self, values):
@@ -298,7 +298,7 @@ class BaseModel:
         for domain, scale in values.items():
             if isinstance(scale, numbers.Number):
                 values[domain] = pybamm.Scalar(scale)
-        self._length_scale = values
+        self._length_scales = values
 
     @property
     def parameters(self):
@@ -376,8 +376,8 @@ class BaseModel:
         new_model = self.__class__(name=self.name)
         new_model.use_jacobian = self.use_jacobian
         new_model.convert_to_format = self.convert_to_format
-        new_model.timescale = self.timescale
-        new_model.length_scales = self.length_scales
+        new_model._timescale = self.timescale
+        new_model._length_scales = self.length_scales
 
         # Variables from discretisation
         new_model.is_discretised = self.is_discretised

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -3,6 +3,7 @@
 #
 
 import pybamm
+import numbers
 
 
 class BatteryModelOptions(pybamm.FuzzyDict):
@@ -133,6 +134,9 @@ class BatteryModelOptions(pybamm.FuzzyDict):
             * "thermal" : str
                 Sets the thermal model to use. Can be "isothermal" (default), "lumped",
                 "x-lumped", or "x-full".
+            * "timescale" : str or number
+                Sets the timescale of the model. If "default", the discharge timescale,
+                as defined by other parameters, is used. Otherwise, the number is used.
             * "total interfacial current density as a state" : str
                 Whether to make a state for the total interfacial current density and
                 solve an algebraic equation for it. Default is "false", unless "SEI film
@@ -213,6 +217,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
             name: options[0] for name, options in self.possible_options.items()
         }
         default_options["external submodels"] = []
+        default_options["timescale"] = "default"
 
         # Change the default for cell geometry based on which thermal option is provided
         extra_options = extra_options or {}
@@ -371,6 +376,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                     "mechanics model"
                 )
 
+        # Check options are valid
         for option, value in options.items():
             if option == "external submodels" or option == "working electrode":
                 pass
@@ -378,7 +384,8 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 if isinstance(value, str) or option in [
                     "dimensionality",
                     "operating mode",
-                ]:  # some options don't take strings
+                    "timescale",
+                ]:  # some options accept non-strings
                     value = (value,)
                 else:
                     if not (
@@ -403,7 +410,12 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                             "2-tuples of strings"
                         )
                 for val in value:
-                    if val not in self.possible_options[option]:
+                    if option == "timescale":
+                        if not (val == "default" or isinstance(val, numbers.Number)):
+                            raise pybamm.OptionError(
+                                "'timescale' option must be either 'default' or a number"
+                            )
+                    elif val not in self.possible_options[option]:
                         if not (option == "operating mode" and callable(val)):
                             raise pybamm.OptionError(
                                 f"\n'{val}' is not recognized in option '{option}'. "
@@ -467,6 +479,21 @@ class BaseBatteryModel(pybamm.BaseModel):
         self.submodels = {}
         self._built = False
         self._built_fundamental_and_external = False
+
+    @pybamm.BaseModel.timescale.setter
+    def timescale(self, value):
+        """Set the timescale"""
+        raise NotImplementedError(
+            "Timescale cannot be directly overwritten for this model. "
+            "Pass a timescale to the 'timescale' option instead."
+        )
+
+    @pybamm.BaseModel.length_scales.setter
+    def length_scales(self, value):
+        """Set the length scales"""
+        raise NotImplementedError(
+            "Length scales cannot be directly overwritten for this model. "
+        )
 
     @property
     def default_geometry(self):
@@ -796,8 +823,8 @@ class BaseBatteryModel(pybamm.BaseModel):
         new_model = self.__class__(name=self.name, options=self.options)
         new_model.use_jacobian = self.use_jacobian
         new_model.convert_to_format = self.convert_to_format
-        new_model.timescale = self.timescale
-        new_model.length_scales = self.length_scales
+        new_model._timescale = self.timescale
+        new_model._length_scales = self.length_scales
         return new_model
 
     @property

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -413,7 +413,8 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                     if option == "timescale":
                         if not (val == "default" or isinstance(val, numbers.Number)):
                             raise pybamm.OptionError(
-                                "'timescale' option must be either 'default' or a number"
+                                "'timescale' option must be either 'default' "
+                                "or a number"
                             )
                     elif val not in self.possible_options[option]:
                         if not (option == "operating mode" and callable(val)):

--- a/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
+++ b/pybamm/models/full_battery_models/lead_acid/base_lead_acid_model.py
@@ -23,11 +23,11 @@ class BaseModel(pybamm.BaseBatteryModel):
         super().__init__(options, name)
         self.param = pybamm.LeadAcidParameters()
 
-        # Default timescale is discharge timescale
-        self.timescale = self.param.tau_discharge
+        # Default timescale
+        self._timescale = self.param.timescale
 
         # Set default length scales
-        self.length_scales = {
+        self._length_scales = {
             "negative electrode": self.param.L_x,
             "separator": self.param.L_x,
             "positive electrode": self.param.L_x,

--- a/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -20,11 +20,11 @@ class BaseModel(pybamm.BaseBatteryModel):
         # Assess whether the submodel is a half-cell model
         self.half_cell = self.options["working electrode"] != "both"
 
-        # Default timescale is discharge timescale
-        self.timescale = self.param.tau_discharge
+        # Default timescale
+        self._timescale = self.param.timescale
 
         # Set default length scales
-        self.length_scales = {
+        self._length_scales = {
             "negative electrode": self.param.L_x,
             "separator": self.param.L_x,
             "positive electrode": self.param.L_x,

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
@@ -123,7 +123,7 @@ class BasicDFN(BaseModel):
         # right side. This is also accessible via `boundary_value(x, "right")`, with
         # "left" providing the boundary value of the left side
         c_s_surf_n = pybamm.surf(c_s_n)
-        j0_n = param.j0_n(c_e_n, c_s_surf_n, T) / param.C_r_n
+        j0_n = param.gamma_n * param.j0_n(c_e_n, c_s_surf_n, T) / param.C_r_n
         j_n = (
             2
             * j0_n
@@ -167,7 +167,11 @@ class BasicDFN(BaseModel):
         self.boundary_conditions[c_s_n] = {
             "left": (pybamm.Scalar(0), "Neumann"),
             "right": (
-                -param.C_n * j_n / param.a_R_n / param.D_n(c_s_surf_n, T),
+                -param.C_n
+                * j_n
+                / param.a_R_n
+                / param.gamma_n
+                / param.D_n(c_s_surf_n, T),
                 "Neumann",
             ),
         }

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -60,7 +60,7 @@ class BasicDFNHalfCell(BaseModel):
             R_w_typ = param.R_p_typ
 
         # Set default length scales
-        self.length_scales = {
+        self._length_scales = {
             "separator": param.L_x,
             "positive electrode": param.L_x,
             "positive particle": R_w_typ,
@@ -425,6 +425,6 @@ class BasicDFNHalfCell(BaseModel):
         new_model = self.__class__(name=self.name, options=self.options)
         new_model.use_jacobian = self.use_jacobian
         new_model.convert_to_format = self.convert_to_format
-        new_model.timescale = self.timescale
-        new_model.length_scales = self.length_scales
+        new_model._timescale = self.timescale
+        new_model._length_scales = self.length_scales
         return new_model

--- a/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
@@ -89,7 +89,11 @@ class BasicSPM(BaseModel):
         self.boundary_conditions[c_s_n] = {
             "left": (pybamm.Scalar(0), "Neumann"),
             "right": (
-                -param.C_n * j_n / param.a_R_n / param.D_n(c_s_surf_n, T),
+                -param.C_n
+                * j_n
+                / param.a_R_n
+                / param.gamma_n
+                / param.D_n(c_s_surf_n, T),
                 "Neumann",
             ),
         }
@@ -135,7 +139,7 @@ class BasicSPM(BaseModel):
         # (Some) variables
         ######################
         # Interfacial reactions
-        j0_n = param.j0_n(1, c_s_surf_n, T) / param.C_r_n
+        j0_n = param.gamma_n * param.j0_n(1, c_s_surf_n, T) / param.C_r_n
         j0_p = param.gamma_p * param.j0_p(1, c_s_surf_p, T) / param.C_r_p
         eta_n = (2 / param.ne_n) * pybamm.arcsinh(j_n / (2 * j0_n))
         eta_p = (2 / param.ne_p) * pybamm.arcsinh(j_p / (2 * j0_p))
@@ -144,12 +148,17 @@ class BasicSPM(BaseModel):
         phi_s_p = eta_p + phi_e + param.U_p(c_s_surf_p, T)
         V = phi_s_p
 
+        pot_scale = self.param.potential_scale
+        U_ref = self.param.U_p_ref - self.param.U_n_ref
+        V_dim = U_ref + pot_scale * V
+
         whole_cell = ["negative electrode", "separator", "positive electrode"]
         # The `variables` dictionary contains all variables that might be useful for
         # visualising the solution of the model
         # Primary broadcasts are used to broadcast scalar quantities across a domain
         # into a vector of the right shape, for multiplying with other vectors
         self.variables = {
+            "Discharge capacity [A.h]": Q,
             "Negative particle surface concentration": pybamm.PrimaryBroadcast(
                 c_s_surf_n, "negative electrode"
             ),
@@ -166,6 +175,7 @@ class BasicSPM(BaseModel):
                 phi_s_p, "positive electrode"
             ),
             "Terminal voltage": V,
+            "Terminal voltage [V]": V_dim,
         }
         self.events += [
             pybamm.Event("Minimum voltage", V - param.voltage_low_cut),

--- a/pybamm/models/submodels/interface/base_interface.py
+++ b/pybamm/models/submodels/interface/base_interface.py
@@ -110,7 +110,7 @@ class BaseInterface(pybamm.BaseSubModel):
             c_s_surf = pybamm.maximum(tol, pybamm.minimum(c_s_surf, 1 - tol))
 
             if self.domain == "Negative":
-                j0 = param.j0_n(c_e, c_s_surf, T) / param.C_r_n
+                j0 = param.gamma_n * param.j0_n(c_e, c_s_surf, T) / param.C_r_n
             elif self.domain == "Positive":
                 j0 = param.gamma_p * param.j0_p(c_e, c_s_surf, T) / param.C_r_p
 

--- a/pybamm/models/submodels/particle/no_distribution/fickian_diffusion.py
+++ b/pybamm/models/submodels/particle/no_distribution/fickian_diffusion.py
@@ -73,7 +73,14 @@ class FickianDiffusion(BaseFickian):
         R = variables[self.domain + " particle radius"]
 
         if self.domain == "Negative":
-            rbc = -self.param.C_n * j * R / self.param.a_R_n / pybamm.surf(D_eff)
+            rbc = (
+                -self.param.C_n
+                * j
+                * R
+                / self.param.a_R_n
+                / self.param.gamma_n
+                / pybamm.surf(D_eff)
+            )
 
         elif self.domain == "Positive":
             rbc = (

--- a/pybamm/models/submodels/particle/no_distribution/polynomial_profile.py
+++ b/pybamm/models/submodels/particle/no_distribution/polynomial_profile.py
@@ -194,7 +194,7 @@ class PolynomialProfile(BaseFickian):
         R = variables[self.domain + " particle radius"]
 
         if self.domain == "Negative":
-            self.rhs = {c_s_rav: -3 * j / self.param.a_R_n / R}
+            self.rhs = {c_s_rav: -3 * j / self.param.a_R_n / self.param.gamma_n / R}
 
         elif self.domain == "Positive":
             self.rhs = {c_s_rav: -3 * j / self.param.a_R_p / self.param.gamma_p / R}
@@ -216,7 +216,7 @@ class PolynomialProfile(BaseFickian):
                         * pybamm.r_average(D_eff)
                         * q_s_rav
                         / self.param.C_n
-                        - 45 * j / self.param.a_R_n / 2
+                        - 45 * j / self.param.a_R_n / self.param.gamma_n / 2
                     }
                 )
             elif self.domain == "Positive":
@@ -247,7 +247,8 @@ class PolynomialProfile(BaseFickian):
             if self.domain == "Negative":
                 self.algebraic = {
                     c_s_surf: pybamm.surf(D_eff) * (c_s_surf - c_s_rav)
-                    + self.param.C_n * (j * R / self.param.a_R_n / 5)
+                    + self.param.C_n
+                    * (j * R / self.param.a_R_n / self.param.gamma_n / 5)
                 }
 
             elif self.domain == "Positive":
@@ -266,7 +267,7 @@ class PolynomialProfile(BaseFickian):
                 self.algebraic = {
                     c_s_surf: pybamm.surf(D_eff)
                     * (35 * (c_s_surf - c_s_rav) - 8 * q_s_rav)
-                    + self.param.C_n * (j * R / self.param.a_R_n)
+                    + self.param.C_n * (j * R / self.param.a_R_n / self.param.gamma_n)
                 }
 
             elif self.domain == "Positive":

--- a/pybamm/models/submodels/particle/no_distribution/x_averaged_fickian_diffusion.py
+++ b/pybamm/models/submodels/particle/no_distribution/x_averaged_fickian_diffusion.py
@@ -90,7 +90,13 @@ class XAveragedFickianDiffusion(BaseFickian):
         ]
 
         if self.domain == "Negative":
-            rbc = -self.param.C_n * j_xav / self.param.a_R_n / pybamm.surf(D_eff_xav)
+            rbc = (
+                -self.param.C_n
+                * j_xav
+                / self.param.a_R_n
+                / self.param.gamma_n
+                / pybamm.surf(D_eff_xav)
+            )
 
         elif self.domain == "Positive":
             rbc = (

--- a/pybamm/models/submodels/particle/no_distribution/x_averaged_polynomial_profile.py
+++ b/pybamm/models/submodels/particle/no_distribution/x_averaged_polynomial_profile.py
@@ -107,7 +107,7 @@ class XAveragedPolynomialProfile(BaseFickian):
             if self.domain == "Negative":
                 j_xav = i_boundary_cc / (a_av * self.param.l_n)
                 c_s_surf_xav = c_s_av - self.param.C_n * (
-                    j_xav / 5 / self.param.a_R_n / D_eff_av
+                    j_xav / 5 / self.param.a_R_n / self.param.gamma_n / D_eff_av
                 )
 
             if self.domain == "Positive":
@@ -127,7 +127,8 @@ class XAveragedPolynomialProfile(BaseFickian):
                 c_s_surf_xav = (
                     c_s_av
                     + 8 * q_s_av / 35
-                    - self.param.C_n * (j_xav / 35 / self.param.a_R_n / D_eff_av)
+                    - self.param.C_n
+                    * (j_xav / 35 / self.param.a_R_n / self.param.gamma_n / D_eff_av)
                 )
 
             if self.domain == "Positive":
@@ -283,7 +284,11 @@ class XAveragedPolynomialProfile(BaseFickian):
         ]
 
         if self.domain == "Negative":
-            self.rhs = {c_s_av: pybamm.source(-3 * j_xav / self.param.a_R_n, c_s_av)}
+            self.rhs = {
+                c_s_av: pybamm.source(
+                    -3 * j_xav / self.param.a_R_n / self.param.gamma_n, c_s_av
+                )
+            }
 
         elif self.domain == "Positive":
             self.rhs = {
@@ -306,7 +311,7 @@ class XAveragedPolynomialProfile(BaseFickian):
                     {
                         q_s_av: pybamm.source(
                             -30 * pybamm.surf(D_eff_xav) * q_s_av / self.param.C_n
-                            - 45 * j_xav / self.param.a_R_n / 2,
+                            - 45 * j_xav / self.param.a_R_n / self.param.gamma_n / 2,
                             q_s_av,
                         )
                     }

--- a/pybamm/models/submodels/particle/size_distribution/fickian_diffusion.py
+++ b/pybamm/models/submodels/particle/size_distribution/fickian_diffusion.py
@@ -36,7 +36,7 @@ class FickianDiffusion(BaseSizeDistribution):
                 auxiliary_domains={
                     "secondary": "negative particle size",
                     "tertiary": "negative electrode",
-                    "quaternary": "current collector"
+                    "quaternary": "current collector",
                 },
                 bounds=(0, 1),
             )
@@ -49,7 +49,7 @@ class FickianDiffusion(BaseSizeDistribution):
                 auxiliary_domains={
                     "secondary": "positive particle size",
                     "tertiary": "positive electrode",
-                    "quaternary": "current collector"
+                    "quaternary": "current collector",
                 },
                 bounds=(0, 1),
             )
@@ -87,19 +87,18 @@ class FickianDiffusion(BaseSizeDistribution):
             [self.domain.lower() + " particle size"],
         )
         T_k = pybamm.PrimaryBroadcast(
-            T_k, [self.domain.lower() + " particle"],
+            T_k,
+            [self.domain.lower() + " particle"],
         )
 
         if self.domain == "Negative":
-            N_s_distribution = (
-                -self.param.D_n(c_s_distribution, T_k)
-                * pybamm.grad(c_s_distribution)
+            N_s_distribution = -self.param.D_n(c_s_distribution, T_k) * pybamm.grad(
+                c_s_distribution
             )
             f_a_dist = self.param.f_a_dist_n(R)
         elif self.domain == "Positive":
-            N_s_distribution = (
-                -self.param.D_p(c_s_distribution, T_k)
-                * pybamm.grad(c_s_distribution)
+            N_s_distribution = -self.param.D_p(c_s_distribution, T_k) * pybamm.grad(
+                c_s_distribution
             )
             f_a_dist = self.param.f_a_dist_p(R)
 
@@ -123,7 +122,7 @@ class FickianDiffusion(BaseSizeDistribution):
         N_s_distribution = variables[self.domain + " particle flux distribution"]
         R = pybamm.PrimaryBroadcast(
             variables[self.domain + " particle sizes"],
-            [self.domain.lower() + " particle"]
+            [self.domain.lower() + " particle"],
         )
 
         if self.domain == "Negative":
@@ -153,7 +152,7 @@ class FickianDiffusion(BaseSizeDistribution):
         R = variables[self.domain + " particle sizes"]
         T_k = pybamm.PrimaryBroadcast(
             variables[self.domain + " electrode temperature"],
-            [self.domain.lower() + " particle size"]
+            [self.domain.lower() + " particle size"],
         )
 
         # Set surface Neumann boundary values
@@ -163,6 +162,7 @@ class FickianDiffusion(BaseSizeDistribution):
                 * R
                 * j_distribution
                 / self.param.a_R_n
+                / self.param.gamma_n
                 / self.param.D_n(c_s_surf_distribution, T_k)
             )
         elif self.domain == "Positive":

--- a/pybamm/models/submodels/particle/size_distribution/uniform_profile.py
+++ b/pybamm/models/submodels/particle/size_distribution/uniform_profile.py
@@ -81,9 +81,7 @@ class UniformProfile(BaseSizeDistribution):
             self.domain + " volume-weighted particle-size distribution"
         ]
         c_s_surf = pybamm.Integral(f_v_dist * c_s_surf_distribution, R)
-        c_s = pybamm.PrimaryBroadcast(
-            c_s_surf, [self.domain.lower() + " particle"]
-        )
+        c_s = pybamm.PrimaryBroadcast(c_s_surf, [self.domain.lower() + " particle"])
         c_s_xav = pybamm.x_average(c_s)
         variables.update(self._get_standard_concentration_variables(c_s, c_s_xav))
 
@@ -108,12 +106,10 @@ class UniformProfile(BaseSizeDistribution):
 
     def set_rhs(self, variables):
         c_s_surf_distribution = variables[
-            self.domain
-            + " particle surface concentration distribution"
+            self.domain + " particle surface concentration distribution"
         ]
         j_distribution = variables[
-            self.domain
-            + " electrode interfacial current density distribution"
+            self.domain + " electrode interfacial current density distribution"
         ]
         R = variables[self.domain + " particle sizes"]
 
@@ -122,6 +118,7 @@ class UniformProfile(BaseSizeDistribution):
                 c_s_surf_distribution: -3
                 * j_distribution
                 / self.param.a_R_n
+                / self.param.gamma_n
                 / R
             }
         elif self.domain == "Positive":
@@ -135,8 +132,7 @@ class UniformProfile(BaseSizeDistribution):
 
     def set_initial_conditions(self, variables):
         c_s_surf_distribution = variables[
-            self.domain
-            + " particle surface concentration distribution"
+            self.domain + " particle surface concentration distribution"
         ]
 
         if self.domain == "Negative":

--- a/pybamm/models/submodels/particle/size_distribution/x_averaged_fickian_diffusion.py
+++ b/pybamm/models/submodels/particle/size_distribution/x_averaged_fickian_diffusion.py
@@ -202,6 +202,7 @@ class XAveragedFickianDiffusion(BaseSizeDistribution):
                 * R
                 * j_xav_distribution
                 / self.param.a_R_n
+                / self.param.gamma_n
                 / self.param.D_n(c_s_surf_xav_distribution, T_k_xav)
             )
 

--- a/pybamm/models/submodels/particle/size_distribution/x_averaged_uniform_profile.py
+++ b/pybamm/models/submodels/particle/size_distribution/x_averaged_uniform_profile.py
@@ -122,6 +122,7 @@ class XAveragedUniformProfile(BaseSizeDistribution):
                 c_s_surf_xav_distribution: -3
                 * j_xav_distribution
                 / self.param.a_R_n
+                / self.param.gamma_n
                 / R
             }
 

--- a/pybamm/parameters/lead_acid_parameters.py
+++ b/pybamm/parameters/lead_acid_parameters.py
@@ -428,7 +428,7 @@ class LeadAcidParameters(BaseParameters):
         """Defines the dimensionless parameters"""
 
         # Timescale ratios
-        self.C_th = self.tau_th_yz / self.tau_discharge
+        self.C_th = self.tau_th_yz / self.timescale
 
         # Macroscale Geometry
         self.l_n = self.geo.l_n
@@ -469,7 +469,7 @@ class LeadAcidParameters(BaseParameters):
             / self.rho_typ
             * (1 - self.M_w * self.V_e / self.V_w * self.M_e)
         )
-        self.C_e = self.tau_diffusion_e / self.tau_discharge
+        self.C_e = self.tau_diffusion_e / self.timescale
         # Ratio of viscous pressure scale to osmotic pressure scale (electrolyte)
         self.pi_os_e = (
             self.mu_typ
@@ -534,13 +534,13 @@ class LeadAcidParameters(BaseParameters):
             self.C_dl_n_dimensional
             * self.potential_scale
             / self.j_scale_n
-            / self.tau_discharge
+            / self.timescale
         )
         self.C_dl_p = (
             self.C_dl_p_dimensional
             * self.potential_scale
             / self.j_scale_p
-            / self.tau_discharge
+            / self.timescale
         )
         self.ne_n = self.ne_n_S
         self.ne_p = self.ne_p_S

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -653,7 +653,7 @@ class LithiumIonParameters(BaseParameters):
         self.C_th = self.tau_th_yz / self.timescale
 
         # Concentration ratios
-        self.gamma_e = self.c_e_typ / self.c_max
+        self.gamma_e = (self.tau_discharge / self.timescale) * self.c_e_typ / self.c_max
         # In most cases gamma_n will be equal to 1
         self.gamma_n = (self.tau_discharge / self.timescale) * self.c_n_max / self.c_max
         self.gamma_p = (self.tau_discharge / self.timescale) * self.c_p_max / self.c_max

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -636,7 +636,10 @@ class LithiumIonParameters(BaseParameters):
         self.tau_th_yz = self.therm.tau_th_yz
 
         # Choose discharge timescale
-        self.timescale = self.tau_discharge
+        if self.options["timescale"] == "default":
+            self.timescale = self.tau_discharge
+        else:
+            self.timescale = pybamm.Scalar(self.options["timescale"])
 
     def _set_dimensionless_parameters(self):
         """Defines the dimensionless parameters"""
@@ -651,7 +654,9 @@ class LithiumIonParameters(BaseParameters):
 
         # Concentration ratios
         self.gamma_e = self.c_e_typ / self.c_max
-        self.gamma_p = self.c_p_max / self.c_max
+        # In most cases gamma_n will be equal to 1
+        self.gamma_n = (self.tau_discharge / self.timescale) * self.c_n_max / self.c_max
+        self.gamma_p = (self.tau_discharge / self.timescale) * self.c_p_max / self.c_max
 
         # Macroscale Geometry
         self.l_cn = self.geo.l_cn

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -324,9 +324,9 @@ class ParameterValues:
                     filename = os.path.join(path, value[9:] + ".json")
                     function_name = value[9:]
                     filename = pybamm.get_parameters_filepath(filename)
-                    with open(filename, 'r') as jsonfile:
+                    with open(filename, "r") as jsonfile:
                         json_data = json.load(jsonfile)
-                    data = json_data['data']
+                    data = json_data["data"]
                     data[0] = [np.array(el) for el in data[0]]
                     data[1] = np.array(data[1])
                     self._dict_items[name] = (function_name, data)
@@ -495,13 +495,13 @@ class ParameterValues:
         ]
 
         # Process timescale
-        model.timescale = self.process_symbol(unprocessed_model.timescale)
+        model._timescale = self.process_symbol(unprocessed_model.timescale)
 
         # Process length scales
         new_length_scales = {}
         for domain, scale in unprocessed_model.length_scales.items():
             new_length_scales[domain] = self.process_symbol(scale)
-        model.length_scales = new_length_scales
+        model._length_scales = new_length_scales
 
         pybamm.logger.info("Finish setting parameters for {}".format(model.name))
 
@@ -655,23 +655,26 @@ class ParameterValues:
                         self.parameter_events.append(
                             pybamm.Event(
                                 "Interpolant {} lower bound".format(name),
-                                pybamm.min(new_children[data_index] -
-                                           min(data[0][data_index])),
+                                pybamm.min(
+                                    new_children[data_index] - min(data[0][data_index])
+                                ),
                                 pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
                             )
                         )
                         self.parameter_events.append(
                             pybamm.Event(
                                 "Interpolant {} upper bound".format(name),
-                                pybamm.min(max(data[0][data_index]) -
-                                           new_children[data_index]),
+                                pybamm.min(
+                                    max(data[0][data_index]) - new_children[data_index]
+                                ),
                                 pybamm.EventType.INTERPOLANT_EXTRAPOLATION,
                             )
                         )
 
                 else:  # pragma: no cover
-                    raise ValueError("Invalid function name length: {0}"
-                                     .format(len(function_name)))
+                    raise ValueError(
+                        "Invalid function name length: {0}".format(len(function_name))
+                    )
 
             elif isinstance(function_name, numbers.Number):
                 # Check not NaN (parameter in csv file but no value given)

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1211,29 +1211,6 @@ class BaseSolver(object):
             del inputs["Power input [W]"]
         ext_and_inputs = {**external_variables, **inputs}
 
-        # Check that any inputs that may affect the scaling have not changed
-        # Set model timescale
-        temp_timescale_eval = model.timescale.evaluate(inputs=inputs)
-        # Set model lengthscales
-        temp_length_scales_eval = {
-            domain: scale.evaluate(inputs=inputs)
-            for domain, scale in model.length_scales.items()
-        }
-        if old_solution is not None:
-            if temp_timescale_eval != old_solution.timescale_eval:
-                raise pybamm.SolverError(
-                    "The model timescale is a function of an input parameter "
-                    "and the value has changed between steps!"
-                )
-            for domain in temp_length_scales_eval.keys():
-                old_dom_eval = old_solution.length_scales_eval[domain]
-                if temp_length_scales_eval[domain] != old_dom_eval:
-                    pybamm.logger.error(
-                        "The {} domain lengthscale is a function of an input "
-                        "parameter and the value has changed between "
-                        "steps!".format(domain)
-                    )
-
         if old_solution is None:
             # Run set up on first step
             pybamm.logger.verbose(

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -143,7 +143,10 @@ class BaseSolver(object):
         inputs = inputs or {}
 
         # Set model timescale
-        model.timescale_eval = model.timescale.evaluate(inputs=inputs)
+        if not isinstance(model.timescale, pybamm.Scalar):
+            raise ValueError("model.timescale must be a scalar")
+
+        model.timescale_eval = model.timescale.evaluate()
         # Set model lengthscales
         model.length_scales_eval = {
             domain: scale.evaluate(inputs=inputs)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
@@ -96,20 +96,25 @@ class TestCompareOutputs(unittest.TestCase):
         """
         Changing the timescale (via options) should not change the result.
         """
-        model1 = pybamm.lithium_ion.SPM()
-        parameter_values = model1.default_parameter_values
-        tau = parameter_values.evaluate(model1.param.timescale)
-        model2 = pybamm.lithium_ion.SPM({"timescale": 2 * tau})
+        for model_class in [pybamm.lithium_ion.SPM, pybamm.lithium_ion.DFN]:
+            model1 = model_class()
+            parameter_values = model1.default_parameter_values
+            tau = parameter_values.evaluate(model1.param.timescale)
+            model2 = model_class({"timescale": 2 * tau})
 
-        sim1 = pybamm.Simulation(model1)
-        sim2 = pybamm.Simulation(model2)
-        sol1 = sim1.solve([0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8))
-        sol2 = sim2.solve([0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8))
+            sim1 = pybamm.Simulation(model1)
+            sim2 = pybamm.Simulation(model2)
+            sol1 = sim1.solve(
+                [0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
+            )
+            sol2 = sim2.solve(
+                [0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
+            )
 
-        # sol.t should be different (different internal scalings for the solver)
-        np.testing.assert_array_equal(sol1.t, 2 * sol2.t)
-        # sol.y should be identical (within solver tolerance)
-        np.testing.assert_array_almost_equal(sol1.y, sol2.y)
+            # sol.t should be different (different internal scalings for the solver)
+            np.testing.assert_array_equal(sol1.t, 2 * sol2.t)
+            # sol.y should be identical (within solver tolerance)
+            np.testing.assert_array_almost_equal(sol1.y, sol2.y)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
@@ -92,6 +92,25 @@ class TestCompareOutputs(unittest.TestCase):
             comparison = StandardOutputComparison(solutions)
             comparison.test_all(skip_first_timestep=True)
 
+    def test_compare_outputs_timescale(self):
+        """
+        Changing the timescale (via options) should not change the result.
+        """
+        model1 = pybamm.lithium_ion.SPM()
+        parameter_values = model1.default_parameter_values
+        tau = parameter_values.evaluate(model1.param.timescale)
+        model2 = pybamm.lithium_ion.SPM({"timescale": 2 * tau})
+
+        sim1 = pybamm.Simulation(model1)
+        sim2 = pybamm.Simulation(model2)
+        sol1 = sim1.solve([0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8))
+        sol2 = sim2.solve([0, 3600], solver=pybamm.CasadiSolver(rtol=1e-8, atol=1e-8))
+
+        # sol.t should be different (different internal scalings for the solver)
+        np.testing.assert_array_equal(sol1.t, 2 * sol2.t)
+        # sol.y should be identical (within solver tolerance)
+        np.testing.assert_array_almost_equal(sol1.y, sol2.y)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -22,9 +22,10 @@ class TestIDAKLUSolver(unittest.TestCase):
     def test_on_spme_sensitivities(self):
         param_name = "Typical current [A]"
         param_value = 0.15652
-        model = pybamm.lithium_ion.SPMe()
+        param = pybamm.ParameterValues("Marquis2019")
+        timescale = param.evaluate(pybamm.LithiumIonParameters().timescale)
+        model = pybamm.lithium_ion.SPMe({"timescale": timescale})
         geometry = model.default_geometry
-        param = model.default_parameter_values
         param.update({param_name: "[input]"})
         inputs = {param_name: param_value}
         param.process_model(model)

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -33,7 +33,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
         disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
         disc.process_model(model)
-        t_eval = np.linspace(0, 3600, 100)
+        t_eval = np.linspace(0, 3500, 100)
         solver = pybamm.IDAKLUSolver(rtol=1e-10, atol=1e-10)
         solution = solver.solve(
             model,

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -935,6 +935,13 @@ class TestBaseModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not var"):
             model.variables = {"not var": var}
 
+    def test_timescale(self):
+        model = pybamm.BaseModel()
+        model.timescale = 2.5
+        self.assertEqual(model.timescale, 2.5)
+        with self.assertRaisesRegex(ValueError, "must be a scalar"):
+            model.timescale = pybamm.InputParameter("a")
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -935,13 +935,6 @@ class TestBaseModel(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not var"):
             model.variables = {"not var": var}
 
-    def test_timescale(self):
-        model = pybamm.BaseModel()
-        model.timescale = 2.5
-        self.assertEqual(model.timescale, 2.5)
-        with self.assertRaisesRegex(ValueError, "must be a scalar"):
-            model.timescale = pybamm.InputParameter("a")
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -39,6 +39,7 @@ PRINT_OPTIONS_OUTPUT = """\
 'total interfacial current density as a state': 'false' (possible: ['false', 'true'])
 'working electrode': 'both' (possible: ['both', 'negative', 'positive'])
 'external submodels': []
+'timescale': 'default'
 """  # noqa: E501
 
 
@@ -85,6 +86,13 @@ class TestBaseBatteryModel(unittest.TestCase):
         self.assertEqual(model.summary_variables, ["var"])
         with self.assertRaisesRegex(KeyError, "No cycling variable defined"):
             model.summary_variables = ["bad var"]
+
+    def test_timescale_lengthscale_errors(self):
+        model = pybamm.BaseBatteryModel()
+        with self.assertRaisesRegex(NotImplementedError, "Timescale cannot be"):
+            model.timescale = 1
+        with self.assertRaisesRegex(NotImplementedError, "Length scales cannot be"):
+            model.length_scales = {}
 
     def test_default_geometry(self):
 
@@ -281,6 +289,10 @@ class TestBaseBatteryModel(unittest.TestCase):
         # hydrolysis
         with self.assertRaisesRegex(pybamm.OptionError, "surface formulation"):
             pybamm.lead_acid.LOQS({"hydrolysis": "true", "surface form": "false"})
+
+        # timescale
+        with self.assertRaisesRegex(pybamm.OptionError, "timescale"):
+            pybamm.BaseBatteryModel({"timescale": "bad timescale"})
 
     def test_build_twice(self):
         model = pybamm.lithium_ion.SPM()  # need to pick a model to set vars and build

--- a/tests/unit/test_parameters/test_lithium_ion_parameters.py
+++ b/tests/unit/test_parameters/test_lithium_ion_parameters.py
@@ -249,6 +249,10 @@ class TestDimensionlessParameterValues(unittest.TestCase):
         values.evaluate(param.D_e(c_e_test, T_test))
         values.evaluate(param.kappa_e(c_e_test, T_test))
 
+    def test_timescale(self):
+        param = pybamm.LithiumIonParameters({"timescale": 2.5})
+        self.assertEqual(param.timescale.evaluate(), 2.5)
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -916,10 +916,32 @@ class TestParameterValues(unittest.TestCase):
         with self.assertRaises(KeyError):
             parameter_values.process_model(model)
 
-    def test_update_model(self):
+    def test_process_model_timescale_lengthscale_not_inputs(self):
+        model = pybamm.BaseModel()
+
+        v = pybamm.Variable("v")
+        model.rhs = {v: 1}
+        model.initial_conditions = {v: 0}
+
+        # Model defined with timescale as an input parameter
+        model.timescale = pybamm.InputParameter("a")
         param = pybamm.ParameterValues({})
-        with self.assertRaises(NotImplementedError):
-            param.update_model(None, None)
+        with self.assertRaisesRegex(ValueError, "model.timescale must be a Scalar"):
+            param.process_model(model)
+
+        # Input parameter in parameter values
+        model.timescale = pybamm.Parameter("a")
+        param = pybamm.ParameterValues({"a": "[input]"})
+        with self.assertRaisesRegex(ValueError, "model.timescale must be a Scalar"):
+            param.process_model(model)
+
+        # Geometry
+        geometry = geometry = {
+            "negative electrode": {"x_n": {"min": 0, "max": pybamm.Parameter("a")}}
+        }
+        parameter_values = pybamm.ParameterValues({"a": "[input]"})
+        with self.assertRaisesRegex(ValueError, "Geometry parameters must be Scalars"):
+            parameter_values.process_geometry(geometry)
 
     def test_inplace(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -39,7 +39,7 @@ class TestQuickPlot(unittest.TestCase):
                 c, "positive particle"
             ),
         }
-        model.timescale = pybamm.Scalar(1)
+        model._timescale = pybamm.Scalar(1)
 
         # ODEs only (don't use jacobian)
         model.use_jacobian = False

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -472,7 +472,9 @@ class TestQuickPlot(unittest.TestCase):
 
     def test_model_with_inputs(self):
         parameter_values = pybamm.ParameterValues("Chen2020")
-        model = pybamm.lithium_ion.SPMe()
+        # Pass the "timescale" option since we are making electrode height an input
+        timescale = parameter_values.evaluate(pybamm.LithiumIonParameters().timescale)
+        model = pybamm.lithium_ion.SPMe({"timescale": timescale})
         parameter_values.update({"Electrode height [m]": "[input]"})
         solver = pybamm.CasadiSolver(mode="safe")
         sim1 = pybamm.Simulation(

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -230,7 +230,7 @@ class TestSimulation(unittest.TestCase):
         drive_cycle = pd.read_csv(
             os.path.join("pybamm", "input", "drive_cycles", "US06.csv"),
             comment="#",
-            header=None
+            header=None,
         ).to_numpy()
         timescale = param.evaluate(model.timescale)
         current_interpolant = pybamm.Interpolant(
@@ -476,15 +476,15 @@ class TestSimulation(unittest.TestCase):
         )
 
     def test_battery_model_with_input_height(self):
-        # load model
-        model = pybamm.lithium_ion.SPM()
-        # load parameter values and process model and geometry
-        param = model.default_parameter_values
-        param.update({"Electrode height [m]": "[input]"})
+        parameter_values = pybamm.ParameterValues("Marquis2019")
+        # Pass the "timescale" option since we are making electrode height an input
+        timescale = parameter_values.evaluate(pybamm.LithiumIonParameters().timescale)
+        model = pybamm.lithium_ion.SPM({"timescale": timescale})
+        parameter_values.update({"Electrode height [m]": "[input]"})
         # solve model for 1 minute
         t_eval = np.linspace(0, 60, 11)
         inputs = {"Electrode height [m]": 0.2}
-        sim = pybamm.Simulation(model=model, parameter_values=param)
+        sim = pybamm.Simulation(model=model, parameter_values=parameter_values)
         sim.solve(t_eval=t_eval, inputs=inputs)
 
 

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -282,6 +282,18 @@ class TestBaseSolver(unittest.TestCase):
         self.assertEqual(model.convert_to_format, "casadi")
         pybamm.set_logging_level("WARNING")
 
+    def test_timescale_input_fail(self):
+        # Make sure timescale can't depend on inputs
+        model = pybamm.BaseModel()
+        v = pybamm.Variable("v")
+        model.rhs = {v: -1}
+        model.initial_conditions = {v: 1}
+        a = pybamm.InputParameter("a")
+        model.timescale = a
+        solver = pybamm.BaseSolver()
+        with self.assertRaisesRegex(ValueError, "model.timescale must be a scalar"):
+            solver.set_up(model)
+
     def test_inputs_step(self):
         # Make sure interpolant inputs are dropped
         model = pybamm.BaseModel()

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -282,20 +282,6 @@ class TestBaseSolver(unittest.TestCase):
         self.assertEqual(model.convert_to_format, "casadi")
         pybamm.set_logging_level("WARNING")
 
-    def test_timescale_input_fail(self):
-        # Make sure timescale can't depend on inputs
-        model = pybamm.BaseModel()
-        v = pybamm.Variable("v")
-        model.rhs = {v: -1}
-        model.initial_conditions = {v: 1}
-        a = pybamm.InputParameter("a")
-        model.timescale = a
-        solver = pybamm.CasadiSolver()
-        solver.set_up(model, inputs={"a": 10})
-        sol = solver.step(old_solution=None, model=model, dt=1.0, inputs={"a": 10})
-        with self.assertRaisesRegex(pybamm.SolverError, "The model timescale"):
-            sol = solver.step(old_solution=sol, model=model, dt=1.0, inputs={"a": 20})
-
     def test_inputs_step(self):
         # Make sure interpolant inputs are dropped
         model = pybamm.BaseModel()


### PR DESCRIPTION
# Description

Fixes #1889 

`model.timescale` cannot be changed any more. `model._timescale` can in theory but users really shouldn't. Instead, the "timescale" option can be passed to the model. The simulation results are independent of this (new test added for this).

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
