### PR TITLE
Temporarily pin tox < 4

### DIFF
--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install tox and asv
-        run: pip install -U pip tox asv
+        run: pip install -U pip "tox<4" asv
       - name: Run benchmarks
         run: |
           asv machine --machine "GitHubRunner"

--- a/.github/workflows/run_benchmarks_over_history.yml
+++ b/.github/workflows/run_benchmarks_over_history.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: 3.8
       - name: Install tox and asv
-        run: pip install -U pip tox asv
+        run: pip install -U pip "tox<4" asv
       - name: Fetch develop branch
         # Not required when worklow trigerred
         # on develop, but useful when

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check style
         run: |
-          python -m pip install tox
+          python -m pip install "tox<4"
           tox -e flake8
 
   build:
@@ -80,7 +80,7 @@ jobs:
       - name: Install standard python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          python -m pip install tox
+          python -m pip install "tox<4"
 
       - name: Install SuiteSparse and Sundials
         if: matrix.os == 'ubuntu-latest'

--- a/docs/install/install-from-source.rst
+++ b/docs/install/install-from-source.rst
@@ -50,7 +50,7 @@ You can install it with
 
 .. code:: bash
 
-	  python3.X -m pip install --user tox
+	  python3.X -m pip install --user "tox<4"
 
 Depending on your operating system, you may or may not have ``pip`` installed along python.
 If ``pip`` is not found, you probably want to install the ``python3-pip`` package.


### PR DESCRIPTION
# Description

#2537 might take some time, given that there are a lot of breaking changes _and_ not all of them are documented well. Additionally, they have enabled `isolated_builds` to be always true, which I think is the reason for the failing ubuntu tests - 

<img width="476" alt="image" src="https://user-images.githubusercontent.com/74055102/206749219-ca0eb7a0-0af6-42a6-bcdd-23ef3bee6adb.png">

The `macOS` and `windows` tests work with `v4` now, but the `ubuntu` tests don't.

This PR aims to temporarily fix the CI by upper-pinning `tox` (till the time `tox.ini` is migrated to `v4`).

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
