### PR TITLE
Issue 1996 vertcat

### DIFF
--- a/examples/scripts/compare_lithium_ion.py
+++ b/examples/scripts/compare_lithium_ion.py
@@ -7,10 +7,10 @@ pybamm.set_logging_level("INFO")
 
 # load models
 models = [
-    pybamm.lithium_ion.SPM(),
-    pybamm.lithium_ion.SPMe(),
+    # pybamm.lithium_ion.SPM(),
+    # pybamm.lithium_ion.SPMe(),
     pybamm.lithium_ion.DFN(),
-    pybamm.lithium_ion.NewmanTobias(),
+    # pybamm.lithium_ion.NewmanTobias(),
 ]
 
 # create and run simulations

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -209,11 +209,13 @@ from .solvers.casadi_algebraic_solver import CasadiAlgebraicSolver
 from .solvers.scikits_dae_solver import ScikitsDaeSolver
 from .solvers.scikits_ode_solver import ScikitsOdeSolver, have_scikits_odes
 from .solvers.scipy_solver import ScipySolver
+from .solvers.solver_utils import NoMemAllocVertcat
 
 from .solvers.jax_solver import JaxSolver
 from .solvers.jax_bdf_solver import jax_bdf_integrate
 
 from .solvers.idaklu_solver import IDAKLUSolver, have_idaklu
+
 
 #
 # Experiments

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1294,7 +1294,7 @@ class BaseSolver(object):
             t = old_solution.all_ts[-1][-1]
             if old_solution.all_models[-1] == model:
                 # initialize with old solution
-                model.y0 = old_solution.all_ys[-1][:, -1]
+                model.y0 = old_solution.y_last
             else:
                 model.y0 = model.set_initial_conditions_from(
                     old_solution

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -402,7 +402,11 @@ class CasadiSolver(pybamm.BaseSolver):
                 t_event = np.nanmin(t_events)
                 # create interpolant to evaluate y in the current integration
                 # window
-                y_sol = interp1d(sol_t, sol_y, kind="linear")
+                sol_event_idx = np.where(t_event < sol_t)[0][0]
+                sol_t_interp = sol_t[sol_event_idx - 1 : sol_event_idx + 1]
+                sol_y_interp = sol_y[:, sol_event_idx - 1 : sol_event_idx + 1]
+                sol_y_interp = casadi.horzcat(sol_y_interp[:, 0], sol_y_interp[:, 1])
+                y_sol = interp1d(sol_t_interp, sol_y_interp, kind="linear")
                 y_event = y_sol(t_event)
 
                 closest_event_idx = event_idx[np.nanargmin(t_events)]

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -699,17 +699,10 @@ class CasadiSolver(pybamm.BaseSolver):
                     x0=y0_diff, z0=y0_alg, p=inputs_with_tmin, **self.extra_options_call
                 )
                 integration_time = timer.time()
-                y_sol = casadi.vertcat(casadi_sol["xf"], casadi_sol["zf"])
-                sol = pybamm.Solution(
-                    t_eval,
-                    y_sol,
-                    model,
-                    inputs_dict,
-                    sensitivities=extract_sensitivities_in_solution,
-                    check_solution=False,
-                )
-                sol.integration_time = integration_time
-                return sol
+                if casadi_sol["zf"].is_empty():
+                    y_sol = casadi_sol["xf"]
+                else:
+                    y_sol = pybamm.NoMemAllocVertcat(casadi_sol["xf"], casadi_sol["zf"])
             else:
                 # Repeated calls to the integrator
                 x = y0_diff
@@ -733,7 +726,7 @@ class CasadiSolver(pybamm.BaseSolver):
                 if z.is_empty():
                     y_sol = y_diff
                 else:
