### PR TITLE
More simplifications

### DIFF
--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -1254,15 +1254,20 @@ def simplified_division(left, right):
             return (left * r_right) / r_left
 
     # Cancelling out common terms
-    if isinstance(left, Multiplication) and isinstance(right, Multiplication):
-        if left.left == right.left:
-            _, l_right = left.orphans
-            _, r_right = right.orphans
-            return l_right / r_right
-        if left.right == right.right:
-            l_left, _ = left.orphans
-            r_left, _ = right.orphans
-            return l_left / r_left
+    if isinstance(left, Multiplication):
+        if left.left == right:
+            return left.right
+        elif left.right == right:
+            return left.left
+        elif isinstance(right, Multiplication):
+            if left.left == right.left:
+                _, l_right = left.orphans
+                _, r_right = right.orphans
+                return l_right / r_right
+            if left.right == right.right:
+                l_left, _ = left.orphans
+                r_left, _ = right.orphans
+                return l_left / r_left
 
     # Negation simplifications
     if isinstance(left, pybamm.Negate) and isinstance(right, pybamm.Negate):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -792,18 +792,20 @@ def simplified_addition(left, right):
     """
     left, right = simplify_elementwise_binary_broadcasts(left, right)
 
+    # Move constant to always be on the left
+    if right.is_constant() and not left.is_constant():
+        left, right = right, left
+
     # Check for Concatenations and Broadcasts
     out = simplified_binary_broadcast_concatenation(left, right, simplified_addition)
     if out is not None:
         return out
 
     # anything added by a scalar zero returns the other child
-    elif pybamm.is_scalar_zero(left):
+    if pybamm.is_scalar_zero(left):
         return right
-    elif pybamm.is_scalar_zero(right):
-        return left
     # Check matrices after checking scalars
-    elif pybamm.is_matrix_zero(left):
+    if pybamm.is_matrix_zero(left):
         if right.evaluates_to_number():
             return right * pybamm.ones_like(left)
         # If left object is zero and has size smaller than or equal to right object in
@@ -820,20 +822,6 @@ def simplified_addition(left, right):
             for dim in left.domains.keys()
         ):
             return right
-    elif pybamm.is_matrix_zero(right):
-        if left.evaluates_to_number():
-            return left * pybamm.ones_like(right)
-        # See comment above
-        elif all(
-            left_dim_size >= right_dim_size
-            for left_dim_size, right_dim_size in zip(
-                left.shape_for_testing, right.shape_for_testing
-            )
-        ) and all(
-            left.evaluates_on_edges(dim) == right.evaluates_on_edges(dim)
-            for dim in left.domains.keys()
-        ):
-            return left
 
     # Return constant if both sides are constant
     if left.is_constant() and right.is_constant():
@@ -855,42 +843,23 @@ def simplified_addition(left, right):
             new_sum.copy_domains(Addition(left, right))
             return new_sum
 
-    if isinstance(right, Addition) and left.is_constant():
-        # Simplify a + (b + c) to (a + b) + c if (a + b) is constant
-        if right.left.is_constant():
+    # Turn a + (-b) into a - b
+    if isinstance(right, pybamm.Negate):
+        return left - right.orphans[0]
+
+    if left.is_constant():
+        if isinstance(right, (Addition, Subtraction)) and right.left.is_constant():
+            # Simplify a + (b +- c) to (a + b) +- c if (a + b) is constant
             r_left, r_right = right.orphans
-            return (left + r_left) + r_right
-        # Simplify a + (b + c) to (a + c) + b if (a + c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left + r_right) + r_left
-    elif isinstance(right, Subtraction) and left.is_constant():
-        # Simplify a + (b - c) to (a + b) - c if (a + b) is constant
-        if right.left.is_constant():
-            r_left, r_right = right.orphans
-            return (left + r_left) - r_right
-        # Simplify a + (b - c) to (a - c) + b if (a - c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left - r_right) + r_left
-    if isinstance(left, Addition) and right.is_constant():
-        # Simplify (a + b) + c to a + (b + c) if (b + c) is constant
-        if left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left + (l_right + right)
-        # Simplify (a + b) + c to (a + c) + b if (a + c) is constant
-        elif left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left + right) + l_right
-    elif isinstance(left, Subtraction) and right.is_constant():
-        # Simplify (a - b) + c to a + (c - b) if (c - b) is constant
-        if left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left + (right - l_right)
-        # Simplify (a - b) + c to (a + c) - b if (a + c) is constant
-        elif left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left + right) - l_right
+            return right._binary_new_copy(left + r_left, r_right)
+    elif isinstance(left, Subtraction):
+        if right == left.right:
+            # Simplify (a - b) + b to a
+            return left.left
+    elif isinstance(right, Subtraction):
+        if left == right.right:
+            # Simplify a + (b - a) to b
+            return right.left
 
     return pybamm.simplify_if_constant(Addition(left, right))
 
@@ -905,6 +874,11 @@ def simplified_subtraction(left, right):
     """
     left, right = simplify_elementwise_binary_broadcasts(left, right)
 
