### PR TITLE
Flake8 to ruff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ Please add a line in the relevant section of [CHANGELOG.md](https://github.com/p
 
 # Key checklist:
 
-- [ ] No style issues: `$ flake8`
+- [ ] No style issues: `$ pre-commit run`
 - [ ] All tests pass: `$ python run-tests.py --unit`
 - [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`
 

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check style
         run: |
           python -m pip install "tox<4"
-          tox -e flake8
+          tox -e ruff
 
   build:
     needs: style

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Check style
         run: |
-          python -m pip install "tox<4"
-          tox -e ruff
+          python -m pip install ruff
+          ruff .
 
   build:
     needs: style

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Check style
         run: |
-          python -m pip install ruff
-          ruff .
+          python -m pip install pre-commit
+          pre-commit run ruff
 
   build:
     needs: style

--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,6 @@ dist/
 coverage.xml
 htmlcov/
 
-# black setup file seems to make Travis CI fail
-pyproject.toml
-
 # virtual enviroment
 env/
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,4 @@ repos:
     rev: "v0.0.236"
     hooks:
       - id: ruff
+        args: [--ignore=E741, --exclude=__init__.py]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.236"
     hooks:
-      - id: flake8
+      - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ python -m pip install pre-commit
 pre-commit run ruff
 ```
 
-ruff is configured inside the file `pre-comit.yaml`, allowing us to ignore some errors. If you think this should be added or removed, please submit an [issue](#issues)
+ruff is configured inside the file `pre-commit-config.yaml`, allowing us to ignore some errors. If you think this should be added or removed, please submit an [issue](#issues)
 
 When you commit your changes they will be checked against ruff automatically (see [infrastructure](#infrastructure)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,17 +63,18 @@ Finally, if you really, really, _really_ love developing PyBaMM, have a look at 
 
 PyBaMM follows the [PEP8 recommendations](https://www.python.org/dev/peps/pep-0008/) for coding style. These are very common guidelines, and community tools have been developed to check how well projects implement them. We recommend using pre-commit hooks to check your code before committing it. See [installing and using pre-commit](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) section for more details.
 
-### Flake8
+### Ruff
 
-We use [flake8](http://flake8.pycqa.org/en/latest/) to check our PEP8 adherence. To try this on your system, navigate to the PyBaMM directory in a console and type
+We use [ruff](https://github.com/charliermarsh/ruff) to check our PEP8 adherence. To try this on your system, navigate to the PyBaMM directory in a console and type
 
 ```bash
-flake8
+python -m pip install pre-commit
+pre-commit run ruff
 ```
 
-Flake8 is configured inside the file `tox.ini`, under the section `[flake8]`, allowing us to ignore some errors. If you think this should be added or removed, please submit an [issue](#issues)
+ruff is configured inside the file `pre-comit.yaml`, allowing us to ignore some errors. If you think this should be added or removed, please submit an [issue](#issues)
 
-When you commit your changes they will be checked against flake8 automatically (see [infrastructure](#infrastructure)).
+When you commit your changes they will be checked against ruff automatically (see [infrastructure](#infrastructure)).
 
 ### Black
 
@@ -89,7 +90,7 @@ black {source_file_or_directory}
 
 If you want to use black in your editor, you may need to change the max line length in your editor settings.
 
-Even when code has been formatted by black, you should still make sure that it adheres to the PEP8 standard set by [Flake8](#flake8).
+Even when code has been formatted by black, you should still make sure that it adheres to the PEP8 standard set by [ruff](#ruff).
 
 ### Naming
 
@@ -111,7 +112,7 @@ On the other hand... We _do_ want to compare several tools, to generate document
 1. Core PyBaMM: A minimal set, including things like NumPy, SciPy, etc. All infrastructure should run against this set of dependencies, as well as any numerical methods we implement ourselves.
 2. Extras: Other inference packages and their dependencies. Methods we don't want to implement ourselves, but do want to provide an interface to can have their dependencies added here.
 3. Documentation generating code: Everything you need to generate and work on the docs.
-4. Development code: Everything you need to do PyBaMM development (so all of the above packages, plus flake8 and other testing tools).
+4. Development code: Everything you need to do PyBaMM development (so all of the above packages, plus ruff and other testing tools).
 
 Only 'core pybamm' is installed by default. The others have to be specified explicitly when running the installation command.
 

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -51,7 +51,6 @@ from .util import (
     is_jax_compatible,
     get_git_commit_info,
 )
-from .logger import logger, set_logging_level
 from .logger import logger, set_logging_level, get_new_logger
 from .settings import settings
 from .citations import Citations, citations, print_citations

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -1087,9 +1087,9 @@ class Discretisation(object):
         if not isinstance(var, pybamm.Variable):
             return False
 
-        this_var_is_independent = not (var.name in all_vars_in_eqns)
-        not_in_y_slices = not (var in list(self.y_slices.keys()))
-        not_in_discretised = not (var in list(self._discretised_symbols.keys()))
+        this_var_is_independent = var.name not in all_vars_in_eqns
+        not_in_y_slices = var not in list(self.y_slices.keys())
+        not_in_discretised = var not in list(self._discretised_symbols.keys())
         is_0D = len(var.domain) == 0
         this_var_is_independent = (
             this_var_is_independent and not_in_y_slices and not_in_discretised and is_0D

--- a/pybamm/input/parameters/lead_acid/Sulzer2019.py
+++ b/pybamm/input/parameters/lead_acid/Sulzer2019.py
@@ -311,18 +311,10 @@ def get_parameter_values():
         "Positive electrode electrons in reaction": 2.0,
         "Positive electrode exchange-current density [A.m-2]"
         "": lead_dioxide_exchange_current_density_Sulzer2019,
-        "Signed stoichiometry of cations (oxygen reaction)": 4.0,
-        "Signed stoichiometry of oxygen (oxygen reaction)": 1.0,
-        "Electrons in oxygen reaction": 4.0,
         "Positive electrode oxygen exchange-current density [A.m-2]"
         "": oxygen_exchange_current_density_Sulzer2019,
-        "Reference oxygen molecule concentration [mol.m-3]": 1000.0,
-        "Oxygen reference OCP vs SHE [V]": 1.229,
-        "Signed stoichiometry of cations (hydrogen reaction)": 2.0,
-        "Electrons in hydrogen reaction": 2.0,
         "Positive electrode reference exchange-current density (hydrogen) [A.m-2]"
         "": 0.0,
-        "Hydrogen reference OCP vs SHE [V]": 0.0,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode density [kg.m-3]": 9375.0,
         "Positive electrode specific heat capacity [J.kg-1.K-1]": 256.0,

--- a/pybamm/input/parameters/lithium_ion/Ai2020.py
+++ b/pybamm/input/parameters/lithium_ion/Ai2020.py
@@ -83,8 +83,9 @@ def graphite_entropy_Enertech_Ai2020_function(sto, c_s_max):
     References
     ----------
     .. [1] Ai, W., Kraft, L., Sturm, J., Jossen, A., & Wu, B. (2020).
-    Electrochemical Thermal-Mechanical Modelling of Stress Inhomogeneity in Lithium-Ion Pouch Cells. # noqa
-    Journal of The Electrochemical Society, 167(1), 013512. DOI: 10.1149/2.0122001JES # noqa
+    Electrochemical Thermal-Mechanical Modelling of Stress Inhomogeneity in
+    Lithium-Ion Pouch Cells.
+    Journal of The Electrochemical Society, 167(1), 013512. DOI: 10.1149/2.0122001JES
 
     Parameters
     ----------

--- a/pybamm/input/parameters/lithium_ion/testing_only/negative_electrodes/graphite_Ai2020/graphite_entropy_Enertech_Ai2020_function.py
+++ b/pybamm/input/parameters/lithium_ion/testing_only/negative_electrodes/graphite_Ai2020/graphite_entropy_Enertech_Ai2020_function.py
@@ -8,8 +8,9 @@ def graphite_entropy_Enertech_Ai2020_function(sto, c_s_max):
     References
     ----------
     .. [1] Ai, W., Kraft, L., Sturm, J., Jossen, A., & Wu, B. (2020).
-    Electrochemical Thermal-Mechanical Modelling of Stress Inhomogeneity in Lithium-Ion Pouch Cells. # noqa
-    Journal of The Electrochemical Society, 167(1), 013512. DOI: 10.1149/2.0122001JES # noqa
+    Electrochemical Thermal-Mechanical Modelling of Stress Inhomogeneity in
+    Lithium-Ion Pouch Cells.
+    Journal of The Electrochemical Society, 167(1), 013512. DOI: 10.1149/2.0122001JES
 
     Parameters
     ----------

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -493,7 +493,7 @@ class CasadiSolver(pybamm.BaseSolver):
         pybamm.logger.debug("Creating CasADi integrator")
 
         # Use grid if t_eval is given
-        use_grid = not (t_eval is None)
+        use_grid = t_eval is not None
         if use_grid is True:
             t_eval_shifted = t_eval - t_eval[0]
             t_eval_shifted_rounded = np.round(t_eval_shifted, decimals=12).tobytes()

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -244,7 +244,7 @@ def load_function(filename, funcname=None):
         root_path = filename.replace(os.getcwd(), "")
     # If the function is not in the current working directory and the path provided is
     # absolute
-    elif os.path.isabs(filename) and not os.getcwd() in filename:  # pragma: no cover
+    elif os.path.isabs(filename) and os.getcwd() not in filename:  # pragma: no cover
         # Change directory to import the function
         dir_path = os.path.split(filename)[0]
         os.chdir(dir_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,0 @@
-[tool.ruff]
-ignore = ["E741"]
-
-[tool.ruff.per-file-ignores]
-"__init__.py" = ["F401", "E402", "F403", "E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+ignore = ["E741"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401", "E402", "F403", "E501"]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = {windows}-{tests,unit,dev},tests,unit,dev
 
 [testenv]
 skipsdist = true
-skip_install = ruff: true
 usedevelop = true
 passenv = !windows-!mac: SUNDIALS_INST
 whitelist_externals = !windows-!mac: sh
@@ -13,7 +12,6 @@ setenv =
 deps =
      dev-!windows-!mac: cmake
      dev: black
-     dev: ruff
      dev,doctests: sphinx>=1.5
      dev,doctests: guzzle-sphinx-theme
      !windows-!mac: scikits.odes
@@ -39,11 +37,6 @@ commands =
          python {toxinidir}/scripts/install_KLU_Sundials.py
       - git clone https://github.com/pybind/pybind11.git {toxinidir}/pybind11
 
-[testenv:ruff]
-skip_install = true
-deps = ruff
-commands = python -m ruff .
-
 [testenv:coverage]
 deps =
      coverage
@@ -68,29 +61,6 @@ deps =
      sphinx-autobuild
 changedir = docs
 commands = sphinx-autobuild --open-browser -qT . {envtmpdir}/html
-
-[ruff]
-max-line-length = 88
-exclude=
-    .git,
-    problems,
-    __init__.py,
-    venv,
-    bin,
-    etc,
-    lib,
-    lib64,
-    share,
-    pyvenv.cfg,
-    third-party,
-    sundials-5.0.0,
-    KLU_module_deps,
-    pybind11,
-    install_KLU_Sundials,
-ignore=
-    # Ambiguous variable names
-    # It's absolutely fine to have i and I
-    E741,
 
 [coverage:run]
 source = pybamm

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = {windows}-{tests,unit,dev},tests,unit,dev
 
 [testenv]
 skipsdist = true
-skip_install = flake8: true
+skip_install = ruff: true
 usedevelop = true
 passenv = !windows-!mac: SUNDIALS_INST
 whitelist_externals = !windows-!mac: sh
@@ -13,7 +13,7 @@ setenv =
 deps =
      dev-!windows-!mac: cmake
      dev: black
-     dev: flake8
+     dev: ruff
      dev,doctests: sphinx>=1.5
      dev,doctests: guzzle-sphinx-theme
      !windows-!mac: scikits.odes
@@ -39,10 +39,10 @@ commands =
          python {toxinidir}/scripts/install_KLU_Sundials.py
       - git clone https://github.com/pybind/pybind11.git {toxinidir}/pybind11
 
-[testenv:flake8]
+[testenv:ruff]
 skip_install = true
-deps = flake8>=3
-commands = python -m flake8
+deps = ruff
+commands = python -m ruff
 
 [testenv:coverage]
 deps =
@@ -69,7 +69,7 @@ deps =
 changedir = docs
 commands = sphinx-autobuild --open-browser -qT . {envtmpdir}/html
 
-[flake8]
+[ruff]
 max-line-length = 88
 exclude=
     .git,
@@ -88,37 +88,9 @@ exclude=
     pybind11,
     install_KLU_Sundials,
 ignore=
-    # False positive for white space before ':' on list slice
-    # black should format these correctly
-    E203,
-
-    # Block comment should start with '# '
-    # Not if it's a commented out line
-    E265,
-
     # Ambiguous variable names
     # It's absolutely fine to have i and I
     E741,
-
-    # List comprehension redefines variable
-    # Re-using throw-away variables like `i`, `x`, etc. is a Good Idea
-    F812,
-
-    # Blank line at end of file
-    # This increases readability
-    W391,
-
-    # Line break before binary operator
-    # This is now actually advised in pep8
-    W503,
-
-    # Line break after binary operator
-    W504,
-
-    # Invalid escape sequence
-    # These happen all the time in latex parts of docstrings,
-    # e.g. \sigma
-    W605,
 
 [coverage:run]
 source = pybamm

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
 [testenv:ruff]
 skip_install = true
 deps = ruff
-commands = python -m ruff
+commands = python -m ruff .
 
 [testenv:coverage]
 deps =


### PR DESCRIPTION
# Description

Tried `ruff` locally, and it really is super fast!

I also tried migrating some of the metadata to `pyproject.toml`, but I ended up with a lot of errors (given that `pyproject.toml` support is still very new and maybe in the beta phase in `setuptools`.)

Some false alarm examples that are being ignored using `pyproject.toml` -
```
pybamm/parameters/__init__.py:5:5: F401 `.process_parameter_data.process_3D_data_csv` imported but unused

pybamm/solvers/jax_bdf_solver.py:293:9: E741 Ambiguous variable name: `I`

tests/__init__.py:15:101: E501 Line too long (106 > 100 characters)  # not a false alarm, but the import names can get lengthy sometimes in the __init__ files

pybamm/__init__.py:61:1: F403 `from .expression_tree.symbol import *` used; unable to detect undefined names

pybamm/__init__.py:235:1: E402 Module level import not at top of file
```

Fixes #2623 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ flake8`
- [ ] All tests pass: `$ python run-tests.py --unit`
- [ ] The documentation builds: `$ cd docs` and then `$ make clean; make html`

You can run all three at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
