### PR TITLE
add unit benchmarks

### DIFF
--- a/benchmarks/unit_benchmarks.py
+++ b/benchmarks/unit_benchmarks.py
@@ -1,13 +1,11 @@
 import pybamm
 import numpy as np
 
-R = 1e-5
-
 
 def time_create_expression():
     global model
     model = pybamm.BaseModel()
-
+    global R
     R = pybamm.Parameter("Particle radius [m]")
     D = pybamm.Parameter("Diffusion coefficient [m2.s-1]")
     j = pybamm.Parameter("Interfacial current density [A.m-2]")

--- a/benchmarks/unit_benchmarks.py
+++ b/benchmarks/unit_benchmarks.py
@@ -1,0 +1,98 @@
+import pybamm
+import numpy as np
+
+R = 1e-5
+
+
+def time_create_expression():
+    global model
+    model = pybamm.BaseModel()
+
+    R = pybamm.Parameter("Particle radius [m]")
+    D = pybamm.Parameter("Diffusion coefficient [m2.s-1]")
+    j = pybamm.Parameter("Interfacial current density [A.m-2]")
+    F = pybamm.Parameter("Faraday constant [C.mol-1]")
+    c0 = pybamm.Parameter("Initial concentration [mol.m-3]")
+
+    c = pybamm.Variable("Concentration [mol.m-3]", domain="negative particle")
+    N = -D * pybamm.grad(c)
+    dcdt = -pybamm.div(N)
+    model.rhs = {c: dcdt}
+
+    lbc = pybamm.Scalar(0)
+    rbc = -j / F / D
+    model.boundary_conditions = {
+        c: {"left": (lbc, "Neumann"), "right": (rbc, "Neumann")}
+    }
+
+    model.initial_conditions = {c: c0}
+    model.variables = {
+        "Concentration [mol.m-3]": c,
+        "Surface concentration [mol.m-3]": pybamm.surf(c),
+        "Flux [mol.m-2.s-1]": N,
+    }
+
+
+def setup_parameterise():
+    time_create_expression()
+
+
+def time_parameterise():
+
+    global param
+    param = pybamm.ParameterValues(
+        {
+            "Particle radius [m]": 10e-6,
+            "Diffusion coefficient [m2.s-1]": 3.9e-14,
+            "Interfacial current density [A.m-2]": 1.4,
+            "Faraday constant [C.mol-1]": 96485,
+            "Initial concentration [mol.m-3]": 2.5e4,
+        }
+    )
+    global r
+    r = pybamm.SpatialVariable(
+        "r", domain=["negative particle"], coord_sys="spherical polar"
+    )
+    global geometry
+    geometry = {"negative particle": {r: {"min": pybamm.Scalar(0), "max": R}}}
+    param.process_model(model)
+    param.process_geometry(geometry)
+
+
+time_parameterise.setup = setup_parameterise
+
+
+def setup_discretise():
+    time_create_expression()
+    time_parameterise()
+
+
+def time_discretise():
+    time_create_expression()
+    time_parameterise()
+
+    submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
+    var_pts = {r: 20}
+    mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
+
+    spatial_methods = {"negative particle": pybamm.FiniteVolume()}
+    disc = pybamm.Discretisation(mesh, spatial_methods)
+    disc.process_model(model)
+
+
+time_discretise.setup = setup_discretise
+
+
+def setup_solve():
+    time_create_expression()
+    time_parameterise()
+    time_discretise()
+
+
+def time_solve():
+    solver = pybamm.ScipySolver()
+    t = np.linspace(0, 3600, 600)
+    solver.solve(model, t)
+
+
+time_solve.setup = setup_solve

--- a/benchmarks/unit_benchmarks.py
+++ b/benchmarks/unit_benchmarks.py
@@ -2,95 +2,84 @@ import pybamm
 import numpy as np
 
 
-def time_create_expression():
-    global model
-    model = pybamm.BaseModel()
-    global R
-    R = pybamm.Parameter("Particle radius [m]")
-    D = pybamm.Parameter("Diffusion coefficient [m2.s-1]")
-    j = pybamm.Parameter("Interfacial current density [A.m-2]")
-    F = pybamm.Parameter("Faraday constant [C.mol-1]")
-    c0 = pybamm.Parameter("Initial concentration [mol.m-3]")
+class TimeCreateExpression:
+    def time_create_expression(self):
+        self.R = pybamm.Parameter("Particle radius [m]")
+        D = pybamm.Parameter("Diffusion coefficient [m2.s-1]")
+        j = pybamm.Parameter("Interfacial current density [A.m-2]")
+        F = pybamm.Parameter("Faraday constant [C.mol-1]")
+        c0 = pybamm.Parameter("Initial concentration [mol.m-3]")
+        self.model = pybamm.BaseModel()
 
-    c = pybamm.Variable("Concentration [mol.m-3]", domain="negative particle")
-    N = -D * pybamm.grad(c)
-    dcdt = -pybamm.div(N)
-    model.rhs = {c: dcdt}
+        c = pybamm.Variable("Concentration [mol.m-3]", domain="negative particle")
+        N = -D * pybamm.grad(c)
+        dcdt = -pybamm.div(N)
+        self.model.rhs = {c: dcdt}
 