+    # Move constant to always be on the left
+    # For a subtraction, this means (var - constant) becomes (-constant + var)
+    if right.is_constant() and not left.is_constant():
+        return -right + left
+
     # Check for Concatenations and Broadcasts
     out = simplified_binary_broadcast_concatenation(left, right, simplified_subtraction)
     if out is not None:
@@ -913,8 +887,6 @@ def simplified_subtraction(left, right):
     # anything added by a scalar zero returns the other child
     if pybamm.is_scalar_zero(left):
         return -right
-    if pybamm.is_scalar_zero(right):
-        return left
     # Check matrices after checking scalars
     if pybamm.is_matrix_zero(left):
         if right.evaluates_to_number():
@@ -930,20 +902,6 @@ def simplified_subtraction(left, right):
             for dim in left.domains.keys()
         ):
             return -right
-    if pybamm.is_matrix_zero(right):
-        if left.evaluates_to_number():
-            return left * pybamm.ones_like(right)
-        # See comments in simplified_addition
-        elif all(
-            left_dim_size >= right_dim_size
-            for left_dim_size, right_dim_size in zip(
-                left.shape_for_testing, right.shape_for_testing
-            )
-        ) and all(
-            left.evaluates_on_edges(dim) == right.evaluates_on_edges(dim)
-            for dim in left.domains.keys()
-        ):
-            return left
 
     # Return constant if both sides are constant
     if left.is_constant() and right.is_constant():
@@ -953,48 +911,47 @@ def simplified_subtraction(left, right):
     if left == right:
         return pybamm.zeros_like(left)
 
-    if isinstance(right, Addition) and left.is_constant():
-        # Simplify a - (b + c) to (a - b) - c if (a - b) is constant
-        if right.left.is_constant():
+    # Turn a - (-b) into a + b
+    if isinstance(right, pybamm.Negate):
+        return left + right.orphans[0]
+
+    if left.is_constant():
+        if isinstance(right, (Addition, Subtraction)) and right.left.is_constant():
+            # Simplify a - (b +- c) to (a - b) -+ c if (a - b) is constant
             r_left, r_right = right.orphans
-            return (left - r_left) - r_right
-        # Simplify a - (b + c) to (a - c) - b if (a - c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left - r_right) - r_left
-    elif isinstance(right, Subtraction) and left.is_constant():
-        # Simplify a - (b - c) to (a - b) + c if (a - b) is constant
-        if right.left.is_constant():
-            r_left, r_right = right.orphans
-            return (left - r_left) + r_right
-        # Simplify a - (b - c) to (a + c) - b if (a + c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left + r_right) - r_left
-    if isinstance(left, Addition) and right.is_constant():
-        # Simplify (a + b) - c to a + (b - c) if (b - c) is constant
-        if left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left + (l_right - right)
-        # Simplify (a + b) - c to (a - c) + b if (a - c) is constant
-        elif left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left - right) + l_right
-    elif isinstance(left, Subtraction) and right.is_constant():
-        # Simplify (a - b) - c to a - (c + b) if (c + b) is constant
-        if left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left - (right + l_right)
-        # Simplify (a - b) - c to (a - c) - b if (a - c) is constant
-        elif left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left - right) - l_right
+            return right._binary_new_copy(left - r_left, -r_right)
+    elif isinstance(left, Addition):
+        if right == left.right:
+            # Simplify (b + a) - a to b
+            return left.left
+        if right == left.left:
+            # Simplify (a + b) - a to b
+            return left.right
+    elif isinstance(left, Subtraction):
+        if right == left.left:
+            # Simplify (b - a) - b to -a
+            return -left.right
+    elif isinstance(right, Addition):
+        if left == right.left:
+            # Simplify a - (a + b) to -b
+            return -right.right
+        if left == right.right:
+            # Simplify a - (b + a) to -b
+            return -right.left
+    elif isinstance(right, Subtraction):
+        if left == right.left:
+            # Simplify a - (a - b) to b
+            return right.right
 
     return pybamm.simplify_if_constant(Subtraction(left, right))
 
 
 def simplified_multiplication(left, right):
     left, right = simplify_elementwise_binary_broadcasts(left, right)
