### PR TITLE
Fix version switcher on readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
     ],
     "switcher": {
         "version_match": release,
-        "json_url": "source/_static/versions.json",
+        "json_url": "https://pybamm.readthedocs.io/en/latest/_static/versions.json",  # noqa: E501
     },
     # turn to False to not fail build if json_url is not found
     "check_switcher": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,12 +136,14 @@ html_theme_options = {
             "url": "https://github.com/pybamm-team/PyBaMM/tree/develop/CONTRIBUTING.md",
         },
     ],
-    # Add light/dark mode and documentation version switcher:
-    # "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
-    # "switcher": {
-    #     "version_match": switcher_version,
-    #     "json_url": "https://numpy.org/doc/_static/versions.json",
-    # },
+    "switcher": {
+        "version_match": release,
+        # make sure to update this file when releasing a new version
+        "json_url": "source/_static/versions.json",
+    },
+    # turn to False to not fail build if json_url is not found
+    "check_switcher": True,
+    "navbar_end": ["version-switcher"],
     "use_edit_page_button": True,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,8 @@ html_theme_options = {
     },
     # turn to False to not fail build if json_url is not found
     "check_switcher": True,
-    "navbar_end": ["version-switcher"],
+    # for dark mode toggle, version switcher, and social media links
+    "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
     "use_edit_page_button": True,
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,6 @@ html_theme_options = {
     ],
     "switcher": {
         "version_match": release,
-        # make sure to update this file when releasing a new version
         "json_url": "source/_static/versions.json",
     },
     # turn to False to not fail build if json_url is not found

--- a/docs/source/_static/pybamm.css
+++ b/docs/source/_static/pybamm.css
@@ -49,7 +49,7 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 */
 
 /* If the active version has the name "dev", style it orange */
-#version_switcher_button[data-active-version-name*="dev"] {
+#version_switcher_button[data-active-version-name*="latest"] {
   background-color: #e69f00;
   border-color: #e69f00;
   color: #000000;
@@ -63,9 +63,8 @@ Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 
 /* red for `old` */
 #version_switcher_button:not(
