### PR TITLE
Benchmarks for model X parameter set combinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ Manifest.toml
 
 # vcpkg
 vcpkg_installed/
+
+# benchmarks
+html/
+results/

--- a/benchmarks/time_setup_models_and_sims.py
+++ b/benchmarks/time_setup_models_and_sims.py
@@ -26,6 +26,7 @@ class TimeBuildSPMMarquis2019:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMORegan2019:
     def __init__(self):
         self.param = pybamm.ParameterValues("ORegan2021")
@@ -34,6 +35,7 @@ class TimeBuildSPMORegan2019:
         self.model = pybamm.lithium_ion.SPM()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMNCA_Kim2011:
     def __init__(self):
@@ -44,6 +46,7 @@ class TimeBuildSPMNCA_Kim2011:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMPrada2013:
     def __init__(self):
         self.param = pybamm.ParameterValues("Prada2013")
@@ -52,6 +55,7 @@ class TimeBuildSPMPrada2013:
         self.model = pybamm.lithium_ion.SPM()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMAi2020:
     def __init__(self):
@@ -62,6 +66,7 @@ class TimeBuildSPMAi2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMRamadass2004:
     def __init__(self):
         self.param = pybamm.ParameterValues("Ramadass2004")
@@ -70,6 +75,7 @@ class TimeBuildSPMRamadass2004:
         self.model = pybamm.lithium_ion.SPM()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMMohtat2020:
     def __init__(self):
@@ -80,6 +86,7 @@ class TimeBuildSPMMohtat2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMChen2020:
     def __init__(self):
         self.param = pybamm.ParameterValues("Chen2020")
@@ -89,6 +96,7 @@ class TimeBuildSPMChen2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMChen2020_plating:
     def __init__(self):
         self.param = pybamm.ParameterValues("Chen2020_plating")
@@ -97,6 +105,7 @@ class TimeBuildSPMChen2020_plating:
         self.model = pybamm.lithium_ion.SPM()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMEcker2015:
     def __init__(self):
@@ -117,6 +126,7 @@ class TimeBuildSPMeMarquis2019:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMeORegan2021:
     def __init__(self):
         self.param = pybamm.ParameterValues("ORegan2021")
@@ -125,6 +135,7 @@ class TimeBuildSPMeORegan2021:
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMeNCA_Kim2011:
     def __init__(self):
@@ -135,6 +146,7 @@ class TimeBuildSPMeNCA_Kim2011:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMePrada2013:
     def __init__(self):
         self.param = pybamm.ParameterValues("Prada2013")
@@ -143,6 +155,7 @@ class TimeBuildSPMePrada2013:
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMeAi2020:
     def __init__(self):
@@ -153,6 +166,7 @@ class TimeBuildSPMeAi2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMeRamadass2004:
     def __init__(self):
         self.param = pybamm.ParameterValues("Ramadass2004")
@@ -161,6 +175,7 @@ class TimeBuildSPMeRamadass2004:
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMeMohtat2020:
     def __init__(self):
@@ -171,6 +186,7 @@ class TimeBuildSPMeMohtat2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMeChen2020:
     def __init__(self):
         self.param = pybamm.ParameterValues("Chen2020")
@@ -179,6 +195,7 @@ class TimeBuildSPMeChen2020:
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMeChen2020_plating:
     def __init__(self):
@@ -189,6 +206,7 @@ class TimeBuildSPMeChen2020_plating:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildSPMeEcker2015:
     def __init__(self):
         self.param = pybamm.ParameterValues("Ecker2015")
@@ -197,6 +215,7 @@ class TimeBuildSPMeEcker2015:
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildDFNMarquis2019:
     def __init__(self):
@@ -207,6 +226,7 @@ class TimeBuildDFNMarquis2019:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildDFNORegan2021:
     def __init__(self):
         self.param = pybamm.ParameterValues("ORegan2021")
@@ -215,6 +235,7 @@ class TimeBuildDFNORegan2021:
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildDFNNCA_Kim2011:
     def __init__(self):
@@ -225,6 +246,7 @@ class TimeBuildDFNNCA_Kim2011:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildDFNPrada2013:
     def __init__(self):
         self.param = pybamm.ParameterValues("Prada2013")
@@ -233,6 +255,7 @@ class TimeBuildDFNPrada2013:
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildDFNAi2020:
     def __init__(self):
@@ -243,6 +266,7 @@ class TimeBuildDFNAi2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildDFNRamadass2004:
     def __init__(self):
         self.param = pybamm.ParameterValues("Ramadass2004")
@@ -251,6 +275,7 @@ class TimeBuildDFNRamadass2004:
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildDFNMohtat2020:
     def __init__(self):
@@ -261,6 +286,7 @@ class TimeBuildDFNMohtat2020:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildDFNChen2020:
     def __init__(self):
         self.param = pybamm.ParameterValues("Chen2020")
@@ -269,6 +295,7 @@ class TimeBuildDFNChen2020:
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildDFNChen2020_plating:
     def __init__(self):
@@ -279,6 +306,7 @@ class TimeBuildDFNChen2020_plating:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+
 class TimeBuildDFNEcker2015:
     def __init__(self):
         self.param = pybamm.ParameterValues("Ecker2015")
@@ -287,6 +315,7 @@ class TimeBuildDFNEcker2015:
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
+
 
 class TimeBuildSPMSimulationMarquis2019:
     # with_experiment
@@ -307,6 +336,7 @@ class TimeBuildSPMSimulationMarquis2019:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMSimulationORegan2021:
     # with_experiment
     params = [False, True]
@@ -325,6 +355,7 @@ class TimeBuildSPMSimulationORegan2021:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMSimulationNCA_Kim2011:
     # with_experiment
@@ -345,6 +376,7 @@ class TimeBuildSPMSimulationNCA_Kim2011:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMSimulationPrada2013:
     # with_experiment
     params = [False, True]
@@ -363,6 +395,7 @@ class TimeBuildSPMSimulationPrada2013:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMSimulationAi2020:
     # with_experiment
@@ -383,6 +416,7 @@ class TimeBuildSPMSimulationAi2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMSimulationRamadass2004:
     # with_experiment
     params = [False, True]
@@ -401,6 +435,7 @@ class TimeBuildSPMSimulationRamadass2004:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMSimulationMohtat2020:
     # with_experiment
@@ -421,6 +456,7 @@ class TimeBuildSPMSimulationMohtat2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMSimulationChen2020:
     # with_experiment
     params = [False, True]
@@ -439,6 +475,7 @@ class TimeBuildSPMSimulationChen2020:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMSimulationChen2020_plating:
     # with_experiment
@@ -459,6 +496,7 @@ class TimeBuildSPMSimulationChen2020_plating:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMSimulationEcker2015:
     # with_experiment
     params = [False, True]
@@ -477,6 +515,7 @@ class TimeBuildSPMSimulationEcker2015:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMeSimulationMarquis2019:
     # with_experiment
