### PR TITLE
Method to calculate theoretical efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added an option for using a banded jacobian and sundials banded solvers for the IDAKLU solve ([#2677](https://github.com/pybamm-team/PyBaMM/pull/2677))
 - The "particle size" option can now be a tuple to allow different behaviour in each electrode ([#2672](https://github.com/pybamm-team/PyBaMM/pull/2672)).
 - Added temperature control to experiment class. ([#2518](https://github.com/pybamm-team/PyBaMM/pull/2518))
+- Added method to calculate maximum theoretical energy. ([#2777](https://github.com/pybamm-team/PyBaMM/pull/2777))
 
 ## Bug fixes
 

--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -558,7 +558,10 @@ def get_min_max_stoichiometries(
     esoh_solver = ElectrodeSOHSolver(parameter_values, param, known_value)
     return esoh_solver.get_min_max_stoichiometries()
 
-def calculate_theoretical_energy(parameter_values, initial_soc=1.0, final_soc=0.0, points=100):
+
+def calculate_theoretical_energy(
+    parameter_values, initial_soc=1.0, final_soc=0.0, points=100
+):
     """
     Calculate maximum energy possible from a cell given OCV, initial soc, and final soc
     given voltage limits, open-circuit potentials, etc defined by parameter_values
@@ -579,28 +582,29 @@ def calculate_theoretical_energy(parameter_values, initial_soc=1.0, final_soc=0.
     E
         The total energy of the cell in Wh
     """
-    #Get initial and final stoichiometric values
+    # Get initial and final stoichiometric values.
     n_i, p_i = get_initial_stoichiometries(initial_soc, parameter_values)
     n_f, p_f = get_initial_stoichiometries(final_soc, parameter_values)
     n_vals = np.linspace(n_i, n_f, num=points)
     p_vals = np.linspace(p_i, p_f, num=points)
-    #Calculate OCV at each stoichiometry
+    # Calculate OCV at each stoichiometry
     Vs = np.empty(n_vals.shape)
     for i in range(n_vals.size):
         V_pos = parameter_values["Positive electrode OCP [V]"](p_vals[i]).value
         V_neg = parameter_values["Negative electrode OCP [V]"](n_vals[i]).value
         Vs[i] = V_pos - V_neg
-        Q_max_pos = parameter_values["Maximum concentration in positive electrode [mol.m-3]"]
-    #Get electrode properties to convert stoich range to moles Li
+        Q_max_pos = parameter_values[
+            "Maximum concentration in positive electrode [mol.m-3]"
+        ]
+    # Get electrode properties to convert stoich range to moles Li
     W = parameter_values["Electrode width [m]"]
     H = parameter_values["Electrode height [m]"]
     T_pos = parameter_values["Positive electrode thickness [m]"]
     eps_s_pos = parameter_values["Positive electrode active material volume fraction"]
-    vol_pos = W*H*T_pos*eps_s_pos
-    #Calculate dQ
-    Q_p = vol_pos*Q_max_pos*(p_f - p_i)
-    dQ = Q_p/(points - 1)
-    #Integrate and convert to W-h
-    E = np.trapz(Vs, dx=dQ)*26.8
+    vol_pos = W * H * T_pos * eps_s_pos
+    # Calculate dQ
+    Q_p = vol_pos * Q_max_pos * (p_f - p_i)
+    dQ = Q_p / (points - 1)
+    # Integrate and convert to W-h
+    E = np.trapz(Vs, dx=dQ) * 26.8
     return E
-    

--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -557,3 +557,50 @@ def get_min_max_stoichiometries(
     """
     esoh_solver = ElectrodeSOHSolver(parameter_values, param, known_value)
     return esoh_solver.get_min_max_stoichiometries()
+
+def calculate_theoretical_energy(parameter_values, initial_soc=1.0, final_soc=0.0, points=100):
+    """
+    Calculate maximum energy possible from a cell given OCV, initial soc, and final soc
+    given voltage limits, open-circuit potentials, etc defined by parameter_values
+
+    Parameters
+    ----------
+    parameter_values : :class:`pybamm.ParameterValues`
+        The parameter values class that will be used for the simulation.
+    initial_soc : float
+        The soc at begining of discharge, default 1.0
+    final_soc : float
+        The soc at end of discharge, default 1.0
+    points : int
+        The number of points at which to calculate voltage.
+
+    Returns
+    -------
+    E
+        The total energy of the cell in Wh
+    """
+    #Get initial and final stoichiometric values
+    n_i, p_i = get_initial_stoichiometries(initial_soc, parameter_values)
+    n_f, p_f = get_initial_stoichiometries(final_soc, parameter_values)
+    n_vals = np.linspace(n_i, n_f, num=points)
+    p_vals = np.linspace(p_i, p_f, num=points)
+    #Calculate OCV at each stoichiometry
+    Vs = np.empty(n_vals.shape)
+    for i in range(n_vals.size):
+        V_pos = parameter_values["Positive electrode OCP [V]"](p_vals[i]).value
+        V_neg = parameter_values["Negative electrode OCP [V]"](n_vals[i]).value
+        Vs[i] = V_pos - V_neg
+        Q_max_pos = parameter_values["Maximum concentration in positive electrode [mol.m-3]"]
+    #Get electrode properties to convert stoich range to moles Li
+    W = parameter_values["Electrode width [m]"]
+    H = parameter_values["Electrode height [m]"]
+    T_pos = parameter_values["Positive electrode thickness [m]"]
+    eps_s_pos = parameter_values["Positive electrode active material volume fraction"]
+    vol_pos = W*H*T_pos*eps_s_pos
+    #Calculate dQ
+    Q_p = vol_pos*Q_max_pos*(p_f - p_i)
+    dQ = Q_p/(points - 1)
+    #Integrate and convert to W-h
+    E = np.trapz(Vs, dx=dQ)*26.8
+    return E
+    

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -142,6 +142,23 @@ class TestElectrodeSOHHalfCell(unittest.TestCase):
         self.assertAlmostEqual(sol["Uw(x_100)"].data[0], V_max, places=5)
         self.assertAlmostEqual(sol["Uw(x_0)"].data[0], V_min, places=5)
 
+class TestCalculateTheoreticalEnergy(unittest.TestCase):
+    def test_efficiency(self):
+        model = pybamm.lithium_ion.DFN(
+            options = {"calculate discharge energy" : True}
+        )
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        sim = pybamm.Simulation(model, parameter_values=parameter_values)
+        sol = sim.solve([0,3600], initial_soc = 1.0)
+        discharge_energy = sol["Discharge energy [W.h]"].entries[-1]
+        theoretical_energy = pybamm.lithium_ion.electrode_soh.calculate_theoretical_energy(parameter_values)
+        # Real energy should be less than discharge energy, and both should be greater than 1
+        self.assertLess(discharge_energy, theoretical_energy)
+        self.assertLess(0, discharge_energy)
+        self.assertLess(0, theoretical_energy)
+
+        
+
 
 class TestGetInitialSOC(unittest.TestCase):
     def test_initial_soc(self):

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -152,10 +152,11 @@ class TestCalculateTheoreticalEnergy(unittest.TestCase):
         sol = sim.solve([0,3600], initial_soc = 1.0)
         discharge_energy = sol["Discharge energy [W.h]"].entries[-1]
         theoretical_energy = pybamm.lithium_ion.electrode_soh.calculate_theoretical_energy(parameter_values)
-        # Real energy should be less than discharge energy, and both should be greater than 1
+        # Real energy should be less than discharge energy, and both should be greater than 0
         self.assertLess(discharge_energy, theoretical_energy)
         self.assertLess(0, discharge_energy)
         self.assertLess(0, theoretical_energy)
+        self.assertEqual(0, 1)
 
         
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -157,7 +157,6 @@ class TestCalculateTheoreticalEnergy(unittest.TestCase):
         )
         # Real energy should be less than discharge energy,
         #  and both should be greater than 0
-        print(discharge_energy / theoretical_energy)
         self.assertLess(discharge_energy, theoretical_energy)
         self.assertLess(0, discharge_energy)
         self.assertLess(0, theoretical_energy)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -142,23 +142,25 @@ class TestElectrodeSOHHalfCell(unittest.TestCase):
         self.assertAlmostEqual(sol["Uw(x_100)"].data[0], V_max, places=5)
         self.assertAlmostEqual(sol["Uw(x_0)"].data[0], V_min, places=5)
 
+
 class TestCalculateTheoreticalEnergy(unittest.TestCase):
     def test_efficiency(self):
-        model = pybamm.lithium_ion.DFN(
-            options = {"calculate discharge energy" : True}
-        )
+        model = pybamm.lithium_ion.DFN(options={"calculate discharge energy": "true"})
         parameter_values = pybamm.ParameterValues("Chen2020")
         sim = pybamm.Simulation(model, parameter_values=parameter_values)
-        sol = sim.solve([0,3600], initial_soc = 1.0)
+        sol = sim.solve([0, 3600], initial_soc=1.0)
         discharge_energy = sol["Discharge energy [W.h]"].entries[-1]
-        theoretical_energy = pybamm.lithium_ion.electrode_soh.calculate_theoretical_energy(parameter_values)
-        # Real energy should be less than discharge energy, and both should be greater than 0
+        theoretical_energy = (
+            pybamm.lithium_ion.electrode_soh.calculate_theoretical_energy(
+                parameter_values
+            )
+        )
+        # Real energy should be less than discharge energy,
+        #  and both should be greater than 0
+        print(discharge_energy / theoretical_energy)
         self.assertLess(discharge_energy, theoretical_energy)
         self.assertLess(0, discharge_energy)
         self.assertLess(0, theoretical_energy)
-        self.assertEqual(0, 1)
-
-        
 
 
 class TestGetInitialSOC(unittest.TestCase):


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Implements integral of VdQ to calculate theoretical maximum energy. Useful for defining battery efficiency. Submitted PR due to discussion with @tinosulzer 

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
