### PR TITLE
Fix building wheels on windows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,7 +62,10 @@ jobs:
 
       - name: Build 32 bits wheels on Windows
         if: matrix.os == 'windows-latest'
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          vcpkg install visualstudio2019community
+          vcpkg install visualstudio2019-workload-nativedesktop
+          python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT: "PYBAMM_USE_VCPKG=ON VCPKG_ROOT_DIR=$VCPKG_INSTALLATION_ROOT VCPKG_DEFAULT_TRIPLET=x86-windows-static VCPKG_FEATURE_FLAGS=manifests,registries CMAKE_GENERATOR=\"Visual Studio 16 2019\" CMAKE_GENERATOR_PLATFORM=Win32"
           CIBW_ARCHS: "x86"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Build 32 bits wheels on Windows
         if: matrix.os == 'windows-latest'
         run: |
-          vcpkg install visualstudio2019community
-          vcpkg install visualstudio2019-workload-nativedesktop
+          choco install --yes visualstudio2019community
+          choco install --yes visualstudio2019-workload-nativedesktop
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT: "PYBAMM_USE_VCPKG=ON VCPKG_ROOT_DIR=$VCPKG_INSTALLATION_ROOT VCPKG_DEFAULT_TRIPLET=x86-windows-static VCPKG_FEATURE_FLAGS=manifests,registries CMAKE_GENERATOR=\"Visual Studio 16 2019\" CMAKE_GENERATOR_PLATFORM=Win32"


### PR DESCRIPTION
# Description

The error -
```
    -- Running vcpkg install - done
    CMake Error at CMakeLists.txt:18 (project):
      Generator
    
        Visual Studio 16 2019
    
      could not find any instance of Visual Studio.
```

I found this StackOverflow answer - https://stackoverflow.com/a/61045418/14746647 - which seems to work as the error above is gone (the workflow running in my fork - https://github.com/Saransh-cpp/PyBaMM/runs/5363685867?check_suite_focus=true). But now we have a new error -
```
  + Download https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip to C:\cibw\pypy3.7-v7.3.3-win32.zip
  Traceback (most recent call last):
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\runpy.py", line 196, in _run_module_as_main
      return _run_code(code, main_globals, None,
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\runpy.py", line 86, in _run_code
      exec(code, run_globals)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\__main__.py", line 377, in <module>
      main()
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\__main__.py", line 289, in main
      cibuildwheel.windows.build(build_options)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\windows.py", line 234, in build
      env = setup_python(config, dependency_constraint_flags, options.environment)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\windows.py", line 129, in setup_python
      installation_path = install_pypy(python_configuration.version, python_configuration.arch, python_configuration.url)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\windows.py", line 108, in install_pypy
      download(url, pypy_zip)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\site-packages\cibuildwheel\util.py", line 135, in download
      response = urllib.request.urlopen(url, context=context)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 216, in urlopen
      return opener.open(url, data, timeout)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 525, in open
      response = meth(req, response)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 634, in http_response
      response = self.parent.error(
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 563, in error
      return self._call_chain(*args)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 496, in _call_chain
      result = func(*args)
    File "C:\hostedtoolcache\windows\Python\3.10.2\x64\lib\urllib\request.py", line 643, in http_error_default
      raise HTTPError(req.full_url, code, msg, hdrs, fp)
  urllib.error.HTTPError: HTTP Error 502: Bad Gateway
```
Looks like the `PyPy` version has changed to - https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip and the link that `cibuildwheel` is trying to use (https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip) is no longer active. I am guessing this is a `cibuildwheel` issue, and we should wait till it is fixed.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
