### PR TITLE
Fix random seed on tests

### DIFF
--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -1,12 +1,13 @@
 #
 # Test some experiments
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
 
 
-class TestExperiments(unittest.TestCase):
+class TestExperiments(TestCase):
     def test_discharge_rest_charge(self):
         experiment = pybamm.Experiment(
             [

--- a/tests/integration/test_models/test_full_battery_models/test_equivalent_circuit/test_thevenin.py
+++ b/tests/integration/test_models/test_full_battery_models/test_equivalent_circuit/test_thevenin.py
@@ -1,9 +1,10 @@
 import pybamm
 import unittest
 import tests
+from tests import TestCase
 
 
-class TestThevenin(unittest.TestCase):
+class TestThevenin(TestCase):
     def test_basic_processing(self):
         model = pybamm.equivalent_circuit.Thevenin()
         modeltest = tests.StandardModelTest(model)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_asymptotics_convergence.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_asymptotics_convergence.py
@@ -1,13 +1,14 @@
 #
 # Tests for the asymptotic convergence of the simplified models
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
 import unittest
 
 
-class TestAsymptoticConvergence(unittest.TestCase):
+class TestAsymptoticConvergence(TestCase):
     def test_leading_order_convergence(self):
         """
         Check that the leading-order model solution converges linearly in C_e to the

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_basic_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_basic_models.py
@@ -1,13 +1,14 @@
 #
 # Compare basic models with full models
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
 import unittest
 
 
-class TestCompareBasicModels(unittest.TestCase):
+class TestCompareBasicModels(TestCase):
     def test_compare_full(self):
         basic_full = pybamm.lead_acid.BasicFull()
         full = pybamm.lead_acid.Full()

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_compare_outputs.py
@@ -1,13 +1,14 @@
 #
 # Tests for the asymptotic convergence of the simplified models
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
 from tests import StandardOutputComparison
 
 
-class TestCompareOutputs(unittest.TestCase):
+class TestCompareOutputs(TestCase):
     def test_compare_averages_asymptotics(self):
         """
         Check that the average value of certain variables is constant across submodels

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_full.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_full.py
@@ -1,6 +1,7 @@
 #
 # Tests for the lead-acid Full model
 #
+from tests import TestCase
 import pybamm
 import tests
 
@@ -8,7 +9,7 @@ import unittest
 import numpy as np
 
 
-class TestLeadAcidFull(unittest.TestCase):
+class TestLeadAcidFull(TestCase):
     def test_basic_processing(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lead_acid.Full(options)
@@ -55,7 +56,7 @@ class TestLeadAcidFull(unittest.TestCase):
         modeltest.test_all(skip_output_tests=True)
 
 
-class TestLeadAcidFullSurfaceForm(unittest.TestCase):
+class TestLeadAcidFullSurfaceForm(TestCase):
     def test_basic_processing_differential(self):
         options = {"surface form": "differential"}
         model = pybamm.lead_acid.Full(options)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_loqs.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_loqs.py
@@ -1,6 +1,7 @@
 #
 # Tests for the lead-acid LOQS model
 #
+from tests import TestCase
 import pybamm
 import tests
 
@@ -8,7 +9,7 @@ import unittest
 import numpy as np
 
 
-class TestLOQS(unittest.TestCase):
+class TestLOQS(TestCase):
     def test_basic_processing(self):
         model = pybamm.lead_acid.LOQS()
         modeltest = tests.StandardModelTest(model)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_loqs_surface_form.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_loqs_surface_form.py
@@ -1,6 +1,7 @@
 #
 # Tests for the lead-acid LOQS model with capacitance
 #
+from tests import TestCase
 import pybamm
 import tests
 
@@ -9,7 +10,7 @@ import unittest
 import numpy as np
 
 
-class TestLeadAcidLoqsSurfaceForm(unittest.TestCase):
+class TestLeadAcidLoqsSurfaceForm(TestCase):
     def test_basic_processing(self):
         options = {"surface form": "algebraic"}
         model = pybamm.lead_acid.LOQS(options)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_side_reactions/test_full_side_reactions.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_side_reactions/test_full_side_reactions.py
@@ -1,6 +1,7 @@
 #
 # Tests for the lead-acid Full model
 #
+from tests import TestCase
 import pybamm
 import tests
 
@@ -8,7 +9,7 @@ import unittest
 import numpy as np
 
 
-class TestLeadAcidFullSideReactions(unittest.TestCase):
+class TestLeadAcidFullSideReactions(TestCase):
     def test_basic_processing(self):
         options = {"hydrolysis": "true"}
         model = pybamm.lead_acid.Full(options)

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_side_reactions/test_loqs_side_reactions.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_side_reactions/test_loqs_side_reactions.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lead-acid LOQS model
 #
+from tests import TestCase
 import pybamm
 import tests
 import unittest
 
 
-class TestLeadAcidLOQSWithSideReactions(unittest.TestCase):
+class TestLeadAcidLOQSWithSideReactions(TestCase):
     def test_discharge_differential(self):
         options = {"surface form": "differential", "hydrolysis": "true"}
         model = pybamm.lead_acid.LOQS(options)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_basic_half_cell_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_basic_half_cell_models.py
@@ -1,13 +1,14 @@
 #
 # Test basic half-cell model with different parameter values
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
 import unittest
 
 
-class TestBasicHalfCellModels(unittest.TestCase):
+class TestBasicHalfCellModels(TestCase):
     def test_runs_Xu2019(self):
         options = {"working electrode": "positive"}
         model = pybamm.lithium_ion.BasicDFNHalfCell(options=options)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
@@ -1,13 +1,14 @@
 #
 # Compare basic models with full models
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
 import unittest
 
 
-class TestCompareBasicModels(unittest.TestCase):
+class TestCompareBasicModels(TestCase):
     def test_compare_dfns(self):
         basic_dfn = pybamm.lithium_ion.BasicDFN()
         dfn = pybamm.lithium_ion.DFN()

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs.py
@@ -1,13 +1,14 @@
 #
 # Tests for the surface formulation
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
 from tests import StandardOutputComparison
 
 
-class TestCompareOutputs(unittest.TestCase):
+class TestCompareOutputs(TestCase):
     def test_compare_outputs_surface_form(self):
         # load models
         options = [

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
@@ -4,9 +4,10 @@
 import pybamm
 import numpy as np
 import unittest
+from tests import TestCase
 
 
-class TestCompareOutputsTwoPhase(unittest.TestCase):
+class TestCompareOutputsTwoPhase(TestCase):
     def compare_outputs_two_phase_graphite_graphite(self, model_class):
         """
         Check that a two-phase graphite-graphite model gives the same results as a

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -1,6 +1,7 @@
 #
 # Tests for the lithium-ion DFN model
 #
+from tests import TestCase
 import pybamm
 import tests
 import numpy as np
@@ -8,7 +9,7 @@ import unittest
 from tests import BaseIntegrationTestLithiumIon
 
 
-class TestDFN(BaseIntegrationTestLithiumIon, unittest.TestCase):
+class TestDFN(BaseIntegrationTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.DFN
 
@@ -34,7 +35,7 @@ class TestDFN(BaseIntegrationTestLithiumIon, unittest.TestCase):
         self.run_basic_processing_test({}, parameter_values=param)
 
 
-class TestDFNWithSizeDistribution(unittest.TestCase):
+class TestDFNWithSizeDistribution(TestCase):
     def setUp(self):
         params = pybamm.ParameterValues("Marquis2019")
         self.params = pybamm.get_size_distribution_parameters(params)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn_half_cell.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn_half_cell.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion DFN half-cell model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIonHalfCell
 
 
-class TestDFNHalfCell(BaseIntegrationTestLithiumIonHalfCell, unittest.TestCase):
+class TestDFNHalfCell(BaseIntegrationTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.DFN
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_external/test_external_temperature.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_external/test_external_temperature.py
@@ -1,12 +1,13 @@
 #
 # Tests for inputting a temperature profile
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
 
 
-class TestInputLumpedTemperature(unittest.TestCase):
+class TestInputLumpedTemperature(TestCase):
     def test_input_lumped_temperature(self):
         model = pybamm.lithium_ion.SPMe()
         parameter_values = model.default_parameter_values

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_initial_soc.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_initial_soc.py
@@ -1,11 +1,12 @@
 #
 # Test edge cases for initial SOC
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestInitialSOC(unittest.TestCase):
+class TestInitialSOC(TestCase):
     def test_interpolant_parameter_sets(self):
         model = pybamm.lithium_ion.SPM()
         params = [

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
@@ -1,13 +1,14 @@
 #
 # Tests for the lithium-ion MPM model
 #
+from tests import TestCase
 import pybamm
 import tests
 import numpy as np
 import unittest
 
 
-class TestMPM(unittest.TestCase):
+class TestMPM(TestCase):
     def test_basic_processing(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lithium_ion.MPM(options)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion Newman-Tobias model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIon
 
 
-class TestNewmanTobias(BaseIntegrationTestLithiumIon, unittest.TestCase):
+class TestNewmanTobias(BaseIntegrationTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.NewmanTobias
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion SPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIon
 
 
-class TestSPM(BaseIntegrationTestLithiumIon, unittest.TestCase):
+class TestSPM(BaseIntegrationTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPM
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm_half_cell.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spm_half_cell.py
@@ -1,12 +1,13 @@
 #
 # Tests for the half-cell lithium-ion SPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIonHalfCell
 
 
-class TestSPMHalfCell(BaseIntegrationTestLithiumIonHalfCell, unittest.TestCase):
+class TestSPMHalfCell(BaseIntegrationTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPM
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion SPMe model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIon
 
 
-class TestSPMe(BaseIntegrationTestLithiumIon, unittest.TestCase):
+class TestSPMe(BaseIntegrationTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPMe
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme_half_cell.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_spme_half_cell.py
@@ -1,12 +1,13 @@
 #
 # Tests for the half-cell lithium-ion SPMe model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseIntegrationTestLithiumIonHalfCell
 
 
-class TestSPMeHalfCell(BaseIntegrationTestLithiumIonHalfCell, unittest.TestCase):
+class TestSPMeHalfCell(BaseIntegrationTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPMe
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_thermal_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_thermal_models.py
@@ -5,9 +5,10 @@
 import pybamm
 import numpy as np
 import unittest
+from tests import TestCase
 
 
-class TestThermal(unittest.TestCase):
+class TestThermal(TestCase):
     def test_consistent_cooling(self):
         # use spme for comparison instead of spm as
         # much larger realistic temperature rises

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_yang2017.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_yang2017.py
@@ -1,9 +1,10 @@
 import pybamm
 import unittest
 import tests
+from tests import TestCase
 
 
-class TestYang2017(unittest.TestCase):
+class TestYang2017(TestCase):
     def test_basic_processing(self):
         model = pybamm.lithium_ion.Yang2017()
         parameter_values = pybamm.ParameterValues("OKane2022")

--- a/tests/integration/test_models/test_submodels/test_external_circuit/test_function_control.py
+++ b/tests/integration/test_models/test_submodels/test_external_circuit/test_function_control.py
@@ -1,12 +1,13 @@
 #
 # Test function control submodel
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
 
 
-class TestFunctionControl(unittest.TestCase):
+class TestFunctionControl(TestCase):
     def test_constant_current(self):
         def constant_current(variables):
             I = variables["Current [A]"]

--- a/tests/integration/test_models/test_submodels/test_interface/test_butler_volmer.py
+++ b/tests/integration/test_models/test_submodels/test_interface/test_butler_volmer.py
@@ -1,6 +1,7 @@
 #
 # Tests for the electrode-electrolyte interface equations
 #
+from tests import TestCase
 import pybamm
 from tests import get_discretisation_for_testing
 
@@ -8,7 +9,7 @@ import unittest
 import numpy as np
 
 
-class TestButlerVolmer(unittest.TestCase):
+class TestButlerVolmer(TestCase):
     def setUp(self):
         self.delta_phi_s_n = pybamm.Variable(
             "surface potential difference [V]",

--- a/tests/integration/test_models/test_submodels/test_interface/test_lead_acid.py
+++ b/tests/integration/test_models/test_submodels/test_interface/test_lead_acid.py
@@ -1,12 +1,13 @@
 #
 # Tests for the electrode-electrolyte interface equations for lead-acid models
 #
+from tests import TestCase
 import pybamm
 from tests import get_discretisation_for_testing
 import unittest
 
 
-class TestMainReaction(unittest.TestCase):
+class TestMainReaction(TestCase):
     def setUp(self):
         c_e_n = pybamm.Variable(
             "Negative electrolyte concentration [mol.m-3]",

--- a/tests/integration/test_models/test_submodels/test_interface/test_lithium_ion.py
+++ b/tests/integration/test_models/test_submodels/test_interface/test_lithium_ion.py
@@ -1,6 +1,7 @@
 #
 # Tests for the electrode-electrolyte interface equations for lithium-ion models
 #
+from tests import TestCase
 import pybamm
 from tests import get_discretisation_for_testing
 
@@ -8,7 +9,7 @@ import unittest
 import numpy as np
 
 
-class TestExchangeCurrentDensity(unittest.TestCase):
+class TestExchangeCurrentDensity(TestCase):
     def setUp(self):
         c_e_n = pybamm.Variable("concentration", domain=["negative electrode"])
         c_e_s = pybamm.Variable("concentration", domain=["separator"])

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -1,11 +1,12 @@
 import pybamm
 import numpy as np
 import sys
+from tests import TestCase
 import unittest
 
 
 @unittest.skipIf(not pybamm.have_idaklu(), "idaklu solver is not installed")
-class TestIDAKLUSolver(unittest.TestCase):
+class TestIDAKLUSolver(TestCase):
     def test_on_spme(self):
         model = pybamm.lithium_ion.SPMe()
         geometry = model.default_geometry

--- a/tests/integration/test_solvers/test_solution.py
+++ b/tests/integration/test_solvers/test_solution.py
@@ -1,12 +1,13 @@
 #
 # Tests for the Solution class
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
 
 
-class TestSolution(unittest.TestCase):
+class TestSolution(TestCase):
     def test_append(self):
         model = pybamm.lithium_ion.SPMe()
         # create geometry

--- a/tests/integration/test_spatial_methods/test_finite_volume.py
+++ b/tests/integration/test_spatial_methods/test_finite_volume.py
@@ -1,6 +1,7 @@
 #
 # Test for the operator class
 #
+from tests import TestCase
 import pybamm
 from tests import (
     get_mesh_for_testing,
@@ -12,7 +13,7 @@ import numpy as np
 import unittest
 
 
-class TestFiniteVolumeConvergence(unittest.TestCase):
+class TestFiniteVolumeConvergence(TestCase):
     def test_grad_div_broadcast(self):
         # create mesh and discretisation
         spatial_methods = {"macroscale": pybamm.FiniteVolume()}

--- a/tests/integration/test_spatial_methods/test_spectral_volume.py
+++ b/tests/integration/test_spatial_methods/test_spectral_volume.py
@@ -1,6 +1,7 @@
 #
 # Test for the operator class
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
@@ -75,7 +76,7 @@ def get_p2d_mesh_for_testing(xpts=None, rpts=10):
     return get_mesh_for_testing(xpts=xpts, rpts=rpts, geometry=geometry)
 
 
-class TestSpectralVolumeConvergence(unittest.TestCase):
+class TestSpectralVolumeConvergence(TestCase):
     def test_grad_div_broadcast(self):
         # create mesh and discretisation
         spatial_methods = {"macroscale": pybamm.SpectralVolume()}

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -1,12 +1,53 @@
 #
-# Custom unittest.TestCase class for pybamm
+# Custom TestCase class for pybamm
 #
 import unittest
+import hashlib
+import numpy as np
+from functools import wraps
+from types import FunctionType
 
 
-class TestCase(unittest.TestCase):
+def FixRandomSeed(method):
     """
-    Custom unittest.TestCase class for pybamm
+    Wraps a method so that the random seed is set to a hash of the method name
+
+    As the wrapper fixes the random seed before calling the method, tests can
+    explicitely reinstate the random seed within their method bodies as desired,
+    e.g. by calling np.random.seed(None) to restore normal behaviour.
+
+    Generatig a random seed from the method name allows particularly awkward
+    sequences to be altered by changing the method name, such as by adding a
+    trailing underscore, or other hash modifier, if required.
+    """
+
+    @wraps(method)
+    def wrapped(*args, **kwargs):
+        np.random.seed(
+            int(hashlib.sha1(method.__name__.encode()).hexdigest(), 16) % (2**32)
+        )
+        return method(*args, **kwargs)
+
+    return wrapped
+
+
+class MakeAllTestsDeterministic(type):
+    """
+    Metaclass that wraps all class methods with FixRandomSeed()
+    """
+
+    def __new__(meta, classname, bases, classDict):
+        newClassDict = {}
+        for attributeName, attribute in classDict.items():
+            if isinstance(attribute, FunctionType):
+                attribute = FixRandomSeed(attribute)
+            newClassDict[attributeName] = attribute
+        return type.__new__(meta, classname, bases, newClassDict)
+
+
+class TestCase(unittest.TestCase, metaclass=MakeAllTestsDeterministic):
+    """
+    Custom TestCase class for pybamm
     """
 
     def assertDomainEqual(self, a, b):

--- a/tests/unit/test_batch_study.py
+++ b/tests/unit/test_batch_study.py
@@ -1,6 +1,7 @@
 """
 Tests for the batch_study.py
 """
+from tests import TestCase
 import os
 import pybamm
 import unittest
@@ -31,7 +32,7 @@ bs_true = pybamm.BatchStudy(
 )
 
 
-class TestBatchStudy(unittest.TestCase):
+class TestBatchStudy(TestCase):
     def test_solve(self):
         # Tests for exceptions
         for name in pybamm.BatchStudy.INPUT_LIST:

--- a/tests/unit/test_callbacks.py
+++ b/tests/unit/test_callbacks.py
@@ -1,6 +1,7 @@
 #
 # Tests the citations class.
 #
+from tests import TestCase
 import pybamm
 import unittest
 import os
@@ -17,7 +18,7 @@ class DummyCallback(callbacks.Callback):
             print(self.name, file=f)
 
 
-class TestCallbacks(unittest.TestCase):
+class TestCallbacks(TestCase):
     def tearDown(self):
         # Remove any test log files that were created, even if the test fails
         for logfile in ["test_callback.log", "test_callback_2.log"]:

--- a/tests/unit/test_citations.py
+++ b/tests/unit/test_citations.py
@@ -1,6 +1,7 @@
 #
 # Tests the citations class.
 #
+from tests import TestCase
 import pybamm
 import os
 import io
@@ -23,7 +24,7 @@ def temporary_filename():
         os.remove(f.name)
 
 
-class TestCitations(unittest.TestCase):
+class TestCitations(TestCase):
     def test_citations(self):
         citations = pybamm.citations
         # Default papers should be in both _all_citations dict and in the papers to cite

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -1,6 +1,7 @@
 #
 # Tests for the base model class
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
@@ -17,7 +18,7 @@ from scipy.sparse import block_diag, csc_matrix
 from scipy.sparse.linalg import inv
 
 
-class TestDiscretise(unittest.TestCase):
+class TestDiscretise(TestCase):
     def test_concatenate_in_order(self):
         a = pybamm.Variable("a")
         b = pybamm.Variable("b")

--- a/tests/unit/test_doc_utils.py
+++ b/tests/unit/test_doc_utils.py
@@ -5,11 +5,12 @@
 
 import pybamm
 import unittest
+from tests import TestCase
 from inspect import getmro
 from pybamm.doc_utils import copy_parameter_doc_from_parent, doc_extend_parent
 
 
-class TestDocUtils(unittest.TestCase):
+class TestDocUtils(TestCase):
     def test_copy_parameter_doc_from_parent(self):
         """Test if parameters from the parent class are copied to
         child class docstring"""

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -1,6 +1,7 @@
 #
 # Test the base experiment class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
@@ -8,7 +9,7 @@ import pandas as pd
 import os
 
 
-class TestExperiment(unittest.TestCase):
+class TestExperiment(TestCase):
     def test_read_strings(self):
         # Import drive cycle from file
         drive_cycle = pd.read_csv(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1,6 +1,7 @@
 #
 # Test setting up a simulation with an experiment
 #
+from tests import TestCase
 import casadi
 import pybamm
 import numpy as np
@@ -8,7 +9,7 @@ import os
 import unittest
 
 
-class TestSimulationExperiment(unittest.TestCase):
+class TestSimulationExperiment(TestCase):
     def test_set_up(self):
         experiment = pybamm.Experiment(
             [

--- a/tests/unit/test_expression_tree/test_array.py
+++ b/tests/unit/test_expression_tree/test_array.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Array class
 #
+from tests import TestCase
 import unittest
 
 import numpy as np
@@ -9,7 +10,7 @@ import sympy
 import pybamm
 
 
-class TestArray(unittest.TestCase):
+class TestArray(TestCase):
     def test_name(self):
         arr = pybamm.Array(np.array([1, 2, 3]))
         self.assertEqual(arr.name, "Array of shape (3, 1)")

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Binary Operator classes
 #
+from tests import TestCase
 import unittest
 
 import numpy as np
@@ -10,7 +11,7 @@ from scipy.sparse import coo_matrix
 import pybamm
 
 
-class TestBinaryOperators(unittest.TestCase):
+class TestBinaryOperators(TestCase):
     def test_binary_operator(self):
         a = pybamm.Symbol("a")
         b = pybamm.Symbol("b")

--- a/tests/unit/test_expression_tree/test_d_dt.py
+++ b/tests/unit/test_expression_tree/test_d_dt.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Scalar class
 #
+from tests import TestCase
 import pybamm
 
 import unittest
 import numpy as np
 
 
-class TestDDT(unittest.TestCase):
+class TestDDT(TestCase):
     def test_time_derivative(self):
         a = pybamm.Scalar(5).diff(pybamm.t)
         self.assertIsInstance(a, pybamm.Scalar)

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Function classes
 #
+from tests import TestCase
 import unittest
 
 import numpy as np
@@ -22,7 +23,7 @@ def test_multi_var_function_cube(arg1, arg2):
     return arg1 + arg2**3
 
 
-class TestFunction(unittest.TestCase):
+class TestFunction(TestCase):
     def test_number_input(self):
         # with numbers
         log = pybamm.Function(np.log, 10)
@@ -145,7 +146,7 @@ class TestFunction(unittest.TestCase):
         self.assertEqual(pybamm.Function(np.log, 10).to_equation(), 10.0)
 
 
-class TestSpecificFunctions(unittest.TestCase):
+class TestSpecificFunctions(TestCase):
     def test_arcsinh(self):
         a = pybamm.InputParameter("a")
         fun = pybamm.arcsinh(a)

--- a/tests/unit/test_expression_tree/test_independent_variable.py
+++ b/tests/unit/test_expression_tree/test_independent_variable.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Parameter class
 #
+from tests import TestCase
 import unittest
 
 import sympy
@@ -8,7 +9,7 @@ import sympy
 import pybamm
 
 
-class TestIndependentVariable(unittest.TestCase):
+class TestIndependentVariable(TestCase):
     def test_variable_init(self):
         a = pybamm.IndependentVariable("a")
         self.assertEqual(a.name, "a")

--- a/tests/unit/test_expression_tree/test_input_parameter.py
+++ b/tests/unit/test_expression_tree/test_input_parameter.py
@@ -1,12 +1,13 @@
 #
 # Tests for the InputParameter class
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
 
 
-class TestInputParameter(unittest.TestCase):
+class TestInputParameter(TestCase):
     def test_input_parameter_init(self):
         a = pybamm.InputParameter("a")
         self.assertEqual(a.name, "a")

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Function classes
 #
+from tests import TestCase
 import pybamm
 
 import unittest
 import numpy as np
 
 
-class TestInterpolant(unittest.TestCase):
+class TestInterpolant(TestCase):
     def test_errors(self):
         with self.assertRaisesRegex(ValueError, "x1"):
             pybamm.Interpolant(np.ones(10), np.ones(11), pybamm.Symbol("a"))

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Matrix class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 
 import unittest
 
 
-class TestMatrix(unittest.TestCase):
+class TestMatrix(TestCase):
     def setUp(self):
         self.A = np.array([[1, 2, 0], [0, 1, 0], [0, 0, 1]])
         self.x = np.array([1, 2, 3])

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -1,6 +1,7 @@
 #
 # Test for the Simplify class
 #
+from tests import TestCase
 import casadi
 import numpy as np
 import pybamm
@@ -9,7 +10,7 @@ from tests import get_mesh_for_testing, get_1p1d_discretisation_for_testing
 from scipy import special
 
 
-class TestCasadiConverter(unittest.TestCase):
+class TestCasadiConverter(TestCase):
     def assert_casadi_equal(self, a, b, evalf=False):
         if evalf is True:
             self.assertTrue((casadi.evalf(a) - casadi.evalf(b)).is_zero())

--- a/tests/unit/test_expression_tree/test_operations/test_copy.py
+++ b/tests/unit/test_expression_tree/test_operations/test_copy.py
@@ -1,13 +1,14 @@
 #
 # Test for making copies
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
 from tests import get_mesh_for_testing
 
 
-class TestCopy(unittest.TestCase):
+class TestCopy(TestCase):
     def test_symbol_new_copy(self):
         a = pybamm.Parameter("a")
         b = pybamm.Parameter("b")

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
@@ -1,6 +1,7 @@
 #
 # Test for the evaluate-to-python functions
 #
+from tests import TestCase
 import pybamm
 
 from tests import get_discretisation_for_testing, get_1p1d_discretisation_for_testing
@@ -21,7 +22,7 @@ def test_function2(arg1, arg2):
     return arg1 + arg2
 
 
-class TestEvaluate(unittest.TestCase):
+class TestEvaluate(TestCase):
     def test_find_symbols(self):
         a = pybamm.StateVector(slice(0, 1))
         b = pybamm.StateVector(slice(1, 2))

--- a/tests/unit/test_expression_tree/test_operations/test_jac.py
+++ b/tests/unit/test_expression_tree/test_operations/test_jac.py
@@ -1,6 +1,7 @@
 #
 # Tests for the jacobian methods
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
@@ -13,7 +14,7 @@ def test_multi_var_function(arg1, arg2):
     return arg1 + arg2
 
 
-class TestJacobian(unittest.TestCase):
+class TestJacobian(TestCase):
     def test_variable_is_statevector(self):
         a = pybamm.Symbol("a")
         with self.assertRaisesRegex(

--- a/tests/unit/test_expression_tree/test_operations/test_jac_2D.py
+++ b/tests/unit/test_expression_tree/test_operations/test_jac_2D.py
@@ -1,6 +1,7 @@
 #
 # Tests for the jacobian methods for two-dimensional objects
 #
+from tests import TestCase
 import pybamm
 
 import numpy as np
@@ -13,7 +14,7 @@ def test_multi_var_function(arg1, arg2):
     return arg1 + arg2
 
 
-class TestJacobian(unittest.TestCase):
+class TestJacobian(TestCase):
     def test_linear(self):
         y = pybamm.StateVector(slice(0, 8))
         u = pybamm.StateVector(slice(0, 2), slice(4, 6))

--- a/tests/unit/test_expression_tree/test_operations/test_latexify.py
+++ b/tests/unit/test_expression_tree/test_operations/test_latexify.py
@@ -1,6 +1,7 @@
 """
 Tests for the latexify.py
 """
+from tests import TestCase
 import os
 import platform
 import unittest
@@ -10,7 +11,7 @@ import pybamm
 from pybamm.expression_tree.operations.latexify import Latexify
 
 
-class TestLatexify(unittest.TestCase):
+class TestLatexify(TestCase):
     def test_latexify(self):
         model_dfn = pybamm.lithium_ion.DFN()
         func_dfn = str(model_dfn.latexify())

--- a/tests/unit/test_expression_tree/test_operations/test_unpack_symbols.py
+++ b/tests/unit/test_expression_tree/test_operations/test_unpack_symbols.py
@@ -1,11 +1,12 @@
 #
 # Tests for the symbol unpacker
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestSymbolUnpacker(unittest.TestCase):
+class TestSymbolUnpacker(TestCase):
     def test_basic_symbols(self):
         a = pybamm.Scalar(1)
         unpacker = pybamm.SymbolUnpacker(pybamm.Scalar)

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Parameter class
 #
+from tests import TestCase
 import numbers
 import unittest
 
@@ -9,7 +10,7 @@ import sympy
 import pybamm
 
 
-class TestParameter(unittest.TestCase):
+class TestParameter(TestCase):
     def test_parameter_init(self):
         a = pybamm.Parameter("a")
         self.assertEqual(a.name, "a")
@@ -31,7 +32,7 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(func1.to_equation(), sympy.Symbol("test_name"))
 
 
-class TestFunctionParameter(unittest.TestCase):
+class TestFunctionParameter(TestCase):
     def test_function_parameter_init(self):
         var = pybamm.Variable("var")
         func = pybamm.FunctionParameter("func", {"var": var})

--- a/tests/unit/test_expression_tree/test_printing/test_print_name.py
+++ b/tests/unit/test_expression_tree/test_printing/test_print_name.py
@@ -1,12 +1,13 @@
 """
 Tests for the print_name.py
 """
+from tests import TestCase
 import unittest
 
 import pybamm
 
 
-class TestPrintName(unittest.TestCase):
+class TestPrintName(TestCase):
     def test_prettify_print_name(self):
         param = pybamm.LithiumIonParameters()
         param2 = pybamm.LeadAcidParameters()

--- a/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
+++ b/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
@@ -1,6 +1,7 @@
 """
 Tests for the sympy_overrides.py
 """
+from tests import TestCase
 import unittest
 
 import sympy
@@ -9,7 +10,7 @@ import pybamm
 from pybamm.expression_tree.printing.sympy_overrides import custom_print_func
 
 
-class TestCustomPrint(unittest.TestCase):
+class TestCustomPrint(TestCase):
     def test_print_Derivative(self):
         # Test force_partial
         der1 = sympy.Derivative("y", "x")

--- a/tests/unit/test_expression_tree/test_scalar.py
+++ b/tests/unit/test_expression_tree/test_scalar.py
@@ -1,12 +1,13 @@
 #
 # Tests for the Scalar class
 #
+from tests import TestCase
 import unittest
 
 import pybamm
 
 
-class TestScalar(unittest.TestCase):
+class TestScalar(TestCase):
     def test_scalar_eval(self):
         a = pybamm.Scalar(5)
         self.assertEqual(a.value, 5)

--- a/tests/unit/test_expression_tree/test_state_vector.py
+++ b/tests/unit/test_expression_tree/test_state_vector.py
@@ -1,13 +1,14 @@
 #
 # Tests for the State Vector class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 
 import unittest
 
 
-class TestStateVector(unittest.TestCase):
+class TestStateVector(TestCase):
     def test_evaluate(self):
         sv = pybamm.StateVector(slice(0, 10))
         y = np.linspace(0, 2, 19)
@@ -62,7 +63,7 @@ class TestStateVector(unittest.TestCase):
             pybamm.StateVector(slice(0, 10), 1)
 
 
-class TestStateVectorDot(unittest.TestCase):
+class TestStateVectorDot(TestCase):
     def test_evaluate(self):
         sv = pybamm.StateVectorDot(slice(0, 10))
         y_dot = np.linspace(0, 2, 19)

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -1,6 +1,7 @@
 #
 # Test for the Symbol class
 #
+from tests import TestCase
 import os
 import unittest
 
@@ -12,7 +13,7 @@ import pybamm
 from pybamm.expression_tree.binary_operators import _Heaviside
 
 
-class TestSymbol(unittest.TestCase):
+class TestSymbol(TestCase):
     def test_symbol_init(self):
         sym = pybamm.Symbol("a symbol")
         self.assertEqual(sym.name, "a symbol")
@@ -482,7 +483,7 @@ class TestSymbol(unittest.TestCase):
         self.assertEqual(pybamm.Symbol("test").to_equation(), sympy.Symbol("test"))
 
 
-class TestIsZero(unittest.TestCase):
+class TestIsZero(TestCase):
     def test_is_scalar_zero(self):
         a = pybamm.Scalar(0)
         b = pybamm.Scalar(2)

--- a/tests/unit/test_expression_tree/test_symbolic_diff.py
+++ b/tests/unit/test_expression_tree/test_symbolic_diff.py
@@ -1,13 +1,14 @@
 #
 # Tests for the symbolic differentiation methods
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
 from numpy import testing
 
 
-class TestSymbolicDifferentiation(unittest.TestCase):
+class TestSymbolicDifferentiation(TestCase):
     def test_advanced(self):
         a = pybamm.StateVector(slice(0, 1))
         b = pybamm.StateVector(slice(1, 2))

--- a/tests/unit/test_expression_tree/test_variable.py
+++ b/tests/unit/test_expression_tree/test_variable.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Variable class
 #
+from tests import TestCase
 import unittest
 
 import numpy as np
@@ -9,7 +10,7 @@ import sympy
 import pybamm
 
 
-class TestVariable(unittest.TestCase):
+class TestVariable(TestCase):
     def test_variable_init(self):
         a = pybamm.Variable("a")
         self.assertEqual(a.name, "a")
@@ -63,7 +64,7 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(pybamm.Variable("name").to_equation(), sympy.Symbol("name"))
 
 
-class TestVariableDot(unittest.TestCase):
+class TestVariableDot(TestCase):
     def test_variable_init(self):
         a = pybamm.VariableDot("a'")
         self.assertEqual(a.name, "a'")

--- a/tests/unit/test_expression_tree/test_vector.py
+++ b/tests/unit/test_expression_tree/test_vector.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Vector class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 
 import unittest
 
 
-class TestVector(unittest.TestCase):
+class TestVector(TestCase):
     def setUp(self):
         self.x = np.array([[1], [2], [3]])
         self.vect = pybamm.Vector(self.x)

--- a/tests/unit/test_geometry/test_battery_geometry.py
+++ b/tests/unit/test_geometry/test_battery_geometry.py
@@ -1,11 +1,12 @@
 #
 # Tests for the base model class
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestBatteryGeometry(unittest.TestCase):
+class TestBatteryGeometry(TestCase):
     def test_geometry_keys(self):
         for cc_dimension in [0, 1, 2]:
             geometry = pybamm.battery_geometry(
@@ -83,7 +84,7 @@ class TestBatteryGeometry(unittest.TestCase):
             pybamm.battery_geometry(form_factor="triangle")
 
 
-class TestReadParameters(unittest.TestCase):
+class TestReadParameters(TestCase):
     # This is the most complicated geometry and should test the parameters are
     # all returned for the deepest dict
     def test_read_parameters(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,11 +1,12 @@
 #
 # Tests the logger class.
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestLogger(unittest.TestCase):
+class TestLogger(TestCase):
     def test_logger(self):
         logger = pybamm.logger
         self.assertEqual(logger.level, 30)

--- a/tests/unit/test_meshes/test_meshes.py
+++ b/tests/unit/test_meshes/test_meshes.py
@@ -1,6 +1,7 @@
 #
 # Test for the Finite Volume Mesh class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
@@ -18,7 +19,7 @@ def get_param():
     )
 
 
-class TestMesh(unittest.TestCase):
+class TestMesh(TestCase):
     def test_mesh_creation_no_parameters(self):
         r = pybamm.SpatialVariable(
             "r", domain=["negative particle"], coord_sys="spherical polar"
@@ -384,7 +385,7 @@ class TestMesh(unittest.TestCase):
         self.assertEqual(mesh["current collector"].tabs["positive tab"], "left")
 
 
-class TestMeshGenerator(unittest.TestCase):
+class TestMeshGenerator(TestCase):
     def test_init_name(self):
         mesh_generator = pybamm.MeshGenerator(pybamm.SubMesh0D)
         self.assertEqual(mesh_generator.__repr__(), "Generator for SubMesh0D")

--- a/tests/unit/test_meshes/test_one_dimensional_submesh.py
+++ b/tests/unit/test_meshes/test_one_dimensional_submesh.py
@@ -1,9 +1,10 @@
 import pybamm
 import unittest
 import numpy as np
+from tests import TestCase
 
 
-class TestSubMesh1D(unittest.TestCase):
+class TestSubMesh1D(TestCase):
     def test_tabs(self):
         edges = np.linspace(0, 1, 10)
         tabs = {"negative": {"z_centre": 0}, "positive": {"z_centre": 1}}
@@ -18,7 +19,7 @@ class TestSubMesh1D(unittest.TestCase):
             pybamm.SubMesh1D(edges, None, tabs=tabs)
 
 
-class TestUniform1DSubMesh(unittest.TestCase):
+class TestUniform1DSubMesh(TestCase):
     def test_exceptions(self):
         lims = {"a": 1, "b": 2}
         with self.assertRaises(pybamm.GeometryError):
@@ -51,7 +52,7 @@ class TestUniform1DSubMesh(unittest.TestCase):
         )
 
 
-class TestExponential1DSubMesh(unittest.TestCase):
+class TestExponential1DSubMesh(TestCase):
     def test_symmetric_mesh_creation_no_parameters_even(self):
         r = pybamm.SpatialVariable(
             "r", domain=["negative particle"], coord_sys="spherical polar"
@@ -177,7 +178,7 @@ class TestExponential1DSubMesh(unittest.TestCase):
         )
 
 
-class TestChebyshev1DSubMesh(unittest.TestCase):
+class TestChebyshev1DSubMesh(TestCase):
     def test_mesh_creation_no_parameters(self):
         r = pybamm.SpatialVariable(
             "r", domain=["negative particle"], coord_sys="spherical polar"
@@ -205,7 +206,7 @@ class TestChebyshev1DSubMesh(unittest.TestCase):
         )
 
 
-class TestUser1DSubMesh(unittest.TestCase):
+class TestUser1DSubMesh(TestCase):
     def test_exceptions(self):
         edges = np.array([0, 0.3, 1])
         submesh_params = {"edges": edges}
@@ -267,7 +268,7 @@ class TestUser1DSubMesh(unittest.TestCase):
         )
 
 
-class TestSpectralVolume1DSubMesh(unittest.TestCase):
+class TestSpectralVolume1DSubMesh(TestCase):
     def test_exceptions(self):
         edges = np.array([0, 0.3, 1])
         submesh_params = {"edges": edges}

--- a/tests/unit/test_meshes/test_scikit_fem_submesh.py
+++ b/tests/unit/test_meshes/test_scikit_fem_submesh.py
@@ -1,6 +1,7 @@
 #
 # Test for the scikit-fem Finite Element Mesh class
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
@@ -24,7 +25,7 @@ def get_param():
     )
 
 
-class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
+class TestScikitFiniteElement2DSubMesh(TestCase):
     def test_mesh_creation(self):
         param = get_param()
         geometry = pybamm.battery_geometry(
@@ -180,7 +181,7 @@ class TestScikitFiniteElement2DSubMesh(unittest.TestCase):
         pybamm.Mesh(geometry, submesh_types, var_pts)
 
 
-class TestScikitFiniteElementChebyshev2DSubMesh(unittest.TestCase):
+class TestScikitFiniteElementChebyshev2DSubMesh(TestCase):
     def test_mesh_creation(self):
         param = get_param()
 
@@ -243,7 +244,7 @@ class TestScikitFiniteElementChebyshev2DSubMesh(unittest.TestCase):
             pybamm.ScikitChebyshev2DSubMesh(lims, None)
 
 
-class TestScikitExponential2DSubMesh(unittest.TestCase):
+class TestScikitExponential2DSubMesh(TestCase):
     def test_mesh_creation(self):
         param = get_param()
 
@@ -312,7 +313,7 @@ class TestScikitExponential2DSubMesh(unittest.TestCase):
             pybamm.ScikitExponential2DSubMesh(None, None, side="bottom")
 
 
-class TestScikitUser2DSubMesh(unittest.TestCase):
+class TestScikitUser2DSubMesh(TestCase):
     def test_mesh_creation(self):
         param = get_param()
 

--- a/tests/unit/test_meshes/test_zero_dimensional_submesh.py
+++ b/tests/unit/test_meshes/test_zero_dimensional_submesh.py
@@ -1,8 +1,9 @@
 import pybamm
 import unittest
+from tests import TestCase
 
 
-class TestSubMesh0D(unittest.TestCase):
+class TestSubMesh0D(TestCase):
     def test_exceptions(self):
         position = {"x": {"position": 0}, "y": {"position": 0}}
         with self.assertRaises(pybamm.GeometryError):

--- a/tests/unit/test_models/test_base_model.py
+++ b/tests/unit/test_models/test_base_model.py
@@ -1,6 +1,7 @@
 #
 # Tests for the base model class
 #
+from tests import TestCase
 import os
 import platform
 import subprocess  # nosec
@@ -12,7 +13,7 @@ import numpy as np
 import pybamm
 
 
-class TestBaseModel(unittest.TestCase):
+class TestBaseModel(TestCase):
     def test_rhs_set_get(self):
         model = pybamm.BaseModel()
         rhs = {

--- a/tests/unit/test_models/test_event.py
+++ b/tests/unit/test_models/test_event.py
@@ -1,12 +1,13 @@
 #
 # Tests Event class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
 
 
-class TestEvent(unittest.TestCase):
+class TestEvent(TestCase):
     def test_event(self):
         expression = pybamm.Scalar(1)
         event = pybamm.Event("my event", expression)

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -1,6 +1,7 @@
 #
 # Tests for the base battery model class
 #
+from tests import TestCase
 from pybamm.models.full_battery_models.base_battery_model import BatteryModelOptions
 import pybamm
 import unittest
@@ -48,7 +49,7 @@ PRINT_OPTIONS_OUTPUT = """\
 """  # noqa: E501
 
 
-class TestBaseBatteryModel(unittest.TestCase):
+class TestBaseBatteryModel(TestCase):
     def test_process_parameters_and_discretise(self):
         model = pybamm.lithium_ion.SPM()
         # Set up geometry and parameters
@@ -408,7 +409,7 @@ class TestBaseBatteryModel(unittest.TestCase):
         self.assertEqual(model.options, options)
 
 
-class TestOptions(unittest.TestCase):
+class TestOptions(TestCase):
     def test_print_options(self):
         with io.StringIO() as buffer, redirect_stdout(buffer):
             BatteryModelOptions(OPTIONS_DICT).print_options()

--- a/tests/unit/test_models/test_full_battery_models/test_equivalent_circuit/test_thevenin.py
+++ b/tests/unit/test_models/test_full_battery_models/test_equivalent_circuit/test_thevenin.py
@@ -1,11 +1,12 @@
 #
 # Tests for the Thevenin equivalant circuit model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestThevenin(unittest.TestCase):
+class TestThevenin(TestCase):
     def test_standard_model(self):
         model = pybamm.equivalent_circuit.Thevenin()
         model.check_well_posedness()

--- a/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_base_lead_acid_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_base_lead_acid_model.py
@@ -1,11 +1,12 @@
 #
 # Tests for the base lead acid model class
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestBaseLeadAcidModel(unittest.TestCase):
+class TestBaseLeadAcidModel(TestCase):
     def test_default_geometry(self):
         model = pybamm.lead_acid.BaseModel({"dimensionality": 0})
         self.assertEqual(

--- a/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_basic_models.py
@@ -1,11 +1,12 @@
 #
 # Tests for the basic lead acid models
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestBasicModels(unittest.TestCase):
+class TestBasicModels(TestCase):
     def test_basic_full_lead_acid_well_posed(self):
         model = pybamm.lead_acid.BasicFull()
         model.check_well_posedness()

--- a/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_full.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_full.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lead-acid Full model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestLeadAcidFull(unittest.TestCase):
+class TestLeadAcidFull(TestCase):
     def test_well_posed(self):
         model = pybamm.lead_acid.Full()
         model.check_well_posedness()
@@ -20,7 +21,7 @@ class TestLeadAcidFull(unittest.TestCase):
         model.check_well_posedness()
 
 
-class TestLeadAcidFullSurfaceForm(unittest.TestCase):
+class TestLeadAcidFullSurfaceForm(TestCase):
     def test_well_posed_differential(self):
         options = {"surface form": "differential"}
         model = pybamm.lead_acid.Full(options)
@@ -37,7 +38,7 @@ class TestLeadAcidFullSurfaceForm(unittest.TestCase):
         model.check_well_posedness()
 
 
-class TestLeadAcidFullSideReactions(unittest.TestCase):
+class TestLeadAcidFullSideReactions(TestCase):
     def test_well_posed(self):
         options = {"hydrolysis": "true"}
         model = pybamm.lead_acid.Full(options)

--- a/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_loqs.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lead_acid/test_loqs.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lead-acid LOQS model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestLeadAcidLOQS(unittest.TestCase):
+class TestLeadAcidLOQS(TestCase):
     def test_well_posed(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lead_acid.LOQS(options)
@@ -79,7 +80,7 @@ class TestLeadAcidLOQS(unittest.TestCase):
         )
 
 
-class TestLeadAcidLOQSWithSideReactions(unittest.TestCase):
+class TestLeadAcidLOQSWithSideReactions(TestCase):
     def test_well_posed_differential(self):
         options = {"surface form": "differential", "hydrolysis": "true"}
         model = pybamm.lead_acid.LOQS(options)
@@ -91,7 +92,7 @@ class TestLeadAcidLOQSWithSideReactions(unittest.TestCase):
         model.check_well_posedness()
 
 
-class TestLeadAcidLOQSSurfaceForm(unittest.TestCase):
+class TestLeadAcidLOQSSurfaceForm(TestCase):
     def test_well_posed_differential(self):
         options = {"surface form": "differential"}
         model = pybamm.lead_acid.LOQS(options)
@@ -120,7 +121,7 @@ class TestLeadAcidLOQSSurfaceForm(unittest.TestCase):
         self.assertIn("current collector", model.default_geometry)
 
 
-class TestLeadAcidLOQSExternalCircuits(unittest.TestCase):
+class TestLeadAcidLOQSExternalCircuits(TestCase):
     def test_well_posed_voltage(self):
         options = {"operating mode": "voltage"}
         model = pybamm.lead_acid.LOQS(options)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_Yang2017.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_Yang2017.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lithium-ion DFN model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestYang2017(unittest.TestCase):
+class TestYang2017(TestCase):
     def test_well_posed(self):
         model = pybamm.lithium_ion.Yang2017()
         model.check_well_posedness()

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
@@ -1,12 +1,13 @@
 #
 # Tests for the base lead acid model class
 #
+from tests import TestCase
 import pybamm
 import unittest
 import os
 
 
-class TestBaseLithiumIonModel(unittest.TestCase):
+class TestBaseLithiumIonModel(TestCase):
     def test_incompatible_options(self):
         with self.assertRaisesRegex(pybamm.OptionError, "convection not implemented"):
             pybamm.lithium_ion.BaseModel({"convection": "uniform transverse"})

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_basic_models.py
@@ -1,11 +1,12 @@
 #
 # Tests for the basic lithium-ion models
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestBasicModels(unittest.TestCase):
+class TestBasicModels(TestCase):
     def test_dfn_well_posed(self):
         model = pybamm.lithium_ion.BasicDFN()
         model.check_well_posedness()

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion DFN model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIon
 
 
-class TestDFN(BaseUnitTestLithiumIon, unittest.TestCase):
+class TestDFN(BaseUnitTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.DFN
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_dfn_half_cell.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_dfn_half_cell.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion half-cell DFN model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIonHalfCell
 
 
-class TestDFNHalfCell(BaseUnitTestLithiumIonHalfCell, unittest.TestCase):
+class TestDFNHalfCell(BaseUnitTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.DFN
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lithium-ion electrode-specific SOH model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestElectrodeSOH(unittest.TestCase):
+class TestElectrodeSOH(TestCase):
     def test_known_solution(self):
         param = pybamm.LithiumIonParameters()
         parameter_values = pybamm.ParameterValues("Mohtat2020")
@@ -136,7 +137,7 @@ class TestElectrodeSOH(unittest.TestCase):
             esoh_solver.solve(inputs)
 
 
-class TestElectrodeSOHHalfCell(unittest.TestCase):
+class TestElectrodeSOHHalfCell(TestCase):
     def test_known_solution(self):
         model = pybamm.lithium_ion.ElectrodeSOHHalfCell("positive")
 
@@ -154,7 +155,7 @@ class TestElectrodeSOHHalfCell(unittest.TestCase):
         self.assertAlmostEqual(sol["Uw(x_0)"].data[0], V_min, places=5)
 
 
-class TestCalculateTheoreticalEnergy(unittest.TestCase):
+class TestCalculateTheoreticalEnergy(TestCase):
     def test_efficiency(self):
         model = pybamm.lithium_ion.DFN(options={"calculate discharge energy": "true"})
         parameter_values = pybamm.ParameterValues("Chen2020")
@@ -173,7 +174,7 @@ class TestCalculateTheoreticalEnergy(unittest.TestCase):
         self.assertLess(0, theoretical_energy)
 
 
-class TestGetInitialSOC(unittest.TestCase):
+class TestGetInitialSOC(TestCase):
     def test_initial_soc(self):
         param = pybamm.LithiumIonParameters()
         parameter_values = pybamm.ParameterValues("Mohtat2020")

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lithium-ion MPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestMPM(unittest.TestCase):
+class TestMPM(TestCase):
     def test_well_posed(self):
         options = {"thermal": "isothermal"}
         model = pybamm.lithium_ion.MPM(options)
@@ -108,7 +109,7 @@ class TestMPM(unittest.TestCase):
             pybamm.lithium_ion.MPM(options)
 
 
-class TestMPMExternalCircuits(unittest.TestCase):
+class TestMPMExternalCircuits(TestCase):
     def test_well_posed_voltage(self):
         options = {"operating mode": "voltage"}
         model = pybamm.lithium_ion.MPM(options)
@@ -130,7 +131,7 @@ class TestMPMExternalCircuits(unittest.TestCase):
         model.check_well_posedness()
 
 
-class TestMPMWithSEI(unittest.TestCase):
+class TestMPMWithSEI(TestCase):
     def test_reaction_limited_not_implemented(self):
         options = {"SEI": "reaction limited"}
         with self.assertRaises(NotImplementedError):
@@ -160,7 +161,7 @@ class TestMPMWithSEI(unittest.TestCase):
             pybamm.lithium_ion.MPM(options)
 
 
-class TestMPMWithMechanics(unittest.TestCase):
+class TestMPMWithMechanics(TestCase):
     def test_well_posed_negative_cracking_not_implemented(self):
         options = {"particle mechanics": ("swelling and cracking", "none")}
         with self.assertRaises(NotImplementedError):
@@ -182,7 +183,7 @@ class TestMPMWithMechanics(unittest.TestCase):
             pybamm.lithium_ion.MPM(options)
 
 
-class TestMPMWithPlating(unittest.TestCase):
+class TestMPMWithPlating(TestCase):
     def test_well_posed_reversible_plating_not_implemented(self):
         options = {"lithium plating": "reversible"}
         with self.assertRaises(NotImplementedError):

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm_half_cell.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm_half_cell.py
@@ -1,11 +1,12 @@
 #
 # Tests for the lithium-ion MPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestMPM(unittest.TestCase):
+class TestMPM(TestCase):
     def test_well_posed(self):
         options = {"thermal": "isothermal", "working electrode": "positive"}
         model = pybamm.lithium_ion.MPM(options)
@@ -45,7 +46,7 @@ class TestMPM(unittest.TestCase):
         model.check_well_posedness()
 
 
-class TestMPMExternalCircuits(unittest.TestCase):
+class TestMPMExternalCircuits(TestCase):
     def test_well_posed_voltage(self):
         options = {"operating mode": "voltage", "working electrode": "positive"}
         model = pybamm.lithium_ion.MPM(options)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion Newman-Tobias model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIon
 
 
-class TestNewmanTobias(BaseUnitTestLithiumIon, unittest.TestCase):
+class TestNewmanTobias(BaseUnitTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.NewmanTobias
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion SPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIon
 
 
-class TestSPM(BaseUnitTestLithiumIon, unittest.TestCase):
+class TestSPM(BaseUnitTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPM
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm_half_cell.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm_half_cell.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion half-cell SPM model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIonHalfCell
 
 
-class TestSPMHalfCell(BaseUnitTestLithiumIonHalfCell, unittest.TestCase):
+class TestSPMHalfCell(BaseUnitTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPM
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spme.py
@@ -1,12 +1,13 @@
 #
 # Tests for the lithium-ion SPMe model
 #
+from tests import TestCase
 import pybamm
 import unittest
 from tests import BaseUnitTestLithiumIon
 
 
-class TestSPMe(BaseUnitTestLithiumIon, unittest.TestCase):
+class TestSPMe(BaseUnitTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPMe
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spme_half_cell.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spme_half_cell.py
@@ -4,10 +4,11 @@
 #
 import pybamm
 import unittest
+from tests import TestCase
 from tests import BaseUnitTestLithiumIonHalfCell
 
 
-class TestSPMeHalfCell(BaseUnitTestLithiumIonHalfCell, unittest.TestCase):
+class TestSPMeHalfCell(BaseUnitTestLithiumIonHalfCell, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.SPMe
 

--- a/tests/unit/test_models/test_model_info.py
+++ b/tests/unit/test_models/test_model_info.py
@@ -1,11 +1,12 @@
 #
 # Tests getting model info
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestModelInfo(unittest.TestCase):
+class TestModelInfo(TestCase):
     def test_find_parameter_info(self):
         model = pybamm.lithium_ion.SPM()
         model.info("Negative electrode diffusivity [m2.s-1]")

--- a/tests/unit/test_models/test_submodels/test_base_submodel.py
+++ b/tests/unit/test_models/test_submodels/test_base_submodel.py
@@ -1,12 +1,13 @@
 #
 # Test base submodel
 #
+from tests import TestCase
 
 import pybamm
 import unittest
 
 
-class TestBaseSubModel(unittest.TestCase):
+class TestBaseSubModel(TestCase):
     def test_domain(self):
         # Accepted string
         submodel = pybamm.BaseSubModel(None, "negative", phase="primary")

--- a/tests/unit/test_models/test_submodels/test_effective_current_collector.py
+++ b/tests/unit/test_models/test_submodels/test_effective_current_collector.py
@@ -1,12 +1,13 @@
 #
 # Tests for the Effective Current Collector Resistance models
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
 
 
-class TestEffectiveResistance(unittest.TestCase):
+class TestEffectiveResistance(TestCase):
     def test_well_posed(self):
         model = pybamm.current_collector.EffectiveResistance({"dimensionality": 1})
         model.check_well_posedness()
@@ -45,7 +46,7 @@ class TestEffectiveResistance(unittest.TestCase):
             pybamm.current_collector.EffectiveResistance({"dimensionality": 10})
 
 
-class TestEffectiveResistancePostProcess(unittest.TestCase):
+class TestEffectiveResistancePostProcess(TestCase):
     def test_get_processed_variables(self):
         # solve cheap SPM to test post-processing (think of an alternative test?)
         models = [

--- a/tests/unit/test_models/test_submodels/test_particle_polynomial_profile.py
+++ b/tests/unit/test_models/test_submodels/test_particle_polynomial_profile.py
@@ -1,11 +1,12 @@
 #
 # Tests for the polynomial profile submodel
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestParticlePolynomialProfile(unittest.TestCase):
+class TestParticlePolynomialProfile(TestCase):
     def test_errors(self):
         with self.assertRaisesRegex(ValueError, "Particle type must be"):
             pybamm.particle.PolynomialProfile(None, "negative", {})

--- a/tests/unit/test_parameters/test_base_parameters.py
+++ b/tests/unit/test_parameters/test_base_parameters.py
@@ -1,11 +1,12 @@
 """
 Tests for the base_parameters.py
 """
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestBaseParameters(unittest.TestCase):
+class TestBaseParameters(TestCase):
     def test_getattr__(self):
         param = pybamm.LithiumIonParameters()
         # ending in _n / _s / _p

--- a/tests/unit/test_parameters/test_bpx.py
+++ b/tests/unit/test_parameters/test_bpx.py
@@ -1,6 +1,7 @@
 #
 # Tests for the create_from_bpx function
 #
+from tests import TestCase
 
 import tempfile
 import unittest
@@ -9,7 +10,7 @@ import pybamm
 import copy
 
 
-class TestBPX(unittest.TestCase):
+class TestBPX(TestCase):
     def setUp(self):
         self.base = {
             "Header": {

--- a/tests/unit/test_parameters/test_current_functions.py
+++ b/tests/unit/test_parameters/test_current_functions.py
@@ -1,13 +1,14 @@
 #
 # Tests for current input functions
 #
+from tests import TestCase
 import pybamm
 import numbers
 import unittest
 import numpy as np
 
 
-class TestCurrentFunctions(unittest.TestCase):
+class TestCurrentFunctions(TestCase):
     def test_constant_current(self):
         # test simplify
         param = pybamm.electrical_parameters

--- a/tests/unit/test_parameters/test_ecm_parameters.py
+++ b/tests/unit/test_parameters/test_ecm_parameters.py
@@ -1,6 +1,7 @@
 #
 # Tests for the equivalent circuit parameters
 #
+from tests import TestCase
 import pybamm
 import unittest
 
@@ -30,7 +31,7 @@ values = {
 parameter_values = pybamm.ParameterValues(values)
 
 
-class TestEcmParameters(unittest.TestCase):
+class TestEcmParameters(TestCase):
     def test_init_parameters(self):
         param = pybamm.EcmParameters()
 

--- a/tests/unit/test_parameters/test_electrical_parameters.py
+++ b/tests/unit/test_parameters/test_electrical_parameters.py
@@ -1,12 +1,13 @@
 #
 # Tests for the electrical parameters
 #
+from tests import TestCase
 import pybamm
 
 import unittest
 
 
-class TestElectricalParameters(unittest.TestCase):
+class TestElectricalParameters(TestCase):
     def test_current_functions(self):
         # create current functions
         param = pybamm.electrical_parameters

--- a/tests/unit/test_parameters/test_geometric_parameters.py
+++ b/tests/unit/test_parameters/test_geometric_parameters.py
@@ -1,11 +1,12 @@
 #
 # Tests for the standard parameters
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestGeometricParameters(unittest.TestCase):
+class TestGeometricParameters(TestCase):
     def test_macroscale_parameters(self):
         geo = pybamm.geometric_parameters
         L_n = geo.n.L

--- a/tests/unit/test_parameters/test_lead_acid_parameters.py
+++ b/tests/unit/test_parameters/test_lead_acid_parameters.py
@@ -1,13 +1,14 @@
 #
 # Test for the standard lead acid parameters
 #
+from tests import TestCase
 import pybamm
 from tests import get_discretisation_for_testing
 
 import unittest
 
 
-class TestStandardParametersLeadAcid(unittest.TestCase):
+class TestStandardParametersLeadAcid(TestCase):
     def test_scipy_constants(self):
         constants = pybamm.constants
         self.assertAlmostEqual(constants.R.evaluate(), 8.314, places=3)

--- a/tests/unit/test_parameters/test_lithium_ion_parameters.py
+++ b/tests/unit/test_parameters/test_lithium_ion_parameters.py
@@ -1,13 +1,14 @@
 #
 # Tests lithium ion parameters load and give expected values
 #
+from tests import TestCase
 import pybamm
 
 import unittest
 import numpy as np
 
 
-class TestLithiumIonParameterValues(unittest.TestCase):
+class TestLithiumIonParameterValues(TestCase):
     def test_print_parameters(self):
         parameters = pybamm.LithiumIonParameters()
         parameter_values = pybamm.lithium_ion.BaseModel().default_parameter_values

--- a/tests/unit/test_parameters/test_parameter_sets/test_Ai2020.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_Ai2020.py
@@ -1,11 +1,12 @@
 #
 # Tests for Ai (2020) Enertech parameter set loads
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestAi2020(unittest.TestCase):
+class TestAi2020(TestCase):
     def test_functions(self):
         param = pybamm.ParameterValues("Ai2020")
         sto = pybamm.Scalar(0.5)

--- a/tests/unit/test_parameters/test_parameter_sets/test_LCO_Ramadass2004.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_LCO_Ramadass2004.py
@@ -1,11 +1,12 @@
 #
 # Tests for Ai (2020) Enertech parameter set loads
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestRamadass2004(unittest.TestCase):
+class TestRamadass2004(TestCase):
     def test_functions(self):
         param = pybamm.ParameterValues("Ramadass2004")
         sto = pybamm.Scalar(0.5)

--- a/tests/unit/test_parameters/test_parameter_sets/test_LGM50_ORegan2022.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_LGM50_ORegan2022.py
@@ -1,11 +1,12 @@
 #
 # Tests for LG M50 parameter set loads
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestORegan2022(unittest.TestCase):
+class TestORegan2022(TestCase):
     def test_functions(self):
         param = pybamm.ParameterValues("ORegan2022")
         T = pybamm.Scalar(298.15)

--- a/tests/unit/test_parameters/test_parameter_sets/test_Landesfeind2019.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_Landesfeind2019.py
@@ -1,12 +1,13 @@
 #
 # Tests for Landesfeind (2019) electrolytes parameter set loads
 #
+from tests import TestCase
 import pybamm
 import unittest
 import os
 
 
-class TestLandesfeind(unittest.TestCase):
+class TestLandesfeind(TestCase):
     def test_load_params(self):
         data_D_e = {
             "EC_DMC_1_1": [1.94664e-10, 1.94233e-10],

--- a/tests/unit/test_parameters/test_parameter_sets/test_OKane2022.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_OKane2022.py
@@ -1,11 +1,12 @@
 #
 # Tests for O'Kane (2022) parameter set
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestOKane2022(unittest.TestCase):
+class TestOKane2022(TestCase):
     def test_functions(self):
         param = pybamm.ParameterValues("OKane2022")
         sto = pybamm.Scalar(0.9)

--- a/tests/unit/test_parameters/test_parameter_sets/test_parameters_with_default_models.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_parameters_with_default_models.py
@@ -1,11 +1,12 @@
 #
 # Tests each parameter set with the standard model associated with that parameter set
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestParameterValuesWithModel(unittest.TestCase):
+class TestParameterValuesWithModel(TestCase):
     def test_parameter_values_with_model(self):
         param_to_model = {
             "Ai2020": pybamm.lithium_ion.DFN(

--- a/tests/unit/test_parameters/test_parameter_sets_class.py
+++ b/tests/unit/test_parameters/test_parameter_sets_class.py
@@ -1,13 +1,14 @@
 #
 # Tests for the ParameterSets class
 #
+from tests import TestCase
 
 import pybamm
 import pkg_resources
 import unittest
 
 
-class TestParameterSets(unittest.TestCase):
+class TestParameterSets(TestCase):
     def test_name_interface(self):
         """Test that pybamm.parameters_sets.<ParameterSetName> returns
         the name of the parameter set and a depreciation warning

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Base Parameter Values class
 #
+from tests import TestCase
 
 import os
 import tempfile
@@ -21,7 +22,7 @@ from pybamm.input.parameters.lithium_ion.Marquis2019 import (
 import casadi
 
 
-class TestParameterValues(unittest.TestCase):
+class TestParameterValues(TestCase):
     def test_find_parameter(self):
         f = tempfile.NamedTemporaryFile()
         pybamm.PARAMETER_PATH.append(tempfile.gettempdir())

--- a/tests/unit/test_parameters/test_parameters_cli.py
+++ b/tests/unit/test_parameters/test_parameters_cli.py
@@ -5,9 +5,10 @@
 
 import pybamm
 import unittest
+from tests import TestCase
 
 
-class TestParametersCLI(unittest.TestCase):
+class TestParametersCLI(TestCase):
     def test_error(self):
         with self.assertRaisesRegex(NotImplementedError, "deprecated"):
             pybamm.add_parameter()

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -1,6 +1,7 @@
 #
 # Tests for the parameter processing functions
 #
+from tests import TestCase
 
 import os
 import numpy as np
@@ -9,7 +10,7 @@ import pybamm
 import unittest
 
 
-class TestProcessParameterData(unittest.TestCase):
+class TestProcessParameterData(TestCase):
     def test_process_1D_data(self):
         name = "lico2_data_example"
         path = os.path.join(

--- a/tests/unit/test_parameters/test_size_distribution_parameters.py
+++ b/tests/unit/test_parameters/test_size_distribution_parameters.py
@@ -3,12 +3,12 @@
 # and give expected values
 #
 import pybamm
-
 import unittest
 import numpy as np
+from tests import TestCase
 
 
-class TestSizeDistributionParameters(unittest.TestCase):
+class TestSizeDistributionParameters(TestCase):
     def test_parameter_values(self):
         values = pybamm.lithium_ion.BaseModel().default_parameter_values
         param = pybamm.LithiumIonParameters()

--- a/tests/unit/test_plotting/test_plot.py
+++ b/tests/unit/test_plotting/test_plot.py
@@ -1,10 +1,11 @@
 import pybamm
 import unittest
 import numpy as np
+from tests import TestCase
 import matplotlib.pyplot as plt
 
 
-class TestPlot(unittest.TestCase):
+class TestPlot(TestCase):
     def test_plot(self):
         x = pybamm.Array(np.array([0, 3, 10]))
         y = pybamm.Array(np.array([6, 16, 78]))

--- a/tests/unit/test_plotting/test_plot_summary_variables.py
+++ b/tests/unit/test_plotting/test_plot_summary_variables.py
@@ -1,9 +1,10 @@
 import pybamm
 import unittest
 import numpy as np
+from tests import TestCase
 
 
-class TestPlotSummaryVariables(unittest.TestCase):
+class TestPlotSummaryVariables(TestCase):
     def test_plot(self):
         model = pybamm.lithium_ion.SPM({"SEI": "ec reaction limited"})
         parameter_values = pybamm.ParameterValues("Mohtat2020")

--- a/tests/unit/test_plotting/test_plot_voltage_components.py
+++ b/tests/unit/test_plotting/test_plot_voltage_components.py
@@ -1,10 +1,11 @@
 import pybamm
 import unittest
 import numpy as np
+from tests import TestCase
 import matplotlib.pyplot as plt
 
 
-class TestPlotVoltageComponents(unittest.TestCase):
+class TestPlotVoltageComponents(TestCase):
     def test_plot(self):
         model = pybamm.lithium_ion.SPM()
         sim = pybamm.Simulation(model)

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -1,10 +1,11 @@
 import os
 import pybamm
 import unittest
+from tests import TestCase
 import numpy as np
 
 
-class TestQuickPlot(unittest.TestCase):
+class TestQuickPlot(TestCase):
     def test_simple_ode_model(self):
         model = pybamm.lithium_ion.BaseModel(name="Simple ODE Model")
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,11 +1,12 @@
 #
 # Tests the settings class.
 #
+from tests import TestCase
 import pybamm
 import unittest
 
 
-class TestSettings(unittest.TestCase):
+class TestSettings(TestCase):
     def test_simplify(self):
         self.assertTrue(pybamm.settings.simplify)
 

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1,13 +1,14 @@
 import pybamm
 import numpy as np
 import pandas as pd
+from tests import TestCase
 import os
 import sys
 import unittest
 import uuid
 
 
-class TestSimulation(unittest.TestCase):
+class TestSimulation(TestCase):
     def test_simple_model(self):
         model = pybamm.BaseModel()
         v = pybamm.Variable("v")

--- a/tests/unit/test_solvers/test_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_algebraic_solver.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Algebraic Solver class
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
 from tests import get_discretisation_for_testing
 
 
-class TestAlgebraicSolver(unittest.TestCase):
+class TestAlgebraicSolver(TestCase):
     def test_algebraic_solver_init(self):
         solver = pybamm.AlgebraicSolver(
             method="hybr", tol=1e-4, extra_options={"maxfev": 100}

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Base Solver class
 #
+from tests import TestCase
 import casadi
 import pybamm
 import numpy as np
@@ -9,7 +10,7 @@ from scipy.sparse import csr_matrix
 import unittest
 
 
-class TestBaseSolver(unittest.TestCase):
+class TestBaseSolver(TestCase):
     def test_base_solver_init(self):
         solver = pybamm.BaseSolver(rtol=1e-2, atol=1e-4)
         self.assertEqual(solver.rtol, 1e-2)

--- a/tests/unit/test_solvers/test_casadi_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_casadi_algebraic_solver.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Casadi Algebraic Solver class
 #
+from tests import TestCase
 import casadi
 import pybamm
 import unittest
@@ -9,7 +10,7 @@ from scipy.optimize import least_squares
 import tests
 
 
-class TestCasadiAlgebraicSolver(unittest.TestCase):
+class TestCasadiAlgebraicSolver(TestCase):
     def test_algebraic_solver_init(self):
         solver = pybamm.CasadiAlgebraicSolver(tol=1e-4)
         self.assertEqual(solver.tol, 1e-4)
@@ -173,7 +174,7 @@ class TestCasadiAlgebraicSolver(unittest.TestCase):
         np.testing.assert_array_equal(solution.y, -7)
 
 
-class TestCasadiAlgebraicSolverSensitivity(unittest.TestCase):
+class TestCasadiAlgebraicSolverSensitivity(TestCase):
     def test_solve_with_symbolic_input(self):
         # Simple system: a single algebraic equation
         var = pybamm.Variable("var")

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Casadi Solver class
 #
+from tests import TestCase
 import pybamm
 import unittest
 import numpy as np
@@ -8,7 +9,7 @@ from tests import get_mesh_for_testing, get_discretisation_for_testing
 from scipy.sparse import eye
 
 
-class TestCasadiSolver(unittest.TestCase):
+class TestCasadiSolver(TestCase):
     def test_bad_mode(self):
         with self.assertRaisesRegex(ValueError, "invalid mode"):
             pybamm.CasadiSolver(mode="bad mode")
@@ -539,7 +540,7 @@ class TestCasadiSolver(unittest.TestCase):
             solver.solve(model, t_eval=[0, 1])
 
 
-class TestCasadiSolverODEsWithForwardSensitivityEquations(unittest.TestCase):
+class TestCasadiSolverODEsWithForwardSensitivityEquations(TestCase):
     def test_solve_sensitivity_scalar_var_scalar_input(self):
         # Create model
         model = pybamm.BaseModel()
@@ -920,7 +921,7 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations(unittest.TestCase):
         )
 
 
-class TestCasadiSolverDAEsWithForwardSensitivityEquations(unittest.TestCase):
+class TestCasadiSolverDAEsWithForwardSensitivityEquations(TestCase):
     def test_solve_sensitivity_scalar_var_scalar_input(self):
         # Create model
         model = pybamm.BaseModel()

--- a/tests/unit/test_solvers/test_dummy_solver.py
+++ b/tests/unit/test_solvers/test_dummy_solver.py
@@ -1,13 +1,14 @@
 #
 # Tests for the Dummy Solver class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
 import sys
 
 
-class TestDummySolver(unittest.TestCase):
+class TestDummySolver(TestCase):
     def test_dummy_solver(self):
         model = pybamm.BaseModel()
         v = pybamm.Scalar(1)

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -1,6 +1,7 @@
 #
 # Tests for the KLU Solver class
 #
+from tests import TestCase
 from contextlib import redirect_stdout
 import io
 import unittest
@@ -12,7 +13,7 @@ from tests import get_discretisation_for_testing
 
 
 @unittest.skipIf(not pybamm.have_idaklu(), "idaklu solver is not installed")
-class TestIDAKLUSolver(unittest.TestCase):
+class TestIDAKLUSolver(TestCase):
     def test_ida_roberts_klu(self):
         # this test implements a python version of the ida Roberts
         # example provided in sundials

--- a/tests/unit/test_solvers/test_jax_bdf_solver.py
+++ b/tests/unit/test_solvers/test_jax_bdf_solver.py
@@ -1,6 +1,7 @@
 import pybamm
 import unittest
 from tests import get_mesh_for_testing
+from tests import TestCase
 import sys
 import time
 import numpy as np
@@ -10,7 +11,7 @@ if pybamm.have_jax():
 
 
 @unittest.skipIf(not pybamm.have_jax(), "jax or jaxlib is not installed")
-class TestJaxBDFSolver(unittest.TestCase):
+class TestJaxBDFSolver(TestCase):
     def test_solver(self):
         # Create model
         model = pybamm.BaseModel()

--- a/tests/unit/test_solvers/test_jax_solver.py
+++ b/tests/unit/test_solvers/test_jax_solver.py
@@ -1,6 +1,7 @@
 import pybamm
 import unittest
 from tests import get_mesh_for_testing
+from tests import TestCase
 import sys
 import time
 import numpy as np
@@ -10,7 +11,7 @@ if pybamm.have_jax():
 
 
 @unittest.skipIf(not pybamm.have_jax(), "jax or jaxlib is not installed")
-class TestJaxSolver(unittest.TestCase):
+class TestJaxSolver(TestCase):
     def test_model_solver(self):
         # Create model
         model = pybamm.BaseModel()

--- a/tests/unit/test_solvers/test_processed_variable.py
+++ b/tests/unit/test_solvers/test_processed_variable.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Processed Variable class
 #
+from tests import TestCase
 import casadi
 import pybamm
 import tests
@@ -57,7 +58,7 @@ def process_and_check_2D_variable(
     return y_sol, first_sol, second_sol, t_sol
 
 
-class TestProcessedVariable(unittest.TestCase):
+class TestProcessedVariable(TestCase):
     def test_processed_variable_0D(self):
         # without space
         t = pybamm.t

--- a/tests/unit/test_solvers/test_scikits_solvers.py
+++ b/tests/unit/test_solvers/test_scikits_solvers.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Scikits Solver classes
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
@@ -10,7 +11,7 @@ import sys
 
 
 @unittest.skipIf(not pybamm.have_scikits_odes(), "scikits.odes not installed")
-class TestScikitsSolvers(unittest.TestCase):
+class TestScikitsSolvers(TestCase):
     def test_model_ode_integrate_failure(self):
         # Turn off warnings to ignore sqrt error
         warnings.simplefilter("ignore")

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -1,6 +1,7 @@
 # Tests for the Scipy Solver class
 #
 import pybamm
+from tests import TestCase
 import unittest
 import numpy as np
 from tests import get_mesh_for_testing, get_discretisation_for_testing
@@ -8,7 +9,7 @@ import warnings
 import sys
 
 
-class TestScipySolver(unittest.TestCase):
+class TestScipySolver(TestCase):
     def test_model_solver_python_and_jax(self):
         if pybamm.have_jax():
             formats = ["python", "jax"]
@@ -492,7 +493,7 @@ class TestScipySolver(unittest.TestCase):
         )
 
 
-class TestScipySolverWithSensitivity(unittest.TestCase):
+class TestScipySolverWithSensitivity(TestCase):
     def test_solve_sensitivity_scalar_var_scalar_input(self):
         # Create model
         model = pybamm.BaseModel()

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Solution class
 #
+from tests import TestCase
 import json
 import pybamm
 import unittest
@@ -10,7 +11,7 @@ from scipy.io import loadmat
 from tests import get_discretisation_for_testing
 
 
-class TestSolution(unittest.TestCase):
+class TestSolution(TestCase):
     def test_init(self):
         t = np.linspace(0, 1)
         y = np.tile(t, (20, 1))

--- a/tests/unit/test_spatial_methods/test_base_spatial_method.py
+++ b/tests/unit/test_spatial_methods/test_base_spatial_method.py
@@ -1,6 +1,7 @@
 #
 # Test for the base Spatial Method class
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
@@ -11,7 +12,7 @@ from tests import (
 )
 
 
-class TestSpatialMethod(unittest.TestCase):
+class TestSpatialMethod(TestCase):
     def test_basics(self):
         mesh = get_mesh_for_testing()
         spatial_method = pybamm.SpatialMethod()

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -1,6 +1,7 @@
 #
 # Test for the extrapolations in the finite volume class
 #
+from tests import TestCase
 import pybamm
 from tests import (
     get_mesh_for_testing,
@@ -55,7 +56,7 @@ def get_errors(function, method_options, pts, bcs=None):
     return l_errors, r_errors
 
 
-class TestExtrapolation(unittest.TestCase):
+class TestExtrapolation(TestCase):
     def test_convergence_without_bcs(self):
         # all tests are performed on x in [0, 1]
         linear = {"extrapolation": {"order": "linear"}}

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -1,6 +1,7 @@
 #
 # Tests for the Finite Volume Method
 #
+from tests import TestCase
 import pybamm
 from tests import (
     get_mesh_for_testing,
@@ -12,7 +13,7 @@ from scipy.sparse import kron, eye
 import unittest
 
 
-class TestFiniteVolume(unittest.TestCase):
+class TestFiniteVolume(TestCase):
     def test_node_to_edge_to_node(self):
         # Create discretisation
         mesh = get_mesh_for_testing()

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_ghost_nodes_and_neumann.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_ghost_nodes_and_neumann.py
@@ -1,13 +1,14 @@
 #
 # Test for adding ghost nodes in finite volumes class
 #
+from tests import TestCase
 import pybamm
 from tests import get_mesh_for_testing, get_p2d_mesh_for_testing
 import numpy as np
 import unittest
 
 
-class TestGhostNodes(unittest.TestCase):
+class TestGhostNodes(TestCase):
     def test_add_ghost_nodes(self):
         # Set up
 

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_grad_div_shapes.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_grad_div_shapes.py
@@ -1,6 +1,7 @@
 #
 # Test for the gradient and divergence in Finite Volumes
 #
+from tests import TestCase
 import pybamm
 from tests import (
     get_mesh_for_testing,
@@ -12,7 +13,7 @@ import numpy as np
 import unittest
 
 
-class TestFiniteVolumeGradDiv(unittest.TestCase):
+class TestFiniteVolumeGradDiv(TestCase):
     def test_grad_div_shapes_Dirichlet_bcs(self):
         """
         Test grad and div with Dirichlet boundary conditions in Cartesian coordinates

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_integration.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_integration.py
@@ -1,6 +1,7 @@
 #
 # Tests for integration using Finite Volume method
 #
+from tests import TestCase
 import pybamm
 from tests import (
     get_mesh_for_testing,
@@ -11,7 +12,7 @@ import numpy as np
 import unittest
 
 
-class TestFiniteVolumeIntegration(unittest.TestCase):
+class TestFiniteVolumeIntegration(TestCase):
     def test_definite_integral(self):
         # create discretisation
         mesh = get_mesh_for_testing(xpts=200, rpts=200)

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -1,13 +1,14 @@
 #
 # Test for the operator class
 #
+from tests import TestCase
 import pybamm
 from tests import get_2p1d_mesh_for_testing, get_unit_2p1D_mesh_for_testing
 import numpy as np
 import unittest
 
 
-class TestScikitFiniteElement(unittest.TestCase):
+class TestScikitFiniteElement(TestCase):
     def test_not_implemented(self):
         mesh = get_2p1d_mesh_for_testing(include_particles=False)
         spatial_method = pybamm.ScikitFiniteElement()

--- a/tests/unit/test_spatial_methods/test_spectral_volume.py
+++ b/tests/unit/test_spatial_methods/test_spectral_volume.py
@@ -1,6 +1,7 @@
 #
 # Test for the operator class
 #
+from tests import TestCase
 import pybamm
 import numpy as np
 import unittest
@@ -86,7 +87,7 @@ def get_1p1d_mesh_for_testing(
     )
 
 
-class TestSpectralVolume(unittest.TestCase):
+class TestSpectralVolume(TestCase):
     def test_exceptions(self):
         sp_meth = pybamm.SpectralVolume()
         with self.assertRaises(ValueError):

--- a/tests/unit/test_spatial_methods/test_zero_dimensional_method.py
+++ b/tests/unit/test_spatial_methods/test_zero_dimensional_method.py
@@ -1,13 +1,14 @@
 #
 # Test for the base Spatial Method class
 #
+from tests import TestCase
 import numpy as np
 import pybamm
 import unittest
 from tests import get_mesh_for_testing, get_discretisation_for_testing
 
 
-class TestZeroDimensionalSpatialMethod(unittest.TestCase):
+class TestZeroDimensionalSpatialMethod(TestCase):
     def test_identity_ops(self):
         test_mesh = np.array([1, 2, 3])
         spatial_method = pybamm.ZeroDimensionalSpatialMethod()

--- a/tests/unit/test_timer.py
+++ b/tests/unit/test_timer.py
@@ -6,9 +6,10 @@
 #
 import pybamm
 import unittest
+from tests import TestCase
 
 
-class TestTimer(unittest.TestCase):
+class TestTimer(TestCase):
     """
     Tests the basic methods of the Timer class.
     """

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,7 @@
 #
 # Tests the utility functions.
 #
+from tests import TestCase
 import numpy as np
 import os
 import sys
@@ -11,7 +12,7 @@ from unittest.mock import patch
 from io import StringIO
 
 
-class TestUtil(unittest.TestCase):
+class TestUtil(TestCase):
     """
     Test the functionality in util.py
     """
@@ -103,7 +104,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(git_commit_info[:2], "v2")
 
 
-class TestSearch(unittest.TestCase):
+class TestSearch(TestCase):
     def test_url_gets_to_stdout(self):
         model = pybamm.BaseModel()
         model.variables = {"Electrolyte concentration": 1, "Electrode potential": 0}


### PR DESCRIPTION
# Description

Some tests in the unit and integration suites call functions that make use of random variables, or include random variables in their calls (specifically numpy.random). This can lead to tests sometimes failing due to reasons that may be unrelated to recent code changes, as outlined (and demonstrated) in issue #2833.

Fixes #2833 

## Type of change

Fixing the numpy random seed within the test routines produces consistent behavior. However, since stochastic elements are present in the PyBaMM codebase in relation to both the Casadi and Idaklu solvers, extensive dependencies on these functions within the test suite are likely to be widespread and opaque. In order to fully rectify the issue (whilst maintaining the same simplicity in test set-up moving forward) a metaclass solution is proposed.

The proposed solution wraps all methods that inherit from `TestCase` with a wrapper function that fixes the random seed to a hash code derived from the method's name. This permits hashes to be changed in problematic circumstances by a hash modifier, such as appending a trailing underscore (or other modifier) to the method name.

Specifically, the `TestCase` class, which is described as the 'Custom TestCase class for pybamm' is given a custom metaclass. However, it was also noted that this test class is not in widespread use across the testbase, and hence `unittest.TestCase` has now been replaced with `TestCase` as imported from `tests` across all test scripts.

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [X] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [X] All tests pass: `$ python run-tests.py --all`
- [X] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [X] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works