### PR TITLE
make coverage fail if ci fails

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - pybamm/parameters_cli.py
   - pybamm/install_odes.py
+if_ci_failed: error

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -15,6 +15,7 @@ from pybamm.expression_tree.binary_operators import _Heaviside
 
 class TestSymbol(unittest.TestCase):
     def test_symbol_init(self):
+        self.assertEqual(1, 0)
         sym = pybamm.Symbol("a symbol")
         self.assertEqual(sym.name, "a symbol")
         self.assertEqual(str(sym), "a symbol")

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -5,9 +5,8 @@ import os
 import unittest
 
 import numpy as np
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix, coo_matrix
 import sympy
-from scipy.sparse import coo_matrix
 
 import pybamm
 from pybamm.expression_tree.binary_operators import _Heaviside
@@ -15,7 +14,6 @@ from pybamm.expression_tree.binary_operators import _Heaviside
 
 class TestSymbol(unittest.TestCase):
     def test_symbol_init(self):
-        self.assertEqual(1, 0)
         sym = pybamm.Symbol("a symbol")
         self.assertEqual(sym.name, "a symbol")
         self.assertEqual(str(sym), "a symbol")

--- a/tox.ini
+++ b/tox.ini
@@ -125,4 +125,3 @@ source = pybamm
 # By default coverage data isn't collected in forked processes, see
 # https://coverage.readthedocs.io/en/coverage-5.3.1/subprocess.html
 concurrency = multiprocessing
-if_ci_failed = error

--- a/tox.ini
+++ b/tox.ini
@@ -125,3 +125,4 @@ source = pybamm
 # By default coverage data isn't collected in forked processes, see
 # https://coverage.readthedocs.io/en/coverage-5.3.1/subprocess.html
 concurrency = multiprocessing
+if_ci_failed = error


### PR DESCRIPTION
# Description

Changes coverage settings so that coverage fails if tests fail

Fixes #1932 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
