### PR TITLE
Lower pin `pybtex` and remove redundant lines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ casadi >= 3.5.0
 imageio>=2.9.0
 julia>=0.5.6
 jupyter  # For example notebooks
-pybtex
+pybtex>=0.24.0
 sympy >= 1.8
 # Note: Matplotlib is loaded for debug plots but to ensure pybamm runs
 # on systems without an attached display it should never be imported

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ setup(
         # julia programming language is not installed
         "julia>=0.5.6",
         "jupyter",  # For example notebooks
-        "pybtex",
+        "pybtex>=0.24.0",
         "sympy>=1.8",
         # Note: Matplotlib is loaded for debug plots, but to ensure pybamm runs
         # on systems without an attached display, it should never be imported
@@ -228,9 +228,3 @@ setup(
         ]
     },
 )
-
-# pybtex adds a folder "tests" to the site packages, so we manually remove this
-path_to_sitepackages = site.getsitepackages()[0]
-path_to_tests_dir = os.path.join(path_to_sitepackages, "tests")
-if os.path.exists(path_to_tests_dir):
-    shutil.rmtree(path_to_tests_dir)

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ import subprocess
 from pathlib import Path
 from platform import system
 import wheel.bdist_wheel as orig
-import site
-import shutil
 
 try:
     from setuptools import setup, find_packages, Extension


### PR DESCRIPTION
# Description

This came up in a discussion with @brosaplanella (about hatch and migration from `setup.py` to `pyproject.toml`)

As long as we use the right lower bound, we will never encounter this issue again -
- https://bitbucket.org/pybtex-devs/pybtex/issues/129/pybtex-0222-installs-a-package-called
- https://bitbucket.org/pybtex-devs/pybtex/pull-requests/37

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
