### PR TITLE
Issue #2333 Adding Single-Layer SEI

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -122,6 +122,11 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                     "solvent-diffusion limited", "electron-migration limited", \
                     "interstitial-diffusion limited", "ec reaction limited" \
                     or "ec reaction limited (asymmetric)": :class:`pybamm.sei.SEIGrowth`
+            * "number of SEI layers": int
+                Number of SEI layers to include in the model. Can be:
+                - "1"(default) : Single outer SEI layer
+                - "2" : Two SEI layers, inner and outer
+                    
             * "SEI film resistance" : str
                 Set the submodel for additional term in the overpotential due to SEI.
                 The default value is "none" if the "SEI" option is "none", and

--- a/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -288,31 +288,65 @@ class BaseModel(pybamm.BaseBatteryModel):
 
         phases = self.options.phases["negative"]
         for phase in phases:
-            if self.options["SEI"] == "none":
-                submodel = pybamm.sei.NoSEI(self.param, self.options, phase)
-            elif self.options["SEI"] == "constant":
-                submodel = pybamm.sei.ConstantSEI(self.param, self.options, phase)
-            else:
-                submodel = pybamm.sei.SEIGrowth(
-                    self.param, reaction_loc, self.options, phase, cracks=False
-                )
-            self.submodels[f"{phase} sei"] = submodel
-            # Do not set "sei on cracks" submodel for half-cells
-            # For full cells, "sei on cracks" submodel must be set, even if it is zero
-            if reaction_loc != "interface":
-                if (
-                    self.options["SEI"] in ["none", "constant"]
-                    or self.options["SEI on cracks"] == "false"
-                ):
+            if self.options["number of SEI layers"] == 2:
+                if self.options["SEI"] == "none":
                     submodel = pybamm.sei.NoSEI(
-                        self.param, self.options, phase, cracks=True
+                        self.param, self.options["number of SEI layers"], phase
                     )
+                elif self.options["SEI"] == "constant":
+                    submodel = pybamm.sei.ConstantSEI(self.param, self.options, phase)
                 else:
                     submodel = pybamm.sei.SEIGrowth(
-                        self.param, reaction_loc, self.options, phase, cracks=True
+                        self.param, reaction_loc, self.options, phase, cracks=False
                     )
-                self.submodels[f"{phase} sei on cracks"] = submodel
+                self.submodels[f"{phase} sei"] = submodel
+                # Do not set "sei on cracks" submodel for half-cells
+                # For full cells, "sei on cracks"
+                # submodel must be set, even if it is zero
+                if reaction_loc != "interface":
+                    if (
+                        self.options["SEI"] in ["none", "constant"]
+                        or self.options["SEI on cracks"] == "false"
+                    ):
+                        submodel = pybamm.sei.NoSEI(
+                            self.param, self.options, phase, cracks=True
+                        )
+                    else:
+                        submodel = pybamm.sei.SEIGrowth(
+                            self.param, reaction_loc, self.options, phase, cracks=True
+                        )
+                    self.submodels[f"{phase} sei on cracks"] = submodel
 
