### PR TITLE
simplify model copy

### DIFF
--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -182,8 +182,8 @@ class Discretisation(object):
             # since they point to the same object
             model_disc = model
         else:
-            # create an empty copy of the original model
-            model_disc = model.new_empty_copy()
+            # create a copy of the original model
+            model_disc = model.new_copy()
 
         # Keep a record of y_slices in the model
         model_disc.y_slices = self.y_slices_explicit

--- a/pybamm/expression_tree/operations/replace_symbols.py
+++ b/pybamm/expression_tree/operations/replace_symbols.py
@@ -54,8 +54,8 @@ class SymbolReplacer(object):
             # since they point to the same object
             model = unprocessed_model
         else:
-            # create a blank model of the same class
-            model = unprocessed_model.new_empty_copy()
+            # create a copy of the model
+            model = unprocessed_model.new_copy()
 
         new_rhs = {}
         for variable, equation in unprocessed_model.rhs.items():

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -864,15 +864,6 @@ class BaseBatteryModel(pybamm.BaseModel):
         self._built = True
         pybamm.logger.info("Finish building {}".format(self.name))
 
-    def new_empty_copy(self):
-        """See :meth:`pybamm.BaseModel.new_empty_copy()`"""
-        new_model = self.__class__(name=self.name, options=self.options)
-        new_model.use_jacobian = self.use_jacobian
-        new_model.convert_to_format = self.convert_to_format
-        new_model._timescale = self.timescale
-        new_model._length_scales = self.length_scales
-        return new_model
-
     @property
     def summary_variables(self):
         return self._summary_variables

--- a/pybamm/models/full_battery_models/lead_acid/basic_full.py
+++ b/pybamm/models/full_battery_models/lead_acid/basic_full.py
@@ -294,6 +294,3 @@ class BasicFull(BaseModel):
                 pybamm.Event("Maximum voltage", voltage - param.voltage_high_cut),
             ]
         )
-
-    def new_empty_copy(self):
-        return pybamm.BaseModel.new_empty_copy(self)

--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
@@ -286,6 +286,3 @@ class BasicDFN(BaseModel):
             pybamm.Event("Minimum voltage", voltage - param.voltage_low_cut),
             pybamm.Event("Maximum voltage", voltage - param.voltage_high_cut),
         ]
-
-    def new_empty_copy(self):
-        return pybamm.BaseModel.new_empty_copy(self)

--- a/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
@@ -182,5 +182,3 @@ class BasicSPM(BaseModel):
             pybamm.Event("Maximum voltage", V - param.voltage_high_cut),
         ]
 
-    def new_empty_copy(self):
-        return pybamm.BaseModel.new_empty_copy(self)

--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh_half_cell.py
@@ -75,7 +75,3 @@ class ElectrodeSOHHalfCell(pybamm.BaseModel):
     def default_solver(self):
         # Use AlgebraicSolver as CasadiAlgebraicSolver gives unnecessary warnings
         return pybamm.AlgebraicSolver()
-
-    def new_empty_copy(self):
-        new_model = ElectrodeSOHHalfCell(self.working_electrode, name=self.name)
-        return new_model

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -422,8 +422,8 @@ class ParameterValues:
             # since they point to the same object
             model = unprocessed_model
         else:
-            # create a blank model of the same class
-            model = unprocessed_model.new_empty_copy()
+            # create a copy of the model
+            model = unprocessed_model.new_copy()
 
         if (
             len(unprocessed_model.rhs) == 0

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -515,11 +515,11 @@ class Simulation:
                 unbuilt_model,
                 parameter_values,
             ) in self.op_conds_to_model_and_param.items():
-                # It's ok to modify the models in-place as they are not accessible
-                # from outside the simulation
                 model_with_set_params = parameter_values.process_model(
-                    unbuilt_model, inplace=True
+                    unbuilt_model, inplace=False
                 )
+                # It's ok to modify the model with set parameters in place as it's
+                # not returned anywhere
                 built_model = self._disc.process_model(
                     model_with_set_params, inplace=True, check_model=check_model
                 )

--- a/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_basic_models.py
@@ -10,9 +10,6 @@ class TestBasicModels(unittest.TestCase):
         model = pybamm.lead_acid.BasicFull()
         model.check_well_posedness()
 
-        copy = model.new_copy()
-        copy.check_well_posedness()
-
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -10,30 +10,18 @@ class TestBasicModels(unittest.TestCase):
         model = pybamm.lithium_ion.BasicDFN()
         model.check_well_posedness()
 
-        copy = model.new_copy()
-        copy.check_well_posedness()
-
     def test_spm_well_posed(self):
         model = pybamm.lithium_ion.BasicSPM()
         model.check_well_posedness()
-
-        copy = model.new_copy()
-        copy.check_well_posedness()
 
     def test_dfn_half_cell_well_posed(self):
         options = {"working electrode": "positive"}
         model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)
         model.check_well_posedness()
 
-        copy = model.new_copy()
-        copy.check_well_posedness()
-
         options = {"working electrode": "negative"}
         model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)
         model.check_well_posedness()
-
-        copy = model.new_copy()
-        copy.check_well_posedness()
 
     def test_dfn_half_cell_simulation_with_experiment_error(self):
         options = {"working electrode": "negative"}


### PR DESCRIPTION
# Description

Remove `model.new_empty_copy()` and simplify `model.new_copy()`.
Not sure why I made it so complicated in the first place, but this seems to work fine and be faster

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
