### PR TITLE
feat: make jupyter a dev dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ autograd >= 1.2
 scikit-fem >= 0.2.0
 casadi >= 3.5.0
 imageio>=2.9.0
-jupyter  # For example notebooks
 pybtex>=0.24.0
 sympy >= 1.8
 bpx

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ setup(
         "autograd>=1.2",
         "scikit-fem>=0.2.0",
         "casadi>=3.5.0",
-        "imageio>=2.9.0", 
+        "imageio>=2.9.0",
         "pybtex>=0.24.0",
         "sympy>=1.8",
         "bpx",
@@ -217,7 +217,7 @@ setup(
         "dev": [
             "pre-commit",  # For code style checking
             "black",  # For code style auto-formatting
-            "jupyter", # For example notebooks
+            "jupyter",  # For example notebooks
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -196,8 +196,7 @@ setup(
         "autograd>=1.2",
         "scikit-fem>=0.2.0",
         "casadi>=3.5.0",
-        "imageio>=2.9.0",
-        "jupyter",  # For example notebooks
+        "imageio>=2.9.0", 
         "pybtex>=0.24.0",
         "sympy>=1.8",
         "bpx",
@@ -218,6 +217,7 @@ setup(
         "dev": [
             "pre-commit",  # For code style checking
             "black",  # For code style auto-formatting
+            "jupyter", # For example notebooks
         ],
     },
     entry_points={


### PR DESCRIPTION
# Description

This PR helps to make `jupyter` a dev depenency. To do this:

1. `jupyter` has been removed from requirements.txt.
2. 'jupyter' has been shifted to "dev" from "install_requires" in setup.py.

Fixes #2457 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
