### PR TITLE
Changed current_sigmoid_ocp to be valid for both electrodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- Fixed current_sigmoid_ocp to be valid for both electrodes ([#2719](https://github.com/pybamm-team/PyBaMM/pull/2719)).
 - Fixed the length scaling for the first dimension of r-R plots ([#2663](https://github.com/pybamm-team/PyBaMM/pull/2663)).
 
 # [v23.1](https://github.com/pybamm-team/PyBaMM/tree/v23.1) - 2023-01-31

--- a/examples/notebooks/models/composite_particle.ipynb
+++ b/examples/notebooks/models/composite_particle.ipynb
@@ -91,7 +91,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "10339d40",
    "metadata": {},
@@ -594,7 +593,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dbc0edb2",
    "metadata": {},
@@ -639,7 +637,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "40467b70",
    "metadata": {},
@@ -849,7 +846,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "977b4c09",
    "metadata": {},
@@ -935,7 +931,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -949,7 +945,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.8.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/pybamm/models/submodels/interface/open_circuit_potential/current_sigmoid_ocp.py
+++ b/pybamm/models/submodels/interface/open_circuit_potential/current_sigmoid_ocp.py
@@ -11,12 +11,13 @@ class CurrentSigmoidOpenCircuitPotential(BaseOpenCircuitPotential):
         current = variables["Total current density"]
         k = 100
 
-        if Domain == "Negative":
-            m_lith = pybamm.sigmoid(current, 0, k)  # for lithation (current < 0)
-            m_delith = 1 - m_lith  # for delithiation (current > 0)
-        elif Domain == "Positive":
-            m_delith = pybamm.sigmoid(current, 0, k)  # for delithation (current < 0)
-            m_lith = 1 - m_delith  # for lithiation (current > 0)
+        if Domain == "Positive":
+            lithiation_current = current
+        elif Domain == "Negative":
+            lithiation_current = -current
+
+        m_lith = pybamm.sigmoid(0, lithiation_current, k)  # lithiation_current > 0
+        m_delith = 1 - m_lith  # lithiation_current < 0
 
         phase_name = self.phase_name
 

--- a/pybamm/models/submodels/interface/open_circuit_potential/current_sigmoid_ocp.py
+++ b/pybamm/models/submodels/interface/open_circuit_potential/current_sigmoid_ocp.py
@@ -7,12 +7,17 @@ from . import BaseOpenCircuitPotential
 
 class CurrentSigmoidOpenCircuitPotential(BaseOpenCircuitPotential):
     def get_coupled_variables(self, variables):
+        domain, Domain = self.domain_Domain
         current = variables["Total current density"]
         k = 100
-        m_lith = pybamm.sigmoid(current, 0, k)  # for lithation (current < 0)
-        m_delith = 1 - m_lith  # for delithiation (current > 0)
 
-        domain, Domain = self.domain_Domain
+        if Domain == "Negative":
+            m_lith = pybamm.sigmoid(current, 0, k)  # for lithation (current < 0)
+            m_delith = 1 - m_lith  # for delithiation (current > 0)
+        elif Domain == "Positive":
+            m_delith = pybamm.sigmoid(current, 0, k)  # for delithation (current < 0)
+            m_lith = 1 - m_delith  # for lithiation (current > 0)
+
         phase_name = self.phase_name
 
         if self.reaction == "lithium-ion main":


### PR DESCRIPTION
# Description

The existing version of current_sigmoid_ocp is only valid for the negative electrode and gives the wrong result for hysteresis in the positive electrode. Fortunately, adding an extra four lines of code fixes this.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
