### PR TITLE
Realign 'count' increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Realign 'count' increment in CasadiSolver._integrate() ([#2927](https://github.com/pybamm-team/PyBaMM/pull/2974))
+
 ## Features
 
 - Enable multithreading in IDAKLU solver ([#2947](https://github.com/pybamm-team/PyBaMM/pull/2947))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- Realign 'count' increment in CasadiSolver._integrate() ([#2927](https://github.com/pybamm-team/PyBaMM/pull/2974))
+- Realign 'count' increment in CasadiSolver._integrate() ([#2974](https://github.com/pybamm-team/PyBaMM/pull/2974))
 
 ## Features
 

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -261,6 +261,7 @@ class CasadiSolver(pybamm.BaseSolver):
                     except pybamm.SolverError as error:
                         pybamm.logger.debug("Failed, halving step size")
                         dt /= 2
+                        count += 1
                         # also reduce maximum step size for future global steps,
                         # but skip them in the beginning
                         # sometimes, for the first integrator smaller timesteps are
@@ -268,7 +269,7 @@ class CasadiSolver(pybamm.BaseSolver):
                         # global timestep will only be reduced after the first timestep.
                         if first_ts_solved:
                             dt_max = dt
-                        if count >= self.max_step_decrease_count:
+                        if count - 1 >= self.max_step_decrease_count:
                             message = (
                                 "Maximum number of decreased steps occurred at "
                                 f"t={t} (final SolverError: '{error}'). "
@@ -287,7 +288,6 @@ class CasadiSolver(pybamm.BaseSolver):
                                     "return the solution object up to the point where "
                                     "failure occured."
                                 )
-                    count += 1
                 if termination_due_to_small_dt:
                     break
                 # Check if the sign of an event changes, if so find an accurate


### PR DESCRIPTION
# Description

Increment 'count' adjacent to the 'dt' change to avoid an off-by-one error of 'max_count'.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ x] All tests pass: `$ python run-tests.py --all`
- [x ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
