### PR TITLE
fix: pybamm.have_julia is True when PyCall.jl uninstalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Bug fixes
 
 - For simulations with events that cause the simulation to stop early, the sensitivities could be evaluated incorrectly to zero ([#2337](https://github.com/pybamm-team/PyBaMM/pull/2337))
-- `pybamm.have_julia()` now checks that julia is properly configured ([#2402]((https://github.com/pybamm-team/PyBaMM/pull/2402)))
+- `pybamm.have_julia()` now checks that julia is properly configured ([#2402](<(https://github.com/pybamm-team/PyBaMM/pull/2402)>))
 
 ## Optimizations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 - For simulations with events that cause the simulation to stop early, the sensitivities could be evaluated incorrectly to zero ([#2337](https://github.com/pybamm-team/PyBaMM/pull/2337))
+- `pybamm.have_julia()` now checks that julia is properly configured ([#2402]((https://github.com/pybamm-team/PyBaMM/pull/2402)))
 
 ## Optimizations
 

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -15,6 +15,7 @@ import sys
 import timeit
 from platform import system
 import difflib
+from julia.api import Julia, JuliaInfo, JuliaError
 
 import numpy as np
 import pkg_resources
@@ -291,12 +292,24 @@ def have_julia():
     """
     Checks whether the Julia programming language has been installed
     """
-    # Try reading the julia version quietly to see whether julia is installed
-    FNULL = open(os.devnull, "w")
+
+    # Try fetching info about julia
     try:
-        subprocess.call(["julia", "--version"], stdout=FNULL, stderr=subprocess.STDOUT)
+        info = JuliaInfo.load()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+    # Compatibility: Checks
+    if not info.is_pycall_built():
+        return False
+    if not info.is_compatible_python():
+        return False
+
+    # Confirm Julia() is callable
+    try:
+        Julia()
         return True
-    except subprocess.CalledProcessError:  # pragma: no cover
+    except JuliaError:
         return False
 
 

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -300,16 +300,16 @@ def have_julia():
         return False
 
     # Compatibility: Checks
-    if not info.is_pycall_built():
+    if not info.is_pycall_built():  # pragma: no cover
         return False
-    if not info.is_compatible_python():
+    if not info.is_compatible_python():  # pragma: no cover
         return False
 
     # Confirm Julia() is callable
     try:
         Julia()
         return True
-    except JuliaError:
+    except JuliaError:  # pragma: no cover
         return False
 
 

--- a/tests/unit/test_models/test_base_model_generate_julia_diffeq.py
+++ b/tests/unit/test_models/test_base_model_generate_julia_diffeq.py
@@ -5,7 +5,7 @@ import platform
 import unittest
 import pybamm
 
-have_julia = True  # pybamm.have_julia()
+have_julia = pybamm.have_julia()
 if have_julia and platform.system() != "Windows":
     from julia.api import Julia
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -92,7 +92,7 @@ class TestUtil(unittest.TestCase):
         self.assertIsInstance(git_commit_info, str)
         self.assertEqual(git_commit_info[:2], "v2")
 
-    @unittest.skipIf(not pybamm.have_julia())
+    @unittest.skipIf(not pybamm.have_julia(), "Julia not installed")
     def test_have_julia(self):
         # Remove julia from the path
         with unittest.mock.patch.dict(

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -3,6 +3,7 @@
 #
 import numpy as np
 import os
+import sys
 import pybamm
 import tempfile
 import unittest
@@ -91,6 +92,17 @@ class TestUtil(unittest.TestCase):
         self.assertIsInstance(git_commit_info, str)
         self.assertEqual(git_commit_info[:2], "v2")
 
+    @unittest.skipIf(not pybamm.have_julia())
+    def test_have_julia(self):
+        # Remove julia from the path
+        with unittest.mock.patch.dict(
+            "os.environ", {"PATH": os.path.dirname(sys.executable)}
+        ):
+            self.assertFalse(pybamm.have_julia())
+
+        # Add it back
+        self.assertTrue(pybamm.have_julia())
+
 
 class TestSearch(unittest.TestCase):
     def test_url_gets_to_stdout(self):
@@ -122,7 +134,6 @@ class TestSearch(unittest.TestCase):
 
 if __name__ == "__main__":
     print("Add -v for more debug output")
-    import sys
 
     if "-v" in sys.argv:
         debug = True


### PR DESCRIPTION
Currently `pybamm.have_julia()` returns True even if PyCall.jl is not configured this results in test failures as the tests assume they can call:

```python
from julia.api import Julia
Julia()
```

Which fails if Julia has not been configured. This commit fixes that.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
