### PR TITLE
I1906 solution json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 -   Added an option to force install compatible versions of jax and jaxlib if already installed using CLI ([#1881](https://github.com/pybamm-team/PyBaMM/pull/1881))
+-   Allow pybamm.Solution.save_data() to return a string if filename is None, and added json to_format option ([#1909](https://github.com/pybamm-team/PyBaMM/pull/1909)
 
 ## Bug fixes
 

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -20,7 +20,8 @@ class NumpyEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
+        # won't be called since we only need to convert numpy arrays
+        return json.JSONEncoder.default(self, obj)  # pragma: no cover
 
 
 class Solution(object):

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -549,13 +549,13 @@ class Solution(object):
         with open(filename, "wb") as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 
-    def save_data(self, filename, variables=None, to_format="pickle", short_names=None):
+    def save_data(self, filename=None, variables=None, to_format="pickle", short_names=None):
         """
         Save solution data only (raw arrays)
 
         Parameters
         ----------
-        filename : str
+        filename : str, optional
             The name of the file to save data to. If None, then a str is returned
         variables : list, optional
             List of variables to save. If None, saves all of the variables that have

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -553,11 +553,18 @@ class Solution(object):
             - 'pickle' (default): creates a pickle file with the data dictionary
             - 'matlab': creates a .mat file, for loading in matlab
             - 'csv': creates a csv file (0D variables only)
+            - 'json': creates a json file
         short_names : dict, optional
             Dictionary of shortened names to use when saving. This may be necessary when
             saving to MATLAB, since no spaces or special characters are allowed in
             MATLAB variable names. Note that not all the variables need to be given
             a short name.
+
+        Returns
+        -------
+        data : str, optional
+            if 'csv' or 'json' is chosen, then this string is returned, otherwise None
+
 
         """
         if variables is None:

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -549,7 +549,10 @@ class Solution(object):
         with open(filename, "wb") as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)
 
-    def save_data(self, filename=None, variables=None, to_format="pickle", short_names=None):
+    def save_data(
+            self, filename=None, variables=None,
+            to_format="pickle", short_names=None
+    ):
         """
         Save solution data only (raw arrays)
 

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -242,7 +242,7 @@ class TestSolution(unittest.TestCase):
         # set variables first then save
         solution.update(["c", "d"])
         with self.assertRaisesRegex(ValueError, "pickle"):
-            solution.save_data(None, to_format="pickle")
+            solution.save_data(to_format="pickle")
         solution.save_data("test.pickle")
 
         data_load = pybamm.load("test.pickle")
@@ -256,7 +256,7 @@ class TestSolution(unittest.TestCase):
         np.testing.assert_array_equal(solution.data["d"], data_load["d"])
 
         with self.assertRaisesRegex(ValueError, "matlab"):
-            solution.save_data(None, to_format="matlab")
+            solution.save_data(to_format="matlab")
 
         # to matlab with bad variables name fails
         solution.update(["c + d"])
@@ -276,7 +276,7 @@ class TestSolution(unittest.TestCase):
             solution.save_data("test.csv", to_format="csv")
         # only save "c" and "2c"
         solution.save_data("test.csv", ["c", "2c"], to_format="csv")
-        csv_str = solution.save_data(None, ["c", "2c"], to_format="csv")
+        csv_str = solution.save_data(variables=["c", "2c"], to_format="csv")
 
         # check string is the same as the file
         with open('test.csv') as f:
@@ -289,7 +289,7 @@ class TestSolution(unittest.TestCase):
 
         # to json
         solution.save_data("test.json", to_format="json")
-        json_str = solution.save_data(None, to_format="json")
+        json_str = solution.save_data(to_format="json")
 
         # check string is the same as the file
         with open('test.json') as f:

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Solution class
 #
+import json
 import pybamm
 import unittest
 import numpy as np
@@ -267,11 +268,26 @@ class TestSolution(unittest.TestCase):
         ):
             solution.save_data("test.csv", to_format="csv")
         # only save "c" and "2c"
-        solution.save_data("test.csv", ["c", "2c"], to_format="csv")
+        csv_str = solution.save_data("test.csv", ["c", "2c"], to_format="csv")
+
+        # check string is the same as the file
+        self.assertEqual(csv_str, open('test.csv').read())
+
         # read csv
         df = pd.read_csv("test.csv")
         np.testing.assert_array_almost_equal(df["c"], solution.data["c"])
         np.testing.assert_array_almost_equal(df["2c"], solution.data["2c"])
+
+        # to json
+        json_str = solution.save_data("test.json", to_format="json")
+
+        # check string is the same as the file
+        self.assertEqual(json_str, open('test.json').read())
+
+        # check if string has the right values
+        json_data = json.loads(json_str)
+        np.testing.assert_array_almost_equal(json_data["c"], solution.data["c"])
+        np.testing.assert_array_almost_equal(json_data["d"], solution.data["d"])
 
         # raise error if format is unknown
         with self.assertRaisesRegex(ValueError, "format 'wrong_format' not recognised"):
@@ -283,6 +299,7 @@ class TestSolution(unittest.TestCase):
         self.assertEqual(solution.all_models[0].name, solution_load.all_models[0].name)
         np.testing.assert_array_equal(solution["c"].entries, solution_load["c"].entries)
         np.testing.assert_array_equal(solution["d"].entries, solution_load["d"].entries)
+
 
     def test_solution_evals_with_inputs(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -280,7 +280,10 @@ class TestSolution(unittest.TestCase):
 
         # check string is the same as the file
         with open('test.csv') as f:
-            self.assertEqual(csv_str, f.read())
+            # need to strip \r chars for windows
+            self.assertEqual(
+                csv_str.replace('\r', ''), f.read()
+            )
 
         # read csv
         df = pd.read_csv("test.csv")
@@ -293,7 +296,10 @@ class TestSolution(unittest.TestCase):
 
         # check string is the same as the file
         with open('test.json') as f:
-            self.assertEqual(json_str, f.read())
+            # need to strip \r chars for windows
+            self.assertEqual(
+                json_str.replace('\r', ''), f.read()
+            )
 
         # check if string has the right values
         json_data = json.loads(json_str)


### PR DESCRIPTION
# Description

- Allow `Solution.save_data()` to return a string if filename is None
- add extra `to_format` of json

Fixes #1906 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
