### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Check style
         run: |
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v3
@@ -96,7 +96,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: tox -e julia
 
-      - name: Run unit tests for GNU/Linux with Python 3.7 and 3.8
+      - name: Run unit tests for GNU/Linux with Python 3.8
         if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
         run: python -m tox -e unit
 

--- a/docs/install/GNU-linux.rst
+++ b/docs/install/GNU-linux.rst
@@ -7,7 +7,7 @@
 Prerequisites
 =============
 
-To use and/or contribute to PyBaMM, you must have Python 3.7, 3.8, or 3.9 installed.
+To use and/or contribute to PyBaMM, you must have Python 3.8 or 3.9 installed.
 
 To install Python 3 on Debian-based distribution (Debian, Ubuntu, Linux
 mint), open a terminal and run
@@ -46,7 +46,7 @@ User install
 
 We recommend to install PyBaMM within a virtual environment, in order
 not to alter any distribution python files.
-First, make sure you are using python 3.7, 3.8, or 3.9.
+First, make sure you are using python 3.8 or 3.9.
 To create a virtual environment ``env`` within your current directory type:
 
 .. code:: bash

--- a/docs/install/install-from-source.rst
+++ b/docs/install/install-from-source.rst
@@ -25,7 +25,7 @@ or download the source archive on the repository's homepage.
 
 To install PyBaMM, you will need:
 
-- Python 3 (PyBaMM supports versions 3.7, 3.8, and 3.9)
+- Python 3 (PyBaMM supports versions 3.8 and 3.9)
 - The python headers file for your current python version.
 - A BLAS library (for instance `openblas <https://www.openblas.net/>`_).
 - A C compiler (ex: ``gcc``).

--- a/docs/install/windows.rst
+++ b/docs/install/windows.rst
@@ -6,13 +6,13 @@ Windows
 Prerequisites
 -------------
 
-To use and/or contribute to PyBaMM, you must have Python 3.7, 3.8, or 3.9 installed.
+To use and/or contribute to PyBaMM, you must have Python 3.8 or 3.9 installed.
 
 To install Python 3 download the installation files from `Python’s
 website <https://www.python.org/downloads/windows/>`__. Make sure to
 tick the box on ``Add Python 3.X to PATH``. For more detailed
 instructions please see the `official Python on Windows
-guide <https://docs.python.org/3.7/using/windows.html>`__.
+guide <https://docs.python.org/3.9/using/windows.html>`__.
 
 Install PyBaMM
 --------------

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ setup(
     },
     package_data={"pybamm": pybamm_data},
     # Python version
-    python_requires=">=3.7,<3.10",
+    python_requires=">=3.8,<3.10",
     # List of dependencies
     install_requires=[
         "numpy>=1.16",


### PR DESCRIPTION
# Description

This change drops support for Python 3.7.

Fixes #2370 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
