### PR TITLE
Add self-hosted actions to periodic tests

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -118,3 +118,45 @@ jobs:
       - name: Install dev dependencies and run example tests
         if: matrix.os == 'ubuntu-latest'
         run: nox -s examples
+
+  #M-series Mac Mini
+  build-apple-mseries:
+    needs: style
+    runs-on: [self-hosted, macOS, ARM64]
+    env: 
+      GITHUB_PATH: ${PYENV_ROOT/bin:$PATH}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install python & create virtualenv
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv install ${{ matrix.python-version }} -s
+          pyenv virtualenv ${{ matrix.python-version }} pybamm-${{ matrix.python-version }}
+
+      - name: Install dependencies & run unit tests for Windows and MacOS
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv activate pybamm-${{ matrix.python-version }}
+          python -m pip install --upgrade pip wheel setuptools nox
+          python -m nox -s unit
+
+      - name: Run integration tests for Windows and MacOS
+        run: |
+          eval "$(pyenv init -)"
+          pyenv activate pybamm-${{ matrix.python-version }}
+          python -m nox -s integration
+
+      - name: Uninstall pyenv-virtualenv & python
+        if: always()
+        shell: bash
+        run: |
+          eval "$(pyenv init -)"
+          pyenv activate pybamm-${{ matrix.python-version }}
+          pyenv uninstall -f $( python --version )


### PR DESCRIPTION
# Description

This updates the `run_periodic_tests.yml` workflow to include the self-hosted m-series runner.

Fixes #2884 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
