### PR TITLE
Running integration tests locally #2674

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -387,8 +387,8 @@ if __name__ == "__main__":
     interpreter = args.interpreter
     # Unit tests
     if args.integration:
-        has_run= True
-        folder=args.folder[1]
+        has_run = True
+        folder = args.folder[1]
         run_code_tests(True, folder, interpreter)
     if args.unit:
         has_run = True

--- a/run-tests.py
+++ b/run-tests.py
@@ -315,7 +315,13 @@ if __name__ == "__main__":
         description="Run unit tests for PyBaMM.",
         epilog="To run individual unit tests, use e.g. '$ tests/unit/test_timer.py'",
     )
+
     # Unit tests
+    parser.add_argument(
+        "--integration",
+        action="store_true",
+        help="Which folder to run the tests from.",
+    )
     parser.add_argument(
         "--unit",
         action="store_true",
@@ -380,6 +386,10 @@ if __name__ == "__main__":
     folder = args.folder[0]
     interpreter = args.interpreter
     # Unit tests
+    if args.integration:
+        has_run= True
+        folder=args.folder[1]
+        run_code_tests(True, folder, interpreter)
     if args.unit:
         has_run = True
         run_code_tests(True, folder, interpreter)

--- a/run-tests.py
+++ b/run-tests.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--integration",
         action="store_true",
-        help="Which folder to run the tests from.",
+        help="Run integration tests using the python interpreter.",
     )
     parser.add_argument(
         "--unit",


### PR DESCRIPTION
I have modified **python run-tests.py --integration**  instead of using **python run-tests.py --unit --folder integration**

Fixes #2674

Added the integration instead of using unit and folder.

