### PR TITLE
Use `imageio.v2` to suppress warning

### DIFF
--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -759,7 +759,7 @@ class QuickPlot(object):
             Name of the generated GIF file.
 
         """
-        import imageio
+        import imageio.v2 as imageio
         import matplotlib.pyplot as plt
 
         # time stamps at which the images/plots will be created


### PR DESCRIPTION
# Description

Currently, the `create_gif` function throws a warning saying -
```
DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning dissapear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.
```

This PR replaces `imageio` with `imageio.v2` to avoid any sudden breaking changes in the future and suppresses this warning for everyone!

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [X] No style issues: `$ flake8`
- [X] All tests pass: `$ python run-tests.py --unit`
- [X] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
