### PR TITLE
Fail release workflows on forks

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   create-release:
+    # This workflow is only of value to PyBaMM and would always fail in forks
+    if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    # This workflow is only of value to PyBaMM and would always fail in forks
+    # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/update_license.yml
+++ b/.github/workflows/update_license.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   license:
+    # This workflow is only of value to PyBaMM and would always fail in forks
+    if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -21,6 +23,8 @@ jobs:
         path: LICENSE.txt
 
   docs:
+    # This workflow is only of value to PyBaMM and would always fail in forks
+    if: github.repository_owner == 'pybamm-team'
     needs: license
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update_license.yml
+++ b/.github/workflows/update_license.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   license:
-    # This workflow is only of value to PyBaMM and would always fail in forks
+    # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +23,7 @@ jobs:
         path: LICENSE.txt
 
   docs:
-    # This workflow is only of value to PyBaMM and would always fail in forks
+    # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
     needs: license
     runs-on: ubuntu-latest

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-version:
-    # This workflow is only of value to PyBaMM and would always fail in forks
+    # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   update-version:
+    # This workflow is only of value to PyBaMM and would always fail in forks
+    if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Description
The workflows are running as scheduled and are creating pull requests on forks. I even checked @Saransh-cpp's fork to confirm (See https://github.com/Saransh-cpp/PyBaMM/pulls?q=is%3Apr).
It will now fail release related workflows on forks.
