### PR TITLE
#1886 added fix within processed variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+
+## Bug fixes
+-   Fixed issue in extraction of sensitivites ([#1894](https://github.com/pybamm-team/PyBaMM/pull/1894))
+
 # [v21.12](https://github.com/pybamm-team/PyBaMM/tree/v21.11) - 2021-12-29
 
 ## Features
@@ -7,8 +12,6 @@
 -   Added cylindrical geometry and finite volume method ([#1824](https://github.com/pybamm-team/PyBaMM/pull/1824))
 
 ## Bug fixes
-
--   Fixed issue in extraction of sensitivites ([#1894](https://github.com/pybamm-team/PyBaMM/pull/1894))
 -   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
--   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/issues/1886))
+-   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/pull/1894/files))
 -   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+-   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/issues/1886))
 -   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
--   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/pull/1894))
+-   Fixed issue in extraction of sensitivites ([#1894](https://github.com/pybamm-team/PyBaMM/pull/1894))
 -   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
--   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/pull/1894/files))
+-   Fixed issue in extraction of sensitivites ([#1886](https://github.com/pybamm-team/PyBaMM/pull/1894))
 -   `PyBaMM` is now importable in `Linux` systems where `jax` is already installed ([#1874](https://github.com/pybamm-team/PyBaMM/pull/1874))
 -   Simulations with drive cycles now support `initial_soc` ([#1842](https://github.com/pybamm-team/PyBaMM/pull/1842))
 -   Fixed bug in expression tree simplification ([#1831](https://github.com/pybamm-team/PyBaMM/pull/1831))

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1459,7 +1459,12 @@ class BaseSolver(object):
                 inputs[name] = casadi.MX.sym(name, input_param._expected_size)
 
         external_variables = external_variables or {}
-        ext_and_inputs = {**external_variables, **inputs}
+
+        ordered_inputs_names = list(inputs.keys())
+        ordered_inputs_names.sort()
+        ordered_inputs = {name: inputs[name] for name in ordered_inputs_names}
+
+        ext_and_inputs = {**external_variables, **ordered_inputs}
         return ext_and_inputs
 
 

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -599,7 +599,12 @@ class ProcessedVariable(object):
 
         # Add the individual sensitivity
         start = 0
-        for name, inp in self.all_inputs[0].items():
+        # Sort the list of input names so that it aligns
+        # with the sorting applied during solver setup
+        sorted_input_names = self.all_inputs[0].keys()
+        sorted_input_names.sort()
+        for name in sorted_input_names:
+            inp = self.all_inputs[0][name]
             end = start + inp.shape[0]
             sensitivities[name] = S_var[:, start:end]
             start = end

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -601,7 +601,7 @@ class ProcessedVariable(object):
         start = 0
         # Sort the list of input names so that it aligns
         # with the sorting applied during solver setup
-        sorted_input_names = self.all_inputs[0].keys()
+        sorted_input_names = list(self.all_inputs[0].keys())
         sorted_input_names.sort()
         for name in sorted_input_names:
             inp = self.all_inputs[0][name]

--- a/pybamm/solvers/processed_variable.py
+++ b/pybamm/solvers/processed_variable.py
@@ -351,10 +351,14 @@ class ProcessedVariable(object):
             self.second_dimension = "x"
             self.R_sol = first_dim_pts
             self.x_sol = second_dim_pts
-        elif self.domain[0] in [
-            "negative particle size",
-            "positive particle size",
-        ] and self.auxiliary_domains["secondary"] == ["current collector"]:
+        elif (
+            self.domain[0]
+            in [
+                "negative particle size",
+                "positive particle size",
+            ]
+            and self.auxiliary_domains["secondary"] == ["current collector"]
+        ):
             self.first_dimension = "R"
             self.second_dimension = "z"
             self.R_sol = first_dim_pts
@@ -563,6 +567,7 @@ class ProcessedVariable(object):
             name: casadi.MX.sym(name, value.shape[0])
             for name, value in self.all_inputs[0].items()
         }
+
         p_casadi_stacked = casadi.vertcat(*[p for p in p_casadi.values()])
 
         # Convert variable to casadi format for differentiating
@@ -599,12 +604,7 @@ class ProcessedVariable(object):
 
         # Add the individual sensitivity
         start = 0
-        # Sort the list of input names so that it aligns
-        # with the sorting applied during solver setup
-        sorted_input_names = list(self.all_inputs[0].keys())
-        sorted_input_names.sort()
-        for name in sorted_input_names:
-            inp = self.all_inputs[0][name]
+        for name, inp in self.all_inputs[0].items():
             end = start + inp.shape[0]
             sensitivities[name] = S_var[:, start:end]
             start = end

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -589,9 +589,10 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations(unittest.TestCase):
         solution = solver.solve(
             model,
             t_eval,
-            inputs={"p": 0.1, "q": 2, "r": -1, "s": 0.5},
+            inputs={"r": -1, "s": 0.5, "q": 2, "p": 0.1},
             calculate_sensitivities=True,
         )
+
         np.testing.assert_allclose(solution.y[0], -1 + 0.2 * solution.t)
         np.testing.assert_allclose(
             solution.sensitivities["p"],


### PR DESCRIPTION
# Description

During the solver setup, the list of inputs/sensitivities is sorted by string and then used to assign elements of the y-array to each sensitivity. This applies the same sorting of the list before extracting the sensitivities during the process variables stage. 

I haven't added a test because I couldn't think of a good way without having a full integration test (passing a full model through the pipeline and then checking that the sensitivities are independent of the order of the inputs dictionary). However, I can add it if you think this is worth it for this. 

Fixes #1886 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
