### PR TITLE
plot voltage components has correct legend order

### DIFF
--- a/pybamm/plotting/plot_voltage_components.py
+++ b/pybamm/plotting/plot_voltage_components.py
@@ -57,12 +57,12 @@ def plot_voltage_components(
     ax.plot(time, V, "k--")
     if show_legend:
         labels = [
-            "Voltage",
             "Open-circuit voltage",
             "Reaction overpotential",
             "Concentration overpotential",
             "Ohmic electrolyte overpotential",
             "Ohmic electrode overpotential",
+            "Voltage",
         ]
         leg = ax.legend(labels, loc="lower left", frameon=True)
         leg.get_frame().set_edgecolor("k")


### PR DESCRIPTION
# Description

The legend and colors were messed up so i fixed it.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
