### PR TITLE
add (optional) progress bar for cycling experiments

### DIFF
--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -8,6 +8,7 @@ import copy
 import warnings
 import sys
 from functools import lru_cache
+import tqdm
 
 
 def is_notebook():
@@ -510,6 +511,7 @@ class Simulation:
         starting_solution=None,
         initial_soc=None,
         callbacks=None,
+        showprogress=False,
         **kwargs,
     ):
         """
@@ -557,6 +559,10 @@ class Simulation:
         callbacks : list of callbacks, optional
             A list of callbacks to be called at each time step. Each callback must
             implement all the methods defined in :class:`pybamm.callbacks.BaseCallback`.
+        showprogress : bool, optional
+            Whether to show a progress bar for cycling. If true, shows a progress bar
+            for cycles. Has no effect when not used with an experiment.
+            Default is False.
         **kwargs
             Additional key-word arguments passed to `solver.solve`.
             See :meth:`pybamm.BaseSolver.solve`.
@@ -698,7 +704,13 @@ class Simulation:
             num_cycles = len(self.experiment.cycle_lengths)
             feasible = True  # simulation will stop if experiment is infeasible
             for cycle_num, cycle_length in enumerate(
-                self.experiment.cycle_lengths, start=1
+                # tqdm is the progress bar.
+                tqdm.tqdm(
+                    self.experiment.cycle_lengths,
+                    disable=(not showprogress),
+                    desc="Cycling",
+                ),
+                start=1,
             ):
                 logs["cycle number"] = (
                     cycle_num + cycle_offset,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ imageio>=2.9.0
 pybtex>=0.24.0
 sympy >= 1.8
 bpx
+tqdm
 # Note: Matplotlib is loaded for debug plots but to ensure pybamm runs
 # on systems without an attached display it should never be imported
 # outside of plot() methods.

--- a/setup.py
+++ b/setup.py
@@ -215,6 +215,7 @@ setup(
         "pybtex>=0.24.0",
         "sympy>=1.8",
         "bpx",
+        "tqdm",
         # Note: Matplotlib is loaded for debug plots, but to ensure pybamm runs
         # on systems without an attached display, it should never be imported
         # outside of plot() methods.

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -342,6 +342,21 @@ class TestSimulationExperiment(TestCase):
         # all but the last value should be above the termination condition
         np.testing.assert_array_less(5.04, C[:-1])
 
+    def test_run_experiment_with_pbar(self):
+        # The only thing to test here is for errors.
+        experiment = pybamm.Experiment(
+            [
+                (
+                    "Discharge at 1C for 1 sec",
+                    "Charge at 1C for 1 sec",
+                ),
+            ]
+            * 10,
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(model, experiment=experiment)
+        sim.solve(showprogress=True)
+
     def test_run_experiment_termination_voltage(self):
         # with percent
         experiment = pybamm.Experiment(


### PR DESCRIPTION
# Description
s/b self evident. tqdm is a very low overhead progress bar (80ns per iteration according to their docs). My motivation for this is running very long cycling experiments (take many hours) it's nice to know something is happening, and setting logging to info is messy and is giving me a lot more information than I really need. Note that tqdm is the same package that liionpack uses for its progress bar. 

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
