### PR TITLE
`InputParameter` in variable bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- Fixed a bug where variable bounds could not contain `InputParameters` ([#2795](https://github.com/pybamm-team/PyBaMM/pull/2795))
 - Improved `model.latexify()` to have a cleaner and more readable output ([#2764](https://github.com/pybamm-team/PyBaMM/pull/2764))
 - Fixed electrolyte conservation in the case of concentration-dependent transference number ([#2758](https://github.com/pybamm-team/PyBaMM/pull/2758))
 - Fixed `plot_voltage_components` so that the sum of overpotentials is now equal to the voltage ([#2740](https://github.com/pybamm-team/PyBaMM/pull/2740))

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -297,9 +297,23 @@ class Discretisation(object):
             # Add to slices
             y_slices[variable].append(slice(start, end))
             y_slices_explicit[variable].append(slice(start, end))
+
             # Add to bounds
-            lower_bounds.extend([variable.bounds[0].evaluate()] * (end - start))
-            upper_bounds.extend([variable.bounds[1].evaluate()] * (end - start))
+            def evaluate_bound(bound, side):
+                if bound.has_symbol_of_classes(pybamm.InputParameter):
+                    if side == "lower":
+                        return -np.inf
+                    elif side == "upper":
+                        return np.inf
+                else:
+                    return bound.evaluate()
+
+            lower_bounds.extend(
+                [evaluate_bound(variable.bounds[0], "lower")] * (end - start)
+            )
+            upper_bounds.extend(
+                [evaluate_bound(variable.bounds[1], "upper")] * (end - start)
+            )
             # Increment start
             start = end
 

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -144,9 +144,10 @@ class TestDiscretise(unittest.TestCase):
 
         # bounds with an InputParameter
         a = pybamm.InputParameter("a")
-        v = pybamm.Variable("v", domain=whole_cell, bounds=(0, a))
+        b = pybamm.InputParameter("b")
+        v = pybamm.Variable("v", domain=whole_cell, bounds=(a, b))
         disc.set_variable_slices([v])
-        np.testing.assert_array_equal(disc.bounds[0], [0] * 100)
+        np.testing.assert_array_equal(disc.bounds[0], [-np.inf] * 100)
         np.testing.assert_array_equal(disc.bounds[1], [np.inf] * 100)
 
     def test_process_symbol_base(self):

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -142,6 +142,13 @@ class TestDiscretise(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "y_slices should be"):
             disc.y_slices = 1
 
+        # bounds with an InputParameter
+        a = pybamm.InputParameter("a")
+        v = pybamm.Variable("v", domain=whole_cell, bounds=(0, a))
+        disc.set_variable_slices([v])
+        np.testing.assert_array_equal(disc.bounds[0], [0] * 100)
+        np.testing.assert_array_equal(disc.bounds[1], [np.inf] * 100)
+
     def test_process_symbol_base(self):
         # create discretisation
         mesh = get_mesh_for_testing()


### PR DESCRIPTION
# Description
If variable bounds contain an `InputParameter` set the bound to +/- inf.

Fixes #2793

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
