### PR TITLE
add function to save which last pybamm commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+-   Added function `pybamm.get_git_commit_info()`, which returns information about the last git commit, useful for reproducibility ([#2293](https://github.com/pybamm-team/PyBaMM/pull/2293))
 -   For experiments, the simulation now automatically checks and skips steps that cannot be performed (e.g. "Charge at 1C until 4.2V" from 100% SOC) ([#2212](https://github.com/pybamm-team/PyBaMM/pull/2212))
 
 ## Optimizations

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,4 +18,3 @@ matplotlib >= 2.0
 #
 guzzle-sphinx-theme
 sphinx>4.0
-numpydocs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,7 @@ casadi >= 3.5.0
 imageio>=2.9.0
 jupyter  # For example notebooks
 pybtex
+sympy >= 1.8
 # Note: Matplotlib is loaded for debug plots but to ensure pybamm runs
 # on systems without an attached display it should never be imported
 # outside of plot() methods.
@@ -17,4 +18,4 @@ matplotlib >= 2.0
 #
 guzzle-sphinx-theme
 sphinx>4.0
-sympy >= 1.8
+numpydocs

--- a/docs/source/util.rst
+++ b/docs/source/util.rst
@@ -28,6 +28,4 @@ Utility functions
 
 .. autofunction:: pybamm.have_jax
 
-.. autofunction:: pybamm.is_jax_compatabile
-
-.. autofunction:: pybamm.install_jax
+.. autofunction:: pybamm.is_jax_compatible

--- a/docs/source/util.rst
+++ b/docs/source/util.rst
@@ -3,7 +3,7 @@ Utility functions
 
 .. autofunction:: pybamm.get_infinite_nested_dict
 
-.. autofunction:: pybamm.load_function
+.. autofunction:: pybamm.get_git_commit_info
 
 .. autofunction:: pybamm.rmse
 
@@ -11,3 +11,23 @@ Utility functions
 
 .. autoclass:: pybamm.Timer
   :members:
+
+.. autoclass:: pybamm.TimerTime
+  :members:
+
+.. autoclass:: pybamm.FuzzyDict
+  :members:
+
+.. autofunction:: pybamm.load_function
+
+.. autofunction:: pybamm.load
+
+.. autofunction:: pybamm.get_parameters_filepath
+
+.. autofunction:: pybamm.have_julia
+
+.. autofunction:: pybamm.have_jax
+
+.. autofunction:: pybamm.is_jax_compatabile
+
+.. autofunction:: pybamm.install_jax

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -44,6 +44,7 @@ from .util import (
     install_jax,
     is_jax_compatible,
     have_julia,
+    get_git_commit_info,
 )
 from .logger import logger, set_logging_level
 from .logger import logger, set_logging_level, get_new_logger

--- a/pybamm/batch_study.py
+++ b/pybamm/batch_study.py
@@ -188,11 +188,11 @@ class BatchStudy:
 
         Parameters
         ----------
-        number_of_images : int (optional)
+        number_of_images : int, optional
             Number of images/plots to be compiled for a GIF.
-        duration : float (optional)
+        duration : float, optional
             Duration of visibility of a single image/plot in the created GIF.
-        output_filename : str (optional)
+        output_filename : str, optional
             Name of the generated GIF file.
 
         """

--- a/pybamm/spatial_methods/finite_volume.py
+++ b/pybamm/spatial_methods/finite_volume.py
@@ -48,7 +48,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         the FiniteVolume method.
 
         Parameters
-        -----------
+        ----------
         symbol : :class:`pybamm.SpatialVariable`
             The spatial variable to be discretised.
 

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -43,7 +43,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         the FiniteElement method.
 
         Parameters
-        -----------
+        ----------
         symbol : :class:`pybamm.SpatialVariable`
             The spatial variable to be discretised.
 
@@ -128,7 +128,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         """
         grad = self.gradient(symbol, discretised_symbol, boundary_conditions)
         grad_y, grad_z = grad.orphans
-        return grad_y ** 2 + grad_z ** 2
+        return grad_y**2 + grad_z**2
 
     def gradient_matrix(self, symbol, boundary_conditions):
         """

--- a/pybamm/spatial_methods/spatial_method.py
+++ b/pybamm/spatial_methods/spatial_method.py
@@ -61,7 +61,7 @@ class SpatialMethod:
         edges).
 
         Parameters
-        -----------
+        ----------
         symbol : :class:`pybamm.SpatialVariable`
             The spatial variable to be discretised.
 
@@ -341,7 +341,7 @@ class SpatialMethod:
         'discretised_child'.
 
         Parameters
-        -----------
+        ----------
         symbol: :class:`pybamm.Symbol`
             The boundary value or flux symbol
         discretised_child : :class:`pybamm.StateVector`

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -32,6 +32,20 @@ def root_dir():
     return str(pathlib.Path(pybamm.__path__[0]).parent)
 
 
+def get_git_commit_info():
+    """Get the git commit info for the current PyBaMM version"""
+    try:
+        # Get the latest git commit hash
+        return str(
+            subprocess.check_output(["git", "describe", "--tags"], cwd=root_dir())
+            .strip()
+            .decode()
+        )
+    except subprocess.CalledProcessError:  # pragma: no cover
+        # Not a git repository so just return the version number
+        return f"v{pybamm.__version__}"
+
+
 class FuzzyDict(dict):
     def get_best_matches(self, key):
         """Get best matches from keys"""

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -33,7 +33,10 @@ def root_dir():
 
 
 def get_git_commit_info():
-    """Get the git commit info for the current PyBaMM version"""
+    """
+    Get the git commit info for the current PyBaMM version, e.g. v22.8-39-gb25ce8c41
+    (version 22.8, commit b25ce8c41)
+    """
     try:
         # Get the latest git commit hash
         return str(

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -149,6 +149,12 @@ class TestUtil(unittest.TestCase):
             compatible = pybamm.is_jax_compatible()
             self.assertTrue(compatible)
 
+    def test_git_commit_info(self):
+        git_commit_info = pybamm.get_git_commit_info()
+        self.assertIsInstance(git_commit_info, str)
+        self.assertEqual(git_commit_info[:2], "v2")
+        self.assertIn("-g", git_commit_info)
+
 
 class TestSearch(unittest.TestCase):
     def test_url_gets_to_stdout(self):

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -153,7 +153,6 @@ class TestUtil(unittest.TestCase):
         git_commit_info = pybamm.get_git_commit_info()
         self.assertIsInstance(git_commit_info, str)
         self.assertEqual(git_commit_info[:2], "v2")
-        self.assertIn("-g", git_commit_info)
 
 
 class TestSearch(unittest.TestCase):


### PR DESCRIPTION
# Description

Function saves information about the commit, and if that is not available it returns the version number

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)


# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
