### PR TITLE
remove deprecated stuff

### DIFF
--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -3,7 +3,6 @@
 #
 
 import numpy as np
-import warnings
 
 examples = """
 

--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -43,17 +43,11 @@ class Experiment:
     ----------
     operating_conditions : list
         List of operating conditions
-    parameters : dict
-        Dictionary of parameters to use for this experiment, replacing default
-        parameters as appropriate
     period : string, optional
         Period (1/frequency) at which to record outputs. Default is 1 minute. Can be
         overwritten by individual operating conditions.
     termination : list, optional
         List of conditions under which to terminate the experiment. Default is None.
-    use_simulation_setup_type : str
-        Whether to use the "new" (default) or "old" simulation set-up type. "new" is
-        faster at simulating individual steps but has higher set-up overhead
     drive_cycles : dict
         Dictionary of drive cycles to use for this experiment.
     cccv_handling : str, optional
@@ -66,32 +60,14 @@ class Experiment:
     def __init__(
         self,
         operating_conditions,
-        parameters=None,
         period="1 minute",
         termination=None,
-        use_simulation_setup_type="new",
         drive_cycles={},
         cccv_handling="two-step",
     ):
         if cccv_handling not in ["two-step", "ode"]:
             raise ValueError("cccv_handling should be either 'two-step' or 'ode'")
         self.cccv_handling = cccv_handling
-        # Deprecations
-        if parameters is not None:
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(
-                "'parameters' as an input to the Experiment class will soon be "
-                "deprecated. Please open an issue if you are using this feature.",
-                DeprecationWarning,
-            )
-        if use_simulation_setup_type == "old":
-            warnings.simplefilter("always", DeprecationWarning)
-            warnings.warn(
-                "'old' simulation setup type for the Experiment class will soon be "
-                "deprecated. Use 'new' instead. Please open an issue if this gives an "
-                "error or unexpected results.",
-                DeprecationWarning,
-            )
 
         self.period = self.convert_time_to_seconds(period.split())
         operating_conditions_cycles = []
@@ -147,15 +123,9 @@ class Experiment:
         self.operating_conditions, self.events = self.read_operating_conditions(
             operating_conditions, drive_cycles
         )
-        parameters = parameters or {}
-        if isinstance(parameters, dict):
-            self.parameters = parameters
-        else:
-            raise TypeError("experimental parameters should be a dictionary")
 
         self.termination_string = termination
         self.termination = self.read_termination(termination)
-        self.use_simulation_setup_type = use_simulation_setup_type
 
     def __str__(self):
         return str(self.operating_conditions_strings)

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -515,19 +515,16 @@ class Simulation:
                 unbuilt_model,
                 parameter_values,
             ) in self.op_conds_to_model_and_param.items():
-                if unbuilt_model in processed_models:
-                    built_model = processed_models[unbuilt_model]
-                else:
-                    # It's ok to modify the models in-place as they are not accessible
-                    # from outside the simulation
-                    model_with_set_params = parameter_values.process_model(
-                        unbuilt_model, inplace=True
-                    )
-                    built_model = self._disc.process_model(
-                        model_with_set_params, inplace=True, check_model=check_model
-                    )
-                    processed_models[unbuilt_model] = built_model
+                # It's ok to modify the models in-place as they are not accessible
+                # from outside the simulation
+                model_with_set_params = parameter_values.process_model(
+                    unbuilt_model, inplace=True
+                )
+                built_model = self._disc.process_model(
+                    model_with_set_params, inplace=True, check_model=check_model
+                )
 
+                processed_models[unbuilt_model] = built_model
                 self.op_conds_to_built_models[op_cond] = built_model
 
     def solve(

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -38,7 +38,6 @@ class TestExperiment(unittest.TestCase):
                 "Run US06 (V) for 5 minutes",
                 "Run US06 (W) for 0.5 hours",
             ],
-            {"test": "test"},
             drive_cycles={"US06": drive_cycle},
             period="20 seconds",
         )
@@ -135,7 +134,6 @@ class TestExperiment(unittest.TestCase):
                 None,
             ],
         )
-        self.assertEqual(experiment.parameters, {"test": "test"})
         self.assertEqual(experiment.period, 20)
 
     def test_read_strings_cccv_combined(self):
@@ -326,10 +324,6 @@ class TestExperiment(unittest.TestCase):
             pybamm.Experiment(["Discharge at 1 B for 2 hours"])
         with self.assertRaisesRegex(ValueError, "time units must be"):
             pybamm.Experiment(["Discharge at 1 A for 2 years"])
-        with self.assertRaisesRegex(
-            TypeError, "experimental parameters should be a dictionary"
-        ):
-            pybamm.Experiment([], "not a dictionary")
 
     def test_termination(self):
         experiment = pybamm.Experiment(["Discharge at 1 C for 20 seconds"])

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -176,23 +176,6 @@ class TestSimulationExperiment(unittest.TestCase):
         self.assertIn(("drive_cycle", "V"), sim.op_conds_to_model_and_param)
         self.assertIn(("drive_cycle", "W"), sim.op_conds_to_model_and_param)
 
-    def test_run_experiment_old_setup_type(self):
-        experiment = pybamm.Experiment(
-            [
-                (
-                    "Discharge at C/20 for 1 hour",
-                    "Charge at 1 A until 4.1 V",
-                    "Hold at 4.1 V until C/2",
-                    "Discharge at 2 W for 1 hour",
-                ),
-            ],
-            use_simulation_setup_type="old",
-        )
-        model = pybamm.lithium_ion.SPM()
-        sim = pybamm.Simulation(model, experiment=experiment)
-        solution1 = sim.solve(solver=pybamm.CasadiSolver())
-        self.assertEqual(solution1.termination, "final time")
-
     def test_run_experiment_breaks_early(self):
         experiment = pybamm.Experiment(["Discharge at 2 C for 1 hour"])
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -43,7 +43,7 @@ class TestBasicModels(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             NotImplementedError,
-            "BasicDFNHalfCell is not compatible with experiment simulations yet.",
+            "BasicDFNHalfCell is not compatible with experiment simulations.",
         ):
             pybamm.Simulation(model, experiment=experiment)
 

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -54,12 +54,6 @@ class TestSimulation(unittest.TestCase):
             if val.size > 1:
                 self.assertTrue(val.has_symbol_of_classes(pybamm.Matrix))
 
-    def test_specs_deprecated(self):
-        model = pybamm.lithium_ion.SPM()
-        sim = pybamm.Simulation(model)
-        with self.assertRaisesRegex(NotImplementedError, "specs"):
-            sim.specs()
-
     def test_solve(self):
 
         sim = pybamm.Simulation(pybamm.lithium_ion.SPM())


### PR DESCRIPTION
# Description

Some inputs to the experiment have been marked as "deprecated, get in touch if you're using these" for a while. Nobody has commented, so this PR gets rid of those inputs

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
