### PR TITLE
Allow 2D cubic interpolation

### DIFF
--- a/pybamm/expression_tree/interpolant.py
+++ b/pybamm/expression_tree/interpolant.py
@@ -48,7 +48,7 @@ class Interpolant(pybamm.Function):
 
         if isinstance(x, (tuple, list)) and len(x) == 2:
             interpolator = interpolator or "linear"
-            if interpolator not in  ["linear", "cubic"]:
+            if interpolator not in ["linear", "cubic"]:
                 raise ValueError(
                     "interpolator should be 'linear' or 'cubic' if x is two-dimensional"
                 )
@@ -56,7 +56,7 @@ class Interpolant(pybamm.Function):
             if y.ndim != 2:
                 raise ValueError("y should be two-dimensional if len(x)=2")
         else:
-            interpolator = interpolator or "cubic spline"
+            interpolator = interpolator or "cubic spline" or "cubic"
             if isinstance(x, (tuple, list)):
                 x1 = x[0]
             else:

--- a/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -134,7 +134,7 @@ class CasadiConverter(object):
             elif isinstance(symbol, pybamm.Interpolant):
                 if symbol.interpolator == "linear":
                     solver = "linear"
-                elif symbol.interpolator == "cubic spline":
+                elif "cubic" in symbol.interpolator:
                     solver = "bspline"
                 elif symbol.interpolator == "pchip":
                     raise NotImplementedError(

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -87,6 +87,11 @@ class TestInterpolant(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             interp.evaluate(y=np.array([0, 0])), 0, decimal=3
         )
+        # cubic
+        interp = pybamm.Interpolant(x, z, (var1, var2), interpolator="cubic")
+        np.testing.assert_array_almost_equal(
+            interp.evaluate(y=np.array([0, 0])), 0, decimal=3
+        )
 
     def test_name(self):
         a = pybamm.Symbol("a")


### PR DESCRIPTION
# Description

Allow cubic interpolation of 2D data

Fixes # 2017

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
