### PR TITLE
bugfix(double-layer cap scaling): rescaling overpotential RHS by 1/a

### DIFF
--- a/pybamm/models/submodels/electrolyte_conductivity/surface_potential_form/full_surface_form_conductivity.py
+++ b/pybamm/models/submodels/electrolyte_conductivity/surface_potential_form/full_surface_form_conductivity.py
@@ -283,4 +283,4 @@ class FullDifferential(BaseModel):
             "Sum of " + self.domain.lower() + " electrode interfacial current densities"
         ]
 
-        self.rhs[delta_phi] = 1 / C_dl * (pybamm.div(i_e) - a * sum_j)
+        self.rhs[delta_phi] = 1 / (a * C_dl) * (pybamm.div(i_e) - a * sum_j)


### PR DESCRIPTION
# Description
Rescaling RHS of overpotential differential equation by 1/a to correct for proper non-dimensionalization for non-constant specific-surface areas (i.e., non-constant active material volume fractions and/or particle radii). 

Changes include:
  - Updating full_surface_form_conductivity RHS to rescale RHS of
    negative-electrode overpotential DE by a factor of 1/a, which
    remains present upon non-dimensionalization
  - 1/a scaling only affects DFN models with 'surface form' =
    'differential' and any of the following:
    - non-constant particle radii across electrodes
    - non-constant active material volume fractions across electrodes
    - loss of active material enabled
    - other forms of non-constant specific surface areas 'a'


See Discussion #2142 for further details

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: $ flake8
- [ ] All tests pass: $ python run-tests.py --unit
- [x] The documentation builds: $ cd docs and then $ make clean; make html

You can run all three at once, using $ python run-tests.py --quick.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
