### PR TITLE
Fix the failing style test + improve the format of printed errors

### DIFF
--- a/pybamm/experiments/experiment.py
+++ b/pybamm/experiments/experiment.py
@@ -108,9 +108,12 @@ class Experiment:
                     badly_typed_conditions = []
                 badly_typed_conditions = badly_typed_conditions or [cycle]
                 raise TypeError(
-                    """Operating conditions should be strings or tuples of strings, not {}. For example: {}
-                """.format(
+                    """Operating conditions should be strings or tuples of strings, not
+                    {}. For example: {}
+                    """.format(
                         type(badly_typed_conditions[0]), examples
+                    ).replace(
+                        "\n                    ", " "
                     )
                 )
         self.cycle_lengths = [len(cycle) for cycle in operating_conditions_cycles]
@@ -177,12 +180,15 @@ class Experiment:
             cond_CC, cond_CV = cond.split(" then ")
             op_CC, _ = self.read_string(cond_CC, drive_cycles)
             op_CV, event_CV = self.read_string(cond_CV, drive_cycles)
-            return {
-                "electric": op_CC["electric"] + op_CV["electric"],
-                "time": op_CV["time"],
-                "period": op_CV["period"],
-                "dc_data": None,
-            }, event_CV
+            return (
+                {
+                    "electric": op_CC["electric"] + op_CV["electric"],
+                    "time": op_CV["time"],
+                    "period": op_CV["period"],
+                    "dc_data": None,
+                },
+                event_CV,
+            )
         # Read period
         if " period)" in cond:
             cond, time_period = cond.split("(")
@@ -257,18 +263,19 @@ class Experiment:
                 events = self.convert_electric(cond_list[idx + 1 :])
             else:
                 raise ValueError(
-                    """Operating conditions must contain keyword 'for' or 'until' or 'Run'.
-                    For example: {}""".format(
+                    """Operating conditions must contain keyword 'for' or 'until' or
+                    'Run'. For example: {}
+                    """.format(
                         examples
+                    ).replace(
+                        "\n                    ", " "
                     )
                 )
 
-        return {
-            "electric": electric,
-            "time": time,
-            "period": period,
-            "dc_data": dc_data,
-        }, events
+        return (
+            {"electric": electric, "time": time, "period": period, "dc_data": dc_data},
+            events,
+        )
 
     def extend_drive_cycle(self, drive_cycle, end_time):
         "Extends the drive cycle to enable for event"
@@ -327,9 +334,11 @@ class Experiment:
                     sign = -1
                 else:
                     raise ValueError(
-                        """Instruction must be 'discharge', 'charge', 'rest', 'hold' or 'Run'.
-                        For example: {}""".format(
+                        """Instruction must be 'discharge', 'charge', 'rest', 'hold' or
+                        'Run'. For example: {}""".format(
                             examples
+                        ).replace(
+                            "\n                        ", " "
                         )
                     )
             elif len(electric) == 2:

--- a/pybamm/meshes/one_dimensional_submeshes.py
+++ b/pybamm/meshes/one_dimensional_submeshes.py
@@ -286,9 +286,11 @@ class UserSupplied1DSubMesh(SubMesh1D):
         # check that npts + 1 equals number of user-supplied edges
         if (npts + 1) != len(edges):
             raise pybamm.GeometryError(
-                """User-suppled edges has should have length (npts + 1) but has length {}.
-                 Number of points (npts) for domain {} is {}.""".format(
+                """User-suppled edges has should have length (npts + 1) but has length
+                {}.Number of points (npts) for domain {} is {}.""".format(
                     len(edges), spatial_var.domain, npts
+                ).replace(
+                    "\n                ", " "
                 )
             )
 


### PR DESCRIPTION
# Description

- Fixed the failing (https://github.com/pybamm-team/PyBaMM/runs/7597766548?check_suite_focus=true) style test.
- The errors are right now printed as -

```
ValueError: Operating conditions must contain keyword 'for' or 'until' or 'Run'.
                    For example:     <---- extra spaces and line endings which should be removed

    Discharge at 1C for 0.5 hours,     <---- extra spaces and line endings which should not be removed
    Discharge at C/20 for 0.5 hours,
    Charge at 0.5 C for 45 minutes,
    Discharge at 1 A for 90 seconds,
    Charge at 200mA for 45 minutes (1 minute period),
    Discharge at 1 W for 0.5 hours,
    Charge at 200 mW for 45 minutes,
    Rest for 10 minutes (5 minute period),
    Hold at 1 V for 20 seconds,
    Charge at 1 C until 4.1V,
    Hold at 4.1 V until 50 mA,
    Hold at 3V until C/50,
    Run US06 (A),
    Run US06 (A) for 20 seconds,
    Run US06 (V) for 45 minutes,
    Run US06 (W) for 2 hours,
```

These extra spaces and line endings have been removed!

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
