### PR TITLE
Issue 2725 reduce Windows and macOS tests and run all tests nightly

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -1,0 +1,128 @@
+# Run all unit tests and integration tests for all Python versions 
+# and platforms at 3am UTC every day and on PRs to the main branch
+name: PyBaMM
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: 
+    - main
+
+  # Run everyday at 3 am UTC
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: "never"
+          cancel_others: "true"
+          paths_ignore: '["**/README.md"]'
+
+  style:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Check style
+        run: |
+          python -m pip install pre-commit
+          pre-commit run ruff
+
+  build:
+    needs: style
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran gcc libopenblas-dev graphviz
+          sudo apt install texlive-full
+
+      # Added fixes to homebrew installs:
+      # rm -f /usr/local/bin/2to3
+      # (see https://github.com/actions/virtual-environments/issues/2322)
+      - name: Install MacOS system dependencies
+        if: matrix.os == 'macos-latest'
+        run: |
+          rm -f /usr/local/bin/2to3*
+          rm -f /usr/local/bin/idle3*
+          rm -f /usr/local/bin/pydoc3*
+          rm -f /usr/local/bin/python3*
+          brew update
+          brew install graphviz
+          brew install openblas
+
+      - name: Install Windows system dependencies
+        if: matrix.os == 'windows-latest'
+        run: choco install graphviz --version=2.38.0.20190211
+
+      - name: Install standard python dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install "tox<4"
+
+      - name: Install SuiteSparse and Sundials
+        if: matrix.os == 'ubuntu-latest'
+        run: tox -e pybamm-requires
+
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+        run: python -m tox -e unit
+
+      - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        run: | 
+          python -m tox -e unit
+          python -m tox -e coverage
+
+      - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        uses: codecov/codecov-action@v2.1.0
+
+      - name: Run integration tests for GNU/Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: python -m tox -e integration
+
+      - name: Run unit tests for Windows and MacOS
+        if: matrix.os != 'ubuntu-latest'
+        run: python -m tox -e mac-windows-unit
+
+      - name: Run integration tests for Windows and MacOS
+        if: matrix.os != 'ubuntu-latest'
+        run: python -m tox -e mac-windows-integration
+
+      - name: Install docs dependencies and run doctests
+        if: matrix.os == 'ubuntu-latest'
+        run: tox -e doctests
+
+      - name: Install dev dependencies and run example tests
+        if: matrix.os == 'ubuntu-latest'
+        run: tox -e examples

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-  # everyday at 3 am UTC
-  schedule:
-    - cron: "0 3 * * *"
-
 jobs:
   pre_job:
     runs-on: ubuntu-latest
@@ -89,34 +85,28 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: tox -e pybamm-requires
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.10, and 3.11
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
-        run: python -m tox -e unit
-
-      - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
-        run: tox -e coverage
+      - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        run: |
+          python -m tox -e unit
+          python -m tox -e coverage
 
       - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         uses: codecov/codecov-action@v2.1.0
 
-      - name: Run integration tests for GNU/Linux
-        if: matrix.os == 'ubuntu-latest'
+      - name: Run integration tests for GNU/Linux with Python 3.11
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: python -m tox -e integration
 
-      - name: Run unit tests for Windows and MacOS
-        if: matrix.os != 'ubuntu-latest'
+      - name: Run unit tests for Windows and MacOS with Python 3.8, 3.9, and 3.10
+        if: matrix.os != 'ubuntu-latest' && matrix.python-version != 3.11
         run: python -m tox -e mac-windows-unit
 
-      - name: Run integration tests for Windows and MacOS
-        if: matrix.os != 'ubuntu-latest'
-        run: python -m tox -e mac-windows-integration
-
-      - name: Install docs dependencies and run doctests
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: tox -e doctests
 
-      - name: Install dev dependencies and run example tests
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install dev dependencies and run example tests for GNU/Linux with Python 3.11
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: tox -e examples


### PR DESCRIPTION
# Description

- `test_on_push.yml` will now run integration tests only on GNU/Linux with Python 3.11; unit tests will run on all platforms – with 3.11 on GNU/Linux and with Python 3.8, 3.9, and 3.10 on Windows and macOS
- Adds a workflow `run_periodic_tests.yml` to run all unit tests and integration tests on all platforms and Python versions, scheduled at 3 am UTC and on PRs to the `main` branch 
- coverage gets generated with Python 3.11 instead of Python 3.9 (on both workflows)

Fixes #2725 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