-    lbc = pybamm.Scalar(0)
-    rbc = -j / F / D
-    model.boundary_conditions = {
-        c: {"left": (lbc, "Neumann"), "right": (rbc, "Neumann")}
-    }
-
-    model.initial_conditions = {c: c0}
-    model.variables = {
-        "Concentration [mol.m-3]": c,
-        "Surface concentration [mol.m-3]": pybamm.surf(c),
-        "Flux [mol.m-2.s-1]": N,
-    }
-
-
-def setup_parameterise():
-    time_create_expression()
-
-
-def time_parameterise():
-
-    global param
-    param = pybamm.ParameterValues(
-        {
-            "Particle radius [m]": 10e-6,
-            "Diffusion coefficient [m2.s-1]": 3.9e-14,
-            "Interfacial current density [A.m-2]": 1.4,
-            "Faraday constant [C.mol-1]": 96485,
-            "Initial concentration [mol.m-3]": 2.5e4,
+        lbc = pybamm.Scalar(0)
+        rbc = -j / F / D
+        self.model.boundary_conditions = {
+            c: {"left": (lbc, "Neumann"), "right": (rbc, "Neumann")}
         }
-    )
-    global r
-    r = pybamm.SpatialVariable(
-        "r", domain=["negative particle"], coord_sys="spherical polar"
-    )
-    global geometry
-    geometry = {"negative particle": {r: {"min": pybamm.Scalar(0), "max": R}}}
-    param.process_model(model)
-    param.process_geometry(geometry)
+
+        self.model.initial_conditions = {c: c0}
+        self.model.variables = {
+            "Concentration [mol.m-3]": c,
+            "Surface concentration [mol.m-3]": pybamm.surf(c),
+            "Flux [mol.m-2.s-1]": N,
+        }
 
 
-time_parameterise.setup = setup_parameterise
+class TimeParameteriseModel:
+    def setup(self):
+        TimeCreateExpression.time_create_expression(self)
+
+    def time_parameterise(self):
+        param = pybamm.ParameterValues(
+            {
+                "Particle radius [m]": 10e-6,
+                "Diffusion coefficient [m2.s-1]": 3.9e-14,
+                "Interfacial current density [A.m-2]": 1.4,
+                "Faraday constant [C.mol-1]": 96485,
+                "Initial concentration [mol.m-3]": 2.5e4,
+            }
+        )
+
+        self.r = pybamm.SpatialVariable(
+            "r", domain=["negative particle"], coord_sys="spherical polar"
+        )
+
+        self.geometry = {
+            "negative particle": {self.r: {"min": pybamm.Scalar(0), "max": self.R}}
+        }
+        param.process_model(self.model)
+        param.process_geometry(self.geometry)
 
 
-def setup_discretise():
-    time_create_expression()
-    time_parameterise()
+class TimeDiscretiseModel:
+    def setup(self):
+        TimeCreateExpression.time_create_expression(self)
+        TimeParameteriseModel.time_parameterise(self)
+
+    def time_discretise(self):
+        TimeCreateExpression.time_create_expression(self)
+        TimeParameteriseModel.time_parameterise(self)
+        submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
+        var_pts = {self.r: 20}
+        mesh = pybamm.Mesh(self.geometry, submesh_types, var_pts)
+
+        spatial_methods = {"negative particle": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(self.model)
 
 
-def time_discretise():
-    time_create_expression()
-    time_parameterise()
+class TimeSolveModel:
+    def setup(self):
+        TimeCreateExpression.time_create_expression(self)
+        TimeParameteriseModel.time_parameterise(self)
+        TimeDiscretiseModel.time_discretise(self)
 
-    submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
-    var_pts = {r: 20}
-    mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
-
-    spatial_methods = {"negative particle": pybamm.FiniteVolume()}
-    disc = pybamm.Discretisation(mesh, spatial_methods)
-    disc.process_model(model)
-
-
-time_discretise.setup = setup_discretise
-
-
-def setup_solve():
-    time_create_expression()
-    time_parameterise()
-    time_discretise()
-
-
-def time_solve():
-    solver = pybamm.ScipySolver()
-    t = np.linspace(0, 3600, 600)
-    solver.solve(model, t)
-
-
-time_solve.setup = setup_solve
+    def time_solve(self):
+        solver = pybamm.ScipySolver()
+        t = np.linspace(0, 3600, 600)
+        solver.solve(self.model, t)


### PR DESCRIPTION
# Description

Created unit benchmarks (create an expression, parameterise a model, discretise a model, and solve a model) using this [example](https://github.com/Vaibhav-Chopra-GT/PyBaMM/blob/develop/examples/notebooks/Creating%20Models/3-negative-particle-problem.ipynb).

I tried developing these benchmarks using classes and inheritance, but `asv` runs `time_*` functions of the parent class in the child classes too. This results in benchmarks running multiple times.


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
