### PR TITLE
Explicitly raise error in parent process while installing SUNDIALS and SuiteSparse

### DIFF
--- a/scripts/install_KLU_Sundials.py
+++ b/scripts/install_KLU_Sundials.py
@@ -82,8 +82,8 @@ install_cmd = [
 print("-" * 10, "Building SuiteSparse", "-" * 40)
 for libdir in ["SuiteSparse_config", "AMD", "COLAMD", "BTF", "KLU"]:
     build_dir = os.path.join(suitesparse_src, libdir)
-    subprocess.run(make_cmd, cwd=build_dir)
-    subprocess.run(install_cmd, cwd=build_dir)
+    subprocess.run(make_cmd, cwd=build_dir, check=True)
+    subprocess.run(install_cmd, cwd=build_dir, check=True)
 
 # 2 --- Download SUNDIALS
 sundials_version = "6.5.0"
@@ -122,8 +122,8 @@ if not os.path.exists(build_dir):
 
 sundials_src = "../sundials-{}".format(sundials_version)
 print("-" * 10, "Running CMake prepare", "-" * 40)
-subprocess.run(["cmake", sundials_src] + cmake_args, cwd=build_dir)
+subprocess.run(["cmake", sundials_src] + cmake_args, cwd=build_dir, check=True)
 
 print("-" * 10, "Building the sundials", "-" * 40)
 make_cmd = ["make", "install"]
-subprocess.run(make_cmd, cwd=build_dir)
+subprocess.run(make_cmd, cwd=build_dir, check=True)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2968 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
