### PR TITLE
Change y-axis limits for charge experiment

### DIFF
--- a/pybamm/plotting/plot_voltage_components.py
+++ b/pybamm/plotting/plot_voltage_components.py
@@ -71,7 +71,7 @@ def plot_voltage_components(
     ax.set_xlim([time[0], time[-1]])
     ax.set_xlabel("Time [h]")
 
-    y_min, y_max = 0.98 * np.nanmin(V), 1.02 * np.nanmax(initial_ocv)
+    y_min, y_max = 0.98 * np.nanmin(V), 1.02 * np.nanmax(V)
     ax.set_ylim([y_min, y_max])
 
     if not testing:  # pragma: no cover


### PR DESCRIPTION



# Description

Previous y-max limit used the initial voltage, which assumes every experiment is a discharge one.

Changed plot settings to find the overall V max.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)