### PR TITLE
I2858-init-cond-sundials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed a bug in the discretisation of initial conditions of a scaled variable ([#2856](https://github.com/pybamm-team/PyBaMM/pull/2856))
 - Fixed keyerror on "all" when getting sensitivities from IDAKLU solver([#2883](https://github.com/pybamm-team/PyBaMM/pull/2883))
+- Initial conditions for sensitivity equations calculated correctly ([#2920](https://github.com/pybamm-team/PyBaMM/pull/2920))
 
 # Breaking changes
 

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -157,7 +157,15 @@ class BaseSolver(object):
             if jacp_ic is None:
                 model.y0S = None
             else:
-                model.y0S = jacp_ic(0.0, y_zero, inputs)
+                # we are calculating the derivative wrt the inputs
+                # so need to make sure we convert int -> float
+                # This is to satisfy JAX jacfwd function which requires
+                # float inputs
+                inputs_float = {
+                    key: float(value) if isinstance(value, int) else value
+                    for key, value in inputs.items()
+                }
+                model.y0S = jacp_ic(0.0, y_zero, inputs_float)
 
         if ics_only:
             pybamm.logger.info("Finish solver set-up")

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -147,17 +147,17 @@ class BaseSolver(object):
         if model.convert_to_format == "casadi":
             # stack inputs
             inputs_casadi = casadi.vertcat(*[x for x in inputs.values()])
-            model.y0 = initial_conditions(0, y_zero, inputs_casadi)
+            model.y0 = initial_conditions(0.0, y_zero, inputs_casadi)
             if jacp_ic is None:
                 model.y0S = None
             else:
-                model.y0S = jacp_ic(0, y_zero, inputs_casadi)
+                model.y0S = jacp_ic(0.0, y_zero, inputs_casadi)
         else:
-            model.y0 = initial_conditions(0, y_zero, inputs)
+            model.y0 = initial_conditions(0.0, y_zero, inputs)
             if jacp_ic is None:
                 model.y0S = None
             else:
-                model.y0S = jacp_ic(0, y_zero, inputs)
+                model.y0S = jacp_ic(0.0, y_zero, inputs)
 
         if ics_only:
             pybamm.logger.info("Finish solver set-up")

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -130,13 +130,14 @@ class BaseSolver(object):
         )
 
         # Process initial conditions
-        initial_conditions = process(
+        initial_conditions, _, jacp_ic, _ = process(
             model.concatenated_initial_conditions,
             "initial_conditions",
             vars_for_processing,
             use_jacobian=False,
-        )[0]
+        )
         model.initial_conditions_eval = initial_conditions
+        model.jacp_initial_conditions_eval = jacp_ic
 
         # evaluate initial condition
         y0_total_size = (
@@ -147,8 +148,16 @@ class BaseSolver(object):
             # stack inputs
             inputs_casadi = casadi.vertcat(*[x for x in inputs.values()])
             model.y0 = initial_conditions(0, y_zero, inputs_casadi)
+            if jacp_ic is None:
+                model.y0S = None
+            else:
+                model.y0S = jacp_ic(0, y_zero, inputs_casadi)
         else:
             model.y0 = initial_conditions(0, y_zero, inputs)
+            if jacp_ic is None:
+                model.y0S = None
+            else:
+                model.y0S = jacp_ic(0, y_zero, inputs)
 
         if ics_only:
             pybamm.logger.info("Finish solver set-up")

--- a/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
@@ -344,25 +344,12 @@ Solution CasadiSolver::solve(np_array t_np, np_array y0_np, np_array yp0_np,
     IDASensReInit(ida_mem, IDA_SIMULTANEOUS, yyS, ypS);
   }
 
-  // TODO: not sure if I need to do this again...
-  for (int is = 0 ; is < number_of_parameters; is++) {
-    ySval[is] = N_VGetArrayPointer(yyS[is]);
-  }
-  yval = N_VGetArrayPointer(yy);
-  ypval = N_VGetArrayPointer(yp);
-
-
   // calculate consistent initial conditions
   DEBUG("IDACalcIC");
   IDACalcIC(ida_mem, IDA_YA_YDP_INIT, t(1));
-  for (int j = 0; j < number_of_parameters; j++) {
-    for (int k = 0; k < number_of_states; k++) {
-      std::cout << "ySval[" << j << "]["<< k << "] = " << ySval[j][k] << std::endl;
-    }
-    //DEBUG_VECTOR(yyS[j]);
-  }
-  for (int k = 0; k < 10; k++) {
-    std::cout << "yval["<< k << "] = " << yval[k] << std::endl;
+  if (number_of_parameters > 0)
+  {
+    IDAGetSens(ida_mem, &t0, yyS);
   }
 
   int t_i = 1;

--- a/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_solver.cpp
@@ -1,6 +1,7 @@
 #include "casadi_solver.hpp"
 #include "casadi_sundials_functions.hpp"
 #include "common.hpp"
+#include <idas/idas.h>
 #include <memory>
 
 CasadiSolver *
@@ -289,7 +290,27 @@ Solution CasadiSolver::solve(np_array t_np, np_array y0_np, np_array yp0_np,
                              np_array_dense inputs)
 {
   DEBUG("CasadiSolver::solve");
+
   int number_of_timesteps = t_np.request().size;
+  auto t = t_np.unchecked<1>();
+  realtype t0 = RCONST(t(0));
+  auto y0 = y0_np.unchecked<1>();
+  auto yp0 = yp0_np.unchecked<1>();
+
+
+  if (y0.size() != number_of_states + number_of_parameters * number_of_states) {
+    throw std::domain_error(
+      "y0 has wrong size. Expected " + 
+      std::to_string(number_of_states + number_of_parameters * number_of_states) + 
+      " but got " + std::to_string(y0.size()));
+  }
+
+  if (yp0.size() != number_of_states + number_of_parameters * number_of_states) {
+    throw std::domain_error(
+      "yp0 has wrong size. Expected " + 
+      std::to_string(number_of_states + number_of_parameters * number_of_states) + 
+      " but got " + std::to_string(yp0.size()));
+  }
 
   // set inputs
   auto p_inputs = inputs.unchecked<2>();
@@ -298,26 +319,51 @@ Solution CasadiSolver::solve(np_array t_np, np_array y0_np, np_array yp0_np,
     functions->inputs[i] = p_inputs(i, 0);
   }
 
+  // set initial conditions
   realtype *yval = N_VGetArrayPointer(yy);
   realtype *ypval = N_VGetArrayPointer(yp);
   std::vector<realtype *> ySval(number_of_parameters);
-  for (int is = 0 ; is < number_of_parameters; is++) {
-    ySval[is] = N_VGetArrayPointer(yyS[is]);
-    N_VConst(RCONST(0.0), yyS[is]);
-    N_VConst(RCONST(0.0), ypS[is]);
+  std::vector<realtype *> ypSval(number_of_parameters);
+  for (int p = 0 ; p < number_of_parameters; p++) {
+    ySval[p] = N_VGetArrayPointer(yyS[p]);
+    ypSval[p] = N_VGetArrayPointer(ypS[p]);
+    for (int i = 0; i < number_of_states; i++) {
+      ySval[p][i] = y0[i + (p + 1) * number_of_states];
+      ypSval[p][i] = yp0[i + (p + 1) * number_of_states];
+    }
   }
 
-  auto t = t_np.unchecked<1>();
-  auto y0 = y0_np.unchecked<1>();
-  auto yp0 = yp0_np.unchecked<1>();
   for (int i = 0; i < number_of_states; i++)
   {
     yval[i] = y0[i];
     ypval[i] = yp0[i];
   }
 
-  realtype t0 = RCONST(t(0));
   IDAReInit(ida_mem, t0, yy, yp);
+  if (number_of_parameters > 0) {
+    IDASensReInit(ida_mem, IDA_SIMULTANEOUS, yyS, ypS);
+  }
+
+  // TODO: not sure if I need to do this again...
+  for (int is = 0 ; is < number_of_parameters; is++) {
+    ySval[is] = N_VGetArrayPointer(yyS[is]);
+  }
+  yval = N_VGetArrayPointer(yy);
+  ypval = N_VGetArrayPointer(yp);
+
+
+  // calculate consistent initial conditions
+  DEBUG("IDACalcIC");
+  IDACalcIC(ida_mem, IDA_YA_YDP_INIT, t(1));
+  for (int j = 0; j < number_of_parameters; j++) {
+    for (int k = 0; k < number_of_states; k++) {
+      std::cout << "ySval[" << j << "]["<< k << "] = " << ySval[j][k] << std::endl;
+    }
+    //DEBUG_VECTOR(yyS[j]);
+  }
+  for (int k = 0; k < 10; k++) {
+    std::cout << "yval["<< k << "] = " << yval[k] << std::endl;
+  }
 
   int t_i = 1;
   realtype tret;
@@ -366,9 +412,7 @@ Solution CasadiSolver::solve(np_array t_np, np_array y0_np, np_array yp0_np,
     }
   }
 
-  // calculate consistent initial conditions
-  DEBUG("IDACalcIC");
-  IDACalcIC(ida_mem, IDA_YA_YDP_INIT, t(1));
+
 
   int retval;
   while (true)

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -24,9 +24,9 @@ int residual_casadi(realtype tres, N_Vector yy, N_Vector yp, N_Vector rr,
   const int ns = p_python_functions->number_of_states;
   casadi::casadi_axpy(ns, -1., tmp, NV_DATA_S(rr));
 
-  DEBUG_VECTOR(yy);
-  DEBUG_VECTOR(yp);
-  DEBUG_VECTOR(rr);
+  //DEBUG_VECTOR(yy);
+  //DEBUG_VECTOR(yp);
+  //DEBUG_VECTOR(rr);
 
   // now rr has rhs_alg(t, y) - mass_matrix * yp
   return 0;
@@ -263,6 +263,7 @@ int sensitivities_casadi(int Ns, realtype t, N_Vector yy, N_Vector yp,
                          N_Vector tmp2, N_Vector tmp3)
 {
 
+  DEBUG("sensitivities_casadi");
   CasadiFunctions *p_python_functions =
       static_cast<CasadiFunctions *>(user_data);
 

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -279,7 +279,7 @@ int sensitivities_casadi(int Ns, realtype t, N_Vector yy, N_Vector yp,
   }
   // resvalsS now has (∂F/∂p i )
   p_python_functions->sens();
-
+  
   for (int i = 0; i < np; i++)
   {
     // put (∂F/∂y)s i (t) in tmp

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -173,6 +173,17 @@ class IDAKLUSolver(pybamm.BaseSolver):
             y0 = y0.full()
         y0 = y0.flatten()
 
+        y0S = model.y0S
+        # only casadi solver needs sensitivity ics
+        if model.convert_to_format != "casadi":
+            y0S = None
+        if y0S is not None:
+            if isinstance(y0S, casadi.DM):
+                y0S = (y0S,)
+
+            y0S = (x.full() for x in y0S)
+            y0S = [x.flatten() for x in y0S]
+
         if ics_only:
             return base_set_up_return
 
@@ -480,8 +491,27 @@ class IDAKLUSolver(pybamm.BaseSolver):
             y0 = y0.full()
         y0 = y0.flatten()
 
+        y0S = model.y0S
+        # only casadi solver needs sensitivity ics
+        if model.convert_to_format != "casadi":
+            y0S = None
+        if y0S is not None:
+            if isinstance(y0S, casadi.DM):
+                y0S = (y0S,)
+
+            y0S = (x.full() for x in y0S)
+            y0S = [x.flatten() for x in y0S]
+        print("integrate y0S", y0S)
+
         # solver works with ydot0 set to zero
         ydot0 = np.zeros_like(y0)
+        if y0S is not None:
+            ydot0S = [np.zeros_like(y0S_i) for y0S_i in y0S]
+            y0full = np.concatenate([y0, *y0S])
+            ydot0full = np.concatenate([ydot0, *ydot0S])
+        else:
+            y0full = y0
+            ydot0full = ydot0
 
         try:
             atol = model.atol
@@ -493,10 +523,11 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
         timer = pybamm.Timer()
         if model.convert_to_format == "casadi":
+            print("sol for ", t_eval)
             sol = self._setup["solver"].solve(
                 t_eval,
-                y0,
-                ydot0,
+                y0full,
+                ydot0full,
                 inputs,
             )
         else:

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -501,7 +501,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
             y0S = (x.full() for x in y0S)
             y0S = [x.flatten() for x in y0S]
-        print("integrate y0S", y0S)
 
         # solver works with ydot0 set to zero
         ydot0 = np.zeros_like(y0)
@@ -523,7 +522,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
         timer = pybamm.Timer()
         if model.convert_to_format == "casadi":
-            print("sol for ", t_eval)
             sol = self._setup["solver"].solve(
                 t_eval,
                 y0full,

--- a/tests/integration/test_models/standard_model_tests.py
+++ b/tests/integration/test_models/standard_model_tests.py
@@ -122,7 +122,7 @@ class StandardModelTest(object):
         output_sens = self.solution[output_name].sensitivities[param_name]
 
         # check via finite differencing
-        h = 1e-4 * param_value
+        h = 1e-2 * param_value
         inputs_plus = {param_name: (param_value + 0.5 * h)}
         inputs_neg = {param_name: (param_value - 0.5 * h)}
         sol_plus = self.solver.solve(self.model, t_eval, inputs=inputs_plus)

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -20,7 +20,10 @@ class BaseIntegrationTestLithiumIon:
     def test_sensitivities(self):
         model = self.model()
         param = pybamm.ParameterValues("Ecker2015")
-        solver = pybamm.IDAKLUSolver()
+        if pybamm.have_idaklu():
+            solver = pybamm.IDAKLUSolver()
+        else:
+            solver = pybamm.CasadiSolver()
         modeltest = tests.StandardModelTest(
             model, parameter_values=param, solver=solver
         )

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -20,7 +20,10 @@ class BaseIntegrationTestLithiumIon:
     def test_sensitivities(self):
         model = self.model()
         param = pybamm.ParameterValues("Ecker2015")
-        modeltest = tests.StandardModelTest(model, parameter_values=param)
+        solver = pybamm.IDAKLUSolver()
+        modeltest = tests.StandardModelTest(
+            model, parameter_values=param, solver=solver
+        )
         modeltest.test_sensitivities("Current function [A]", 0.15652)
 
     def test_basic_processing_1plus1D(self):

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -13,10 +13,6 @@ class TestDFN(BaseIntegrationTestLithiumIon, TestCase):
     def setUp(self):
         self.model = pybamm.lithium_ion.DFN
 
-    def test_sensitivities(self):
-        # skip sensitivities test for now as it is failing with casadi 3.6
-        pass
-
     def test_particle_distribution_in_x(self):
         model = pybamm.lithium_ion.DFN()
         param = model.default_parameter_values

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -204,10 +204,8 @@ class TestIDAKLUSolver(TestCase):
             model, t_eval, inputs={"a": a_value}, calculate_sensitivities=True
         )
 
-        print(sol["2v"].sensitivities["a"].full().flatten())
-
         np.testing.assert_array_almost_equal(
-            sol["2v"].sensitivities["a"].full().flatten(), np.exp(-sol.t) * 2
+            sol["2v"].sensitivities["a"].full().flatten(), np.exp(-sol.t) * 2, decimal=4
         )
 
     def test_ida_roberts_klu_sensitivities(self):

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -181,6 +181,35 @@ class TestIDAKLUSolver(TestCase):
             true_solution = b_value * sol.t
             np.testing.assert_array_almost_equal(sol.y[1:3], true_solution)
 
+    def test_sensitivites_initial_condition(self):
+        model = pybamm.BaseModel()
+        model.convert_to_format = "casadi"
+        u = pybamm.Variable("u")
+        v = pybamm.Variable("v")
+        a = pybamm.InputParameter("a")
+        model.rhs = {u: -u}
+        model.algebraic = {v: a * u - v}
+        model.initial_conditions = {u: 1, v: 1}
+        model.variables = {"2v": 2 * v}
+
+        disc = pybamm.Discretisation()
+        disc.process_model(model)
+
+        solver = pybamm.IDAKLUSolver()
+
+        t_eval = np.linspace(0, 3, 100)
+        a_value = 0.1
+
+        sol = solver.solve(
+            model, t_eval, inputs={"a": a_value}, calculate_sensitivities=True
+        )
+
+        print(sol["2v"].sensitivities["a"].full().flatten())
+
+        np.testing.assert_array_almost_equal(
+            sol["2v"].sensitivities["a"].full().flatten(), np.exp(-sol.t) * 2
+        )
+
     def test_ida_roberts_klu_sensitivities(self):
         # this test implements a python version of the ida Roberts
         # example provided in sundials


### PR DESCRIPTION
# Description

1. feed initial conditions for the sensitivity vectors to the idaklu solver (before was just initialised to 0)
2. call idagetsens after idacalcic to get the corrected initial conditions for sensitivity vectors
3. make the FD h a bit smaller to reduce numerical errors in sensitivity validation for models

Fixes #2858

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
