### PR TITLE
Remove anytree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 -   Added an option to force install compatible versions of jax and jaxlib if already installed using CLI ([#1881](https://github.com/pybamm-team/PyBaMM/pull/1881))
 
+## Optimizations
+
+-   The `Symbol` nodes no longer subclasses `anytree.NodeMixIn`. This removes some checks that were not really needed ([#1912](https://github.com/pybamm-team/PyBaMM/pull/1912))
+
 ## Bug fixes
 
 -   Parameters can now be imported from any given path in `Windows` ([#1900](https://github.com/pybamm-team/PyBaMM/pull/1900))

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -1043,18 +1043,14 @@ class Discretisation(object):
             # Return a new copy of the input parameter, but set the expected size
             # according to the domain of the input parameter
             expected_size = self._get_variable_size(symbol)
-            new_input_parameter = symbol.new_copy()
-            new_input_parameter.set_expected_size(expected_size)
+            new_input_parameter = pybamm.InputParameter(
+                symbol.name, symbol.domain, expected_size
+            )
             return new_input_parameter
 
         else:
-            # Backup option: return new copy of the object
-            try:
-                return symbol.new_copy()
-            except NotImplementedError:
-                raise NotImplementedError(
-                    "Cannot discretise symbol of type '{}'".format(type(symbol))
-                )
+            # Backup option: return the object
+            return symbol
 
     def concatenate(self, *symbols, sparse=False):
         if sparse:

--- a/pybamm/expression_tree/averages.py
+++ b/pybamm/expression_tree/averages.py
@@ -115,9 +115,7 @@ def x_average(symbol):
         )
         for domain in symbol.domains.values()
     ):
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
     # If symbol is a broadcast, reduce by one dimension
     if isinstance(
         symbol,
@@ -217,9 +215,7 @@ def z_average(symbol):
         )
     # If symbol doesn't have a domain, its average value is itself
     if symbol.domain == []:
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
     # If symbol is a Broadcast, its average value is its child
     elif isinstance(symbol, pybamm.Broadcast):
         return symbol.orphans[0]
@@ -252,9 +248,7 @@ def yz_average(symbol):
         )
     # If symbol doesn't have a domain, its average value is itself
     if symbol.domain == []:
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
     # If symbol is a Broadcast, its average value is its child
     elif isinstance(symbol, pybamm.Broadcast):
         return symbol.orphans[0]
@@ -287,9 +281,7 @@ def r_average(symbol):
         ["negative particle"],
         ["working particle"],
     ]:
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
     # If symbol is a secondary broadcast onto "negative electrode" or
     # "positive electrode", take the r-average of the child then broadcast back
     elif isinstance(symbol, pybamm.SecondaryBroadcast) and symbol.domains[
@@ -334,9 +326,7 @@ def size_average(symbol, f_a_dist=None):
         domain in [["negative particle size"], ["positive particle size"]]
         for domain in list(symbol.domains.values())
     ):
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
 
     # If symbol is a primary broadcast to "particle size", take the orphan
     elif isinstance(symbol, pybamm.PrimaryBroadcast) and symbol.domain in [

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -58,7 +58,7 @@ class Concatenation(pybamm.Symbol):
 
     def _diff(self, variable):
         """See :meth:`pybamm.Symbol._diff()`."""
-        children_diffs = [child.diff(variable) for child in self.cached_children]
+        children_diffs = [child.diff(variable) for child in self.children]
         if len(children_diffs) == 1:
             diff = children_diffs[0]
         else:
@@ -92,7 +92,7 @@ class Concatenation(pybamm.Symbol):
 
     def evaluate(self, t=None, y=None, y_dot=None, inputs=None, known_evals=None):
         """See :meth:`pybamm.Symbol.evaluate()`."""
-        children = self.cached_children
+        children = self.children
         if known_evals is not None:
             if self.id not in known_evals:
                 children_eval = [None] * len(children)
@@ -189,7 +189,7 @@ class NumpyConcatenation(Concatenation):
 
     def _concatenation_jac(self, children_jacs):
         """See :meth:`pybamm.Concatenation.concatenation_jac()`."""
-        children = self.cached_children
+        children = self.children
         if len(children) == 0:
             return pybamm.Scalar(0)
         else:
@@ -252,7 +252,7 @@ class DomainConcatenation(Concatenation):
 
             # create disc of domain => slice for each child
             self._children_slices = [
-                self.create_slices(child) for child in self.cached_children
+                self.create_slices(child) for child in self.children
             ]
         else:
             self._full_mesh = copy.copy(copy_this._full_mesh)

--- a/pybamm/expression_tree/input_parameter.py
+++ b/pybamm/expression_tree/input_parameter.py
@@ -22,27 +22,20 @@ class InputParameter(pybamm.Symbol):
     domain : iterable of str, or str
         list of domains over which the node is valid (empty list indicates the symbol
         is valid over all domains)
+    expected_size : int
+        The size of the input parameter expected, defaults to 1 (scalar input)
     """
 
-    def __init__(self, name, domain=None):
-        # Expected shape defaults to 1
-        self._expected_size = 1
+    def __init__(self, name, domain=None, expected_size=1):
+        self._expected_size = expected_size
         super().__init__(name, domain=domain)
 
     def create_copy(self):
         """See :meth:`pybamm.Symbol.new_copy()`."""
-        new_input_parameter = InputParameter(self.name, self.domain)
-        new_input_parameter._expected_size = self._expected_size
+        new_input_parameter = InputParameter(
+            self.name, self.domain, expected_size=self._expected_size
+        )
         return new_input_parameter
-
-    def set_expected_size(self, size):
-        """Specify the size that the input parameter should be."""
-        self._expected_size = size
-
-        # We also need to update the saved size and shape
-        self._saved_size = size
-        self._saved_shape = (size, 1)
-        self._saved_evaluate_for_shape = self._evaluate_for_shape()
 
     def _evaluate_for_shape(self):
         """

--- a/pybamm/expression_tree/operations/jacobian.py
+++ b/pybamm/expression_tree/operations/jacobian.py
@@ -53,7 +53,7 @@ class Jacobian(object):
             return jac
 
     def _jac(self, symbol, variable):
-        """ See :meth:`Jacobian.jac()`. """
+        """See :meth:`Jacobian.jac()`."""
 
         if isinstance(symbol, pybamm.BinaryOperator):
             left, right = symbol.children
@@ -76,9 +76,7 @@ class Jacobian(object):
             jac = symbol._function_jac(children_jacs)
 
         elif isinstance(symbol, pybamm.Concatenation):
-            children_jacs = [
-                self.jac(child, variable) for child in symbol.cached_children
-            ]
+            children_jacs = [self.jac(child, variable) for child in symbol.children]
             if len(children_jacs) == 1:
                 jac = children_jacs[0]
             else:

--- a/pybamm/expression_tree/operations/replace_symbols.py
+++ b/pybamm/expression_tree/operations/replace_symbols.py
@@ -210,6 +210,5 @@ class SymbolReplacer(object):
         else:
             # Only other option is that the symbol is a leaf (doesn't have children)
             # In this case, since we have already ruled out that the symbol is one of
-            # the symbols that needs to be replaced, we can just return a new copy of
-            # the symbol
-            return symbol.new_copy()
+            # the symbols that needs to be replaced, we can just return the symbol
+            return symbol

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -179,7 +179,7 @@ def simplify_if_constant(symbol):
     return symbol
 
 
-class Symbol(anytree.NodeMixin):
+class Symbol:
     """
     Base node class for the expression tree.
 
@@ -210,18 +210,9 @@ class Symbol(anytree.NodeMixin):
         if children is None:
             children = []
 
-        # Store "orphans", which are separate from children as they do not have a
-        # parent node, so they do not cause tree corruption errors when used again
-        # in a different part of the tree
+        self._children = children
+        # Keep a separate "oprhans" attribute for backwards compatibility
         self._orphans = children
-
-        for child in children:
-            # copy child before adding
-            # this also adds copy.copy(child) to self.children
-            copy.copy(child).parent = self
-
-        # cache children
-        self.cached_children = super(Symbol, self).children
 
         # Set auxiliary domains
         self._domains = {"primary": None}
@@ -250,7 +241,7 @@ class Symbol(anytree.NodeMixin):
         Note: it is assumed that children of a node are not modified after initial
         creation
         """
-        return self.cached_children
+        return self._children
 
     @property
     def name(self):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -1,7 +1,6 @@
 #
 # Base Symbol Class for the expression tree
 #
-import copy
 import numbers
 
 import anytree

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -150,13 +150,11 @@ class AbsoluteValue(UnaryOperator):
 
     def diff(self, variable):
         """See :meth:`pybamm.Symbol.diff()`."""
-        child = self.child.new_copy()
-        return sign(child) * child.diff(variable)
+        return sign(self.child) * self.child.diff(variable)
 
     def _unary_jac(self, child_jac):
         """See :meth:`pybamm.UnaryOperator._unary_jac()`."""
-        child = self.child.new_copy()
-        return sign(child) * child_jac
+        return sign(self.child) * child_jac
 
     def _unary_evaluate(self, child):
         """See :meth:`UnaryOperator._unary_evaluate()`."""

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -1273,9 +1273,7 @@ def boundary_value(symbol, side):
 
     # If symbol doesn't have a domain, its boundary value is itself
     if symbol.domain == []:
-        new_symbol = symbol.new_copy()
-        new_symbol.parent = None
-        return new_symbol
+        return symbol
     # If symbol is a primary or full broadcast, reduce by one dimension
     if isinstance(symbol, (pybamm.PrimaryBroadcast, pybamm.FullBroadcast)):
         return symbol.reduce_one_dimension()

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -634,7 +634,7 @@ class ParameterValues:
                 ):
                     # Wrap with NotConstant to avoid simplification,
                     # which would stop symbolic diff from working properly
-                    new_child = pybamm.NotConstant(child.new_copy())
+                    new_child = pybamm.NotConstant(child)
                     new_children.append(self.process_symbol(new_child))
                 else:
                     new_children.append(self.process_symbol(child))
@@ -766,15 +766,8 @@ class ParameterValues:
             return symbol._concatenation_new_copy(new_children)
 
         else:
-            # Backup option: return new copy of the object
-            try:
-                return symbol.new_copy()
-            except NotImplementedError:
-                raise NotImplementedError(
-                    "Cannot process parameters for symbol of type '{}'".format(
-                        type(symbol)
-                    )
-                )
+            # Backup option: return the object
+            return symbol
 
     def evaluate(self, symbol):
         """

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -480,23 +480,17 @@ class BaseSolver(object):
                             found_t = True
                         # Dimensional
                         elif symbol.right.id == (pybamm.t * model.timescale_eval).id:
-                            expr = (
-                                symbol.left.new_copy() / symbol.right.right.new_copy()
-                            )
+                            expr = symbol.left / symbol.right.right
                             found_t = True
                         elif symbol.left.id == (pybamm.t * model.timescale_eval).id:
-                            expr = (
-                                symbol.right.new_copy() / symbol.left.right.new_copy()
-                            )
+                            expr = symbol.right / symbol.left.right
                             found_t = True
 
                         # Update the events if the heaviside function depended on t
                         if found_t:
                             model.events.append(
                                 pybamm.Event(
-                                    str(symbol),
-                                    expr.new_copy(),
-                                    pybamm.EventType.DISCONTINUITY,
+                                    str(symbol), expr, pybamm.EventType.DISCONTINUITY
                                 )
                             )
                     elif isinstance(symbol, pybamm.Modulo):
@@ -507,9 +501,7 @@ class BaseSolver(object):
                             found_t = True
                         # Dimensional
                         elif symbol.left.id == (pybamm.t * model.timescale_eval).id:
-                            expr = (
-                                symbol.right.new_copy() / symbol.left.right.new_copy()
-                            )
+                            expr = symbol.right / symbol.left.right
                             found_t = True
 
                         # Update the events if the modulo function depended on t
@@ -523,7 +515,7 @@ class BaseSolver(object):
                                 model.events.append(
                                     pybamm.Event(
                                         str(symbol),
-                                        expr.new_copy() * pybamm.Scalar(i + 1),
+                                        expr * pybamm.Scalar(i + 1),
                                         pybamm.EventType.DISCONTINUITY,
                                     )
                                 )

--- a/tests/unit/test_expression_tree/test_input_parameter.py
+++ b/tests/unit/test_expression_tree/test_input_parameter.py
@@ -5,6 +5,8 @@ import numpy as np
 import pybamm
 import unittest
 
+from pybamm.expression_tree.functions import exp
+
 
 class TestInputParameter(unittest.TestCase):
     def test_input_parameter_init(self):
@@ -13,15 +15,14 @@ class TestInputParameter(unittest.TestCase):
         self.assertEqual(a.evaluate(inputs={"a": 1}), 1)
         self.assertEqual(a.evaluate(inputs={"a": 5}), 5)
 
-    def test_set_expected_size(self):
-        a = pybamm.InputParameter("a")
-        a.set_expected_size(10)
+        a = pybamm.InputParameter("a", expected_size=10)
         self.assertEqual(a._expected_size, 10)
         np.testing.assert_array_equal(
             a.evaluate(inputs="shape test"), np.nan * np.ones((10, 1))
         )
         y = np.linspace(0, 1, 10)
         np.testing.assert_array_equal(a.evaluate(inputs={"a": y}), y[:, np.newaxis])
+
         with self.assertRaisesRegex(
             ValueError,
             "Input parameter 'a' was given an object of size '1' but was expecting an "
@@ -34,7 +35,7 @@ class TestInputParameter(unittest.TestCase):
         self.assertTrue(np.isnan(a.evaluate_for_shape()))
         self.assertEqual(a.shape, ())
 
-        a.set_expected_size(10)
+        a = pybamm.InputParameter("a", expected_size=10)
         self.assertEqual(a.shape, (10, 1))
         np.testing.assert_equal(a.evaluate_for_shape(), np.nan * np.ones((10, 1)))
         self.assertEqual(a.evaluate_for_shape().shape, (10, 1))

--- a/tests/unit/test_expression_tree/test_input_parameter.py
+++ b/tests/unit/test_expression_tree/test_input_parameter.py
@@ -5,8 +5,6 @@ import numpy as np
 import pybamm
 import unittest
 
-from pybamm.expression_tree.functions import exp
-
 
 class TestInputParameter(unittest.TestCase):
     def test_input_parameter_init(self):

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -22,7 +22,6 @@ class TestSymbol(unittest.TestCase):
     def test_children(self):
         symc1 = pybamm.Symbol("child1")
         symc2 = pybamm.Symbol("child2")
-        symc3 = pybamm.Symbol("child3")
         symp = pybamm.Symbol("parent", children=[symc1, symc2])
 
         # test tuples of children for equality based on their name

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -19,7 +19,7 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual(sym.name, "a symbol")
         self.assertEqual(str(sym), "a symbol")
 
-    def test_cached_children(self):
+    def test_children(self):
         symc1 = pybamm.Symbol("child1")
         symc2 = pybamm.Symbol("child2")
         symc3 = pybamm.Symbol("child3")
@@ -31,15 +31,7 @@ class TestSymbol(unittest.TestCase):
             for i in range(len(children1)):
                 self.assertEqual(children1[i].name, children2[i].name)
 
-        check_are_equal(symp.children, super(pybamm.Symbol, symp).children)
         check_are_equal(symp.children, (symc1, symc2))
-
-        # update children, since we cache the children they will be unchanged
-        symc3.parent = symp
-        check_are_equal(symp.children, (symc1, symc2))
-
-        # check that the *actual* children are updated
-        check_are_equal(super(pybamm.Symbol, symp).children, (symc1, symc2, symc3))
 
     def test_symbol_domains(self):
         a = pybamm.Symbol("a", domain="test")
@@ -414,8 +406,6 @@ class TestSymbol(unittest.TestCase):
         summ = a + b
 
         a_orp, b_orp = summ.orphans
-        self.assertIsNone(a_orp.parent)
-        self.assertIsNone(b_orp.parent)
         self.assertEqual(a.id, a_orp.id)
         self.assertEqual(b.id, b_orp.id)
 

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -294,11 +294,6 @@ class TestParameterValues(unittest.TestCase):
             processed_g.evaluate(y=np.ones(10)), np.ones((10, 1))
         )
 
-        # not implemented
-        sym = pybamm.Symbol("sym")
-        with self.assertRaises(NotImplementedError):
-            parameter_values.process_symbol(sym)
-
         # not found
         with self.assertRaises(KeyError):
             x = pybamm.Parameter("x")

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -760,7 +760,7 @@ class TestScikitsSolvers(unittest.TestCase):
     def test_model_step_nonsmooth_events(self):
         # Create model
         model = pybamm.BaseModel()
-        model.timescale = pybamm.Scalar(1)
+        model.timescale = pybamm.Scalar(2)
         var1 = pybamm.Variable("var1")
         var2 = pybamm.Variable("var2")
         a = 0.6

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -760,7 +760,7 @@ class TestScikitsSolvers(unittest.TestCase):
     def test_model_step_nonsmooth_events(self):
         # Create model
         model = pybamm.BaseModel()
-        model.timescale = pybamm.Scalar(2)
+        model.timescale = pybamm.Scalar(1)
         var1 = pybamm.Variable("var1")
         var2 = pybamm.Variable("var2")
         a = 0.6


### PR DESCRIPTION
# Description

It seems like we can get away with not using `anytree` when creating expression trees, which saves a fair amount of overhead. Functionality like `render` still works fine, as long as the symbol has a `children` attribute.
`Symbol.new_copy` no longer needs to be used, but I have left the functions there in case we need to go back.

Let's give it a couple of releases to be sure, but if things are working well without `anytree` we can also:
- remove `Symbol.id` and implement `__eq__` and `__hash__` instead (previously, these were not implemented to avoid loops in anytree)
- Simplify `model.new_copy` to just make shallow copies

I'll open an issue for that if this PR is approved.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