-                    y_sol = casadi.vertcat(y_diff, y_alg)
+                    y_sol = pybamm.NoMemAllocVertcat(y_diff, y_alg)
 
             sol = pybamm.Solution(
                 t_eval,

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -97,25 +97,6 @@ class Solution(object):
         else:
             self.all_inputs = all_inputs
 
-        if not (
-            len(self.all_ts) == len(self.all_ys)
-            or len(self.all_ts) == 1
-            or len(self.all_ys) == 1
-        ):
-            raise ValueError("all_ts and all_ys must be the same length")
-        if not (
-            len(self.all_ts) == len(self.all_models)
-            or len(self.all_ts) == 1
-            or len(self.all_models) == 1
-        ):
-            raise ValueError("all_ts and all_models must be the same length")
-        if not (
-            len(self.all_ts) == len(self.all_inputs)
-            or len(self.all_ts) == 1
-            or len(self.all_inputs) == 1
-        ):
-            raise ValueError("all_ts and all_inputs must be the same length")
-
         self.sensitivities = sensitivities
 
         self._t_event = t_event
@@ -383,7 +364,7 @@ class Solution(object):
         except AttributeError:
             all_ys_last = self.all_ys[-1]
             if isinstance(all_ys_last, pybamm.NoMemAllocVertcat):
-                self._y_last = all_ys_last.get_value()
+                self._y_last = all_ys_last[:, -1]
             elif all_ys_last.shape[1] == 1:
                 self._y_last = all_ys_last
             else:
@@ -751,19 +732,13 @@ class Solution(object):
         # Update list of sub-solutions
         if other.all_ts[0][0] == self.all_ts[-1][-1]:
             # Skip first time step if it is repeated
-            if len(other.all_ts[0]) == 1:
-                all_ts = self.all_ts + other.all_ts[1:]
-                all_ys = self.all_ys + other.all_ys[1:]
-                all_models = self.all_models + other.all_models[1:]
-                all_inputs = self.all_inputs + other.all_inputs[1:]
-            else:
-                all_ts = self.all_ts + [other.all_ts[0][1:]] + other.all_ts[1:]
-                all_ys = self.all_ys + [other.all_ys[0][:, 1:]] + other.all_ys[1:]
-                all_models = (self.all_models + other.all_models,)
-                all_inputs = (self.all_inputs + other.all_inputs,)
+            all_ts = self.all_ts + [other.all_ts[0][1:]] + other.all_ts[1:]
+            all_ys = self.all_ys + [other.all_ys[0][:, 1:]] + other.all_ys[1:]
         else:
             all_ts = self.all_ts + other.all_ts
             all_ys = self.all_ys + other.all_ys
+            all_models = self.all_models + other.all_models
+            all_inputs = self.all_inputs + other.all_inputs
 
         new_sol = Solution(
             all_ts,

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -737,8 +737,8 @@ class Solution(object):
         else:
             all_ts = self.all_ts + other.all_ts
             all_ys = self.all_ys + other.all_ys
-            all_models = self.all_models + other.all_models
-            all_inputs = self.all_inputs + other.all_inputs
+        all_models = self.all_models + other.all_models
+        all_inputs = self.all_inputs + other.all_inputs
 
         new_sol = Solution(
             all_ts,

--- a/pybamm/solvers/solver_utils.py
+++ b/pybamm/solvers/solver_utils.py
@@ -1,6 +1,7 @@
 #
 # Utility functions and classes for solvers
 #
+import numpy as np
 
 
 class NoMemAllocVertcat:
@@ -11,51 +12,18 @@ class NoMemAllocVertcat:
     def __init__(self, a, b):
         arrays = [a, b]
         self.arrays = arrays
-
-        for array in arrays:
-            if not 1 <= len(array.shape) <= 2:
-                raise ValueError("Only 1D or 2D arrays are supported")
-            self._ndim = len(array.shape)
-
         self.len_a = a.shape[0]
-        shape0 = a.shape[0] + b.shape[0]
-
-        if self._ndim == 1:
-            self._shape = (shape0,)
-            self._size = shape0
-        else:
-            if a.shape[1] != b.shape[1]:
-                raise ValueError("All arrays must have the same number of columns")
-            shape1 = a.shape[1]
-
-            self._shape = (shape0, shape1)
-            self._size = shape0 * shape1
+        self.len_b = b.shape[0]
+        self.len = self.len_a + self.len_b
+        self._shape = (self.len, 1)
 
     @property
     def shape(self):
         return self._shape
 
-    @property
-    def size(self):
-        return self._size
-
-    @property
-    def ndim(self):
-        return self._ndim
-
-    def __getitem__(self, key):
-        if self._ndim == 1 or isinstance(key, int):
-            if key < self.len_a:
-                return self.arrays[0][key]
-            else:
-                return self.arrays[1][key - self.len_a]
-
-        if key[0] == slice(None):
-            return NoMemAllocVertcat(*[arr[:, key[1]] for arr in self.arrays])
-        elif isinstance(key[0], int):
-            if key[0] < self.len_a:
-                return self.arrays[0][key[0], key[1]]
-            else:
-                return self.arrays[1][key[0] - self.len_a, key[1]]
-        else:
-            raise NotImplementedError
+    def get_value(self, out=None):
+        if out is None:
+            out = np.empty((self.len, 1))
+        out[: self.len_a] = self.arrays[0]
+        out[self.len_a :] = self.arrays[1]
+        return out

--- a/pybamm/solvers/solver_utils.py
+++ b/pybamm/solvers/solver_utils.py
@@ -1,0 +1,61 @@
+#
+# Utility functions and classes for solvers
+#
+
+
+class NoMemAllocVertcat:
+    """
+    Acts like a vertcat, but does not allocate new memory.
+    """
+
+    def __init__(self, a, b):
+        arrays = [a, b]
+        self.arrays = arrays
+
+        for array in arrays:
+            if not 1 <= len(array.shape) <= 2:
+                raise ValueError("Only 1D or 2D arrays are supported")
+            self._ndim = len(array.shape)
+
+        self.len_a = a.shape[0]
+        shape0 = a.shape[0] + b.shape[0]
+
+        if self._ndim == 1:
+            self._shape = (shape0,)
+            self._size = shape0
+        else:
+            if a.shape[1] != b.shape[1]:
+                raise ValueError("All arrays must have the same number of columns")
+            shape1 = a.shape[1]
+
+            self._shape = (shape0, shape1)
+            self._size = shape0 * shape1
+
+    @property
+    def shape(self):
+        return self._shape
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def ndim(self):
+        return self._ndim
+
+    def __getitem__(self, key):
+        if self._ndim == 1 or isinstance(key, int):
+            if key < self.len_a:
+                return self.arrays[0][key]
+            else:
+                return self.arrays[1][key - self.len_a]
+
+        if key[0] == slice(None):
+            return NoMemAllocVertcat(*[arr[:, key[1]] for arr in self.arrays])
+        elif isinstance(key[0], int):
+            if key[0] < self.len_a:
+                return self.arrays[0][key[0], key[1]]
+            else:
+                return self.arrays[1][key[0] - self.len_a, key[1]]
+        else:
+            raise NotImplementedError

--- a/pybamm/solvers/solver_utils.py
+++ b/pybamm/solvers/solver_utils.py
@@ -9,16 +9,22 @@ class NoMemAllocVertcat:
     Acts like a vertcat, but does not allocate new memory.
     """
 
-    def __init__(self, xs, ys, len_x=None, len_y=None, items=None):
+    def __init__(self, xs, zs, len_x=None, len_z=None, items=None):
         self.xs = xs
-        self.ys = ys
+        self.zs = zs
         self.len_x = len_x or xs[0].shape[0]
-        self.len_y = len_y or ys[0].shape[0]
+        self.len_z = len_z or zs[0].shape[0]
         len_items = len(xs)
-        self.shape = (self.len_x + self.len_y, len_items)
+        self.shape = (self.len_x + self.len_z, len_items)
 
         if items is None:
             items = [None] * len_items
+            for idx in range(len_items):
+                out = casadi.DM.zeros((self.shape[0], 1))
+                out[: self.len_x] = self.xs[idx]
+                out[self.len_x :] = self.zs[idx]
+                items[idx] = out
+
         self.items = items
 
     def __getitem__(self, idx):
@@ -29,15 +35,7 @@ class NoMemAllocVertcat:
         idx = idx[1]
         if isinstance(idx, slice):
             return NoMemAllocVertcat(
-                self.xs[idx], self.ys[idx], self.len_x, self.len_y, self.items[idx]
+                self.xs[idx], self.zs[idx], self.len_x, self.len_z, self.items[idx]
             )
         else:
-            item = self.items[idx]
-            if item is not None:
-                return item
-            else:
-                out = casadi.DM.zeros((self.shape[0], 1))
-                out[: self.len_x] = self.xs[idx]
-                out[self.len_x :] = self.ys[idx]
-                self.items[idx] = out
-                return out
+            return self.items[idx]

--- a/tests/integration/test_models/standard_model_tests.py
+++ b/tests/integration/test_models/standard_model_tests.py
@@ -80,7 +80,7 @@ class StandardModelTest(object):
         if Crate == 0:
             Crate = 1
         if t_eval is None:
-            t_eval = np.linspace(0, 3600 / Crate, 100)
+            t_eval = np.linspace(0, 3600 / Crate, 1000)
 
         self.solution = self.solver.solve(
             self.model,

--- a/tests/unit/test_solvers/test_solver_utils.py
+++ b/tests/unit/test_solvers/test_solver_utils.py
@@ -1,0 +1,51 @@
+#
+# Tests for the solver utility functions and classes
+#
+import json
+import pybamm
+import unittest
+import numpy as np
+import pandas as pd
+from scipy.io import loadmat
+from tests import get_discretisation_for_testing
+
+
+class TestSolverUtils(unittest.TestCase):
+    def test_compare_numpy_vertcat(self):
+        a0 = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]])
+        a1 = np.array([[1, 2, 3]])
+        b0 = np.array([[13, 14, 15], [16, 17, 18]])
+
+        for a, b in zip([a0, b0], [a1, b0]):
+            pybamm_vertcat = pybamm.NoMemAllocVertcat(a, b)
+            np_vertcat = np.concatenate((a, b), axis=0)
+            self.assertEqual(pybamm_vertcat.shape, np_vertcat.shape)
+            self.assertEqual(pybamm_vertcat.size, np_vertcat.size)
+            for i in range(pybamm_vertcat.shape[0]):
+                for j in range(pybamm_vertcat.shape[1]):
+                    self.assertEqual(pybamm_vertcat[i, j], np_vertcat[i, j])
+                    self.assertEqual(pybamm_vertcat[:, j][i], np_vertcat[:, j][i])
+            for i in range(pybamm_vertcat.shape[0]):
+                np.testing.assert_array_equal(pybamm_vertcat[i, :], np_vertcat[i, :])
+
+    def test_errors(self):
+        a = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        b = np.ones((4, 5, 6))
+        with self.assertRaisesRegex(ValueError, "Only 1D or 2D arrays are supported"):
+            pybamm.NoMemAllocVertcat(a, b)
+
+        b = np.array([[10, 11], [13, 14]])
+        with self.assertRaisesRegex(
+            ValueError, "All arrays must have the same number of columns"
+        ):
+            pybamm.NoMemAllocVertcat(a, b)
+
+
+if __name__ == "__main__":
+    print("Add -v for more debug output")
+    import sys
+
+    if "-v" in sys.argv:
+        debug = True
+    pybamm.settings.debug_mode = True
+    unittest.main()


### PR DESCRIPTION
# Description

Avoids doing vertcat in the casadi solver, since vertcat is slow (because of the way the 2D arrays are stored in casadi).
Instead, does `horzsplit` so that both `x` (differential variables) and `z` (algebraic variables) are a list (of length len(t)) of vectors (of length `num_diff_states` and `num_alg_states`), then vertcats these item-by-item but does not re-concatenate to create the whole `sol.y` vector. Each `sol.y[:,idx]` is then accessed as an entry in a list of arrays. This is faster than actually doing `sol.y[:,idx]` from a 2D matrix in casadi.

This doesn't make a big difference for the standard solving with `np.linspace(0,3600,100)`, but becomes important when there are more time points (e.g. 1000, 10000) e.g. with a shorter period - in those cases, `vertcat` was taking up to 20% of the solve time. 

Fixes #1996 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
