### PR TITLE
Reduce pybamm.parameter_sets init time

### DIFF
--- a/pybamm/parameters/parameter_sets.py
+++ b/pybamm/parameters/parameter_sets.py
@@ -76,16 +76,14 @@ class ParameterSets(Mapping):
             # For backwards compatibility, parameter sets that used to be defined in
             # this file now return the name as a string, which will load the same
             # parameter set as before when passed to `ParameterValues`
-            if name in self.__all_parameter_sets:
-                out = name
-            else:
-                raise error
-            warnings.warn(
-                f"Parameter sets should be called directly by their name ({name}), "
-                f"instead of via pybamm.parameter_sets (pybamm.parameter_sets.{name}).",
-                DeprecationWarning,
-            )
-            return out
+            if name in self:
+                msg = (
+                    "Parameter sets should be called directly by their name ({0}), "
+                    "instead of via pybamm.parameter_sets (pybamm.parameter_sets.{0})."
+                ).format(name)
+                warnings.warn(msg, DeprecationWarning)
+                return name
+            raise error
 
 
 #: Singleton Instance of :class:ParameterSets """

--- a/tests/unit/test_parameters/test_parameter_sets_class.py
+++ b/tests/unit/test_parameters/test_parameter_sets_class.py
@@ -32,7 +32,7 @@ class TestParameterSets(unittest.TestCase):
     def test_get_docstring(self):
         """Test that :meth:`pybamm.parameter_sets.get_doctstring` works"""
         docstring = pybamm.parameter_sets.get_docstring("Marquis2019")
-        self.assertRegexpMatches(docstring, "Parameters for a Kokam SLPB78205130H cell")
+        self.assertRegex(docstring, "Parameters for a Kokam SLPB78205130H cell")
 
     def test_iter(self):
         """Test that iterating `pybamm.parameter_sets` iterates over keys"""


### PR DESCRIPTION
- fix: lazily load parameter set entry points
- refactor: Avoid calling dunder methods in parameter_sets

# Description

Lazily load parameter sets instead of doing it on creation, reduces `import pybamm` by ~0.5s

Fixes #2436

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
