### PR TITLE
Use Python 3.11 for generating coverage in CI

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -93,16 +93,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: tox -e pybamm-requires
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.10, and 3.11
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         run: python -m tox -e unit
 
-      - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+      - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: python -m tox -e coverage
 
       - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         uses: codecov/codecov-action@v2.1.0
 
       - name: Run integration tests for GNU/Linux

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -85,16 +85,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: tox -e pybamm-requires
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.10, and 3.11
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.9
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         run: python -m tox -e unit
 
-      - name: Run unit tests for GNU/Linux with Python 3.9 and generate coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+      - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: python -m tox -e coverage
 
       - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         uses: codecov/codecov-action@v2.1.0
 
       - name: Run integration tests for GNU/Linux with Python 3.11


### PR DESCRIPTION
# Description

This PR updates the version on the GitHub Actions steps so that coverage is generated with Python 3.11 via `tox -e coverage`. This was discussed on an earlier PR (#2867) and should work fine since `Jax` was updated recently (#2927)

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
