### PR TITLE
Add current collector domains and correct units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fix `pybamm_install_odes` and update the required SUNDIALS version ([#2958](https://github.com/pybamm-team/PyBaMM/pull/2958))
 - Remove brew install for Mac from the recommended developer installation options for SUNDIALS ([#2925](https://github.com/pybamm-team/PyBaMM/pull/2925))
+- Fix `bpx.py` to correctly generate parameters for "lumped" thermal model ([#2860](https://github.com/pybamm-team/PyBaMM/issues/2860))
 
 ## Breaking changes
 

--- a/pybamm/parameters/bpx.py
+++ b/pybamm/parameters/bpx.py
@@ -156,6 +156,11 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
         pybamm_dict[domain.pre_name + "thickness [m]"] = 0
         pybamm_dict[domain.pre_name + "conductivity [S.m-1]"] = 4e7
 
+    # add a default heat transfer coefficient
+    pybamm_dict.update(
+        {"Total heat transfer coefficient [W.m-2.K-1]": 0}, check_already_exists=False
+    )
+
     # BET surface area
     for domain in [negative_electrode, positive_electrode]:
         pybamm_dict[domain.pre_name + "active material volume fraction"] = (

--- a/pybamm/parameters/bpx.py
+++ b/pybamm/parameters/bpx.py
@@ -44,6 +44,18 @@ positive_electrode = Domain(
     pre_name="Positive electrode ",
     short_pre_name="Positive ",
 )
+positive_current_collector = Domain(
+    name="positive current collector",
+    pre_name="Positive current collector ",
+    short_pre_name="",
+)
+
+negative_current_collector = Domain(
+    name="negative current collector",
+    pre_name="Negative current collector ",
+    short_pre_name="",
+)
+
 electrolyte = Domain(name="electrolyte", pre_name="Electrolyte ", short_pre_name="")
 separator = Domain(name="separator", pre_name="Separator ", short_pre_name="")
 experiment = Domain(name="experiment", pre_name="", short_pre_name="")
@@ -114,10 +126,35 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
         "Density [kg.m-3]",
         "Thermal conductivity [W.m-1.K-1]",
     ]:
-        for domain in [negative_electrode, positive_electrode, separator]:
+        for domain in [
+            negative_electrode,
+            positive_electrode,
+            separator,
+            negative_current_collector,
+            positive_current_collector,
+        ]:
             pybamm_name = domain.pre_name + name[:1].lower() + name[1:]
             if name in pybamm_dict:
                 pybamm_dict[pybamm_name] = pybamm_dict[name]
+
+    # correct BPX specific heat capacity units to be consistent with pybamm
+    for domain in [
+        negative_electrode,
+        positive_electrode,
+        separator,
+        negative_current_collector,
+        positive_current_collector,
+    ]:
+        incorrect_name = domain.pre_name + "specific heat capacity [J.K-1.kg-1]"
+        new_name = domain.pre_name + "specific heat capacity [J.kg-1.K-1]"
+        if incorrect_name in pybamm_dict:
+            pybamm_dict[new_name] = pybamm_dict[incorrect_name]
+            del pybamm_dict[incorrect_name]
+
+    # lumped thermal model requires current collector parameters. Arbitrarily assign
+    for domain in [negative_current_collector, positive_current_collector]:
+        pybamm_dict[domain.pre_name + "thickness [m]"] = 0
+        pybamm_dict[domain.pre_name + "conductivity [S.m-1]"] = 4e7
 
     # BET surface area
     for domain in [negative_electrode, positive_electrode]:


### PR DESCRIPTION
# Description

Fixes a bug where parameter sets imported from BPX using `create_from_BPX` were incompatible with the "lumped" thermal model. 
- Added current collector domains when assigning thermal properties
- Corrected notation of units from BPX to match PyBaMM
- Assigned arbitrary values for current collector thickness and conductivity

Fixes # [2860](https://github.com/pybamm-team/PyBaMM/issues/2860)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
