### PR TITLE
quick=>unit

### DIFF
--- a/docs/install/install-from-source.rst
+++ b/docs/install/install-from-source.rst
@@ -180,9 +180,9 @@ Is is often sufficient to run the unit tests only. To do so, use
 
    .. code:: bash
 
-      tox -e quick # (GNU/Linux and MacOS)
+      tox -e unit # (GNU/Linux and MacOS)
       #
-      python -m tox -e windows-quick # (Windows)
+      python -m tox -e windows-unit # (Windows)
 
 
 Using the test runner 
@@ -237,7 +237,7 @@ Note for Windows users
 If you are running Windows, the following tox commands must be prefixed by ``windows-``:
 
 - ``tests``
-- ``quick``
+- ``unit``
 - ``examples``
 - ``doctests``
 - ``dev``


### PR DESCRIPTION
# Description

Replaced `quick` tox command with `unit` in `Install from source (developer install)` docs

Fixes #1946

## Type of change


- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`
.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
