### PR TITLE
Add `IDAKLUSolver`'s API to the docs

### DIFF
--- a/docs/source/solvers/idaklu_solver.rst
+++ b/docs/source/solvers/idaklu_solver.rst
@@ -1,0 +1,5 @@
+IDAKLU Solver
+=============
+
+.. autoclass:: pybamm.IDAKLUSolver
+  :members:

--- a/docs/source/solvers/index.rst
+++ b/docs/source/solvers/index.rst
@@ -7,6 +7,7 @@ Solvers
   dummy_solver
   scipy_solver
   jax_solver
+  idaklu_solver
   scikits_solvers
   casadi_solver
   algebraic_solvers

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -26,7 +26,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
     """
     Solve a discretised model, using sundials with the KLU sparse linear solver.
 
-     Parameters
+    Parameters
     ----------
     rtol : float, optional
         The relative tolerance for the solver (default is 1e-6).
@@ -80,7 +80,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
         variables_with_tols : dict
             A dictionary with keys that are strings indicating the variable you
             wish to set the tolerance of and values that are the tolerances.
-
         model : :class:`pybamm.BaseModel`
             The model that is going to be solved.
         """

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -23,7 +23,8 @@ def have_idaklu():
 
 
 class IDAKLUSolver(pybamm.BaseSolver):
-    """Solve a discretised model, using sundials with the KLU sparse linear solver.
+    """
+    Solve a discretised model, using sundials with the KLU sparse linear solver.
 
      Parameters
     ----------


### PR DESCRIPTION
# Description

I am not sure why this was not included in the docs at the first place

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
