### PR TITLE
Fix failing build

### DIFF
--- a/.github/release_checklist.md
+++ b/.github/release_checklist.md
@@ -1,6 +1,7 @@
 - Run `scripts/update_version.py` to
   - Increment version number in
     - `pybamm/version.py`
+    - `docs/conf.py`
     - `CITATION.cff`
     - `vcpkg.json`
   - Update baseline of registries in `vcpkg-configuration.json` as the latest commit id from [pybamm-team/sundials-vcpkg-registry](https://github.com/pybamm-team/sundials-vcpkg-registry)

--- a/.github/workflows/url_checker.yml
+++ b/.github/workflows/url_checker.yml
@@ -28,7 +28,7 @@ jobs:
         retry_count: 5
 
         # A comma separated patterns to exclude during URL checks
-        exclude_patterns: https://www.datacamp.com/community/tutorials/fuzzy-string-python,http://127.0.0.1
+        exclude_patterns: https://www.datacamp.com/community/tutorials/fuzzy-string-python,http://127.0.0.1,https://github.com/pybamm-team/PyBaMM/tree/v
 
         # A comma separated list of file patterns (direct paths work as well) to exclude
         exclude_files: CHANGELOG.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@ import os
 import sys
 
 import guzzle_sphinx_theme
-from pybamm import __version__
 
 sys.path.insert(0, os.path.abspath("../"))
 
@@ -28,9 +27,9 @@ copyright = "2021, The PyBaMM Team"
 author = "The PyBaMM Team"
 
 # The short X.Y version
-version = __version__
+version = "21.12"
 # The full version, including alpha/beta/rc tags
-release = __version__
+release = version
 
 
 # -- General configuration ---------------------------------------------------

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -31,6 +31,14 @@ def update_version():
         file.seek(0)
         file.write(replace_version)
 
+    # docs/conf.py
+    with open(os.path.join(pybamm.root_dir(), "docs", "conf.py"), "r+") as file:
+        output = file.read()
+        replace_version = re.sub('(?<=version = ")(.+)(?=")', release_version, output)
+        file.truncate(0)
+        file.seek(0)
+        file.write(replace_version)
+
     # CITATION.cff
     with open(os.path.join(pybamm.root_dir(), "CITATION.cff"), "r+") as file:
         output = file.read()


### PR DESCRIPTION
# Description

- The documentation build is still failing (https://readthedocs.org/projects/pybamm/builds/15835390/) as pybamm is just cloned and not installed to build docs
- Fix version and automate conf.py