### PR TITLE
remove chemistry from parameter set dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Bug fixes
 
+- Parameter sets can now contain the key "chemistry", and will ignore its value (this previously would give errors in some cases) ([#2901](https://github.com/pybamm-team/PyBaMM/pull/2901))
 - Fixed a bug in the discretisation of initial conditions of a scaled variable ([#2856](https://github.com/pybamm-team/PyBaMM/pull/2856))
 - Fixed keyerror on "all" when getting sensitivities from IDAKLU solver([#2883](https://github.com/pybamm-team/PyBaMM/pull/2883))
 

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -71,13 +71,13 @@ class ParameterValues:
                 self.update_from_chemistry(values)
             else:
                 # Remove chemistry if present
-                values.pop("chemistry")
+                values.pop("chemistry", None)
                 self.update(values, check_already_exists=False)
         else:
             # Check if values is a named parameter set
             if isinstance(values, str) and values in pybamm.parameter_sets:
                 values = pybamm.parameter_sets[values]
-                values.pop("chemistry")
+                values.pop("chemistry", None)
                 self.update(values, check_already_exists=False)
 
             else:

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -70,6 +70,8 @@ class ParameterValues:
                 )
                 self.update_from_chemistry(values)
             else:
+                # Remove chemistry if present
+                values.pop("chemistry")
                 self.update(values, check_already_exists=False)
         else:
             # Check if values is a named parameter set

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -56,6 +56,10 @@ class TestParameterValues(TestCase):
         self.assertIn("a", param.keys())
         self.assertIn(1, param.values())
 
+        # from dict "chemistry" key gets removed
+        param = pybamm.ParameterValues({"a": 1, "chemistry": "lithium-ion"})
+        self.assertNotIn("chemistry", param.keys())
+
         # from file
         param = pybamm.ParameterValues(
             "lithium_ion/testing_only/positive_electrodes/lico2_Ai2020/parameters.csv"


### PR DESCRIPTION
# Description

Fixes a small bug when inputting parameters as a dictionary

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