+
+    # Move constant to always be on the left
+    if right.is_constant() and not left.is_constant():
+        left, right = right, left
 
     # Check for Concatenations and Broadcasts
     out = simplified_binary_broadcast_concatenation(
@@ -1006,24 +963,18 @@ def simplified_multiplication(left, right):
     # simplify multiply by scalar zero, being careful about shape
     if pybamm.is_scalar_zero(left):
         return pybamm.zeros_like(right)
-    if pybamm.is_scalar_zero(right):
-        return pybamm.zeros_like(left)
 
     # if one of the children is a zero matrix, we have to be careful about shapes
-    if pybamm.is_matrix_zero(left) or pybamm.is_matrix_zero(right):
+    if pybamm.is_matrix_zero(left):
         return pybamm.zeros_like(Multiplication(left, right))
 
     # anything multiplied by a scalar one returns itself
     if pybamm.is_scalar_one(left):
         return right
-    if pybamm.is_scalar_one(right):
-        return left
 
     # anything multiplied by a scalar negative one returns negative itself
     if pybamm.is_scalar_minus_one(left):
         return -right
-    if pybamm.is_scalar_minus_one(right):
-        return -left
 
     # Return constant if both sides are constant
     if left.is_constant() and right.is_constant():
@@ -1052,69 +1003,32 @@ def simplified_multiplication(left, right):
     except NotImplementedError:
         pass
 
-    # Simplify (B @ c) * a to (a * B) @ c if (a * B) is constant
-    # This is a common construction that appears from discretisation of spatial
-    # operators
-    if (
-        isinstance(left, MatrixMultiplication)
-        and left.left.is_constant()
-        and right.is_constant()
-        and not (right.ndim_for_testing == 2 and right.shape_for_testing[1] > 1)
-    ):
-        l_left, l_right = left.orphans
-        new_left = right * l_left
-        # be careful about domains to avoid weird errors
-        new_left.clear_domains()
-        new_mul = new_left @ l_right
-        # Keep the domain of the old left
-        new_mul.copy_domains(left)
-        return new_mul
-
-    elif isinstance(left, Multiplication) and right.is_constant():
-        # Simplify (a * b) * c to (a * c) * b if (a * c) is constant
-        if left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left * right) * l_right
-        # Simplify (a * b) * c to a * (b * c) if (b * c) is constant
-        elif left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left * (l_right * right)
-    elif isinstance(left, Division) and right.is_constant():
-        # Simplify (a / b) * c to a * (c / b) if (c / b) is constant
-        if left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left * (right / l_right)
-
-    # Simplify a * (B @ c) to (a * B) @ c if (a * B) is constant
-    if (
-        isinstance(right, MatrixMultiplication)
-        and right.left.is_constant()
-        and left.is_constant()
-        and not (left.ndim_for_testing == 2 and left.shape_for_testing[1] > 1)
-    ):
-        r_left, r_right = right.orphans
-        new_left = left * r_left
-        # be careful about domains to avoid weird errors
-        new_left.clear_domains()
-        new_mul = new_left @ r_right
-        # Keep the domain of the old right
-        new_mul.copy_domains(right)
-        return new_mul
-
-    elif isinstance(right, Multiplication) and left.is_constant():
-        # Simplify a * (b * c) to (a * b) * c if (a * b) is constant
-        if right.left.is_constant():
+    if left.is_constant():
+        # Simplify a * (B @ c) to (a * B) @ c if (a * B) is constant
+        if (
+            isinstance(right, MatrixMultiplication)
+            and right.left.is_constant()
+            and not (left.ndim_for_testing == 2 and left.shape_for_testing[1] > 1)
+        ):
             r_left, r_right = right.orphans
-            return (left * r_left) * r_right
-        # Simplify a * (b * c) to (a * c) * b if (a * c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left * r_right) * r_left
-    elif isinstance(right, Division) and left.is_constant():
-        # Simplify a * (b / c) to (a / c) * b if (a / c) is constant
-        if right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left / r_right) * r_left
+            new_left = left * r_left
+            # be careful about domains to avoid weird errors
+            new_left.clear_domains()
+            new_mul = new_left @ r_right
+            # Keep the domain of the old right
+            new_mul.copy_domains(right)
+            return new_mul
+
+        elif isinstance(right, Multiplication):
+            # Simplify a * (b * c) to (a * b) * c if (a * b) is constant
+            if right.left.is_constant():
+                r_left, r_right = right.orphans
+                return (left * r_left) * r_right
+        elif isinstance(right, Division):
+            # Simplify a * (b / c) to (a * b) / c if (a * c) is constant
+            if right.left.is_constant():
+                r_left, r_right = right.orphans
+                return (left * r_left) / r_right
 
     # Simplify a * (b + c) to (a * b) + (a * c) if (a * b) or (a * c) is constant
     # This is a common construction that appears from discretisation of spatial
@@ -1137,13 +1051,20 @@ def simplified_multiplication(left, right):
                 elif isinstance(right, Subtraction):
                     return (left * r_left) - (left * r_right)
 
