### PR TITLE
Rename to entrypoint to `pybamm_parameter_sets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Breaking changes
 
+- Renamed entry point for parameter sets to `pybamm_parameter_sets` ([#2475](https://github.com/pybamm-team/PyBaMM/pull/2475))
 - Removed code for generating `ModelingToolkit` problems ([#2432](https://github.com/pybamm-team/PyBaMM/pull/2432))
 - Removed `FirstOrder` and `Composite` lead-acid models, and some submodels specific to those models ([#2431](https://github.com/pybamm-team/PyBaMM/pull/2431))
 
@@ -19,7 +20,7 @@
 
 ## Features
 
-- Third-party parameter sets can be added by registering entry points to `pybamm_parameter_set` ([#2396](https://github.com/pybamm-team/PyBaMM/pull/2396))
+- Third-party parameter sets can be added by registering entry points to ~~`pybamm_parameter_set`~~`pybamm_parameter_sets` ([#2396](https://github.com/pybamm-team/PyBaMM/pull/2396), changed in [#2475](https://github.com/pybamm-team/PyBaMM/pull/2475))
 - Added three-dimensional interpolation ([#2380](https://github.com/pybamm-team/PyBaMM/pull/2380))
 
 ## Bug fixes

--- a/docs/source/parameters/parameter_sets.rst
+++ b/docs/source/parameters/parameter_sets.rst
@@ -17,7 +17,7 @@ Adding Parameter Sets
 *********************
 
 Parameter sets can be added to PyBaMM by creating a python package, and
-registering a `entry point`_ to ``pybamm_parameter_set``. At a minimum, the
+registering a `entry point`_ to ``pybamm_parameter_sets``. At a minimum, the
 package (``cell_parameters``) should consist of the following::
 
     cell_parameters
@@ -46,32 +46,17 @@ For an example, see the `Marquis2019`_ parameter sets.
             ...
         }
 
-Then register ``get_parameter_values`` to ``pybamm_parameter_set`` in ``pyproject.toml``:
+Then register ``get_parameter_values`` to ``pybamm_parameter_sets`` in ``pyproject.toml``:
 
 .. code-block:: toml
 
-    [project.entry-points.pybamm_parameter_set]
+    [project.entry-points.pybamm_parameter_sets]
     cell_alpha = "cell_parameters.cell_alpha:get_parameter_values"
 
 If you are using ``setup.py`` or ``setup.cfg`` to setup your package, please
 see SetupTools' documentation for registering `entry points`_.
 
 .. _entry points: https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins
-
-Finally install you package (``python -m pip install .``), to complete the process.
-You will need to reinstall your package every time you add a new parameter set.
-If you're actively editing the parameter set it may be helpful to install in
-editing mode (``python -m pip install -e .``) instead.
-
-Once successfully registered, your parameter set will appear within the contents
-of ``pybamm.parameter_sets``, along with any other bundled or installed
-third-party parameter sets.
-
-.. doctest::
-
-        >>> import pybamm
-        >>> list(pybamm.parameter_sets)
-        ['Ai2020', 'Chen2020', ...]
 
 If you're willing to open-source your parameter set,
 `let us know`_, and we can add an entry to
@@ -85,7 +70,7 @@ If you're willing to open-source your parameter set,
 Third-Party Parameter Sets
 **************************
 
-Registered a new parameter set to ``pybamm_parameter_set``?
+Registered a new parameter set to ``pybamm_parameter_sets``?
 `Let us know`_, and we'll update our list.
 
 .. _bundled-parameter-sets:

--- a/docs/source/parameters/parameter_sets.rst
+++ b/docs/source/parameters/parameter_sets.rst
@@ -17,7 +17,7 @@ Adding Parameter Sets
 *********************
 
 Parameter sets can be added to PyBaMM by creating a python package, and
-registering a `entry point`_ to ``pybamm_parameter_sets``. At a minimum, the
+registering a `entry point`_ to ``pybamm_parameter_set``. At a minimum, the
 package (``cell_parameters``) should consist of the following::
 
     cell_parameters
@@ -46,17 +46,32 @@ For an example, see the `Marquis2019`_ parameter sets.
             ...
         }
 
-Then register ``get_parameter_values`` to ``pybamm_parameter_sets`` in ``pyproject.toml``:
+Then register ``get_parameter_values`` to ``pybamm_parameter_set`` in ``pyproject.toml``:
 
 .. code-block:: toml
 
-    [project.entry-points.pybamm_parameter_sets]
+    [project.entry-points.pybamm_parameter_set]
     cell_alpha = "cell_parameters.cell_alpha:get_parameter_values"
 
 If you are using ``setup.py`` or ``setup.cfg`` to setup your package, please
 see SetupTools' documentation for registering `entry points`_.
 
 .. _entry points: https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins
+
+Finally install you package (``python -m pip install .``), to complete the process.
+You will need to reinstall your package every time you add a new parameter set.
+If you're actively editing the parameter set it may be helpful to install in
+editing mode (``python -m pip install -e .``) instead.
+
+Once successfully registered, your parameter set will appear within the contents
+of ``pybamm.parameter_sets``, along with any other bundled or installed
+third-party parameter sets.
+
+.. doctest::
+
+        >>> import pybamm
+        >>> list(pybamm.parameter_sets)
+        ['Ai2020', 'Chen2020', ...]
 
 If you're willing to open-source your parameter set,
 `let us know`_, and we can add an entry to
@@ -70,7 +85,7 @@ If you're willing to open-source your parameter set,
 Third-Party Parameter Sets
 **************************
 
-Registered a new parameter set to ``pybamm_parameter_sets``?
+Registered a new parameter set to ``pybamm_parameter_set``?
 `Let us know`_, and we'll update our list.
 
 .. _bundled-parameter-sets:

--- a/pybamm/parameters/parameter_sets.py
+++ b/pybamm/parameters/parameter_sets.py
@@ -36,7 +36,7 @@ class ParameterSets(Mapping):
     def __init__(self):
         # Dict of entry points for parameter sets, lazily load entry points as
         self.__all_parameter_sets = dict()
-        for entry_point in pkg_resources.iter_entry_points("pybamm_parameter_set"):
+        for entry_point in pkg_resources.iter_entry_points("pybamm_parameter_sets"):
             self.__all_parameter_sets[entry_point.name] = entry_point
 
     def __new__(cls):
@@ -49,7 +49,7 @@ class ParameterSets(Mapping):
         return self.__load_entry_point__(key)()
 
     def __load_entry_point__(self, key) -> callable:
-        """Check that ``key`` is a registered ``pybamm_parameter_set``,
+        """Check that ``key`` is a registered ``pybamm_parameter_sets``,
         and return the entry point for the parameter set, loading it needed.
         """
         if key not in self.__all_parameter_sets:

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
             "pybamm_install_odes = pybamm.install_odes:main",
             "pybamm_install_jax = pybamm.util:install_jax",
         ],
-        "pybamm_parameter_set": [
+        "pybamm_parameter_sets": [
             "Sulzer2019 = pybamm.input.parameters.lead_acid.Sulzer2019:get_parameter_values",  # noqa: E501
             "Ai2020 = pybamm.input.parameters.lithium_ion.Ai2020:get_parameter_values",  # noqa: E501
             "Chen2020 = pybamm.input.parameters.lithium_ion.Chen2020:get_parameter_values",  # noqa: E501

--- a/tests/unit/test_parameters/test_parameter_sets_class.py
+++ b/tests/unit/test_parameters/test_parameter_sets_class.py
@@ -22,9 +22,9 @@ class TestParameterSets(unittest.TestCase):
 
     def test_all_registered(self):
         """Check that all parameter sets have been registered with the
-        ``pybamm_parameter_set`` entry point"""
+        ``pybamm_parameter_sets`` entry point"""
         known_entry_points = set(
-            ep.name for ep in pkg_resources.iter_entry_points("pybamm_parameter_set")
+            ep.name for ep in pkg_resources.iter_entry_points("pybamm_parameter_sets")
         )
         self.assertEqual(set(pybamm.parameter_sets.keys()), known_entry_points)
         self.assertEqual(len(known_entry_points), len(pybamm.parameter_sets))


### PR DESCRIPTION
Fixed a typo in docs on adding a new parameter set and added emphasis on installing/reinstalling the parameter set package.

Typo found via: https://github.com/pybamm-team/PyBaMM/discussions/2452