### PR TITLE
#1932 fix failing test

### DIFF
--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -121,13 +121,8 @@ class TestFunction(unittest.TestCase):
             pybamm.Function(test_multi_var_function, a, b)
 
     def test_function_unnamed(self):
-        t = np.linspace(0, 1)
-        entries = 2 * t
-        interpfun = interp1d(t, entries)
-        fun = pybamm.Function(interpfun, pybamm.t)
-        self.assertEqual(
-            fun.name, "function (<class 'scipy.interpolate.interpolate.interp1d'>)"
-        )
+        fun = pybamm.Function(np.cos, pybamm.t)
+        self.assertEqual(fun.name, "function (cos)")
 
     def test_to_equation(self):
         a = pybamm.Symbol("a", domain="test")

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -6,7 +6,6 @@ import unittest
 import numpy as np
 import sympy
 from scipy import special
-from scipy.interpolate import interp1d
 
 import pybamm
 


### PR DESCRIPTION
# Description

Fix failing test by using a different function than interp1d.
The coverage bug remains, looking for a solution in #1933 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