-    [data-active-version-name*="stable"],
-    [data-active-version-name*="dev"],
-    [data-active-version-name=""]
+    [data-active-version-name*="latest"],
+    [data-active-version-name*="dev"]
   ) {
   background-color: #980f0f;
   border-color: #980f0f;

--- a/docs/source/_static/pybamm.css
+++ b/docs/source/_static/pybamm.css
@@ -38,7 +38,7 @@ h3 {
 
 /* Style the active version button.
 
-- dev: orange
+- latest: orange
 - stable: green
 - old, PR: red
 
@@ -48,23 +48,23 @@ Wong, B. Points of view: Color blindness.
 Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
 */
 
-/* If the active version has the name "dev", style it orange */
-#version_switcher_button[data-active-version-name*="latest"] {
+/* If the active version has the name "latest", style it orange */
+.version-switcher__button[data-active-version-name*="latest"] {
   background-color: #e69f00;
   border-color: #e69f00;
   color: #000000;
 }
 
 /* green for `stable` */
-#version_switcher_button[data-active-version-name*="stable"] {
+.version-switcher__button[data-active-version-name*="stable"] {
   background-color: #009e73;
   border-color: #009e73;
 }
 
 /* red for `old` */
-#version_switcher_button:not(
+.version-switcher__button:not(
     [data-active-version-name*="latest"],
-    [data-active-version-name*="dev"]
+    [data-active-version-name*="stable"]
   ) {
   background-color: #980f0f;
   border-color: #980f0f;

--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -1,0 +1,120 @@
+[
+    {
+        "name": "latest",
+        "version": "latest",
+        "url": "https://pybamm.readthedocs.io/en/latest/"
+    },
+    {
+        "name": "stable",
+        "version": "stable",
+        "url": "https://pybamm.readthedocs.io/en/stable/"
+    },
+    {
+        "version": "v23.2",
+        "url": "https://pybamm.readthedocs.io/en/v23.2/"
+    },
+    {
+        "version": "v23.1",
+        "url": "https://pybamm.readthedocs.io/en/v23.1/"
+    },
+    {
+        "version": "v22.12",
+        "url": "https://pybamm.readthedocs.io/en/v22.12/"
+    },
+    {
+        "version": "v22.11.1",
+        "url": "https://pybamm.readthedocs.io/en/v22.11.1/"
+    },
+    {
+        "version": "v22.11",
+        "url": "https://pybamm.readthedocs.io/en/v22.11/"
+    },
+    {
+        "version": "v22.10",
+        "url": "https://pybamm.readthedocs.io/en/v22.10/"
+    },
+    {
+        "version": "v22.9",
+        "url": "https://pybamm.readthedocs.io/en/v22.9/"
+    },
+    {
+        "version": "v22.8",
+        "url": "https://pybamm.readthedocs.io/en/v22.8/"
+    },
+    {
+        "version": "v22.7",
+        "url": "https://pybamm.readthedocs.io/en/v22.7/"
+    },
+    {
+        "version": "v22.6",
+        "url": "https://pybamm.readthedocs.io/en/v22.6/"
+    },
+    {
+        "version": "v22.5",
+        "url": "https://pybamm.readthedocs.io/en/v22.5/"
+    },
+    {
+        "version": "v22.4",
+        "url": "https://pybamm.readthedocs.io/en/v22.4/"
+    },
+    {
+        "version": "v22.3",
+        "url": "https://pybamm.readthedocs.io/en/v22.3/"
+    },
+    {
+        "version": "v22.2",
+        "url": "https://pybamm.readthedocs.io/en/v22.3/"
+    },
+    {
+        "version": "v22.1",
+        "url": "https://pybamm.readthedocs.io/en/v22.1/"
+    },
+    {
+        "version": "v21.12",
+        "url": "https://pybamm.readthedocs.io/en/v21.12/"
+    },
+    {
+        "version": "v21.11",
+        "url": "https://pybamm.readthedocs.io/en/v21.11/"
+    },
+    {
+        "version": "v21.10",
+        "url": "https://pybamm.readthedocs.io/en/v21.10/"
+    },
+    {
+        "version": "v21.9",
+        "url": "https://pybamm.readthedocs.io/en/v21.9/"
+    },
+    {
+        "version": "v21.08",
+        "url": "https://pybamm.readthedocs.io/en/v21.08/"
+    },
+    {
+        "version": "v0.4.0",
+        "url": "https://pybamm.readthedocs.io/en/v0.4.0/"
+    },
+    {
+        "version": "v0.3.0",
+        "url": "https://pybamm.readthedocs.io/en/v0.3.0/"
+    },
+    {
+        "version": "v0.2.3",
+        "url": "https://pybamm.readthedocs.io/en/v0.2.3/"
+    },
+    {
+        "version": "v0.2.2",
+        "url": "https://pybamm.readthedocs.io/en/v0.2.2/"
+    },
+    {
+        "version": "v0.2.1",
+        "url": "https://pybamm.readthedocs.io/en/v0.2.1/"
+    },
+    {
+        "version": "v0.2.0",
+        "url": "https://pybamm.readthedocs.io/en/v0.2.0/"
+    },
+    {
+        "version": "v0.1.0",
+        "url": "https://pybamm.readthedocs.io/en/v0.1.0/"
+    }
+]

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -47,7 +47,7 @@ def update_version():
         file.truncate(0)
         file.seek(0)
         file.write(replace_version)
-    
+
     # docs/source/_static/versions.json for readthedocs build
     with open(
         os.path.join(pybamm.root_dir(), "docs", "source", "_static", "versions.json"),
@@ -55,7 +55,13 @@ def update_version():
     ) as file:
         output = file.read()
         json_data = json.loads(output)
-        json_data.insert(2, {"version": f"v{release_version}", "url": f"https://pybamm.readthedocs.io/en/v{release_version}/"})  # noqa: E501
+        json_data.insert(
+            2,
+            {
+                "version": f"v{release_version}",
+                "url": f"https://pybamm.readthedocs.io/en/v{release_version}/",
+            },
+        )  # noqa: E501
         file.truncate(0)
         file.seek(0)
         file.write(json.dumps(json_data))

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -47,6 +47,18 @@ def update_version():
         file.truncate(0)
         file.seek(0)
         file.write(replace_version)
+    
+    # docs/source/_static/versions.json for readthedocs build
+    with open(
+        os.path.join(pybamm.root_dir(), "docs", "source", "_static", "versions.json"),
+        "r+",
+    ) as file:
+        output = file.read()
+        json_data = json.loads(output)
+        json_data.insert(2, {"version": f"v{release_version}", "url": f"https://pybamm.readthedocs.io/en/v{release_version}/"})  # noqa: E501
+        file.truncate(0)
+        file.seek(0)
+        file.write(json.dumps(json_data))
 
     # vcpkg.json
     with open(os.path.join(pybamm.root_dir(), "vcpkg.json"), "r+") as file:


### PR DESCRIPTION
# Description

This updates the version switcher styling on readthedocs and configures a `.json` file for the version switcher dropdown

Fixes #2766 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