+    # Cancelling out common terms
+    if isinstance(left, Division):
+        # Simplify (a / b) * b to a
+        if left.right == right:
+            return left.left
+    if isinstance(right, Division):
+        # Simplify a * (b / a) to b
+        if left == right.right:
+            return right.left
+
     # Negation simplifications
     if isinstance(left, pybamm.Negate) and isinstance(right, pybamm.Negate):
         # Double negation cancels out
         return left.orphans[0] * right.orphans[0]
-    elif isinstance(left, pybamm.Negate) and right.is_constant():
-        # Simplify (-a) * b to a * (-b) if (-b) is constant
-        return left.orphans[0] * (-right)
     elif isinstance(right, pybamm.Negate) and left.is_constant():
         # Simplify a * (-b) to (-a) * b if (-a) is constant
         return (-left) * right.orphans[0]
@@ -1153,6 +1074,15 @@ def simplified_multiplication(left, right):
 
 def simplified_division(left, right):
     left, right = simplify_elementwise_binary_broadcasts(left, right)
+
+    # anything divided by zero raises error
+    if pybamm.is_scalar_zero(right):
+        raise ZeroDivisionError
+
+    # Move constant to always be on the left
+    # For a division, this means (var / constant) becomes (1/constant * var)
+    if right.is_constant() and not left.is_constant():
+        return (1 / right) * left
 
     # Check for Concatenations and Broadcasts
     out = simplified_binary_broadcast_concatenation(left, right, simplified_division)
@@ -1167,91 +1097,22 @@ def simplified_division(left, right):
     if pybamm.is_matrix_zero(left):
         return pybamm.zeros_like(Division(left, right))
 
-    # anything divided by zero raises error
-    if pybamm.is_scalar_zero(right):
-        raise ZeroDivisionError
-
-    # anything divided by one is itself
-    if pybamm.is_scalar_one(right):
-        return left
-
     # a symbol divided by itself is 1s of the same shape
     if left == right:
         return pybamm.ones_like(left)
-
-    # anything multiplied by a matrix one returns itself if
-    # - the shapes are the same
-    # - both left and right evaluate on edges, or both evaluate on nodes, in all
-    # dimensions
-    # (and possibly more generally, but not implemented here)
-    try:
-        if left.shape_for_testing == right.shape_for_testing and all(
-            left.evaluates_on_edges(dim) == right.evaluates_on_edges(dim)
-            for dim in left.domains.keys()
-        ):
-            if pybamm.is_matrix_one(right):
-                return left
-            # also check for negative one
-            if pybamm.is_matrix_minus_one(right):
-                return -left
-
-    except NotImplementedError:
-        pass
 
     # Return constant if both sides are constant
     if left.is_constant() and right.is_constant():
         return pybamm.simplify_if_constant(Division(left, right))
 
-    # Simplify (B @ c) / a to (B / a) @ c if (B / a) is constant
-    # This is a common construction that appears from discretisation of averages
-    elif isinstance(left, MatrixMultiplication) and right.is_constant():
-        l_left, l_right = left.orphans
-        new_left = l_left / right
-        if new_left.is_constant():
-            # be careful about domains to avoid weird errors
-            new_left.clear_domains()
-            new_division = new_left @ l_right
-            # Keep the domain of the old left
-            new_division.copy_domains(left)
-            return new_division
-
-    if isinstance(left, Multiplication) and right.is_constant():
-        # Simplify (a * b) / c to (a / c) * b if (a / c) is constant
-        if left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left / right) * l_right
-        # Simplify (a * b) / c to a * (b / c) if (b / c) is constant
-        elif left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left * (l_right / right)
-    elif isinstance(left, Division) and right.is_constant():
-        # Simplify (a / b) / c to (a / c) / b if (a / c) is constant
-        if left.left.is_constant():
-            l_left, l_right = left.orphans
-            return (l_left / right) / l_right
-        # Simplify (a / b) / c to a / (b * c) if (b * c) is constant
-        elif left.right.is_constant():
-            l_left, l_right = left.orphans
-            return l_left / (l_right * right)
-
-    if isinstance(right, Multiplication) and left.is_constant():
-        # Simplify a / (b * c) to (a / b) / c if (a / b) is constant
-        if right.left.is_constant():
+    if left.is_constant():
+        if isinstance(right, (Multiplication, Division)) and right.left.is_constant():
             r_left, r_right = right.orphans
