### PR TITLE
#403 add special case for constant function parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Optimizations
 
+- `ParameterValues` now avoids trying to process children if a function parameter is an object that doesn't depend on its children ([#2477](https://github.com/pybamm-team/PyBaMM/pull/2477))
 - Added more rules for simplifying expressions, especially around Concatenations. Also, meshes constructed from multiple domains are now cached ([#2443](https://github.com/pybamm-team/PyBaMM/pull/2443))
 - Added more rules for simplifying expressions. Constants in binary operators are now moved to the left by default (e.g. `x*2` returns `2*x`) ([#2424](https://github.com/pybamm-team/PyBaMM/pull/2424))
 

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -568,7 +568,7 @@ class ParameterValues:
                 # Check not NaN (parameter in csv file but no value given)
                 if np.isnan(value):
                     raise ValueError(f"Parameter '{symbol.name}' not found")
-                # Scalar inherits name (for updating parameters)
+                # Scalar inherits name
                 return pybamm.Scalar(value, name=symbol.name)
             elif isinstance(value, pybamm.Symbol):
                 new_value = self.process_symbol(value)
@@ -578,18 +578,29 @@ class ParameterValues:
                 raise TypeError("Cannot process parameter '{}'".format(value))
 
         elif isinstance(symbol, pybamm.FunctionParameter):
-            new_children = []
-            for child in symbol.children:
-                if symbol.diff_variable is not None and any(
-                    x == symbol.diff_variable for x in child.pre_order()
-                ):
-                    # Wrap with NotConstant to avoid simplification,
-                    # which would stop symbolic diff from working properly
-                    new_child = pybamm.NotConstant(child)
-                    new_children.append(self.process_symbol(new_child))
-                else:
-                    new_children.append(self.process_symbol(child))
             function_name = self[symbol.name]
+            if isinstance(
+                function_name,
+                (numbers.Number, pybamm.Interpolant, pybamm.InputParameter),
+            ) or (
+                isinstance(function_name, pybamm.Symbol)
+                and function_name.size_for_testing == 1
+            ):
+                # no need to process children, they will only be used for shape
+                new_children = symbol.children
+            else:
+                # process children
+                new_children = []
+                for child in symbol.children:
+                    if symbol.diff_variable is not None and any(
+                        x == symbol.diff_variable for x in child.pre_order()
+                    ):
+                        # Wrap with NotConstant to avoid simplification,
+                        # which would stop symbolic diff from working properly
+                        new_child = pybamm.NotConstant(child)
+                        new_children.append(self.process_symbol(new_child))
+                    else:
+                        new_children.append(self.process_symbol(child))
 
             # Create Function or Interpolant or Scalar object
             if isinstance(function_name, tuple):

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -343,7 +343,10 @@ class TestParameterValues(unittest.TestCase):
         self.assertEqual(processed_func.evaluate(inputs={"a": 3}), 369)
 
         # process constant function
-        const = pybamm.FunctionParameter("const", {"a": a})
+        # this should work even if the parameter in the function is not provided
+        const = pybamm.FunctionParameter(
+            "const", {"a": pybamm.Parameter("not provided")}
+        )
         processed_const = parameter_values.process_symbol(const)
         self.assertIsInstance(processed_const, pybamm.Scalar)
         self.assertEqual(processed_const.evaluate(), 254)


### PR DESCRIPTION
# Description

Avoids trying to process children if a function parameter is an object that doesn't depend on its children

Fixes #2704

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
