### PR TITLE
Remove 32 bits support

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,7 +62,10 @@ jobs:
 
       - name: Build 64 bits wheels on Windows
         if: matrix.os == 'windows-latest'
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          choco install --yes visualstudio2019community
+          choco install --yes visualstudio2019-workload-nativedesktop
+          python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ENVIRONMENT: "PYBAMM_USE_VCPKG=ON VCPKG_ROOT_DIR=$cd/vcpkg VCPKG_DEFAULT_TRIPLET=x64-windows-static VCPKG_FEATURE_FLAGS=manifests,registries CMAKE_GENERATOR=\"Visual Studio 16 2019\" CMAKE_GENERATOR_PLATFORM=x64"
           CIBW_ARCHS: "AMD64"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,16 +60,6 @@ jobs:
           path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('vcpkg.json') }}
 
-      - name: Build 32 bits wheels on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install --yes visualstudio2019community
-          choco install --yes visualstudio2019-workload-nativedesktop
-          python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_ENVIRONMENT: "PYBAMM_USE_VCPKG=ON VCPKG_ROOT_DIR=$VCPKG_INSTALLATION_ROOT VCPKG_DEFAULT_TRIPLET=x86-windows-static VCPKG_FEATURE_FLAGS=manifests,registries CMAKE_GENERATOR=\"Visual Studio 16 2019\" CMAKE_GENERATOR_PLATFORM=Win32"
-          CIBW_ARCHS: "x86"
-
       - name: Build 64 bits wheels on Windows
         if: matrix.os == 'windows-latest'
         run: python -m cibuildwheel --output-dir wheelhouse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Breaking changes