-            return (left / r_left) / r_right
-        # Simplify a / (b * c) to (a / c) / b if (a / c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left / r_right) / r_left
-    elif isinstance(right, Division) and left.is_constant():
-        # Simplify a / (b / c) to (a / b) * c if (a / b) is constant
-        if right.left.is_constant():
-            r_left, r_right = right.orphans
-            return (left / r_left) * r_right
-        # Simplify a / (b / c) to (a * c) / b if (a * c) is constant
-        elif right.right.is_constant():
-            r_left, r_right = right.orphans
-            return (left * r_right) / r_left
+            # Simplify a / (b */ c) to (a / b) /* c if (a / b) is constant
+            if isinstance(right, Multiplication):
+                return (left / r_left) / r_right
+            elif isinstance(right, Division):
+                return (left / r_left) * r_right
 
     # Cancelling out common terms
     if isinstance(left, Multiplication):
@@ -1270,16 +1131,13 @@ def simplified_division(left, right):
                 return l_left / r_left
 
     # Negation simplifications
-    if isinstance(left, pybamm.Negate) and isinstance(right, pybamm.Negate):
-        # Double negation cancels out
-        return left.orphans[0] / right.orphans[0]
-    elif isinstance(left, pybamm.Negate) and right.is_constant():
-        # Simplify (-a) / b to a / (-b) if (-b) is constant
-        return left.orphans[0] / (-right)
-
-    if isinstance(right, pybamm.Negate) and left.is_constant():
-        # Simplify a / (-b) to (-a) / b if (-a) is constant
-        return (-left) / right.orphans[0]
+    if isinstance(right, pybamm.Negate):
+        if isinstance(left, pybamm.Negate):
+            # Double negation cancels out
+            return left.orphans[0] / right.orphans[0]
+        elif left.is_constant():
+            # Simplify a / (-b) to (-a) / b if (-a) is constant
+            return (-left) / right.orphans[0]
 
     return pybamm.simplify_if_constant(Division(left, right))
 

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -570,6 +570,7 @@ class TestBinaryOperators(unittest.TestCase):
         B = pybamm.Matrix(np.random.rand(10, 10))
         # C = pybamm.Matrix(np.random.rand(10, 10))
         var = pybamm.StateVector(slice(0, 10))
+        sym = pybamm.Symbol("sym")
         # var2 = pybamm.StateVector(slice(10, 20))
         vec = pybamm.Vector(np.random.rand(10))
 
@@ -679,6 +680,11 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(expr, ((5 / 7) * var))
         expr = 5 / (var / 7)
         self.assertEqual(expr, (35 / var))
+
+        expr = (var * sym) / sym
+        self.assertEqual(expr, var)
+        expr = (sym * var) / sym
+        self.assertEqual(expr, var)
 
         # use power rules on multiplications and divisions
         expr = (var * 5) ** 2

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -314,13 +314,13 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertAlmostEqual(sigm.evaluate(y=np.array([2]))[0, 0], 1)
         self.assertEqual(sigm.evaluate(y=np.array([1])), 0.5)
         self.assertAlmostEqual(sigm.evaluate(y=np.array([0]))[0, 0], 0)
-        self.assertEqual(str(sigm), "(1.0 + tanh((10.0 * y[0:1]) - 10.0)) / 2.0")
+        self.assertEqual(str(sigm), "0.5 * (1.0 + tanh(10.0 * (-1.0 + y[0:1])))")
 
         sigm = pybamm.sigmoid(b, a, 10)
         self.assertAlmostEqual(sigm.evaluate(y=np.array([2]))[0, 0], 0)
         self.assertEqual(sigm.evaluate(y=np.array([1])), 0.5)
         self.assertAlmostEqual(sigm.evaluate(y=np.array([0]))[0, 0], 1)
-        self.assertEqual(str(sigm), "(1.0 + tanh(10.0 - (10.0 * y[0:1]))) / 2.0")
+        self.assertEqual(str(sigm), "0.5 * (1.0 + tanh(10.0 * (1.0 - y[0:1])))")
 
     def test_modulo(self):
         a = pybamm.StateVector(slice(0, 1))
@@ -356,19 +356,19 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertAlmostEqual(minimum.evaluate(y=np.array([2]))[0, 0], 1)
         self.assertAlmostEqual(minimum.evaluate(y=np.array([0]))[0, 0], 0)
         self.assertEqual(
-            str(minimum), "log(1.9287498479639178e-22 + exp(-50.0 * y[0:1])) / -50.0"
+            str(minimum), "-0.02 * log(1.9287498479639178e-22 + exp(-50.0 * y[0:1]))"
         )
 
         maximum = pybamm.softplus(a, b, 50)
         self.assertAlmostEqual(maximum.evaluate(y=np.array([2]))[0, 0], 2)
         self.assertAlmostEqual(maximum.evaluate(y=np.array([0]))[0, 0], 1)
         self.assertEqual(
-            str(maximum)[:15],
-            "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"[:15],
+            str(maximum)[:20],
+            "0.02 * log(5.184705528587072e+21 + exp(50.0 * y[0:1]))"[:20],
         )
         self.assertEqual(
-            str(maximum)[-33:],
-            "log(5.184705528587072e+21 + exp(50.0 * y[0:1])) / 50.0"[-33:],
+            str(maximum)[-20:],
+            "0.02 * log(5.184705528587072e+21 + exp(50.0 * y[0:1]))"[-20:],
         )
 
         # Test that smooth min/max are used when the setting is changed