+                else:
+                    if self.options["SEI"] == "none":
+                        submodel = pybamm.sei.NoSEI(
+                            self.param, self.options["number of SEI layers"], phase
+                        )
+                    elif self.options["SEI"] == "constant":
+                        submodel = pybamm.sei.ConstantSEI(
+                            self.param, self.options, phase
+                        )
+                    else:
+                        submodel = pybamm.sei.SEIGrowth(
+                            self.param, reaction_loc, self.options, phase, cracks=False
+                        )
+                self.submodels[f"{phase} sei"] = submodel
+                # Do not set "sei on cracks" submodel for half-cells
+                # For full cells, "sei on cracks" submodel must be set,
+                # even if it is zero
+                if reaction_loc != "interface":
+                    if (
+                        self.options["SEI"] in ["none", "constant"]
+                        or self.options["SEI on cracks"] == "false"
+                    ):
+                        submodel = pybamm.sei.NoSEI(
+                            self.param, self.options, phase, cracks=True
+                        )
+                    else:
+                        submodel = pybamm.sei.SEIGrowth(
+                            self.param, reaction_loc, self.options, phase, cracks=True
+                        )
+                    self.submodels[f"{phase} sei on cracks"] = submodel
         if len(phases) > 1:
             self.submodels["total sei"] = pybamm.sei.TotalSEI(self.param, self.options)
             self.submodels["total sei on cracks"] = pybamm.sei.TotalSEI(

--- a/pybamm/models/submodels/interface/sei/base_sei.py
+++ b/pybamm/models/submodels/interface/sei/base_sei.py
@@ -90,38 +90,71 @@ class BaseModel(BaseInterface):
         variables : dict
             The variables which can be derived from the SEI thicknesses.
         """
-        # Set length scale to one for the "no SEI" model so that it is not
-        # required by parameter values in general
-        if isinstance(self, pybamm.sei.NoSEI):
-            L_scale = 1
+        if self.options["number of SEI layers"] == 2:
+            # Set length scale to one for the "no SEI" model so that it is not
+            # required by parameter values in general
+            if isinstance(self, pybamm.sei.NoSEI):
+                L_scale = 1
+            else:
+                L_scale = self.phase_param.L_sei_0_dim
+
+            variables = {
+                f"Inner {self.reaction_name}thickness": L_inner,
+                f"Inner {self.reaction_name}thickness [m]": L_inner * L_scale,
+                f"Outer {self.reaction_name}thickness": L_outer,
+                f"Outer {self.reaction_name}thickness [m]": L_outer * L_scale,
+            }
+
+            if self.reaction_loc != "interface":
+                L_inner_av = pybamm.x_average(L_inner)
+                L_outer_av = pybamm.x_average(L_outer)
+                variables.update(
+                    {
+                        f"X-averaged inner {self.reaction_name}thickness": L_inner_av,
+                        f"X-averaged inner {self.reaction_name}thickness [m]": {
+                            L_inner_av * L_scale
+                        },
+                        f"X-averaged outer {self.reaction_name}thickness": L_outer_av,
+                        f"X-averaged outer {self.reaction_name}thickness [m]": {
+                            L_outer_av * L_scale
+                        },
+                    }
+                )
+            # Get variables related to the total thickness
+            L_sei = L_inner + L_outer
+            variables.update(self._get_standard_total_thickness_variables(L_sei))
+
+            return variables
+
+        # Single layer SEI
         else:
-            L_scale = self.phase_param.L_sei_0_dim
+            # Set length scale to one for the "no SEI" model so that it is not
+            # required by parameter values in general
+            if isinstance(self, pybamm.sei.NoSEI):
+                L_scale = 1
+            else:
+                L_scale = self.phase_param.L_sei_0_dim
 
-        variables = {
-            f"Inner {self.reaction_name}thickness": L_inner,
-            f"Inner {self.reaction_name}thickness [m]": L_inner * L_scale,
-            f"Outer {self.reaction_name}thickness": L_outer,
-            f"Outer {self.reaction_name}thickness [m]": L_outer * L_scale,
-        }
+            variables = {
+                f"SEI {self.reaction_name}thickness": L_sei,
+                f"SEI {self.reaction_name}thickness [m]": L_sei * L_scale,
+            }
 
-        if self.reaction_loc != "interface":
-            L_inner_av = pybamm.x_average(L_inner)
-            L_outer_av = pybamm.x_average(L_outer)
-            variables.update(
-                {
-                    f"X-averaged inner {self.reaction_name}thickness": L_inner_av,
-                    f"X-averaged inner {self.reaction_name}thickness [m]": L_inner_av
-                    * L_scale,
-                    f"X-averaged outer {self.reaction_name}thickness": L_outer_av,
-                    f"X-averaged outer {self.reaction_name}thickness [m]": L_outer_av
-                    * L_scale,
-                }
-            )
-        # Get variables related to the total thickness
-        L_sei = L_inner + L_outer
-        variables.update(self._get_standard_total_thickness_variables(L_sei))
+            if self.reaction_loc != "interface":
+                L_outer_av = pybamm.x_average(L_outer)
+                variables.update(
+                    {
+                        f"X-averaged outer {self.reaction_name}thickness": L_outer_av,
+                        f"X-averaged outer {self.reaction_name}thickness [m]": {
+                            L_outer_av * L_scale
+                        },
+                    }
+                )
+            # Get variables related to the total thickness
+            L_sei = L_outer
+            variables.update(self._get_standard_total_thickness_variables(L_sei))
 
-        return variables
+            return variables
 
     def _get_standard_total_thickness_variables(self, L_sei):
         """Update variables related to total SEI thickness."""
@@ -214,50 +247,104 @@ class BaseModel(BaseInterface):
                 L_outer_crack_0 = phase_param.L_outer_crack_0
 
         if self.reaction == "SEI":
-            L_inner = variables[f"Inner {reaction_name}thickness"]
-            L_outer = variables[f"Outer {reaction_name}thickness"]
+            if self.options["number of SEI layers"] == 2:
+                L_inner = variables[f"Inner {reaction_name}thickness"]
+                L_outer = variables[f"Outer {reaction_name}thickness"]
 
-            n_inner = L_inner  # inner SEI concentration
-            n_outer = L_outer  # outer SEI concentration
+                n_inner = L_inner  # inner SEI concentration
+                n_outer = L_outer  # outer SEI concentration
 
-            n_inner_av = pybamm.x_average(n_inner)
-            n_outer_av = pybamm.x_average(n_outer)
+                n_inner_av = pybamm.x_average(n_inner)
+                n_outer_av = pybamm.x_average(n_outer)
 
-            n_SEI = n_inner + n_outer / v_bar  # SEI concentration
-            n_SEI_xav = pybamm.x_average(n_SEI)
-            n_SEI_av = pybamm.yz_average(n_SEI_xav)
+                n_sei = n_inner + n_outer / v_bar  # SEI concentration
+                n_sei_xav = pybamm.x_average(n_sei)
+                n_sei_av = pybamm.yz_average(n_sei_xav)
 
-            # Calculate change in SEI concentration with respect to initial state
-            delta_n_SEI = n_SEI_av - (L_inner_0 + L_outer_0 / v_bar)
+                # Calculate change in SEI concentration with respect to initial state
+                delta_n_sei = n_sei_av - (L_inner_0 + L_outer_0 / v_bar)
 
-            # Q_sei in mol
-            if self.reaction_loc == "interface":
-                L_n = 1
+                # Q_sei in mol
+                if self.reaction_loc == "interface":
+                    L_n = 1
+                else:
+                    L_n = self.param.n.L
+
+                Q_sei = (
+                    z_sei
+                    * delta_n_sei
+                    * n_scale
+                    * L_n
+                    * self.param.L_y
+                    * self.param.L_z
+                )
+
+                variables.update(
+                    {
+                        f"Inner {reaction_name}concentration [mol.m-3]": n_inner
+                        * n_scale,
+                        f"X-averaged inner {reaction_name}"
+                        "concentration [mol.m-3]": n_inner_av * n_scale,
+                        f"Outer {reaction_name}"
+                        "concentration [mol.m-3]": n_outer * n_outer_scale,
+                        f"X-averaged outer {reaction_name}"
+                        "concentration [mol.m-3]": n_outer_av * n_outer_scale,
+                        f"{reaction_name}concentration [mol.m-3]": n_sei * n_scale,
+                        f"X-averaged {reaction_name}"
+                        "concentration [mol.m-3]": n_sei_xav * n_scale,
+                        f"Loss of lithium to {reaction_name}[mol]": Q_sei,
+                        f"Loss of capacity to {reaction_name}[A.h]": Q_sei
+                        * self.param.F
+                        / 3600,
+                    }
+                )
+            # Single layer SEI
             else:
-                L_n = self.param.n.L
+                L_sei = variables[f"SEI {reaction_name}thickness"]
 
-            Q_sei = (
-                z_sei * delta_n_SEI * n_scale * L_n * self.param.L_y * self.param.L_z
-            )
+                n_sei = L_sei  # inner SEI concentration
 
-            variables.update(
-                {
-                    f"Inner {reaction_name}concentration [mol.m-3]": n_inner * n_scale,
-                    f"X-averaged inner {reaction_name}"
-                    "concentration [mol.m-3]": n_inner_av * n_scale,
-                    f"Outer {reaction_name}"
-                    "concentration [mol.m-3]": n_outer * n_outer_scale,
-                    f"X-averaged outer {reaction_name}"
-                    "concentration [mol.m-3]": n_outer_av * n_outer_scale,
-                    f"{reaction_name}concentration [mol.m-3]": n_SEI * n_scale,
-                    f"X-averaged {reaction_name}"
-                    "concentration [mol.m-3]": n_SEI_xav * n_scale,
-                    f"Loss of lithium to {reaction_name}[mol]": Q_sei,
-                    f"Loss of capacity to {reaction_name}[A.h]": Q_sei
-                    * self.param.F
-                    / 3600,
-                }
-            )
+                n_sei_av = pybamm.x_average(n_sei)
+                n_sei_xav = pybamm.x_average(n_sei)
+                n_sei_av = pybamm.yz_average(n_sei_xav)
+
+                # Calculate change in SEI concentration with respect to initial state
+                delta_n_sei = n_sei_av - n_sei
+
+                # Q_sei in mol
+                if self.reaction_loc == "interface":
+                    L_n = 1
+                else:
+                    L_n = self.param.n.L
+
+                Q_sei = (
+                    z_sei
+                    * delta_n_sei
+                    * n_scale
+                    * L_n
+                    * self.param.L_y
+                    * self.param.L_z
+                )
+
+                variables.update(
+                    {
+                        f"Inner {reaction_name}concentration [mol.m-3]": n_inner
+                        * n_scale,
+                        f"X-averaged inner {reaction_name}"
+                        "concentration [mol.m-3]": n_inner_av * n_scale,
+                        f"Outer {reaction_name}"
+                        "concentration [mol.m-3]": n_outer * n_outer_scale,
+                        f"X-averaged outer {reaction_name}"
+                        "concentration [mol.m-3]": n_outer_av * n_outer_scale,
+                        f"{reaction_name}concentration [mol.m-3]": n_sei * n_scale,
+                        f"X-averaged {reaction_name}"
+                        "concentration [mol.m-3]": n_sei_xav * n_scale,
+                        f"Loss of lithium to {reaction_name}[mol]": Q_sei,
+                        f"Loss of capacity to {reaction_name}[A.h]": Q_sei
+                        * self.param.F
+                        / 3600,
+                    }
+                )
         # Concentration variables are handled slightly differently for SEI on cracks
         elif self.reaction == "SEI on cracks":
             L_inner_cr = variables[f"Inner {reaction_name}thickness"]
@@ -270,24 +357,24 @@ class BaseModel(BaseInterface):
             n_inner_cr_av = pybamm.x_average(n_inner_cr)
             n_outer_cr_av = pybamm.x_average(n_outer_cr)
 
-            n_SEI_cr = n_inner_cr + n_outer_cr / v_bar  # SEI on cracks concentration
-            n_SEI_cr_xav = pybamm.x_average(n_SEI_cr)
-            n_SEI_cr_av = pybamm.yz_average(n_SEI_cr_xav)
+            n_sei_cr = n_inner_cr + n_outer_cr / v_bar  # SEI on cracks concentration
+            n_sei_cr_xav = pybamm.x_average(n_sei_cr)
+            n_sei_cr_av = pybamm.yz_average(n_sei_cr_xav)
 
             # Calculate change in SEI cracks concentration
             # Initial state depends on roughness (to avoid division by zero)
             roughness_av = pybamm.yz_average(pybamm.x_average(roughness))
             # choose an initial condition that is as close to zero to get the
             # physics right, but doesn't cause a division by zero error
-            n_SEI_cr_init = (L_inner_crack_0 + L_outer_crack_0 / v_bar) * (
+            n_sei_cr_init = (L_inner_crack_0 + L_outer_crack_0 / v_bar) * (
                 roughness_av - 1
             )
-            delta_n_SEI_cr = n_SEI_cr_av - n_SEI_cr_init
+            delta_n_sei_cr = n_sei_cr_av - n_sei_cr_init
 
             # Q_sei_cr in mol
             Q_sei_cr = (
                 z_sei
-                * delta_n_SEI_cr
+                * delta_n_sei_cr
                 * n_scale
                 * self.param.n.L
                 * self.param.L_y
@@ -304,9 +391,9 @@ class BaseModel(BaseInterface):
                     "concentration [mol.m-3]": n_outer_cr * n_outer_scale,
                     f"X-averaged outer {reaction_name}"
                     "concentration [mol.m-3]": n_outer_cr_av * n_outer_scale,
-                    f"{reaction_name}" "concentration [mol.m-3]": n_SEI_cr * n_scale,
+                    f"{reaction_name}" "concentration [mol.m-3]": n_sei_cr * n_scale,
                     f"X-averaged {reaction_name}"
-                    "concentration [mol.m-3]": n_SEI_cr_xav * n_scale,
+                    "concentration [mol.m-3]": n_sei_cr_xav * n_scale,
                     f"Loss of lithium to {reaction_name}[mol]": Q_sei_cr,
                     f"Loss of capacity to {reaction_name}[A.h]": Q_sei_cr
                     * self.param.F

--- a/pybamm/models/submodels/interface/sei/constant_sei.py
+++ b/pybamm/models/submodels/interface/sei/constant_sei.py
@@ -33,13 +33,21 @@ class ConstantSEI(BaseModel):
             self.reaction_loc = "full electrode"
 
     def get_fundamental_variables(self):
-        # Constant thicknesses
-        L_inner = self.phase_param.L_inner_0
-        L_outer = self.phase_param.L_outer_0
-        variables = self._get_standard_thickness_variables(L_inner, L_outer)
+        if self.options["number of SEI layers"] == 2:
+            # Constant thicknesses
+            L_inner = self.phase_param.L_inner_0
+            L_outer = self.phase_param.L_outer_0
+            variables = self._get_standard_thickness_variables(L_inner, L_outer)
 
-        # Concentrations (derived from thicknesses)
-        variables.update(self._get_standard_concentration_variables(variables))
+            # Concentrations (derived from thicknesses)
+            variables.update(self._get_standard_concentration_variables(variables))
+        else:
+            # Constant thickness
+            L = self.phase_param.L_0
+            variables = self._get_standard_thickness_variables(L, L)
+
+            # Concentration (derived from thickness)
+            variables.update(self._get_standard_concentration_variables(variables))
 
         # Reactions
         if self.reaction_loc == "interface":


### PR DESCRIPTION
# Description
This PR edits the SEI defaults to single-layer SEI and allows changing to the original with inner and outer layer SEI.
A "number of SEI layers" option was added to `BatteryModelOptions`, if it's "2", use the original code. If it's "1", only create a single variable L_sei (instead of L_inner and L_outer), and then only write equations for that variable.
Then references to two SEI thicknesses are edited reading `self.options["number of SEI layers"]`

Fixes #2333 

## Type of change

- [X] New feature (non-breaking change which adds functionality)


# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [X] Code is commented, particularly in hard-to-understand areas