+
+-   Dropped support for Windows 32-bit architecture ([#1696](https://github.com/pybamm-team/PyBaMM/pull/1696))
+
 # [v22.2](https://github.com/pybamm-team/PyBaMM/tree/v22.2) - 2022-02-28
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
--   Dropped support for Windows 32-bit architecture ([#1696](https://github.com/pybamm-team/PyBaMM/pull/1696))
+-   Dropped support for Windows 32-bit architecture ([#1964](https://github.com/pybamm-team/PyBaMM/pull/1964))
 
 # [v22.2](https://github.com/pybamm-team/PyBaMM/tree/v22.2) - 2022-02-28
 

--- a/scripts/replace-cmake/sundials-3.1.1/CMakeLists.txt
+++ b/scripts/replace-cmake/sundials-3.1.1/CMakeLists.txt
@@ -259,25 +259,6 @@ ENDIF()
 OPTION(BUILD_STATIC_LIBS "Build static libraries" ON)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-# Prepare substitution variable SUNDIALS_EXPORT for sundials_config.h
-# When building shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllexport)
-# When linking to shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllimport)
-# In all other cases (other platforms or static libraries
-# under Windows), the SUNDIALS_EXPORT macro is empty
-
-IF(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT
-    "#ifdef BUILD_SUNDIALS_LIBRARY
-#define SUNDIALS_EXPORT __declspec(dllexport)
-#else
-#define SUNDIALS_EXPORT __declspec(dllimport)
-#endif")
-ELSE(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT "#define SUNDIALS_EXPORT")
-ENDIF(BUILD_SHARED_LIBS AND WIN32)
-
 # Make sure we build at least one type of libraries
 IF(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
   PRINT_WARNING("Both static and shared library generation were disabled"
@@ -596,13 +577,6 @@ MARK_AS_ADVANCED(FORCE SUNDIALS_DEVTESTS)
 # ===============================================================
 # Add any other necessary compiler flags & definitions
 # ===============================================================
-
-# Under Windows, add compiler directive to inhibit warnings
-# about use of unsecure functions
-
-IF(WIN32)
-  ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
-ENDIF(WIN32)
 
 IF(APPLE)
   SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -undefined dynamic_lookup")

--- a/scripts/replace-cmake/sundials-4.1.0/CMakeLists.txt
+++ b/scripts/replace-cmake/sundials-4.1.0/CMakeLists.txt
@@ -311,25 +311,6 @@ ENDIF()
 OPTION(BUILD_STATIC_LIBS "Build static libraries" ON)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-# Prepare substitution variable SUNDIALS_EXPORT for sundials_config.h
-# When building shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllexport)
-# When linking to shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllimport)
-# In all other cases (other platforms or static libraries
-# under Windows), the SUNDIALS_EXPORT macro is empty
-
-IF(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT
-    "#ifdef BUILD_SUNDIALS_LIBRARY
-#define SUNDIALS_EXPORT __declspec(dllexport)
-#else
-#define SUNDIALS_EXPORT __declspec(dllimport)
-#endif")
-ELSE(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT "#define SUNDIALS_EXPORT")
-ENDIF(BUILD_SHARED_LIBS AND WIN32)
-
 # Make sure we build at least one type of libraries
 IF(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
   PRINT_WARNING("Both static and shared library generation were disabled"
@@ -647,13 +628,6 @@ MARK_AS_ADVANCED(FORCE SUNDIALS_DEVTESTS)
 # ===============================================================
 # Add any platform specifc settings
 # ===============================================================
-
-# Under Windows, add compiler directive to inhibit warnings
-# about use of unsecure functions
-
-IF(WIN32)
-  ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
-ENDIF(WIN32)
 
 IF(APPLE)
   SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -undefined dynamic_lookup")

--- a/scripts/replace-cmake/sundials-5.0.0/CMakeLists.txt
+++ b/scripts/replace-cmake/sundials-5.0.0/CMakeLists.txt
@@ -311,25 +311,6 @@ ENDIF()
 OPTION(BUILD_STATIC_LIBS "Build static libraries" ON)
 OPTION(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-# Prepare substitution variable SUNDIALS_EXPORT for sundials_config.h
-# When building shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllexport)
-# When linking to shared SUNDIALS libraries under Windows, use
-#      #define SUNDIALS_EXPORT __declspec(dllimport)
-# In all other cases (other platforms or static libraries
-# under Windows), the SUNDIALS_EXPORT macro is empty
-
-IF(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT
-    "#ifdef BUILD_SUNDIALS_LIBRARY
-#define SUNDIALS_EXPORT __declspec(dllexport)
-#else
-#define SUNDIALS_EXPORT __declspec(dllimport)
-#endif")
-ELSE(BUILD_SHARED_LIBS AND WIN32)
-  SET(SUNDIALS_EXPORT "#define SUNDIALS_EXPORT")
-ENDIF(BUILD_SHARED_LIBS AND WIN32)
-
 # Make sure we build at least one type of libraries
 IF(NOT BUILD_STATIC_LIBS AND NOT BUILD_SHARED_LIBS)
   PRINT_WARNING("Both static and shared library generation were disabled"
@@ -647,13 +628,6 @@ MARK_AS_ADVANCED(FORCE SUNDIALS_DEVTESTS)
 # ===============================================================
 # Add any platform specifc settings
 # ===============================================================
-
-# Under Windows, add compiler directive to inhibit warnings
-# about use of unsecure functions
-
-IF(WIN32)
-  ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
-ENDIF(WIN32)
 
 IF(APPLE)
   SET(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS} -undefined dynamic_lookup")


### PR DESCRIPTION
# Description

Removed support for Windows 32-bits from workflows. Additionally, all the `CMakeLists.txt` files had some conditions for 32-bit windows, and I am not sure if they should be removed. The tests are passing when these lines are removed but I'll revert the deletions if they are supposed to stay.
https://github.com/pybamm-team/PyBaMM/blob/9f8f2c3fe769c15b9c4f1dca98eb6dbe07a587d1/scripts/replace-cmake/sundials-4.1.0/CMakeLists.txt#L322-L331 

Fixes #1955 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