@@ -392,6 +392,7 @@ class TestBinaryOperators(unittest.TestCase):
         a = pybamm.Scalar(0)
         b = pybamm.Scalar(1)
         c = pybamm.Parameter("c")
+        d = pybamm.Parameter("d")
         v = pybamm.Vector(np.zeros((10, 1)))
         v1 = pybamm.Vector(np.ones((10, 1)))
         f = pybamm.StateVector(slice(0, 10))
@@ -419,18 +420,15 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual((var**broad2_edge).right, broad2_edge)
 
         # addition
-        self.assertIsInstance((a + b), pybamm.Scalar)
-        self.assertEqual((a + b).evaluate(), 1)
-        self.assertIsInstance((b + b), pybamm.Scalar)
-        self.assertEqual((b + b).evaluate(), 2)
-        self.assertIsInstance((b + a), pybamm.Scalar)
-        self.assertEqual((b + a).evaluate(), 1)
-        self.assertIsInstance((0 + b), pybamm.Scalar)
-        self.assertEqual((0 + b).evaluate(), 1)
-        self.assertIsInstance((0 + c), pybamm.Parameter)
-        self.assertIsInstance((c + 0), pybamm.Parameter)
-        self.assertIsInstance((c + 1), pybamm.Addition)
-        self.assertIsInstance((1 + c), pybamm.Addition)
+        self.assertEqual(a + b, pybamm.Scalar(1))
+        self.assertEqual(b + b, pybamm.Scalar(2))
+        self.assertEqual(b + a, pybamm.Scalar(1))
+        self.assertEqual(0 + b, pybamm.Scalar(1))
+        self.assertEqual(0 + c, c)
+        self.assertEqual(c + 0, c)
+        # addition with subtraction
+        self.assertEqual(c + (d - c), d)
+        self.assertEqual((c - d) + d, c)
         # addition with broadcast zero
         self.assertIsInstance((1 + broad0), pybamm.PrimaryBroadcast)
         np.testing.assert_array_equal((1 + broad0).child.evaluate(), 1)
@@ -443,12 +441,15 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual((broad2 + c), pybamm.PrimaryBroadcast(2 + c, "domain"))
 
         # subtraction
-        self.assertIsInstance((a - b), pybamm.Scalar)
-        self.assertEqual((a - b).evaluate(), -1)
-        self.assertIsInstance((b - b), pybamm.Scalar)
-        self.assertEqual((b - b).evaluate(), 0)
-        self.assertIsInstance((b - a), pybamm.Scalar)
-        self.assertEqual((b - a).evaluate(), 1)
+        self.assertEqual(a - b, pybamm.Scalar(-1))
+        self.assertEqual(b - b, pybamm.Scalar(0))
+        self.assertEqual(b - a, pybamm.Scalar(1))
+        # subtraction with addition
+        self.assertEqual(c - (d + c), -d)
+        self.assertEqual(c - (c - d), d)
+        self.assertEqual((c + d) - d, c)
+        self.assertEqual((d + c) - d, c)
+        self.assertEqual((d - c) - d, -c)
         # subtraction with broadcasts
         self.assertEqual((c - broad2), pybamm.PrimaryBroadcast(c - 2, "domain"))
         self.assertEqual((broad2 - c), pybamm.PrimaryBroadcast(2 - c, "domain"))
@@ -457,30 +458,19 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual((broad2 - broad2), broad0)
 
         # addition and subtraction with matrix zero
-        self.assertIsInstance((b + v), pybamm.Array)
-        np.testing.assert_array_equal((b + v).evaluate(), np.ones((10, 1)))
-        self.assertIsInstance((v + b), pybamm.Array)
-        np.testing.assert_array_equal((v + b).evaluate(), np.ones((10, 1)))
-        self.assertIsInstance((b - v), pybamm.Array)
-        np.testing.assert_array_equal((b - v).evaluate(), np.ones((10, 1)))
-        self.assertIsInstance((v - b), pybamm.Array)
-        np.testing.assert_array_equal((v - b).evaluate(), -np.ones((10, 1)))
+        self.assertEqual(b + v, pybamm.Vector(np.ones((10, 1))))
+        self.assertEqual(v + b, pybamm.Vector(np.ones((10, 1))))
+        self.assertEqual(b - v, pybamm.Vector(np.ones((10, 1))))
+        self.assertEqual(v - b, pybamm.Vector(-np.ones((10, 1))))
 
         # multiplication
