### PR TITLE
Updating the notebook in parameter management

### DIFF
--- a/examples/notebooks/parameterization/parameter-management.ipynb
+++ b/examples/notebooks/parameterization/parameter-management.ipynb
@@ -54,6 +54,13 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "ERROR: Invalid requirement: '#'\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -63,9 +70,9 @@
     {
      "data": {
       "text/plain": [
-       "['/home/priyanshu/work/PyBaMM',\n",
-       " '/home/priyanshu/work/notebooks',\n",
-       " '/home/priyanshu/work/PyBaMM/pybamm/input/parameters']"
+       "['C:\\\\Users\\\\seckr\\\\anaconda3\\\\envs\\\\tensorflow_env\\\\lib\\\\site-packages',\n",
+       " 'c:\\\\PyBaMM\\\\examples\\\\notebooks\\\\parameterization',\n",
+       " 'C:\\\\Users\\\\seckr\\\\anaconda3\\\\envs\\\\tensorflow_env\\\\lib\\\\site-packages\\\\pybamm\\\\input\\\\parameters']"
       ]
      },
      "execution_count": 1,
@@ -122,12 +129,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "module 'pybamm' has no attribute 'edit_parameter'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-5-09b56f93d50e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mpybamm\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0medit_parameter\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m\"lithium_ion\"\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m: module 'pybamm' has no attribute 'edit_parameter'"
+     ]
+    }
+   ],
    "source": [
-    "%%bash\n",
-    "pybamm_edit_parameter lithium_ion"
+    "pybamm.edit_parameter([\"lithium_ion\"])"
    ]
   },
   {
@@ -428,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

 instead of
%%bash
pybamm_edit_parameter lithium_ion

pybamm.edit_parameter(["lithium_ion"])
Fixes  #1697


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

