### PR TITLE
save diffusivity variables

### DIFF
--- a/pybamm/models/submodels/particle/fickian_diffusion.py
+++ b/pybamm/models/submodels/particle/fickian_diffusion.py
@@ -216,28 +216,22 @@ class FickianDiffusion(BaseParticle):
         )
 
         if self.size_distribution is True:
-            R = variables[f"{Domain} {phase_name}particle sizes [m]"]
             # Size-dependent flux variables
-            variables.update(self._get_standard_flux_distribution_variables(N_s))
-            f_a_dist = self.phase_param.f_a_dist(R)
-            # Size-averaged flux variables (perform area-weighted avg manually as flux
-            # evals on edges)
-            N_s = pybamm.Integral(f_a_dist * N_s, R)
-
-            # Volume-weighted average for effective diffusivity
             variables.update(
                 self._get_standard_diffusivity_distribution_variables(D_eff)
             )
+            variables.update(self._get_standard_flux_distribution_variables(N_s))
+            # Size-averaged flux variables
+            R = variables[f"{Domain} {phase_name}particle sizes [m]"]
+            f_a_dist = self.phase_param.f_a_dist(R)
+            D_eff = pybamm.Integral(f_a_dist * D_eff, R)
+            N_s = pybamm.Integral(f_a_dist * N_s, R)
 
         if self.x_average is True:
             D_eff = pybamm.SecondaryBroadcast(D_eff, [f"{domain} electrode"])
             N_s = pybamm.SecondaryBroadcast(N_s, [f"{domain} electrode"])
 
-        if self.size_distribution is False:
-            # Save diffusivity variables for the no-size-distrbution case
-            # (they were saved earlier for the size-distribution case)
-            variables.update(self._get_standard_diffusivity_variables(D_eff))
-
+        variables.update(self._get_standard_diffusivity_variables(D_eff))
         variables.update(self._get_standard_flux_variables(N_s))
 
         return variables

--- a/pybamm/models/submodels/particle_mechanics/base_mechanics.py
+++ b/pybamm/models/submodels/particle_mechanics/base_mechanics.py
@@ -69,16 +69,18 @@ class BaseMechanics(pybamm.BaseSubModel):
         # Averages
         stress_r_surf_av = pybamm.x_average(stress_r_surf)
         stress_t_surf_av = pybamm.x_average(stress_t_surf)
+        disp_surf_av = pybamm.x_average(disp_surf)
 
         variables.update(
             {
-                f"{Domain} particle surface tangential stress [Pa]": stress_t_surf,
                 f"{Domain} particle surface radial stress [Pa]": stress_r_surf,
+                f"{Domain} particle surface tangential stress [Pa]": stress_t_surf,
                 f"{Domain} particle surface displacement [m]": disp_surf,
                 f"X-averaged {domain} particle surface "
                 "radial stress [Pa]": stress_r_surf_av,
                 f"X-averaged {domain} particle surface "
                 "tangential stress [Pa]": stress_t_surf_av,
+                f"X-averaged {domain} particle surface displacement [m]": disp_surf_av,
                 f"{Domain} electrode thickness change [m]": electrode_thickness_change,
             }
         )


### PR DESCRIPTION
# Description

Save diffusivity variables that were missed when using a particle size distribution and add an x-averaged surface displacement variable.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