-        self.assertIsInstance((a * b), pybamm.Scalar)
-        self.assertEqual((a * b).evaluate(), 0)
-        self.assertIsInstance((b * a), pybamm.Scalar)
-        self.assertEqual((b * a).evaluate(), 0)
-        self.assertIsInstance((b * b), pybamm.Scalar)
-        self.assertEqual((b * b).evaluate(), 1)
-        self.assertIsInstance((a * a), pybamm.Scalar)
-        self.assertEqual((a * a).evaluate(), 0)
-        self.assertIsInstance((a * c), pybamm.Scalar)
-        self.assertEqual((a * c).evaluate(), 0)
-        self.assertIsInstance((c * a), pybamm.Scalar)
-        self.assertEqual((c * a).evaluate(), 0)
-        self.assertIsInstance((b * c), pybamm.Parameter)
-        self.assertIsInstance((2 * c), pybamm.Multiplication)
+        self.assertEqual(a * b, pybamm.Scalar(0))
+        self.assertEqual(b * a, pybamm.Scalar(0))
+        self.assertEqual(b * b, pybamm.Scalar(1))
+        self.assertEqual(a * a, pybamm.Scalar(0))
+        self.assertEqual(a * c, pybamm.Scalar(0))
+        self.assertEqual(c * a, pybamm.Scalar(0))
+        self.assertEqual(b * c, c)
         # multiplication with -1
         self.assertEqual((c * -1), (-c))
         self.assertEqual((-1 * c), (-c))
@@ -488,15 +478,16 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual((-c * -f), (c * f))
         self.assertEqual((-c * 4), (c * -4))
         self.assertEqual((4 * -c), (-4 * c))
+        # multiplication with division
+        self.assertEqual((c * (d / c)), d)
+        self.assertEqual((c / d) * d, c)
         # multiplication with broadcasts
         self.assertEqual((c * broad2), pybamm.PrimaryBroadcast(c * 2, "domain"))
         self.assertEqual((broad2 * c), pybamm.PrimaryBroadcast(2 * c, "domain"))
 
         # multiplication with matrix zero
-        self.assertIsInstance((b * v), pybamm.Array)
-        np.testing.assert_array_equal((b * v).evaluate(), np.zeros((10, 1)))
-        self.assertIsInstance((v * b), pybamm.Array)
-        np.testing.assert_array_equal((v * b).evaluate(), np.zeros((10, 1)))
+        self.assertEqual(b * v, pybamm.Vector(np.zeros((10, 1))))
+        self.assertEqual(v * b, pybamm.Vector(np.zeros((10, 1))))
         # multiplication with matrix one
         self.assertEqual((f * v1), f)
         self.assertEqual((v1 * f), f)
@@ -518,8 +509,11 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual((broad2 / broad2), broad1)
         # division with a negation
         self.assertEqual((-c / -f), (c / f))
-        self.assertEqual((-c / 4), (c / -4))
+        self.assertEqual((-c / 4), -0.25 * c)
         self.assertEqual((4 / -c), (-4 / c))
+        # division with multiplication
+        self.assertEqual((c * d) / c, d)
+        self.assertEqual((d * c) / c, d)
         # division with broadcasts
         self.assertEqual((c / broad2), pybamm.PrimaryBroadcast(c / 2, "domain"))
         self.assertEqual((broad2 / c), pybamm.PrimaryBroadcast(2 / c, "domain"))
@@ -606,16 +600,16 @@ class TestBinaryOperators(unittest.TestCase):
         expr = A @ (var * 5)
         self.assertEqual(expr, ((A * 5) @ var))
         # Do A/e first if it is constant
-        expr = A @ (var / 5)
-        self.assertEqual(expr, ((A / 5) @ var))
-        # Do (d*A) first if it is constant
+        expr = A @ (var / 2)
+        self.assertEqual(expr, ((A / 2) @ var))
+        # Do (vec*A) first if it is constant
         expr = vec * (A @ var)
         self.assertEqual(expr, ((vec * A) @ var))
         expr = (A @ var) * vec
         self.assertEqual(expr, ((vec * A) @ var))
-        # Do (A/d) first if it is constant
-        expr = (A @ var) / vec
-        self.assertEqual(expr, ((A / vec) @ var))
+        # Do (A/vec) first if it is constant
+        # expr = (A @ var) / vec
+        # self.assertEqual(expr, ((A / vec) @ var))
 
         # simplify additions and subtractions
         expr = 7 + (var + 5)
@@ -652,49 +646,40 @@ class TestBinaryOperators(unittest.TestCase):
         self.assertEqual(expr, (-2 - var))
 
         # simplify multiplications and divisions
