### PR TITLE
fix: build docs with pybamm installed

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_parameter_set.yml
+++ b/.github/ISSUE_TEMPLATE/new_parameter_set.yml
@@ -8,20 +8,21 @@ body:
         point with `pybamm-parameter-sets` as described in our
         [documentation](https://pybamm.readthedocs.io/en/latest/source/parameters/parameter_sets.html).
   - type: input
+    id: parameter-set-url
     attributes:
-      id: parameter-set-url
       label: Where can we find your parameter set?
       description: Provide the Github URL or PyPi package name for your parameter set
       placeholder: https://github.com/AwesomeOrg/NewParameterSet
     validations:
       required: true
   - type: dropdown
+    id: open-source-approved
     attributes:
-      id: open-source-approved
-      label: Is it licensed under an [Open Source Initiative Approved License](https://opensource.org/licenses)?
+      label: Is your package open source?
+      description: See the [Open Source Initiative's List of Approved Licenses](https://opensource.org/licenses)
       options: ["Yes", "No"]
   - type: textarea
+    id: feedback
     attributes:
-      id: feedback
       label: Any additional information?
       description: Thank you for making parameter set! Is there anything else we should know about it?

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,3 +16,6 @@ python:
   version: 3.8
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,3 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
-


### PR DESCRIPTION
RTD currently builds the docs without pybamm installed, causing build errors as #2396 added `import pybamm` to `conf.py`

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #

RTD not building after #2396 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
