### PR TITLE
save variables for individual lithium plating terms

### DIFF
--- a/pybamm/models/submodels/interface/lithium_plating/no_plating.py
+++ b/pybamm/models/submodels/interface/lithium_plating/no_plating.py
@@ -25,7 +25,7 @@ class NoPlating(BasePlating):
         )
         variables = self._get_standard_concentration_variables(zero, zero)
         variables.update(self._get_standard_overpotential_variables(zero))
-        variables.update(self._get_standard_reaction_variables(zero))
+        variables.update(self._get_standard_reaction_variables(zero, zero, zero))
         return variables
 
     def get_coupled_variables(self, variables):

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -231,7 +231,10 @@ class BaseIntegrationTestLithiumIon:
     def test_negative_cracking(self):
         options = {"particle mechanics": ("swelling and cracking", "none")}
         parameter_values = pybamm.ParameterValues("Ai2020")
-        self.run_basic_processing_test(options, parameter_values=parameter_values)
+        var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 50, "r_p": 20}
+        self.run_basic_processing_test(
+            options, parameter_values=parameter_values, var_pts=var_pts
+        )
 
     def test_positive_cracking(self):
         options = {"particle mechanics": ("none", "swelling and cracking")}
@@ -241,7 +244,10 @@ class BaseIntegrationTestLithiumIon:
     def test_both_cracking(self):
         options = {"particle mechanics": "swelling and cracking"}
         parameter_values = pybamm.ParameterValues("Ai2020")
-        self.run_basic_processing_test(options, parameter_values=parameter_values)
+        var_pts = {"x_n": 20, "x_s": 20, "x_p": 20, "r_n": 50, "r_p": 20}
+        self.run_basic_processing_test(
+            options, parameter_values=parameter_values, var_pts=var_pts
+        )
 
     def test_both_swelling_only(self):
         options = {"particle mechanics": "swelling only"}


### PR DESCRIPTION
# Description

Add some variables for each term in the lithium plating equation to see different contributions

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
