### PR TITLE
remove stoich and ne params, hardcode instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## Breaking changes
 
+- Removed "... cation signed stoichiometry" and "... electrons in reaction" parameters, they are now hardcoded. ([#2778](https://github.com/pybamm-team/PyBaMM/pull/2778))
 - Renamed "Measured open circuit voltage [V]" to "Surface open-circuit voltage [V]". This variable was calculated from surface particle concentrations, and hence "hid" the overpotential from particle gradients. The new variable "Open-circuit voltage [V]" is calculated from bulk particle concentrations instead. ([#2740](https://github.com/pybamm-team/PyBaMM/pull/2740))
 - Renamed all references to "open circuit" to be "open-circuit" instead. ([#2740](https://github.com/pybamm-team/PyBaMM/pull/2740))
 - Renamed parameter "1 + dlnf/dlnc" to "Thermodynamic factor". ([#2727](https://github.com/pybamm-team/PyBaMM/pull/2727))

--- a/pybamm/input/parameters/lead_acid/Sulzer2019.py
+++ b/pybamm/input/parameters/lead_acid/Sulzer2019.py
@@ -256,8 +256,6 @@ def get_parameter_values():
         "Negative electrode Bruggeman coefficient (electrode)": 1.5,
         "Negative electrode morphological parameter": 0.6,
         "Negative electrode capacity [C.m-3]": 3473000000.0,
-        "Negative electrode cation signed stoichiometry": 1.0,
-        "Negative electrode electrons in reaction": 2.0,
         "Negative electrode exchange-current density [A.m-2]"
         "": lead_exchange_current_density_Sulzer2019,
         "Signed stoichiometry of cations (oxygen reaction)": 4.0,
@@ -291,8 +289,6 @@ def get_parameter_values():
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
         "Positive electrode morphological parameter": 0.6,
         "Positive electrode capacity [C.m-3]": 2745000000.0,
-        "Positive electrode cation signed stoichiometry": 3.0,
-        "Positive electrode electrons in reaction": 2.0,
         "Positive electrode exchange-current density [A.m-2]"
         "": lead_dioxide_exchange_current_density_Sulzer2019,
         "Positive electrode oxygen exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Ai2020.py
+++ b/pybamm/input/parameters/lithium_ion/Ai2020.py
@@ -618,8 +618,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 2.914,
         "Negative electrode Bruggeman coefficient (electrode)": 0.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -656,8 +654,6 @@ def get_parameter_values():
         "Positive electrode surface area to volume ratio [m-1]": 620000.0,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.83,
         "Positive electrode Bruggeman coefficient (electrode)": 0.0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Chen2020.py
+++ b/pybamm/input/parameters/lithium_ion/Chen2020.py
@@ -305,8 +305,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5.86e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -325,8 +323,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 5.22e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Chen2020_composite.py
+++ b/pybamm/input/parameters/lithium_ion/Chen2020_composite.py
@@ -406,8 +406,6 @@ def get_parameter_values():
         "Primary: Negative particle radius [m]": 5.86e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Primary: Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Primary: Negative electrode exchange-current density [A.m-2]"
@@ -425,7 +423,6 @@ def get_parameter_values():
         "": silicon_ocp_delithiation_Mark2016,
         "Secondary: Negative electrode active material volume fraction": 0.015,
         "Secondary: Negative particle radius [m]": 1.52e-06,
-        "Secondary: Negative electrode electrons in reaction": 1.0,
         "Secondary: Negative electrode exchange-current density [A.m-2]"
         "": silicon_LGM50_electrolyte_exchange_current_density_Chen2020,
         "Secondary: Negative electrode density [kg.m-3]": 2650.0,
@@ -440,8 +437,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 5.22e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Ecker2015.py
+++ b/pybamm/input/parameters/lithium_ion/Ecker2015.py
@@ -508,8 +508,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 1.37e-05,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.6372789338386007,
         "Negative electrode Bruggeman coefficient (electrode)": 0.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode exchange-current density [A.m-2]"
         "": graphite_electrolyte_exchange_current_density_Ecker2015,
         "Negative electrode density [kg.m-3]": 1555.0,
@@ -528,8 +526,6 @@ def get_parameter_values():
         "Positive electrode Bruggeman coefficient (electrode)": 0.0,
         "Positive electrode exchange-current density [A.m-2]"
         "": nco_electrolyte_exchange_current_density_Ecker2015,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode density [kg.m-3]": 2895.0,
         "Positive electrode specific heat capacity [J.kg-1.K-1]": 1270.0,
         "Positive electrode thermal conductivity [W.m-1.K-1]": 1.04,

--- a/pybamm/input/parameters/lithium_ion/Marquis2019.py
+++ b/pybamm/input/parameters/lithium_ion/Marquis2019.py
@@ -436,8 +436,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 1e-05,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 1.5,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -457,8 +455,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 1e-05,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Mohtat2020.py
+++ b/pybamm/input/parameters/lithium_ion/Mohtat2020.py
@@ -430,8 +430,6 @@ def get_parameter_values():
         "Negative electrode Bruggeman coefficient (electrode)": 1.5,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode transport efficiency": 0.16,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode reference exchange-current density [A.m-2(m3.mol)1.5]"
         "": 1.061e-06,
         "Negative electrode charge transfer coefficient": 0.5,
@@ -454,8 +452,6 @@ def get_parameter_values():
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode transport efficiency": 0.16,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode reference exchange-current density [A.m-2(m3.mol)1.5]"
         "": 4.824e-06,
         "Positive electrode charge transfer coefficient": 0.5,

--- a/pybamm/input/parameters/lithium_ion/NCA_Kim2011.py
+++ b/pybamm/input/parameters/lithium_ion/NCA_Kim2011.py
@@ -379,8 +379,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5.083e-07,
         "Negative electrode Bruggeman coefficient (electrolyte)": 2.0,
         "Negative electrode Bruggeman coefficient (electrode)": 2.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -399,8 +397,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 1.633e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 2.0,
         "Positive electrode Bruggeman coefficient (electrode)": 2.0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/OKane2022.py
+++ b/pybamm/input/parameters/lithium_ion/OKane2022.py
@@ -593,8 +593,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5.86e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 1.5,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -628,8 +626,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 5.22e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/ORegan2022.py
+++ b/pybamm/input/parameters/lithium_ion/ORegan2022.py
@@ -974,8 +974,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5.86e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 0.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -998,8 +996,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 5.22e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 0.0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Prada2013.py
+++ b/pybamm/input/parameters/lithium_ion/Prada2013.py
@@ -278,8 +278,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 5.86e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Negative electrode Bruggeman coefficient (electrode)": 1.5,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -298,8 +296,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 1e-08,
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode density [kg.m-3]": 2341.17,

--- a/pybamm/input/parameters/lithium_ion/Ramadass2004.py
+++ b/pybamm/input/parameters/lithium_ion/Ramadass2004.py
@@ -449,8 +449,6 @@ def get_parameter_values():
         "Negative particle radius [m]": 2e-06,
         "Negative electrode Bruggeman coefficient (electrolyte)": 4.0,
         "Negative electrode Bruggeman coefficient (electrode)": 4.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Negative electrode charge transfer coefficient": 0.5,
         "Negative electrode double-layer capacity [F.m-2]": 0.2,
         "Negative electrode exchange-current density [A.m-2]"
@@ -470,8 +468,6 @@ def get_parameter_values():
         "Positive particle radius [m]": 2e-06,
         "Positive electrode Bruggeman coefficient (electrolyte)": 4.0,
         "Positive electrode Bruggeman coefficient (electrode)": 4.0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode double-layer capacity [F.m-2]": 0.2,
         "Positive electrode exchange-current density [A.m-2]"

--- a/pybamm/input/parameters/lithium_ion/Xu2019.py
+++ b/pybamm/input/parameters/lithium_ion/Xu2019.py
@@ -274,8 +274,6 @@ def get_parameter_values():
         "Negative electrode OCP [V]": 0.0,
         "Negative electrode conductivity [S.m-1]": 10776000.0,
         "Negative electrode OCP entropic change [V.K-1]": 0.0,
-        "Negative electrode cation signed stoichiometry": -1.0,
-        "Negative electrode electrons in reaction": 1.0,
         "Typical plated lithium concentration [mol.m-3]": 76900.0,
         "Exchange-current density for plating [A.m-2]"
         "": li_metal_electrolyte_exchange_current_density_Xu2019,
@@ -292,8 +290,6 @@ def get_parameter_values():
         "Positive electrode Bruggeman coefficient (electrolyte)": 1.5,
         "Positive electrode Bruggeman coefficient (electrode)": 1.5,
         "Positive electrode OCP entropic change [V.K-1]": 0.0,
-        "Positive electrode cation signed stoichiometry": -1.0,
-        "Positive electrode electrons in reaction": 1.0,
         "Positive electrode charge transfer coefficient": 0.5,
         "Positive electrode exchange-current density [A.m-2]"
         "": nmc_electrolyte_exchange_current_density_Xu2019,

--- a/pybamm/input/parameters/lithium_ion/testing_only/negative_electrodes/graphite_Ai2020/parameters.csv
+++ b/pybamm/input/parameters/lithium_ion/testing_only/negative_electrodes/graphite_Ai2020/parameters.csv
@@ -15,8 +15,6 @@ Negative electrode Bruggeman coefficient (electrolyte),2.914,Ai 2020,theoretical
 Negative electrode Bruggeman coefficient (electrode),0,default,
 ,,,
 # Interfacial reactions,,,
-Negative electrode cation signed stoichiometry,-1,,
-Negative electrode electrons in reaction,1,,
 Negative electrode charge transfer coefficient,0.5,Ai 2020,
 Negative electrode double-layer capacity [F.m-2],0.2,,guess
 Negative electrode exchange-current density [A.m-2],[function]graphite_electrolyte_exchange_current_density_Dualfoil1998,,

--- a/pybamm/input/parameters/lithium_ion/testing_only/positive_electrodes/lico2_Ai2020/parameters.csv
+++ b/pybamm/input/parameters/lithium_ion/testing_only/positive_electrodes/lico2_Ai2020/parameters.csv
@@ -16,8 +16,6 @@ Positive electrode Bruggeman coefficient (electrolyte),1.83,Ai 2020,
 Positive electrode Bruggeman coefficient (electrode),0,Ai 2020,
 ,,,
 # Interfacial reactions,,,
-Positive electrode cation signed stoichiometry,-1,,
-Positive electrode electrons in reaction,1,,
 Positive electrode charge transfer coefficient,0.5,Ai 2020,
 Positive electrode double-layer capacity [F.m-2],0.2,,guess
 Positive electrode exchange-current density [A.m-2],[function]lico2_electrolyte_exchange_current_density_Dualfoil1998,,

--- a/pybamm/parameters/bpx.py
+++ b/pybamm/parameters/bpx.py
@@ -74,10 +74,6 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
     # i.e. a default C-rate of 1
     pybamm_dict["Current function [A]"] = pybamm_dict["Nominal cell capacity [A.h]"]
 
-    # number of electrons in reaction (1 for li-ion)
-    for domain in [negative_electrode, positive_electrode]:
-        pybamm_dict[domain.pre_name + "electrons in reaction"] = 1.0
-
     # activity
     pybamm_dict["Thermodynamic factor"] = 1.0
 

--- a/pybamm/parameters/lead_acid_parameters.py
+++ b/pybamm/parameters/lead_acid_parameters.py
@@ -349,10 +349,11 @@ class PhaseLeadAcidParameters(BaseParameters):
 
         # Electrochemical reactions
         # Main
-        self.s_plus_S = pybamm.Parameter(
-            f"{Domain} electrode cation signed stoichiometry"
-        )
-        self.ne_S = pybamm.Parameter(f"{Domain} electrode electrons in reaction")
+        if domain == "negative":
+            self.s_plus_S = pybamm.Scalar(1)
+        elif domain == "positive":
+            self.s_plus_S = pybamm.Scalar(3)
+        self.ne_S = pybamm.Scalar(2)
         self.ne = self.ne_S
         self.s_plus_S = self.s_plus_S / self.ne_S
         self.alpha_bv = pybamm.Parameter(

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -377,7 +377,7 @@ class ParticleLithiumIonParameters(BaseParameters):
         pref = self.phase_prefactor
 
         # Electrochemical reactions
-        self.ne = pybamm.Parameter(f"{pref}{Domain} electrode electrons in reaction")
+        self.ne = pybamm.Scalar(1)
 
         # Intercalation kinetics
         self.mhc_lambda = pybamm.Parameter(

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
@@ -32,7 +32,6 @@ class TestCompareOutputsTwoPhase(unittest.TestCase):
             "Negative particle radius [m]",
             "Negative electrode diffusivity [m2.s-1]",
             "Negative electrode exchange-current density [A.m-2]",
-            "Negative electrode electrons in reaction",
         ]:
             parameter_values_two_phase.update(
                 {


### PR DESCRIPTION
# Description

I'm pretty sure these parameters can be hard-coded based on battery chemistry (lithium-ion, lead-acid, etc). Let me know if you have a counter-example

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
