### PR TITLE
Fix build 22.11

### DIFF
--- a/CMakeBuild.py
+++ b/CMakeBuild.py
@@ -83,7 +83,7 @@ class CMakeBuild(build_ext):
         else:
             use_python_casadi = True
 
-        build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "")
+        build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "RELEASE")
         cmake_args = [
             "-DCMAKE_BUILD_TYPE={}".format(build_type),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),

--- a/CMakeBuild.py
+++ b/CMakeBuild.py
@@ -83,7 +83,7 @@ class CMakeBuild(build_ext):
         else:
             use_python_casadi = True
 
-        build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "Release")
+        build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "")
         cmake_args = [
             "-DCMAKE_BUILD_TYPE={}".format(build_type),
             "-DPYTHON_EXECUTABLE={}".format(sys.executable),

--- a/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
@@ -147,11 +147,11 @@ CasadiSolver::CasadiSolver(np_array atol_np, double rel_tol,
   //else if (options.linear_solver == "SUNLinSol_LapackDense")
   //{
   //  DEBUG("\tsetting SUNLinSol_LapackDense linear solver");
-#i//f SUNDIALS_VERSION_MAJOR >= 6
+  //#if SUNDIALS_VERSION_MAJOR >= 6
   //  LS = SUNLinSol_LapackDense(yy, J, sunctx);
-#e//lse
+  //#else
   //  LS = SUNLinSol_LapackDense(yy, J);
-#e//ndif
+  //#endif
   //}
   else if (options.linear_solver == "SUNLinSol_KLU")
   {

--- a/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
@@ -144,15 +144,6 @@ CasadiSolver::CasadiSolver(np_array atol_np, double rel_tol,
     LS = SUNLinSol_Dense(yy, J);
 #endif
   }
-  //else if (options.linear_solver == "SUNLinSol_LapackDense")
-  //{
-  //  DEBUG("\tsetting SUNLinSol_LapackDense linear solver");
-  //#if SUNDIALS_VERSION_MAJOR >= 6
-  //  LS = SUNLinSol_LapackDense(yy, J, sunctx);
-  //#else
-  //  LS = SUNLinSol_LapackDense(yy, J);
-  //#endif
-  //}
   else if (options.linear_solver == "SUNLinSol_KLU")
   {
     DEBUG("\tsetting SUNLinSol_KLU linear solver");

--- a/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
@@ -144,15 +144,15 @@ CasadiSolver::CasadiSolver(np_array atol_np, double rel_tol,
     LS = SUNLinSol_Dense(yy, J);
 #endif
   }
-  else if (options.linear_solver == "SUNLinSol_LapackDense")
-  {
-    DEBUG("\tsetting SUNLinSol_LapackDense linear solver");
-#if SUNDIALS_VERSION_MAJOR >= 6
-    LS = SUNLinSol_LapackDense(yy, J, sunctx);
-#else
-    LS = SUNLinSol_LapackDense(yy, J);
-#endif
-  }
+  //else if (options.linear_solver == "SUNLinSol_LapackDense")
+  //{
+  //  DEBUG("\tsetting SUNLinSol_LapackDense linear solver");
+#i//f SUNDIALS_VERSION_MAJOR >= 6
+  //  LS = SUNLinSol_LapackDense(yy, J, sunctx);
+#e//lse
+  //  LS = SUNLinSol_LapackDense(yy, J);
+#e//ndif
+  //}
   else if (options.linear_solver == "SUNLinSol_KLU")
   {
     DEBUG("\tsetting SUNLinSol_KLU linear solver");

--- a/pybamm/solvers/c_solvers/idaklu/common.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/common.hpp
@@ -16,7 +16,6 @@
 
 #include <sunlinsol/sunlinsol_klu.h> /* access to KLU linear solver          */
 #include <sunlinsol/sunlinsol_dense.h> /* access to dense linear solver          */
-#include <sunlinsol/sunlinsol_lapackdense.h> /* access to lapack linear solver          */
 #include <sunlinsol/sunlinsol_spbcgs.h> /* access to spbcgs iterative linear solver          */
 #include <sunlinsol/sunlinsol_spfgmr.h>
 #include <sunlinsol/sunlinsol_spgmr.h>

--- a/pybamm/solvers/c_solvers/idaklu/options.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/options.cpp
@@ -37,9 +37,6 @@ Options::Options(py::dict options)
   if (linear_solver == "SUNLinSol_Dense" && (jacobian == "dense" || jacobian == "none"))
   {
   }
-  else if (linear_solver == "SUNLinSol_LapackDense" && (jacobian == "dense" || jacobian == "none"))
-  {
-  }
   else if (linear_solver == "SUNLinSol_KLU" && jacobian == "sparse")
   {
   }

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -56,7 +56,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 "jacobian": "sparse",
 
                 # name of sundials linear solver to use options are: "SUNLinSol_KLU",
-                # "SUNLinSol_Dense", "SUNLinSol_LapackDense" "SUNLinSol_SPBCGS",
+                # "SUNLinSol_Dense", "SUNLinSol_SPBCGS",
                 # "SUNLinSol_SPFGMR", "SUNLinSol_SPGMR", "SUNLinSol_SPTFQMR",
                 "linear_solver": "SUNLinSol_KLU",
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -481,7 +481,6 @@ class TestIDAKLUSolver(unittest.TestCase):
             for linear_solver in [
                 "SUNLinSol_SPBCGS",
                 "SUNLinSol_Dense",
-                "SUNLinSol_LapackDense",
                 "SUNLinSol_KLU",
                 "SUNLinSol_SPFGMR",
                 "SUNLinSol_SPGMR",
@@ -499,24 +498,20 @@ class TestIDAKLUSolver(unittest.TestCase):
                         jacobian == "none"
                         and (
                             linear_solver == "SUNLinSol_Dense"
-                            or linear_solver == "SUNLinSol_LapackDense"
                         )
                         or jacobian == "dense"
                         and (
                             linear_solver == "SUNLinSol_Dense"
-                            or linear_solver == "SUNLinSol_LapackDense"
                         )
                         or jacobian == "sparse"
                         and (
                             linear_solver != "SUNLinSol_Dense"
-                            and linear_solver != "SUNLinSol_LapackDense"
                             and linear_solver != "garbage"
                         )
                         or jacobian == "matrix-free"
                         and (
                             linear_solver != "SUNLinSol_KLU"
                             and linear_solver != "SUNLinSol_Dense"
-                            and linear_solver != "SUNLinSol_LapackDense"
                             and linear_solver != "garbage"
                         )
                     ):

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -496,13 +496,9 @@ class TestIDAKLUSolver(unittest.TestCase):
                     solver = pybamm.IDAKLUSolver(options=options)
                     if (
                         jacobian == "none"
-                        and (
-                            linear_solver == "SUNLinSol_Dense"
-                        )
+                        and (linear_solver == "SUNLinSol_Dense")
                         or jacobian == "dense"
-                        and (
-                            linear_solver == "SUNLinSol_Dense"
-                        )
+                        and (linear_solver == "SUNLinSol_Dense")
                         or jacobian == "sparse"
                         and (
                             linear_solver != "SUNLinSol_Dense"


### PR DESCRIPTION
# Description

Fixes 22.11 build

## Type of change

lapack dense solver caused issues with building wheels (sundials not compiled with lapack), so this solver has been removed for this release

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ flake8`
- [x] All tests pass: `$ python run-tests.py --unit`
- [x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
