### PR TITLE
Add Jax solver example for SPMe model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 -   Added "Discharge energy [W.h]", which is the integral of the power in Watts, as an optional output. Set the option "calculate discharge energy" to "true" to get this output ("false" by default, since it can slow down some of the simple models) ([#1969](https://github.com/pybamm-team/PyBaMM/pull/1969)))
 -   Added an option "calculate heat source for isothermal models" to choose whether or not the heat generation terms are computed when running models with the option `thermal="isothermal"`  ([#1958](https://github.com/pybamm-team/PyBaMM/pull/1958))
+-   Added a Jax solver example using the SPMe model ([#1990](https://github.com/pybamm-team/PyBaMM/pull/1990))
 
 ## Bug fixes
 

--- a/examples/scripts/SPMe_jax_solver.py
+++ b/examples/scripts/SPMe_jax_solver.py
@@ -1,0 +1,37 @@
+"""
+Example of Jax solver with the SPMe model. Use the `pybamm_install_jax`
+command to automatically download and install jax and jaxlib on your system.
+"""
+
+import matplotlib.pylab as plt
+import pybamm
+
+# Load the SPMe model with Jax support
+model = pybamm.lithium_ion.SPMe(options={'timescale': 1.0})
+model.convert_to_format = 'jax'
+model.events = []
+
+# Create geometry
+geometry = model.default_geometry
+
+# Load parameter values and process model and geometry
+param = model.default_parameter_values
+param.process_model(model)
+param.process_geometry(geometry)
+
+# Set the mesh and discretize the model
+mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+discrete = pybamm.Discretisation(mesh, model.default_spatial_methods)
+discrete.process_model(model)
+
+# Use Jax to solve the model and get solution object
+solver = pybamm.JaxSolver()
+solution = solver.solve(model, [0, 3600])
+
+# Plot results
+_, ax = plt.subplots()
+ax.plot(solution['Time [s]'].entries, solution['Terminal voltage [V]'].entries)
+ax.set_xlabel('Time [s]')
+ax.set_ylabel('Voltage [V]')
+
+plt.show()


### PR DESCRIPTION
# Description

There are no examples of using the Jax solver in the PyBaMM repository or in the documentation. This request adds an example script that uses the Jax solver with the SPMe model.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
