### PR TITLE
Fixing some docs bug

### DIFF
--- a/docs/tutorials/add-model.rst
+++ b/docs/tutorials/add-model.rst
@@ -113,7 +113,7 @@ For example, we might wish to output the terminal voltage which is given by
 
     self.variables = {"Terminal voltage [V]": V}
 
-Note that we indicate that the quanitity is dimensional by including the dimensions, Volts in square brackets. We do this to distinguish between dimensional and dimensionless outputs which may otherwise share the same name.
+Note that we indicate that the quantity is dimensional by including the dimensions, Volts in square brackets. We do this to distinguish between dimensional and dimensionless outputs which may otherwise share the same name.
 
 Note that if your model inherits from :class:`pybamm.StandardBatteryBaseModel`, then there is a standard set of output parameters which is enforced to ensure consistency across models so that they can be easily tested and compared.
 


### PR DESCRIPTION
# Description

The " quantity " was mispelled as "quanitity" in [add-model.rst](https://github.com/pybamm-team/PyBaMM/blob/develop/docs/tutorials/add-model.rst).

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.


- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