@@ -497,6 +536,7 @@ class TimeBuildSPMeSimulationMarquis2019:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMeSimulationORegan2021:
     # with_experiment
     params = [False, True]
@@ -515,6 +555,7 @@ class TimeBuildSPMeSimulationORegan2021:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMeSimulationNCA_Kim2011:
     # with_experiment
@@ -535,6 +576,7 @@ class TimeBuildSPMeSimulationNCA_Kim2011:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMeSimulationPrada2013:
     # with_experiment
     params = [False, True]
@@ -553,6 +595,7 @@ class TimeBuildSPMeSimulationPrada2013:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMeSimulationAi2020:
     # with_experiment
@@ -573,6 +616,7 @@ class TimeBuildSPMeSimulationAi2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMeSimulationRamadass2004:
     # with_experiment
     params = [False, True]
@@ -591,6 +635,7 @@ class TimeBuildSPMeSimulationRamadass2004:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMeSimulationMohtat2020:
     # with_experiment
@@ -611,6 +656,7 @@ class TimeBuildSPMeSimulationMohtat2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMeSimulationChen2020:
     # with_experiment
     params = [False, True]
@@ -629,6 +675,7 @@ class TimeBuildSPMeSimulationChen2020:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildSPMeSimulationChen2020_plating:
     # with_experiment
@@ -649,6 +696,7 @@ class TimeBuildSPMeSimulationChen2020_plating:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildSPMeSimulationEcker2015:
     # with_experiment
     params = [False, True]
@@ -667,6 +715,7 @@ class TimeBuildSPMeSimulationEcker2015:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildDFNSimulationMarquis2019:
     # with_experiment
@@ -687,6 +736,7 @@ class TimeBuildDFNSimulationMarquis2019:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildDFNSimulationORegan2021:
     # with_experiment
     params = [False, True]
@@ -705,6 +755,7 @@ class TimeBuildDFNSimulationORegan2021:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildDFNSimulationNCA_Kim2011:
     # with_experiment
@@ -725,6 +776,7 @@ class TimeBuildDFNSimulationNCA_Kim2011:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildDFNSimulationPrada2013:
     # with_experiment
     params = [False, True]
@@ -743,6 +795,7 @@ class TimeBuildDFNSimulationPrada2013:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildDFNSimulationAi2020:
     # with_experiment
@@ -763,6 +816,7 @@ class TimeBuildDFNSimulationAi2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildDFNSimulationRamadass2004:
     # with_experiment
     params = [False, True]
@@ -781,6 +835,7 @@ class TimeBuildDFNSimulationRamadass2004:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildDFNSimulationMohtat2020:
     # with_experiment
@@ -801,6 +856,7 @@ class TimeBuildDFNSimulationMohtat2020:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildDFNSimulationChen2020:
     # with_experiment
     params = [False, True]
@@ -819,6 +875,7 @@ class TimeBuildDFNSimulationChen2020:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
 
 class TimeBuildDFNSimulationChen2020_plating:
     # with_experiment
@@ -839,6 +896,7 @@ class TimeBuildDFNSimulationChen2020_plating:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+
 class TimeBuildDFNSimulationEcker2015:
     # with_experiment
     params = [False, True]
@@ -857,4 +915,3 @@ class TimeBuildDFNSimulationEcker2015:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-

--- a/benchmarks/time_setup_models_and_sims.py
+++ b/benchmarks/time_setup_models_and_sims.py
@@ -17,314 +17,92 @@ def compute_discretisation(model, param):
     return pybamm.Discretisation(mesh, model.default_spatial_methods)
 
 
-class TimeBuildSPMMarquis2019:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
+class TimeBuildSPM:
 
