### PR TITLE
Support for Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Steps in `Experiment` can now be tagged and cycle numbers be searched based on those tags ([#2593](https://github.com/pybamm-team/PyBaMM/pull/2593)).
+- Python 3.10 now supported ([#2615](https://github.com/pybamm-team/PyBaMM/pull/2615)).
 
 # [v22.12](https://github.com/pybamm-team/PyBaMM/tree/v22.12) - 2022-12-31
 

--- a/pybamm/parameters/parameter_sets.py
+++ b/pybamm/parameters/parameter_sets.py
@@ -1,5 +1,11 @@
+import sys
 import warnings
-import importlib_metadata
+
+if sys.version_info.minor <= 9:
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
 import textwrap
 from collections.abc import Mapping
 

--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ setup(
     },
     package_data={"pybamm": pybamm_data},
     # Python version
-    python_requires=">=3.8,<3.10",
+    python_requires=">=3.8,<3.11",
     # List of dependencies
     install_requires=[
         "numpy>=1.16",


### PR DESCRIPTION
# Description

Now it works under Python 3.10



# Key checklist:

- [ x] No style issues: `$ flake8`
- [ x] All tests pass: `$ python run-tests.py --unit`
- [ x] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:
N/A

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
