### PR TITLE
Test scikit.odes installation nightly

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -124,3 +124,7 @@ jobs:
       - name: Install dev dependencies and run example tests
         if: matrix.os == 'ubuntu-latest'
         run: tox -e examples
+
+      - name: Test installation of scikit.odes
+        if: matrix.os == 'ubuntu-latest'
+        run: pybamm_install_odes


### PR DESCRIPTION
# Description

- `run_periodic_tests.yml` will now run test for `pybamm_install_odes` only on GNU/Linux

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