-    def time_setup_SPM(self):
+    params = [
+        "Marquis2019",
+        "ORegan2021",
+        "NCA_Kim2011",
+        "Prada2013",
+        "Ai2020",
+        "Ramadass2004",
+        "Mohtat2020",
+        "Chen2020",
+        "Chen2020_plating",
+        "Ecker2015",
+    ]
+
+    def time_setup_SPM(self, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.SPM()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
 
-class TimeBuildSPMORegan2019:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
+class TimeBuildSPMe:
 
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
+    params = [
+        "Marquis2019",
+        "ORegan2021",
+        "NCA_Kim2011",
+        "Prada2013",
+        "Ai2020",
+        "Ramadass2004",
+        "Mohtat2020",
+        "Chen2020",
+        "Chen2020_plating",
+        "Ecker2015",
+    ]
 
-
-class TimeBuildSPMNCA_Kim2011:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMPrada2013:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMAi2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMRamadass2004:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMMohtat2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMChen2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMChen2020_plating:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMEcker2015:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_SPM(self):
-        self.model = pybamm.lithium_ion.SPM()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeMarquis2019:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
-
-    def time_setup_SPMe(self):
+    def time_setup_SPMe(self, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.SPMe()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
 
-class TimeBuildSPMeORegan2021:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
+class TimeBuildDFN:
 
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
+    params = [
+        "Marquis2019",
+        "ORegan2021",
+        "NCA_Kim2011",
+        "Prada2013",
+        "Ai2020",
+        "Ramadass2004",
+        "Mohtat2020",
+        "Chen2020",
+        "Chen2020_plating",
+        "Ecker2015",
+    ]
 
-
-class TimeBuildSPMeNCA_Kim2011:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMePrada2013:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeAi2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeRamadass2004:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeMohtat2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeChen2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeChen2020_plating:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMeEcker2015:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_SPMe(self):
-        self.model = pybamm.lithium_ion.SPMe()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNMarquis2019:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
-
-    def time_setup_DFN(self):
+    def time_setup_DFN(self, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.DFN()
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
 
-class TimeBuildDFNORegan2021:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNNCA_Kim2011:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNPrada2013:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNAi2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNRamadass2004:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNMohtat2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNChen2020:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNChen2020_plating:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildDFNEcker2015:
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_DFN(self):
-        self.model = pybamm.lithium_ion.DFN()
-        self.param.process_model(self.model)
-        compute_discretisation(self.model, self.param).process_model(self.model)
-
-
-class TimeBuildSPMSimulationMarquis2019:
+class TimeBuildSPMSimulation:
     # with_experiment
-    params = [False, True]
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
 
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
-
-    def time_setup_SPM_simulation(self, with_experiment):
+    def time_setup_SPM_simulation(self, with_experiment, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.SPM()
         if with_experiment:
             exp = pybamm.Experiment(
@@ -337,194 +115,26 @@ class TimeBuildSPMSimulationMarquis2019:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
 
-class TimeBuildSPMSimulationORegan2021:
+class TimeBuildSPMeSimulation:
     # with_experiment
-    params = [False, True]
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
 
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationNCA_Kim2011:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationPrada2013:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationAi2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationRamadass2004:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationMohtat2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationChen2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationChen2020_plating:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMSimulationEcker2015:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_SPM_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPM()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationMarquis2019:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
+    def time_setup_SPMe_simulation(self, with_experiment, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.SPMe()
         if with_experiment:
             exp = pybamm.Experiment(
@@ -537,374 +147,26 @@ class TimeBuildSPMeSimulationMarquis2019:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
 
-class TimeBuildSPMeSimulationORegan2021:
+class TimeBuildDFNSimulation:
     # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationNCA_Kim2011:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationPrada2013:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationAi2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationRamadass2004:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationMohtat2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationChen2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationChen2020_plating:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildSPMeSimulationEcker2015:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_SPMe_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.SPMe()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationMarquis2019:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Marquis2019")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationORegan2021:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("ORegan2021")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationNCA_Kim2011:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("NCA_Kim2011")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationPrada2013:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Prada2013")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationAi2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ai2020")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationRamadass2004:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ramadass2004")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationMohtat2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Mohtat2020")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationChen2020:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationChen2020_plating:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Chen2020_plating")
-
-    def time_setup_DFN_simulation(self, with_experiment):
-        self.model = pybamm.lithium_ion.DFN()
-        if with_experiment:
-            exp = pybamm.Experiment(
-                [
-                    "Discharge at 0.1C until 3.105 V",
-                ]
-            )
-            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
-        else:
-            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
-
-
-class TimeBuildDFNSimulationEcker2015:
-    # with_experiment
-    params = [False, True]
-
-    def __init__(self):
-        self.param = pybamm.ParameterValues("Ecker2015")
-
-    def time_setup_DFN_simulation(self, with_experiment):
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
+
+    def time_setup_DFN_simulation(self, with_experiment, parameters):
+        self.param = pybamm.ParameterValues(parameters)
         self.model = pybamm.lithium_ion.DFN()
         if with_experiment:
             exp = pybamm.Experiment(

--- a/benchmarks/time_setup_models_and_sims.py
+++ b/benchmarks/time_setup_models_and_sims.py
@@ -17,7 +17,7 @@ def compute_discretisation(model, param):
     return pybamm.Discretisation(mesh, model.default_spatial_methods)
 
 
-class TimeBuildSPM:
+class TimeBuildSPMMarquis2019:
     def __init__(self):
         self.param = pybamm.ParameterValues("Marquis2019")
 
@@ -26,8 +26,89 @@ class TimeBuildSPM:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+class TimeBuildSPMORegan2019:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
 
-class TimeBuildSPMe:
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMNCA_Kim2011:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMPrada2013:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMAi2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMRamadass2004:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMMohtat2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMChen2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMChen2020_plating:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMEcker2015:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_SPM(self):
+        self.model = pybamm.lithium_ion.SPM()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+
+class TimeBuildSPMeMarquis2019:
     def __init__(self):
         self.param = pybamm.ParameterValues("Marquis2019")
 
@@ -36,8 +117,88 @@ class TimeBuildSPMe:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+class TimeBuildSPMeORegan2021:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
 
-class TimeBuildDFN:
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeNCA_Kim2011:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMePrada2013:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeAi2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeRamadass2004:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeMohtat2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeChen2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeChen2020_plating:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMeEcker2015:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_SPMe(self):
+        self.model = pybamm.lithium_ion.SPMe()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNMarquis2019:
     def __init__(self):
         self.param = pybamm.ParameterValues("Marquis2019")
 
@@ -46,8 +207,88 @@ class TimeBuildDFN:
         self.param.process_model(self.model)
         compute_discretisation(self.model, self.param).process_model(self.model)
 
+class TimeBuildDFNORegan2021:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
 
-class TimeBuildSPMSimulation:
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNNCA_Kim2011:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNPrada2013:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNAi2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNRamadass2004:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNMohtat2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNChen2020:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNChen2020_plating:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildDFNEcker2015:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_DFN(self):
+        self.model = pybamm.lithium_ion.DFN()
+        self.param.process_model(self.model)
+        compute_discretisation(self.model, self.param).process_model(self.model)
+
+class TimeBuildSPMSimulationMarquis2019:
     # with_experiment
     params = [False, True]
 
@@ -66,8 +307,178 @@ class TimeBuildSPMSimulation:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+class TimeBuildSPMSimulationORegan2021:
+    # with_experiment
+    params = [False, True]
 
-class TimeBuildSPMeSimulation:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationNCA_Kim2011:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationPrada2013:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationAi2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationRamadass2004:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationMohtat2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationChen2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationChen2020_plating:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMSimulationEcker2015:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_SPM_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPM()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationMarquis2019:
     # with_experiment
     params = [False, True]
 
@@ -86,8 +497,178 @@ class TimeBuildSPMeSimulation:
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
 
+class TimeBuildSPMeSimulationORegan2021:
+    # with_experiment
+    params = [False, True]
 
-class TimeBuildDFNSimulation:
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationNCA_Kim2011:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationPrada2013:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationAi2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationRamadass2004:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationMohtat2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationChen2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationChen2020_plating:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildSPMeSimulationEcker2015:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_SPMe_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.SPMe()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationMarquis2019:
     # with_experiment
     params = [False, True]
 
@@ -105,3 +686,175 @@ class TimeBuildDFNSimulation:
             pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
         else:
             pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationORegan2021:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("ORegan2021")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationNCA_Kim2011:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("NCA_Kim2011")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationPrada2013:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Prada2013")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationAi2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ai2020")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationRamadass2004:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ramadass2004")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationMohtat2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Mohtat2020")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationChen2020:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationChen2020_plating:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Chen2020_plating")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+
+class TimeBuildDFNSimulationEcker2015:
+    # with_experiment
+    params = [False, True]
+
+    def __init__(self):
+        self.param = pybamm.ParameterValues("Ecker2015")
+
+    def time_setup_DFN_simulation(self, with_experiment):
+        self.model = pybamm.lithium_ion.DFN()
+        if with_experiment:
+            exp = pybamm.Experiment(
+                [
+                    "Discharge at 0.1C until 3.105 V",
+                ]
+            )
+            pybamm.Simulation(self.model, parameter_values=self.param, experiment=exp)
+        else:
+            pybamm.Simulation(self.model, parameter_values=self.param, C_rate=1)
+

--- a/benchmarks/time_setup_models_and_sims.py
+++ b/benchmarks/time_setup_models_and_sims.py
@@ -18,7 +18,7 @@ def compute_discretisation(model, param):
 
 
 class TimeBuildSPM:
-
+    param_names = ['parameter']
     params = [
         "Marquis2019",
         "ORegan2021",
@@ -40,7 +40,7 @@ class TimeBuildSPM:
 
 
 class TimeBuildSPMe:
-
+    param_names = ['parameter']
     params = [
         "Marquis2019",
         "ORegan2021",
@@ -62,7 +62,7 @@ class TimeBuildSPMe:
 
 
 class TimeBuildDFN:
-
+    param_names = ['parameter']
     params = [
         "Marquis2019",
         "ORegan2021",
@@ -84,7 +84,7 @@ class TimeBuildDFN:
 
 
 class TimeBuildSPMSimulation:
-    # with_experiment
+    param_names = ['with experiment', 'parameter']
     params = (
         [False, True],
         [
@@ -116,7 +116,7 @@ class TimeBuildSPMSimulation:
 
 
 class TimeBuildSPMeSimulation:
-    # with_experiment
+    param_names = ['with experiment', 'parameter']
     params = (
         [False, True],
         [
@@ -148,7 +148,7 @@ class TimeBuildSPMeSimulation:
 
 
 class TimeBuildDFNSimulation:
-    # with_experiment
+    param_names = ['with experiment', 'parameter']
     params = (
         [False, True],
         [

--- a/benchmarks/time_setup_models_and_sims.py
+++ b/benchmarks/time_setup_models_and_sims.py
@@ -1,5 +1,18 @@
 import pybamm
 
+parameters = [
+    "Marquis2019",
+    "ORegan2021",
+    "NCA_Kim2011",
+    "Prada2013",
+    "Ai2020",
+    "Ramadass2004",
+    "Mohtat2020",
+    "Chen2020",
+    "Chen2020_plating",
+    "Ecker2015",
+]
+
 
 def compute_discretisation(model, param):
     var_pts = {
@@ -18,19 +31,8 @@ def compute_discretisation(model, param):
 
 
 class TimeBuildSPM:
-    param_names = ['parameter']
-    params = [
-        "Marquis2019",
-        "ORegan2021",
-        "NCA_Kim2011",
-        "Prada2013",
-        "Ai2020",
-        "Ramadass2004",
-        "Mohtat2020",
-        "Chen2020",
-        "Chen2020_plating",
-        "Ecker2015",
-    ]
+    param_names = ["parameter"]
+    params = parameters
 
     def time_setup_SPM(self, parameters):
         self.param = pybamm.ParameterValues(parameters)
@@ -40,19 +42,8 @@ class TimeBuildSPM:
 
 
 class TimeBuildSPMe:
-    param_names = ['parameter']
-    params = [
-        "Marquis2019",
-        "ORegan2021",
-        "NCA_Kim2011",
-        "Prada2013",
-        "Ai2020",
-        "Ramadass2004",
-        "Mohtat2020",
-        "Chen2020",
-        "Chen2020_plating",
-        "Ecker2015",
-    ]
+    param_names = ["parameter"]
+    params = parameters
 
     def time_setup_SPMe(self, parameters):
         self.param = pybamm.ParameterValues(parameters)
@@ -62,19 +53,8 @@ class TimeBuildSPMe:
 
 
 class TimeBuildDFN:
-    param_names = ['parameter']
-    params = [
-        "Marquis2019",
-        "ORegan2021",
-        "NCA_Kim2011",
-        "Prada2013",
-        "Ai2020",
-        "Ramadass2004",
-        "Mohtat2020",
-        "Chen2020",
-        "Chen2020_plating",
-        "Ecker2015",
-    ]
+    param_names = ["parameter"]
+    params = parameters
 
     def time_setup_DFN(self, parameters):
         self.param = pybamm.ParameterValues(parameters)
@@ -84,22 +64,8 @@ class TimeBuildDFN:
 
 
 class TimeBuildSPMSimulation:
-    param_names = ['with experiment', 'parameter']
-    params = (
-        [False, True],
-        [
-            "Marquis2019",
-            "ORegan2021",
-            "NCA_Kim2011",
-            "Prada2013",
-            "Ai2020",
-            "Ramadass2004",
-            "Mohtat2020",
-            "Chen2020",
-            "Chen2020_plating",
-            "Ecker2015",
-        ],
-    )
+    param_names = ["with experiment", "parameter"]
+    params = ([False, True], parameters)
 
     def time_setup_SPM_simulation(self, with_experiment, parameters):
         self.param = pybamm.ParameterValues(parameters)
@@ -116,22 +82,8 @@ class TimeBuildSPMSimulation:
 
 
 class TimeBuildSPMeSimulation:
-    param_names = ['with experiment', 'parameter']
-    params = (
-        [False, True],
-        [
-            "Marquis2019",
-            "ORegan2021",
-            "NCA_Kim2011",
-            "Prada2013",
-            "Ai2020",
-            "Ramadass2004",
-            "Mohtat2020",
-            "Chen2020",
-            "Chen2020_plating",
-            "Ecker2015",
-        ],
-    )
+    param_names = ["with experiment", "parameter"]
+    params = ([False, True], parameters)
 
     def time_setup_SPMe_simulation(self, with_experiment, parameters):
         self.param = pybamm.ParameterValues(parameters)
@@ -148,22 +100,8 @@ class TimeBuildSPMeSimulation:
 
 
 class TimeBuildDFNSimulation:
-    param_names = ['with experiment', 'parameter']
-    params = (
-        [False, True],
-        [
-            "Marquis2019",
-            "ORegan2021",
-            "NCA_Kim2011",
-            "Prada2013",
-            "Ai2020",
-            "Ramadass2004",
-            "Mohtat2020",
-            "Chen2020",
-            "Chen2020_plating",
-            "Ecker2015",
-        ],
-    )
+    param_names = ["with experiment", "parameter"]
+    params = ([False, True], parameters)
 
     def time_setup_DFN_simulation(self, with_experiment, parameters):
         self.param = pybamm.ParameterValues(parameters)

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -21,6 +21,7 @@ def prepare_model_Marquis2019(model):
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
 
+
 def prepare_model_ORegan2021(model):
     geometry = model.default_geometry
 
@@ -36,6 +37,7 @@ def prepare_model_ORegan2021(model):
     # discretise model
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
+
 
 def prepare_model_NCA_Kim2011(model):
     geometry = model.default_geometry
@@ -53,6 +55,7 @@ def prepare_model_NCA_Kim2011(model):
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
 
+
 def prepare_model_Prada2013(model):
     geometry = model.default_geometry
 
@@ -68,6 +71,7 @@ def prepare_model_Prada2013(model):
     # discretise model
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
+
 
 def prepare_model_Ai2020(model):
     geometry = model.default_geometry
@@ -85,6 +89,7 @@ def prepare_model_Ai2020(model):
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
 
+
 def prepare_model_Ramadass2004(model):
     geometry = model.default_geometry
 
@@ -100,6 +105,7 @@ def prepare_model_Ramadass2004(model):
     # discretise model
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
+
 
 def prepare_model_Mohtat2020(model):
     geometry = model.default_geometry
@@ -117,6 +123,7 @@ def prepare_model_Mohtat2020(model):
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
 
+
 def prepare_model_Chen2020(model):
     geometry = model.default_geometry
 
@@ -133,6 +140,7 @@ def prepare_model_Chen2020(model):
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
 
+
 def prepare_model_Chen2020_plating(model):
     geometry = model.default_geometry
 
@@ -148,6 +156,7 @@ def prepare_model_Chen2020_plating(model):
     # discretise model
     disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
     disc.process_model(model)
+
 
 def prepare_model_Ecker2015(model):
     geometry = model.default_geometry
@@ -187,6 +196,7 @@ class TimeSolveSPMMarquis2019:
     def time_solve_model(self, solve_first):
         TimeSolveSPMMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMORegan2021:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -203,6 +213,7 @@ class TimeSolveSPMORegan2021:
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMORegan2021.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMNCA_Kim2011:
     params = [True, False]
@@ -221,6 +232,7 @@ class TimeSolveSPMNCA_Kim2011:
     def time_solve_model(self, solve_first):
         TimeSolveSPMNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMPrada2013:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -237,6 +249,7 @@ class TimeSolveSPMPrada2013:
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMPrada2013.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMAi2020:
     params = [True, False]
@@ -255,6 +268,7 @@ class TimeSolveSPMAi2020:
     def time_solve_model(self, solve_first):
         TimeSolveSPMAi2020.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMRamadass2004:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -271,6 +285,7 @@ class TimeSolveSPMRamadass2004:
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMMohtat2020:
     params = [True, False]
@@ -289,6 +304,7 @@ class TimeSolveSPMMohtat2020:
     def time_solve_model(self, solve_first):
         TimeSolveSPMMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMChen2020:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -306,6 +322,7 @@ class TimeSolveSPMChen2020:
     def time_solve_model(self, solve_first):
         TimeSolveSPMChen2020.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMChen2020_plating:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -318,10 +335,13 @@ class TimeSolveSPMChen2020_plating:
         self.t_eval = np.linspace(0, tmax, nb_points)
         prepare_model_Chen2020_plating(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPMChen2020_plating.solver, self.t_eval)
+            solve_model_once(
+                self.model, TimeSolveSPMChen2020_plating.solver, self.t_eval
+            )
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMEcker2015:
     params = [True, False]
@@ -358,6 +378,7 @@ class TimeSolveSPMeMarquis2019:
     def time_solve_model(self, solve_first):
         TimeSolveSPMeMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMeORegan2021:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -374,6 +395,7 @@ class TimeSolveSPMeORegan2021:
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMeORegan2021.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMeNCA_Kim2011:
     params = [True, False]
@@ -392,6 +414,7 @@ class TimeSolveSPMeNCA_Kim2011:
     def time_solve_model(self, solve_first):
         TimeSolveSPMeNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMePrada2013:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -409,6 +432,7 @@ class TimeSolveSPMePrada2013:
     def time_solve_model(self, solve_first):
         TimeSolveSPMePrada2013.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMeAi2020:
     params = [True, False]
     solver = pybamm.ScikitsDaeSolver()
@@ -424,7 +448,10 @@ class TimeSolveSPMeAi2020:
             solve_model_once(self.model, TimeSolveSPMeAi2020.solver, self.t_eval)
 
     def time_solve_model(self, solve_first):
-        TimeSolveSPMeAi2020.solver.solve(self.model, t_eval=self.t_eval, calc_esoh=False)
+        TimeSolveSPMeAi2020.solver.solve(
+            self.model, t_eval=self.t_eval, calc_esoh=False
+        )
+
 
 class TimeSolveSPMeRamadass2004:
     params = [True, False]
@@ -443,6 +470,7 @@ class TimeSolveSPMeRamadass2004:
     def time_solve_model(self, solve_first):
         TimeSolveSPMeRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMeMohtat2020:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -459,6 +487,7 @@ class TimeSolveSPMeMohtat2020:
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMeMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMeChen2020:
     params = [True, False]
@@ -477,6 +506,7 @@ class TimeSolveSPMeChen2020:
     def time_solve_model(self, solve_first):
         TimeSolveSPMeChen2020.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveSPMeChen2020_plating:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -489,10 +519,13 @@ class TimeSolveSPMeChen2020_plating:
         self.t_eval = np.linspace(0, tmax, nb_points)
         prepare_model_Chen2020_plating(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeChen2020_plating.solver, self.t_eval)
+            solve_model_once(
+                self.model, TimeSolveSPMeChen2020_plating.solver, self.t_eval
+            )
 
     def time_solve_model(self, solve_first):
         TimeSolveSPMeChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveSPMeEcker2015:
     params = [True, False]
@@ -511,6 +544,7 @@ class TimeSolveSPMeEcker2015:
     def time_solve_model(self, solve_first):
         TimeSolveSPMeEcker2015.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveDFNMarquis2019:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -527,6 +561,7 @@ class TimeSolveDFNMarquis2019:
 
     def time_solve_model(self, solve_first):
         TimeSolveDFNMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveDFNORegan2021:
     params = [True, False]
@@ -545,6 +580,7 @@ class TimeSolveDFNORegan2021:
     def time_solve_model(self, solve_first):
         TimeSolveDFNORegan2021.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveDFNNCA_Kim2011:
     params = [True, False]
     solver = pybamm.ScikitsDaeSolver()
@@ -561,6 +597,7 @@ class TimeSolveDFNNCA_Kim2011:
 
     def time_solve_model(self, solve_first):
         TimeSolveDFNNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveDFNPrada2013:
     params = [True, False]
@@ -579,6 +616,7 @@ class TimeSolveDFNPrada2013:
     def time_solve_model(self, solve_first):
         TimeSolveDFNPrada2013.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveDFNAi2020:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -595,6 +633,7 @@ class TimeSolveDFNAi2020:
 
     def time_solve_model(self, solve_first):
         TimeSolveDFNAi2020.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveDFNRamadass2004:
     params = [True, False]
@@ -613,6 +652,7 @@ class TimeSolveDFNRamadass2004:
     def time_solve_model(self, solve_first):
         TimeSolveDFNRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
 
+
 # class TimeSolveDFNMohtat2020:
 #     params = [True, False]
 #     solver = pybamm.CasadiSolver()
@@ -629,6 +669,7 @@ class TimeSolveDFNRamadass2004:
 
 #     def time_solve_model(self, solve_first):
 #         TimeSolveDFNMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveDFNChen2020:
     params = [True, False]
@@ -647,6 +688,7 @@ class TimeSolveDFNChen2020:
     def time_solve_model(self, solve_first):
         TimeSolveDFNChen2020.solver.solve(self.model, t_eval=self.t_eval)
 
+
 class TimeSolveDFNChen2020_plating:
     params = [True, False]
     solver = pybamm.CasadiSolver()
@@ -659,10 +701,13 @@ class TimeSolveDFNChen2020_plating:
         self.t_eval = np.linspace(0, tmax, nb_points)
         prepare_model_Chen2020_plating(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveDFNChen2020_plating.solver, self.t_eval)
+            solve_model_once(
+                self.model, TimeSolveDFNChen2020_plating.solver, self.t_eval
+            )
 
     def time_solve_model(self, solve_first):
         TimeSolveDFNChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
 
 class TimeSolveDFNEcker2015:
     params = [True, False]

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -10,6 +10,7 @@ def solve_model_once(model, solver, t_eval):
 
 
 class TimeSolveSPM:
+    param_names = ['solve first', 'parameter']
     params = (
         [False, True],
         [
@@ -17,7 +18,7 @@ class TimeSolveSPM:
             "ORegan2021",
             "NCA_Kim2011",
             "Prada2013",
-            "Ai2020",
+            # "Ai2020",
             "Ramadass2004",
             "Mohtat2020",
             "Chen2020",
@@ -63,6 +64,7 @@ class TimeSolveSPM:
 
 
 class TimeSolveSPMe:
+    param_names = ['solve first', 'parameter']
     params = (
         [False, True],
         [
@@ -70,7 +72,7 @@ class TimeSolveSPMe:
             "ORegan2021",
             "NCA_Kim2011",
             "Prada2013",
-            "Ai2020",
+            # "Ai2020",
             "Ramadass2004",
             "Mohtat2020",
             "Chen2020",
@@ -116,16 +118,17 @@ class TimeSolveSPMe:
 
 
 class TimeSolveDFN:
+    param_names = ['solve first', 'parameter']
     params = (
         [False, True],
         [
             "Marquis2019",
             "ORegan2021",
-            "NCA_Kim2011",
+            # "NCA_Kim2011",
             "Prada2013",
             "Ai2020",
             "Ramadass2004",
-            "Mohtat2020",
+            # "Mohtat2020",
             "Chen2020",
             "Chen2020_plating",
             "Ecker2015",

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -5,723 +5,164 @@ import pybamm
 import numpy as np
 
 
-def prepare_model_Marquis2019(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Marquis2019")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_ORegan2021(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("ORegan2021")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_NCA_Kim2011(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("NCA_Kim2011")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Prada2013(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Prada2013")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Ai2020(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Ai2020")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Ramadass2004(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Ramadass2004")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Mohtat2020(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Mohtat2020")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Chen2020(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Chen2020")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Chen2020_plating(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Chen2020_plating")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
-def prepare_model_Ecker2015(model):
-    geometry = model.default_geometry
-
-    # load parameter values and process model and geometry
-    param = pybamm.ParameterValues("Ecker2015")
-    param.process_model(model)
-    param.process_geometry(geometry)
-
-    # set mesh
-    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
-    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-
-    # discretise model
-    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
-    disc.process_model(model)
-
-
 def solve_model_once(model, solver, t_eval):
     solver.solve(model, t_eval=t_eval)
 
 
-class TimeSolveSPMMarquis2019:
-    params = [True, False]
+class TimeSolveSPM:
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
     solver = pybamm.CasadiSolver()
 
-    def setup(self, solve_first):
+    def setup(self, solve_first, parameters):
         self.model = pybamm.lithium_ion.SPM()
         c_rate = 1
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Marquis2019(self.model)
+        geometry = self.model.default_geometry
+
+        # load parameter values and process model and geometry
+        param = pybamm.ParameterValues(parameters)
+        param.process_model(self.model)
+        param.process_geometry(geometry)
+
+        # set mesh
+        var_pts = {
+            "x_n": 20,
+            "x_s": 20,
+            "x_p": 20,
+            "r_n": 30,
+            "r_p": 30,
+            "y": 10,
+            "z": 10,
+        }
+        mesh = pybamm.Mesh(geometry, self.model.default_submesh_types, var_pts)
+
+        # discretise model
+        disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
+        disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPMMarquis2019.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveSPM.solver, self.t_eval)
 
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
+    def time_solve_model(self, solve_first, parameters):
+        TimeSolveSPM.solver.solve(self.model, t_eval=self.t_eval)
 
 
-class TimeSolveSPMORegan2021:
-    params = [True, False]
+class TimeSolveSPMe:
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
     solver = pybamm.CasadiSolver()
 
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_ORegan2021(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMORegan2021.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMORegan2021.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMNCA_Kim2011:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_NCA_Kim2011(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMNCA_Kim2011.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMPrada2013:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Prada2013(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMPrada2013.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMPrada2013.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMAi2020:
-    params = [True, False]
-    solver = pybamm.ScikitsDaeSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ai2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMAi2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMAi2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMRamadass2004:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ramadass2004(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMRamadass2004.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMMohtat2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Mohtat2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMMohtat2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMChen2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMChen2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMChen2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMChen2020_plating:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020_plating(self.model)
-        if solve_first:
-            solve_model_once(
-                self.model, TimeSolveSPMChen2020_plating.solver, self.t_eval
-            )
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMEcker2015:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPM()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ecker2015(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMEcker2015.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMEcker2015.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeMarquis2019:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
+    def setup(self, solve_first, parameters):
         self.model = pybamm.lithium_ion.SPMe()
         c_rate = 1
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Marquis2019(self.model)
+        geometry = self.model.default_geometry
+
+        # load parameter values and process model and geometry
+        param = pybamm.ParameterValues(parameters)
+        param.process_model(self.model)
+        param.process_geometry(geometry)
+
+        # set mesh
+        var_pts = {
+            "x_n": 20,
+            "x_s": 20,
+            "x_p": 20,
+            "r_n": 30,
+            "r_p": 30,
+            "y": 10,
+            "z": 10,
+        }
+        mesh = pybamm.Mesh(geometry, self.model.default_submesh_types, var_pts)
+
+        # discretise model
+        disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
+        disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeMarquis2019.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveSPMe.solver, self.t_eval)
 
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
+    def time_solve_model(self, solve_first, parameters):
+        TimeSolveSPMe.solver.solve(self.model, t_eval=self.t_eval)
 
 
-class TimeSolveSPMeORegan2021:
-    params = [True, False]
+class TimeSolveDFN:
+    params = (
+        [False, True],
+        [
+            "Marquis2019",
+            "ORegan2021",
+            "NCA_Kim2011",
+            "Prada2013",
+            "Ai2020",
+            "Ramadass2004",
+            "Mohtat2020",
+            "Chen2020",
+            "Chen2020_plating",
+            "Ecker2015",
+        ],
+    )
     solver = pybamm.CasadiSolver()
 
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_ORegan2021(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeORegan2021.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeORegan2021.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeNCA_Kim2011:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_NCA_Kim2011(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeNCA_Kim2011.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMePrada2013:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Prada2013(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMePrada2013.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMePrada2013.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeAi2020:
-    params = [True, False]
-    solver = pybamm.ScikitsDaeSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ai2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeAi2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeAi2020.solver.solve(
-            self.model, t_eval=self.t_eval, calc_esoh=False
-        )
-
-
-class TimeSolveSPMeRamadass2004:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ramadass2004(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeRamadass2004.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeMohtat2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Mohtat2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeMohtat2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeChen2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeChen2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeChen2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeChen2020_plating:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020_plating(self.model)
-        if solve_first:
-            solve_model_once(
-                self.model, TimeSolveSPMeChen2020_plating.solver, self.t_eval
-            )
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveSPMeEcker2015:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.SPMe()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ecker2015(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveSPMeEcker2015.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveSPMeEcker2015.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNMarquis2019:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
+    def setup(self, solve_first, parameters):
         self.model = pybamm.lithium_ion.DFN()
         c_rate = 1
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Marquis2019(self.model)
+        geometry = self.model.default_geometry
+
+        # load parameter values and process model and geometry
+        param = pybamm.ParameterValues(parameters)
+        param.process_model(self.model)
+        param.process_geometry(geometry)
+
+        # set mesh
+        var_pts = {
+            "x_n": 20,
+            "x_s": 20,
+            "x_p": 20,
+            "r_n": 30,
+            "r_p": 30,
+            "y": 10,
+            "z": 10,
+        }
+        mesh = pybamm.Mesh(geometry, self.model.default_submesh_types, var_pts)
+
+        # discretise model
+        disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
+        disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveDFNMarquis2019.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveDFN.solver, self.t_eval)
 
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNORegan2021:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_ORegan2021(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNORegan2021.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNORegan2021.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNNCA_Kim2011:
-    params = [True, False]
-    solver = pybamm.ScikitsDaeSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_NCA_Kim2011(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNNCA_Kim2011.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNPrada2013:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Prada2013(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNPrada2013.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNPrada2013.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNAi2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ai2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNAi2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNAi2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNRamadass2004:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ramadass2004(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNRamadass2004.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
-
-
-# class TimeSolveDFNMohtat2020:
-#     params = [True, False]
-#     solver = pybamm.CasadiSolver()
-
-#     def setup(self, solve_first):
-#         self.model = pybamm.lithium_ion.DFN()
-#         c_rate = 1
-#         tmax = 4000 / c_rate
-#         nb_points = 500
-#         self.t_eval = np.linspace(0, tmax, nb_points)
-#         prepare_model_Mohtat2020(self.model)
-#         if solve_first:
-#             solve_model_once(self.model, TimeSolveDFNMohtat2020.solver, self.t_eval)
-
-#     def time_solve_model(self, solve_first):
-#         TimeSolveDFNMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNChen2020:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNChen2020.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNChen2020.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNChen2020_plating:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Chen2020_plating(self.model)
-        if solve_first:
-            solve_model_once(
-                self.model, TimeSolveDFNChen2020_plating.solver, self.t_eval
-            )
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
-
-
-class TimeSolveDFNEcker2015:
-    params = [True, False]
-    solver = pybamm.CasadiSolver()
-
-    def setup(self, solve_first):
-        self.model = pybamm.lithium_ion.DFN()
-        c_rate = 1
-        tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model_Ecker2015(self.model)
-        if solve_first:
-            solve_model_once(self.model, TimeSolveDFNEcker2015.solver, self.t_eval)
-
-    def time_solve_model(self, solve_first):
-        TimeSolveDFNEcker2015.solver.solve(self.model, t_eval=self.t_eval)
+    def time_solve_model(self, solve_first, parameters):
+        TimeSolveDFN.solver.solve(self.model, t_eval=self.t_eval)

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -5,11 +5,155 @@ import pybamm
 import numpy as np
 
 
-def prepare_model(model):
+def prepare_model_Marquis2019(model):
     geometry = model.default_geometry
 
     # load parameter values and process model and geometry
     param = pybamm.ParameterValues("Marquis2019")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_ORegan2021(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("ORegan2021")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_NCA_Kim2011(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("NCA_Kim2011")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Prada2013(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Prada2013")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Ai2020(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Ai2020")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Ramadass2004(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Ramadass2004")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Mohtat2020(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Mohtat2020")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Chen2020(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Chen2020")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Chen2020_plating(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Chen2020_plating")
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+    # set mesh
+    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
+
+    # discretise model
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+
+def prepare_model_Ecker2015(model):
+    geometry = model.default_geometry
+
+    # load parameter values and process model and geometry
+    param = pybamm.ParameterValues("Ecker2015")
     param.process_model(model)
     param.process_geometry(geometry)
 
@@ -26,7 +170,7 @@ def solve_model_once(model, solver, t_eval):
     solver.solve(model, t_eval=t_eval)
 
 
-class TimeSolveSPM:
+class TimeSolveSPMMarquis2019:
     params = [True, False]
     solver = pybamm.CasadiSolver()
 
@@ -36,15 +180,168 @@ class TimeSolveSPM:
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model(self.model)
+        prepare_model_Marquis2019(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPM.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveSPMMarquis2019.solver, self.t_eval)
 
     def time_solve_model(self, solve_first):
-        TimeSolveSPM.solver.solve(self.model, t_eval=self.t_eval)
+        TimeSolveSPMMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMORegan2021:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_ORegan2021(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMORegan2021.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMORegan2021.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMNCA_Kim2011:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_NCA_Kim2011(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMNCA_Kim2011.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMPrada2013:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Prada2013(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMPrada2013.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMPrada2013.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMAi2020:
+    params = [True, False]
+    solver = pybamm.ScikitsDaeSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ai2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMAi2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMAi2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMRamadass2004:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ramadass2004(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMRamadass2004.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMMohtat2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Mohtat2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMMohtat2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMChen2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMChen2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMChen2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMChen2020_plating:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020_plating(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMChen2020_plating.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMEcker2015:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPM()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ecker2015(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMEcker2015.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMEcker2015.solver.solve(self.model, t_eval=self.t_eval)
 
 
-class TimeSolveSPMe:
+class TimeSolveSPMeMarquis2019:
     params = [True, False]
     solver = pybamm.CasadiSolver()
 
@@ -54,15 +351,167 @@ class TimeSolveSPMe:
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model(self.model)
+        prepare_model_Marquis2019(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveSPMe.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveSPMeMarquis2019.solver, self.t_eval)
 
     def time_solve_model(self, solve_first):
-        TimeSolveSPMe.solver.solve(self.model, t_eval=self.t_eval)
+        TimeSolveSPMeMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
 
+class TimeSolveSPMeORegan2021:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
 
-class TimeSolveDFN:
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_ORegan2021(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeORegan2021.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeORegan2021.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeNCA_Kim2011:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_NCA_Kim2011(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeNCA_Kim2011.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMePrada2013:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Prada2013(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMePrada2013.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMePrada2013.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeAi2020:
+    params = [True, False]
+    solver = pybamm.ScikitsDaeSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ai2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeAi2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeAi2020.solver.solve(self.model, t_eval=self.t_eval, calc_esoh=False)
+
+class TimeSolveSPMeRamadass2004:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ramadass2004(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeRamadass2004.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeMohtat2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Mohtat2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeMohtat2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeChen2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeChen2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeChen2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeChen2020_plating:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020_plating(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeChen2020_plating.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveSPMeEcker2015:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.SPMe()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ecker2015(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveSPMeEcker2015.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveSPMeEcker2015.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNMarquis2019:
     params = [True, False]
     solver = pybamm.CasadiSolver()
 
@@ -72,9 +521,162 @@ class TimeSolveDFN:
         tmax = 4000 / c_rate
         nb_points = 500
         self.t_eval = np.linspace(0, tmax, nb_points)
-        prepare_model(self.model)
+        prepare_model_Marquis2019(self.model)
         if solve_first:
-            solve_model_once(self.model, TimeSolveDFN.solver, self.t_eval)
+            solve_model_once(self.model, TimeSolveDFNMarquis2019.solver, self.t_eval)
 
     def time_solve_model(self, solve_first):
-        TimeSolveDFN.solver.solve(self.model, t_eval=self.t_eval)
+        TimeSolveDFNMarquis2019.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNORegan2021:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_ORegan2021(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNORegan2021.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNORegan2021.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNNCA_Kim2011:
+    params = [True, False]
+    solver = pybamm.ScikitsDaeSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_NCA_Kim2011(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNNCA_Kim2011.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNNCA_Kim2011.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNPrada2013:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Prada2013(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNPrada2013.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNPrada2013.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNAi2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ai2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNAi2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNAi2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNRamadass2004:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ramadass2004(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNRamadass2004.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNRamadass2004.solver.solve(self.model, t_eval=self.t_eval)
+
+# class TimeSolveDFNMohtat2020:
+#     params = [True, False]
+#     solver = pybamm.CasadiSolver()
+
+#     def setup(self, solve_first):
+#         self.model = pybamm.lithium_ion.DFN()
+#         c_rate = 1
+#         tmax = 4000 / c_rate
+#         nb_points = 500
+#         self.t_eval = np.linspace(0, tmax, nb_points)
+#         prepare_model_Mohtat2020(self.model)
+#         if solve_first:
+#             solve_model_once(self.model, TimeSolveDFNMohtat2020.solver, self.t_eval)
+
+#     def time_solve_model(self, solve_first):
+#         TimeSolveDFNMohtat2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNChen2020:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNChen2020.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNChen2020.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNChen2020_plating:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Chen2020_plating(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNChen2020_plating.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNChen2020_plating.solver.solve(self.model, t_eval=self.t_eval)
+
+class TimeSolveDFNEcker2015:
+    params = [True, False]
+    solver = pybamm.CasadiSolver()
+
+    def setup(self, solve_first):
+        self.model = pybamm.lithium_ion.DFN()
+        c_rate = 1
+        tmax = 4000 / c_rate
+        nb_points = 500
+        self.t_eval = np.linspace(0, tmax, nb_points)
+        prepare_model_Ecker2015(self.model)
+        if solve_first:
+            solve_model_once(self.model, TimeSolveDFNEcker2015.solver, self.t_eval)
+
+    def time_solve_model(self, solve_first):
+        TimeSolveDFNEcker2015.solver.solve(self.model, t_eval=self.t_eval)


### PR DESCRIPTION
# Description

Added benchmarks for `SPM`, `SPMe`, and `DFN` with all the parameter sets (except Sulzer2019 and Xu2019).

Some concerns -
- I could not solve the `DFN` model with `Mohtat2020` parameter sets for the benchmarks (commented code). I tried varying `dt_max` and used different solvers but nothing worked. Here is a reproducible example for the same-
```python
import numpy as np
import pybamm
import matplotlib.pyplot as plt

def prepare_model_Mohtat2020(model):
    geometry = model.default_geometry

    param = pybamm.ParameterValues("Mohtat2020")
    param.process_model(model)
    param.process_geometry(geometry)

    var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 30, "r_p": 30, "y": 10, "z": 10}
    mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)

    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
    disc.process_model(model)

solver = pybamm.CasadiSolver()
model = pybamm.lithium_ion.DFN()
c_rate = 1
tmax = 4000 / c_rate
nb_points = 500
t_eval = np.linspace(0, tmax, nb_points)
prepare_model_Mohtat2020(model)
solver.solve(model, t_eval=t_eval)
solution = solver.solve(model, t_eval=t_eval)
voltage = solution['Terminal voltage [V]']
c_s_n_surf = solution['Negative particle surface concentration']
c_s_p_surf = solution['Positive particle surface concentration']
t = solution["Time [s]"].entries
x = solution["x [m]"].entries[:, 0]
f, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(13,4))

ax1.plot(t, voltage(t))
ax1.set_xlabel(r'$Time [s]$')
ax1.set_ylabel('Terminal voltage [V]')

ax2.plot(t, c_s_n_surf(t=t, x=x[0]))  
ax2.set_xlabel(r'$Time [s]$')
ax2.set_ylabel('Negative particle surface concentration')

ax3.plot(t, c_s_p_surf(t=t, x=x[-1])) 
ax3.set_xlabel(r'$Time [s]$')
ax3.set_ylabel('Positive particle surface concentration')

plt.tight_layout()
plt.show()
```
The error-
```
The linesearch algorithm failed with too small a step.
At t = 3.7305e-005 and h = 3.3406e-019, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.73046e-005 and h = 3.12482e-019, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.73044e-005 and h = 3.16429e-020, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.7305e-005 and h = 3.3406e-019, the corrector convergence failed repeatedly or with |h| = hmin.
Traceback (most recent call last):
  File "d:\LearningProjects\python\second.py", line 25, in <module>
    solver.solve(model, t_eval=t_eval)
  File "C:\Users\Vaibhav Chopra\AppData\Local\Programs\Python\Python39\lib\site-packages\pybamm\solvers\base_solver.py", line 1018, in solve
    new_solution = self._integrate(
  File "C:\Users\Vaibhav Chopra\AppData\Local\Programs\Python\Python39\lib\site-packages\pybamm\solvers\casadi_solver.py", line 263, in _integrate
    raise pybamm.SolverError(
pybamm.expression_tree.exceptions.SolverError: Maximum number of decreased steps occurred at t=0.0. Try solving the model up to this time only or reducing dt_max (currently, dt_max=5.010622778599846).
PS D:\LearningProjects> python -u "d:\LearningProjects\python\second.py"
The linesearch algorithm failed with too small a step.
At t = 3.7305e-005 and h = 3.3406e-019, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.73046e-005 and h = 3.12482e-019, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.73044e-005 and h = 3.16429e-020, the corrector convergence failed repeatedly or with |h| = hmin.
At t = 3.7305e-005 and h = 3.3406e-019, the corrector convergence failed repeatedly or with |h| = hmin.
Traceback (most recent call last):
  File "d:\LearningProjects\python\second.py", line 25, in <module>
    solver.solve(model, t_eval=t_eval)
  File "C:\Users\Vaibhav Chopra\AppData\Local\Programs\Python\Python39\lib\site-packages\pybamm\solvers\base_solver.py", line 1018, in solve
    new_solution = self._integrate(
  File "C:\Users\Vaibhav Chopra\AppData\Local\Programs\Python\Python39\lib\site-packages\pybamm\solvers\casadi_solver.py", line 263, in _integrate
    raise pybamm.SolverError(
pybamm.expression_tree.exceptions.SolverError: Maximum number of decreased steps occurred at t=0.0. Try solving the model up to this time only or reducing dt_max (currently, dt_max=5.010622778599846).
```
- Should I group these benchmarks in some way. For example- multiple files with each file containing benchmarks of a particular parameter or model.
- As discussed with @brosaplanella on slack I have used `ScikitsDaeSolver` for some benchmarks, will this create a problem or is it safe to use different solvers for similar benchmarks?

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
