### PR TITLE
Remove brew-sundials from the recommended developer installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## Bug fixes
 
+- Remove brew install for Mac from the recommended developer installation options for SUNDIALS ([#2925](https://github.com/pybamm-team/PyBaMM/pull/2925))
 - Parameter sets can now contain the key "chemistry", and will ignore its value (this previously would give errors in some cases) ([#2901](https://github.com/pybamm-team/PyBaMM/pull/2901))
 - Fixed a bug in the discretisation of initial conditions of a scaled variable ([#2856](https://github.com/pybamm-team/PyBaMM/pull/2856))
 - Fixed keyerror on "all" when getting sensitivities from IDAKLU solver([#2883](https://github.com/pybamm-team/PyBaMM/pull/2883))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Remove brew install for Mac from the recommended developer installation options for SUNDIALS ([#2925](https://github.com/pybamm-team/PyBaMM/pull/2925))
+
 # [v23.4.1](https://github.com/pybamm-team/PyBaMM/tree/v23.4) - 2023-05-01
 
 ## Bug fixes
@@ -21,7 +25,6 @@
 
 ## Bug fixes
 
-- Remove brew install for Mac from the recommended developer installation options for SUNDIALS ([#2925](https://github.com/pybamm-team/PyBaMM/pull/2925))
 - Parameter sets can now contain the key "chemistry", and will ignore its value (this previously would give errors in some cases) ([#2901](https://github.com/pybamm-team/PyBaMM/pull/2901))
 - Fixed a bug in the discretisation of initial conditions of a scaled variable ([#2856](https://github.com/pybamm-team/PyBaMM/pull/2856))
 - Fixed keyerror on "all" when getting sensitivities from IDAKLU solver([#2883](https://github.com/pybamm-team/PyBaMM/pull/2883))

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -65,9 +65,6 @@ installed on your system.
 The IDA-based solver is currently unavailable on windows.
 If you are running windows, you can simply skip this section and jump to :ref:`pybamm-install`.
 
-Using Tox (recommended for GNU/Linux users)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 .. code:: bash
 
 	  # in the PyBaMM/ directory
@@ -75,24 +72,6 @@ Using Tox (recommended for GNU/Linux users)
 
 This will download, compile and install the SuiteSparse and SUNDIALS libraries.
 Both libraries are installed in ``~/.local``.
-
-Using Homebrew (recommended for MacOS users)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you are using MacOS, an alternative to the above is to get the required SUNDIALS components from Homebrew:
-
-.. code:: bash
-
-	  brew install sundials
-
-Next, clone the pybind11 and casadi-headers repositories:
-
-.. code:: bash
-
-	  # in the PyBaMM/ directory
-	  git clone https://github.com/pybind/pybind11.git
-
-That's it.
 
 Manual install of build time requirements
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

The (Mac recommended) `brew` install procedure for sundials does not link the cmake args that are required by `tox -e dev`. Here, we simplify the developer installation procedure for Mac, bringing it in-line with that for linux, by using `tox -e pybamm-requires` to download, compile and install the SuiteSparse and SUNDIALS libraries.

Fixes #2897 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

_(documentation change only)_
~~[ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)~~
~~[ ] All tests pass: `$ python run-tests.py --all`~~
- [X] The documentation builds: `$ python run-tests.py --doctest`

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
