### PR TITLE
Add a workaround for the failing tests

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -2,7 +2,6 @@ name: PyBaMM
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
 
   # everyday at 3 am UTC
@@ -88,16 +87,16 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: tox -e pybamm-requires
 
-    - name: Run unit tests for GNU/Linux with Python 3.8 and 3.9
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.7
+    - name: Run unit tests for GNU/Linux with Python 3.7 and 3.8
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
       run: python -m tox -e unit
 
-    - name: Run unit tests for GNU/Linux with Python 3.7 and generate coverage report
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
+    - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
       run: tox -e coverage
 
     - name: Upload coverage report
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.7
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
       uses: codecov/codecov-action@v2.1.0
 
     - name: Run integration tests for GNU/Linux

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -2,6 +2,7 @@ name: PyBaMM
 
 on:
   workflow_dispatch:
+  push:
   pull_request:
 
   # everyday at 3 am UTC

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -132,6 +132,11 @@ class TestCasadiConverter(unittest.TestCase):
                 pybamm.Function(np_fun, c).to_casadi(), casadi.MX(np_fun(3)), evalf=True
             )
 
+        # A workaround to fix the tests running on GitHub Actions -
+        # casadi.evalf(
+        #       pybamm.Function(np_fun, c).to_casadi()
+        # ) - casadi.evalf(casadi.MX(np_fun(3)))
+        # is not zero, but a small number of the order 10^-15 when np_func is np.cosh
         for np_fun in [
             np.cosh
         ]:

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -11,8 +11,6 @@ from scipy import special
 
 class TestCasadiConverter(unittest.TestCase):
     def assert_casadi_equal(self, a, b, evalf=False):
-        print(a, b)
-        print(casadi.evalf(a), casadi.evalf(b), casadi.evalf(a) - casadi.evalf(b))
         if evalf is True:
             self.assertTrue((casadi.evalf(a) - casadi.evalf(b)).is_zero())
         else:
@@ -130,7 +128,6 @@ class TestCasadiConverter(unittest.TestCase):
             np.arccosh,
             np.arcsinh,
         ]:
-            print(np_fun)
             self.assert_casadi_equal(
                 pybamm.Function(np_fun, c).to_casadi(), casadi.MX(np_fun(3)), evalf=True
             )

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -11,6 +11,7 @@ from scipy import special
 
 class TestCasadiConverter(unittest.TestCase):
     def assert_casadi_equal(self, a, b, evalf=False):
+        print(a, b)
         if evalf is True:
             self.assertTrue((casadi.evalf(a) - casadi.evalf(b)).is_zero())
         else:
@@ -129,6 +130,7 @@ class TestCasadiConverter(unittest.TestCase):
             np.arccosh,
             np.arcsinh,
         ]:
+            print(np_fun)
             self.assert_casadi_equal(
                 pybamm.Function(np_fun, c).to_casadi(), casadi.MX(np_fun(3)), evalf=True
             )

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -121,7 +121,6 @@ class TestCasadiConverter(unittest.TestCase):
         for np_fun in [
             np.sqrt,
             np.tanh,
-            np.cosh,
             np.sinh,
             np.exp,
             np.log,
@@ -134,6 +133,16 @@ class TestCasadiConverter(unittest.TestCase):
             print(np_fun)
             self.assert_casadi_equal(
                 pybamm.Function(np_fun, c).to_casadi(), casadi.MX(np_fun(3)), evalf=True
+            )
+
+        for np_fun in [
+            np.cosh
+        ]:
+            self.assert_casadi_almost_equal(
+                pybamm.Function(np_fun, c).to_casadi(),
+                casadi.MX(np_fun(3)),
+                decimal=14,
+                evalf=True,
             )
 
         # test functions with assert_casadi_almost_equal

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -12,6 +12,7 @@ from scipy import special
 class TestCasadiConverter(unittest.TestCase):
     def assert_casadi_equal(self, a, b, evalf=False):
         print(a, b)
+        print(casadi.evalf(a), casadi.evalf(b), casadi.evalf(a) - casadi.evalf(b))
         if evalf is True:
             self.assertTrue((casadi.evalf(a) - casadi.evalf(b)).is_zero())
         else:


### PR DESCRIPTION
# Description

The tests are passing locally but are failing on GitHub Actions (I don't really know why). `cosh` function was behaving weirdly, others are working fine -

```
# func
# casadi.evalf(a), casadi.evalf(b), casadi.evalf(a) - casadi.evalf(b)
<ufunc 'sqrt'>
1.73205 1.73205 0
<ufunc 'tanh'>
0.995055 0.995055 0
<ufunc 'cosh'>
10.0677 10.0677 1.77636e-15
```

Another workaround would be to remove the `cosh` function completely from this test.

Fixes #1882

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
