### PR TITLE
update BPX reaction rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Steps in `Experiment` can now be tagged and cycle numbers be searched based on those tags ([#2593](https://github.com/pybamm-team/PyBaMM/pull/2593)).
 
+## Bug fixes
+
+- Fixed a bug where a factor of 2 was missing when converting the reaction rate for Butler-Volmer from BPX to PyBaMM ([#2610](https://github.com/pybamm-team/PyBaMM/pull/2610))
+
 # [v22.12](https://github.com/pybamm-team/PyBaMM/tree/v22.12) - 2022-12-31
 
 ## Features

--- a/pybamm/parameters/bpx.py
+++ b/pybamm/parameters/bpx.py
@@ -194,7 +194,9 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
     E_a_n = pybamm_dict.get(
         negative_electrode.pre_name + "reaction rate activation energy [J.mol-1]", 0.0
     )
-    k_n = k_n_norm * F / (c_n_max * c_e**0.5)
+    # Note that in BPX j = F*k_norm*sqrt((ce/ce0)*(c/c_max)*(1-c/c_max))*sinh(...),
+    # and in PyBaMM j = 2*k*sqrt(ce*c*(c_max - c))*sinh(...)
+    k_n = k_n_norm * F / (2 * c_n_max * c_e**0.5)
 
     def _negative_electrode_exchange_current_density(c_e, c_s_surf, c_s_max, T):
         k_ref = k_n  # (A/m2)(m3/mol)**1.5 - includes ref concentrations
@@ -222,7 +224,9 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
     E_a_p = pybamm_dict.get(
         positive_electrode.pre_name + "reaction rate activation energy [J.mol-1]", 0.0
     )
-    k_p = k_p_norm * F / (c_p_max * c_e**0.5)
+    # Note that in BPX j = F*k_norm*sqrt((ce/ce0)*(c/c_max)*(1-c/c_max))*sinh(...),
+    # and in PyBaMM j = 2*k*sqrt(ce*c*(c_max - c))*sinh(...)
+    k_p = k_p_norm * F / (2 * c_p_max * c_e**0.5)
 
     def _positive_electrode_exchange_current_density(c_e, c_s_surf, c_s_max, T):
         k_ref = k_p  # (A/m2)(m3/mol)**1.5 - includes ref concentrations


### PR DESCRIPTION
# Description
Fixes a bug where a factor of 2 was missing when convertign the reaction rate for Butler-Volmer from BPX to PyBaMM.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
