### PR TITLE
Fix release

### DIFF
--- a/.github/release_checklist.md
+++ b/.github/release_checklist.md
@@ -8,4 +8,4 @@
   - Update `CHANGELOG.md` with a summary of the release
 
 - Update jax and jaxlib to latest version in `pybamm.util` and fix any bugs that arise
-- Update baseline of default-registry in `vcpkg-configuration.json`
+- If building wheels on Windows gives a `vcpkg` related error - revert the baseline of default-registry to a stable commit in `vcpkg-configuration.json` 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -41,6 +41,16 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: "bash build_manylinux_wheels/install_sundials.sh 5.8.1 5.7.0"
           CIBW_BEFORE_BUILD_LINUX: "python -m pip install cmake"
 
+      # see https://github.com/pybamm-team/PyBaMM/pull/1930
+      - name: Install the latest version of vcpkg on windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd C:\
+          rm -r -fo 'C:\vcpkg'
+          git clone https://github.com/microsoft/vcpkg
+          cd vcpkg
+          .\bootstrap-vcpkg.bat
+
       - name: Cache packages installed through vcpkg on windows
         if: matrix.os == 'windows-latest'
         uses: actions/cache@v2

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "builtin",
-    "baseline": "699c8779f1b0feb4ed3564716d1ed31f69663ea6"
+    "baseline": ""
   },
   "registries": [
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,5 +9,6 @@
         "klu"
       ]
     }
-  ]
+  ],
+  "builtin-baseline": "2b543e52da6a7a595760f10c1160e808d89c41ed"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,5 @@
         "klu"
       ]
     }
-  ],
-  "builtin-baseline": "2b543e52da6a7a595760f10c1160e808d89c41ed"
+  ]
 }


### PR DESCRIPTION
# Description

The `wheel` file is not building for `windows` on `GitHub Actions` (https://github.com/pybamm-team/PyBaMM/runs/5023662038?check_suite_focus=true). The error -
```
    [DEBUG] Downloading https://mirror.bit.edu.cn/msys2/mingw/i686/mingw-w64-i686-gcc-fortran-10.2.0-1-any.pkg.tar.zst
    [DEBUG] Download failed -- retrying after 1000 ms.
    [DEBUG] Download failed -- retrying after 2000 ms.
    [DEBUG] Download failed -- retrying after 4000 ms.
    [DEBUG] Downloading https://mirror.selfnet.de/msys2/mingw/i686/mingw-w64-i686-gcc-fortran-10.2.0-1-any.pkg.tar.zst
    [DEBUG] Download failed -- retrying after 1000 ms.
    [DEBUG] Download failed -- retrying after 2000 ms.
    [DEBUG] Download failed -- retrying after 4000 ms.
    [DEBUG] Downloading https://mirrors.sjtug.sjtu.edu.cn/msys2/mingw/i686/mingw-w64-i686-gcc-fortran-10.2.0-1-any.pkg.tar.zst
    Error: Failed to download from mirror set:
```

The failing links are not active anymore, they have been moved somewhere else. Note how https://mirror.bit.edu.cn/msys2/mingw/i686/mingw-w64-i686-gcc-fortran-10.2.0-1-any.pkg.tar.zst does not work but https://mirrors.bit.edu.cn/msys2/mingw/i686/mingw-w64-i686-gcc-fortran-10.2.0-1-any.pkg.tar.zst does (mirror -> mirrors).

I found a similar issue on GitHub that says this was fixed a couple of weeks back - https://github.com/microsoft/vcpkg/issues/22594
I tried updating the commit hash (baseline) of default vcpkg repository in vcpkg-configuration.json which gave me an error -
```
    running build_ext
    -- Building for: Visual Studio 16 2019
    -- Running vcpkg install
    Fetching registry information from https://github.com/pybamm-team/sundials-vcpkg-registry.git (HEAD)...
    Error: while checking out baseline from commit '2b543e52da6a7a595760f10c1160e808d89c41ed' at subpath 'versions/baseline.json':
    fatal: path 'versions/baseline.json' exists on disk, but not in '2b543e52da6a7a595760f10c1160e808d89c41ed'
    
    This may be fixed by updating vcpkg to the latest master via `git pull` or fetching commits via `git fetch`.
    
    You can use the current commit as a baseline, which is:
        "builtin-baseline": "df40d1c476dc02d71b113e4a63c3a32b00ebb5bd"
    -- Running vcpkg install - failed
```

This comment - https://github.com/microsoft/vcpkg/issues/18533#issuecomment-871865858 - says that we should update vcpkg by pulling in the latest code.

I tried removing the old `vcpkg` files and replaced them with the cloned GitHub repository, and it worked! The PR is a bit messy because of all the debugging, I will clean it up.

The passing workflow - https://github.com/Saransh-cpp/PyBaMM/runs/5033220394?check_suite_focus=true

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
