### PR TITLE
unpin numpy since scikits is fixed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Requirements for readthedocs.io
-numpy <= 1.22 # change back to numpy>=1.16 once scikit.odes is fixed
+numpy >= 1.16
 scipy >= 1.3
 pandas >= 0.24
 anytree >= 2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy <= 1.22 # change back to numpy>=1.16 once scikit.odes is fixed
+numpy >= 1.16
 scipy >= 1.3
 pandas >= 0.24
 anytree >= 2.4.3

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ setup(
     python_requires=">=3.7,<3.10",
     # List of dependencies
     install_requires=[
-        "numpy<=1.22",  # change back to numpy>=1.16 once scikit.odes is fixed
+        "numpy>=1.16",
         "scipy>=1.3",
         "pandas>=0.24",
         "anytree>=2.4.3",

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 import sympy
-from scipy.sparse.coo import coo_matrix
+from scipy.sparse import coo_matrix
 
 import pybamm
 
@@ -360,7 +360,12 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertAlmostEqual(maximum.evaluate(y=np.array([2]))[0, 0], 2)
         self.assertAlmostEqual(maximum.evaluate(y=np.array([0]))[0, 0], 1)
         self.assertEqual(
-            str(maximum), "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"
+            str(maximum)[:15],
+            "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"[:15],
+        )
+        self.assertEqual(
+            str(maximum)[-33:],
+            "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"[-33:],
         )
 
         # Test that smooth min/max are used when the setting is changed

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -128,7 +128,7 @@ class TestCasadiConverter(unittest.TestCase):
             np.arccosh,
             np.arcsinh,
         ]:
-            self.assert_casadi_equal(
+            self.assert_casadi_almost_equal(
                 pybamm.Function(np_fun, c).to_casadi(), casadi.MX(np_fun(3)), evalf=True
             )
 
@@ -137,9 +137,7 @@ class TestCasadiConverter(unittest.TestCase):
         #       pybamm.Function(np_fun, c).to_casadi()
         # ) - casadi.evalf(casadi.MX(np_fun(3)))
         # is not zero, but a small number of the order 10^-15 when np_func is np.cosh
-        for np_fun in [
-            np.cosh
-        ]:
+        for np_fun in [np.cosh]:
             self.assert_casadi_almost_equal(
                 pybamm.Function(np_fun, c).to_casadi(),
                 casadi.MX(np_fun(3)),
@@ -196,9 +194,11 @@ class TestCasadiConverter(unittest.TestCase):
             interp_casadi = interp.to_casadi(y=casadi_y)
 
         # error for converted children count
-        y3 = (pybamm.StateVector(slice(0, 1)),
-              pybamm.StateVector(slice(0, 1)),
-              pybamm.StateVector(slice(0, 1)))
+        y3 = (
+            pybamm.StateVector(slice(0, 1)),
+            pybamm.StateVector(slice(0, 1)),
+            pybamm.StateVector(slice(0, 1)),
+        )
         x3_ = [np.linspace(0, 1) for _ in range(3)]
         x3 = np.column_stack(x3_)
         data3 = 2 * x3  # np.tile(2 * x3, (10, 1)).T
@@ -218,18 +218,14 @@ class TestCasadiConverter(unittest.TestCase):
         y_test = np.array([0.4, 0.6])
         Y = (2 * x).sum(axis=1).reshape(*[len(el) for el in x_])
         for interpolator in ["linear"]:
-            interp = pybamm.Interpolant(x_,
-                                        Y,
-                                        y, interpolator=interpolator)
+            interp = pybamm.Interpolant(x_, Y, y, interpolator=interpolator)
             interp_casadi = interp.to_casadi(y=casadi_y)
             f = casadi.Function("f", [casadi_y], [interp_casadi])
             np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
         # square
         y = (pybamm.StateVector(slice(0, 1)), pybamm.StateVector(slice(0, 1)))
         Y = (x ** 2).sum(axis=1).reshape(*[len(el) for el in x_])
-        interp = pybamm.Interpolant(x_,
-                                    Y,
-                                    y, interpolator="linear")
+        interp = pybamm.Interpolant(x_, Y, y, interpolator="linear")
         interp_casadi = interp.to_casadi(y=casadi_y)
         f = casadi.Function("f", [casadi_y], [interp_casadi])
         np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))


### PR DESCRIPTION
# Description

Revert numpy to >= 1.16 since scikits.odes has released fixed version