-        expr = 7 * (var * 5)
-        self.assertEqual(expr, (35 * var))
-        expr = (var * 5) * 7
-        self.assertEqual(expr, (var * 35))
-        expr = 7 * (5 * var)
-        self.assertEqual(expr, (35 * var))
-        expr = (5 * var) * 7
-        self.assertEqual(expr, (35 * var))
-        expr = 7 * (var / 5)
-        self.assertEqual(expr, ((7 / 5) * var))
-        expr = (var / 5) * 7
-        self.assertEqual(expr, (var * (7 / 5)))
-        expr = (var * 5) / 7
-        self.assertEqual(expr, (var * (5 / 7)))
-        expr = (5 * var) / 7
-        self.assertEqual(expr, ((5 / 7) * var))
-        expr = 5 / (7 * var)
-        self.assertEqual(expr, ((5 / 7) / var))
-        expr = 5 / (var * 7)
-        self.assertEqual(expr, ((5 / 7) / var))
-        expr = (var / 5) / 7
-        self.assertEqual(expr, (var / 35))
-        expr = (5 / var) / 7
-        self.assertEqual(expr, ((5 / 7) / var))
-        expr = 5 / (7 / var)
-        self.assertEqual(expr, ((5 / 7) * var))
-        expr = 5 / (var / 7)
-        self.assertEqual(expr, (35 / var))
-
-        expr = (var * sym) / sym
-        self.assertEqual(expr, var)
-        expr = (sym * var) / sym
-        self.assertEqual(expr, var)
+        expr = 10 * (var * 5)
+        self.assertEqual(expr, 50 * var)
+        expr = (var * 5) * 10
+        self.assertEqual(expr, var * 50)
+        expr = 10 * (5 * var)
+        self.assertEqual(expr, 50 * var)
+        expr = (5 * var) * 10
+        self.assertEqual(expr, 50 * var)
+        expr = 10 * (var / 5)
+        self.assertEqual(expr, (10 / 5) * var)
+        expr = (var / 5) * 10
+        self.assertEqual(expr, var * (10 / 5))
+        expr = (var * 5) / 10
+        self.assertEqual(expr, var * (5 / 10))
+        expr = (5 * var) / 10
+        self.assertEqual(expr, (5 / 10) * var)
+        expr = 5 / (10 * var)
+        self.assertEqual(expr, (5 / 10) / var)
+        expr = 5 / (var * 10)
+        self.assertEqual(expr, (5 / 10) / var)
+        expr = (5 / var) / 10
+        self.assertEqual(expr, (5 / 10) / var)
+        expr = 5 / (10 / var)
+        self.assertEqual(expr, (5 / 10) * var)
+        expr = 5 / (var / 10)
+        self.assertEqual(expr, 50 / var)
 
         # use power rules on multiplications and divisions
         expr = (var * 5) ** 2
-        self.assertEqual(expr, (var**2 * 25))
+        self.assertEqual(expr, var**2 * 25)
         expr = (5 * var) ** 2
-        self.assertEqual(expr, (25 * var**2))
-        expr = (var / 5) ** 2
-        self.assertEqual(expr, (var**2 / 25))
+        self.assertEqual(expr, 25 * var**2)
         expr = (5 / var) ** 2
-        self.assertEqual(expr, (25 / var**2))
+        self.assertEqual(expr, 25 / var**2)
 
     def test_inner_simplifications(self):
         a1 = pybamm.Scalar(0)

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -119,10 +119,8 @@ class TestSymbol(unittest.TestCase):
         self.assertIsInstance(-a, pybamm.Negate)
         self.assertIsInstance(abs(a), pybamm.AbsoluteValue)
         # special cases
-        neg_a = -a
-        self.assertEqual(-neg_a, a)
-        abs_a = abs(a)
-        self.assertEqual(abs(abs_a), abs_a)
+        self.assertEqual(-(-a), a)
+        self.assertEqual(abs(abs(a)), abs(a))
 
         # binary - two symbols
         self.assertIsInstance(a + b, pybamm.Addition)
@@ -139,10 +137,10 @@ class TestSymbol(unittest.TestCase):
 
         # binary - symbol and number
         self.assertIsInstance(a + 2, pybamm.Addition)
-        self.assertIsInstance(a - 2, pybamm.Subtraction)
+        self.assertIsInstance(2 - a, pybamm.Subtraction)
         self.assertIsInstance(a * 2, pybamm.Multiplication)
         self.assertIsInstance(a @ 2, pybamm.MatrixMultiplication)
-        self.assertIsInstance(a / 2, pybamm.Division)
+        self.assertIsInstance(2 / a, pybamm.Division)
         self.assertIsInstance(a**2, pybamm.Power)
 
         # binary - number and symbol


### PR DESCRIPTION
# Description

More simplifications of the expression tree. Whenever there is a binary operator with a constant, the constant is moved to the left. This makes it easier to find constants.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
