### PR TITLE
Add inline-tabs for Sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     "sphinx_copybutton",
     "myst_parser",
     "sphinx_extend_parent",
+    "sphinx_inline_tabs",
 ]
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -22,3 +22,4 @@ pydata-sphinx-theme
 sphinx_design
 sphinx-copybutton
 myst-parser
+sphinx-inline-tabs

--- a/docs/source/user_guide/installation/GNU-linux.rst
+++ b/docs/source/user_guide/installation/GNU-linux.rst
@@ -9,32 +9,37 @@ Prerequisites
 
 To use and/or contribute to PyBaMM, you must have Python 3.8, 3.9, 3.10, or 3.11 installed.
 
-To install Python 3 on Debian-based distribution (Debian, Ubuntu, Linux
-mint), open a terminal and run
+   .. tab:: Debian-based distributions (Debian, Ubuntu, Linux Mint)
 
-.. code:: bash
+      To install Python 3 on Debian-based distributions (Debian, Ubuntu, Linux Mint), open a terminal and run
 
-   sudo apt update
-   sudo apt install python3
+      .. code:: bash
 
-On Fedora or CentOS, you can use DNF or Yum. For example
+         sudo apt update
+         sudo apt install python3
 
-.. code:: bash
+   .. tab:: Fedora/CentOS
 
-   sudo dnf install python3
+      On Fedora or CentOS, you can use DNF or Yum. For example
 
-On Mac OS distributions, you can use ``homebrew``. First `install
-brew <https://docs.python-guide.org/starting/install3/osx/>`__:
+      .. code:: bash
 
-.. code:: bash
+         sudo dnf install python3
 
-   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   .. tab:: macOS
 
-then follow instructions in link on adding brew to path, and run
+      On macOS, you can use the ``homebrew`` package manager. First, `install
+      brew <https://docs.python-guide.org/starting/install3/osx/>`__:
 
-.. code:: bash
+      .. code:: bash
 
-   brew install python3
+         ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      then follow instructions in the link on adding ``brew`` to path, and run
+
+      .. code:: bash
+
+         brew install python3
 
 Install PyBaMM
 ==============
@@ -70,18 +75,22 @@ the environment and go back to your original system, just type:
 PyBaMM can be installed via pip. On macOS, it is necessary to install the `SUNDIALS <https://computing.llnl.gov/projects/sundials/>`__
 library beforehand.
 
-GNU/Linux and Windows
-~~~~~~~~~~~~~~~~~~~~~
-.. code:: bash
+.. tab:: GNU/Linux and Windows
 
-   pip install pybamm
+   In a terminal, run the following command:
 
-macOS
-~~~~~
-.. code:: bash
+   .. code:: bash
 
-   brew install sundials
-   pip install pybamm
+      pip install pybamm
+
+.. tab:: macOS
+
+   In a terminal, run the following commands:
+
+   .. code:: bash
+
+      brew install sundials
+      pip install pybamm
 
 PyBaMM’s dependencies (such as ``numpy``, ``scipy``, etc) will be
 installed automatically when you install PyBaMM using ``pip``.
@@ -99,25 +108,27 @@ order to use the wrapped SUNDIALS ODE and DAE
 `solvers <https://pybamm.readthedocs.io/en/latest/source/api/solvers/scikits_solvers.html>`__.
 Currently, only GNU/Linux and macOS are supported.
 
-GNU/Linux
-~~~~~~~~~
+.. tab:: GNU/Linux
 
-.. code:: bash
+   In a terminal, run the following commands:
 
-	  apt install libopenblas-dev
-	  pybamm_install_odes
+   .. code:: bash
 
-The ``pybamm_install_odes`` command is installed with PyBaMM. It automatically downloads and installs the SUNDIALS library on your
-system (under ``~/.local``), before installing ``sckits.odes`` (by running ``pip install scikits.odes``).
+	   apt install libopenblas-dev
+	   pybamm_install_odes
 
-macOS
-~~~~~
+   The ``pybamm_install_odes`` command is installed with PyBaMM. It automatically downloads and installs the SUNDIALS library on your
+   system (under ``~/.local``), before installing ``scikits.odes`` (by running ``pip install scikits.odes``).
 
-.. code:: bash
+.. tab:: macOS
+
+   In a terminal, run the following command:
+
+   .. code:: bash
 
 	  pip install scikits.odes
 
-Assuming that the SUNDIALS were installed as described :ref:`above<user-install-label>`.
+   Assuming that SUNDIALS was installed as described :ref:`above<user-install-label>`.
 
 Optional - JaxSolver
 --------------------
@@ -138,20 +149,24 @@ Developer install
 -----------------
 
 If you wish to contribute to PyBaMM, you should get the latest version
-from the GitHub repository. To do so, you must have Git and graphviz
-installed. For instance run
+from the GitHub repository. To do so, you must have ``Git`` and ``graphviz``
+installed. For instance, run
 
-.. code:: bash
+   .. tab:: Debian-based distributions (Debian, Ubuntu, Linux Mint)
 
-   sudo apt install git graphviz
+      In a terminal, run the following command:
 
-on Debian-based distributions, or
+      .. code:: bash
 
-.. code:: bash
+         sudo apt install git graphviz
 
-   brew install git graphviz
+   .. tab:: macOS
 
-on Mac OS.
+      In a terminal, run the following command:
+
+      .. code:: bash
+
+         brew install git graphviz
 
 To install PyBaMM, the first step is to get the code by cloning this
 repository
@@ -163,9 +178,15 @@ repository
 
 Then, to install PyBaMM as a `developer <https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md>`__, type
 
- .. code:: bash
+.. code:: bash
 
    pip install -e .[dev,docs]
+
+or on ``zsh`` shells, type
+
+.. code:: bash
+   
+   pip install -e .'[dev,docs]'
 
 To check whether PyBaMM has installed properly, you can run the tests:
 

--- a/docs/source/user_guide/installation/GNU-linux.rst
+++ b/docs/source/user_guide/installation/GNU-linux.rst
@@ -9,37 +9,37 @@ Prerequisites
 
 To use and/or contribute to PyBaMM, you must have Python 3.8, 3.9, 3.10, or 3.11 installed.
 
-   .. tab:: Debian-based distributions (Debian, Ubuntu, Linux Mint)
+.. tab:: Debian-based distributions (Debian, Ubuntu, Linux Mint)
 
-      To install Python 3 on Debian-based distributions (Debian, Ubuntu, Linux Mint), open a terminal and run
+   To install Python 3 on Debian-based distributions (Debian, Ubuntu, Linux Mint), open a terminal and run
 
-      .. code:: bash
+   .. code:: bash
 
-         sudo apt update
-         sudo apt install python3
+      sudo apt update
+      sudo apt install python3
 
-   .. tab:: Fedora/CentOS
+.. tab:: Fedora/CentOS
 
-      On Fedora or CentOS, you can use DNF or Yum. For example
+   On Fedora or CentOS, you can use DNF or Yum. For example
 
-      .. code:: bash
+   .. code:: bash
 
-         sudo dnf install python3
+      sudo dnf install python3
 
-   .. tab:: macOS
+.. tab:: macOS
 
-      On macOS, you can use the ``homebrew`` package manager. First, `install
-      brew <https://docs.python-guide.org/starting/install3/osx/>`__:
+   On macOS, you can use the ``homebrew`` package manager. First, `install
+   brew <https://docs.python-guide.org/starting/install3/osx/>`__:
 
-      .. code:: bash
+   .. code:: bash
 
-         ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-      then follow instructions in the link on adding ``brew`` to path, and run
+   then follow instructions in the link on adding ``brew`` to path, and run
 
-      .. code:: bash
+   .. code:: bash
 
-         brew install python3
+      brew install python3
 
 Install PyBaMM
 ==============

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -2,35 +2,45 @@ Installation
 ============
 
 PyBaMM is available on GNU/Linux, MacOS and Windows.
-It can be installed using pip or conda, or from source.
+It can be installed using `pip` or `conda`, or from source.
 
-Using pip
-----------
+.. tab:: GNU/Linux and Windows
 
-PyBaMM can be installed via pip from `PyPI <https://pypi.org/project/pybamm>`__
+   .. tab:: pip
 
-GNU/Linux and Windows
-~~~~~~~~~~~~~~~~~~~~~
+      PyBaMM can be installed via pip from `PyPI <https://pypi.org/project/pybamm>`__.
 
-.. code:: bash
+      .. code:: bash
 
-   pip install pybamm
+         pip install pybamm
 
-macOS
-~~~~~
+   .. tab:: conda
 
-.. code:: bash
+      PyBaMM is part of the `Anaconda <https://docs.continuum.io/anaconda/>`_ distribution and is available as a conda package through the conda-forge channel.
 
-   brew install sundials && pip install pybamm
+      .. code:: bash
 
-Using conda
------------
+         conda install -c conda-forge pybamm
 
-PyBaMM is part of the `Anaconda <https://docs.continuum.io/anaconda/>`_ distribution and is available as a conda package through the conda-forge channel
+.. tab:: macOS
 
-.. code:: bash
+   .. tab:: pip
 
-   conda install -c conda-forge pybamm
+      PyBaMM can be installed via pip from `PyPI <https://pypi.org/project/pybamm>`__.
+
+      .. code:: bash
+
+         brew install sundials && pip install pybamm
+
+
+   .. tab:: conda
+
+      PyBaMM is part of the `Anaconda <https://docs.continuum.io/anaconda/>`_ distribution and is available as a conda package through the conda-forge channel.
+
+      .. code:: bash
+
+         conda install -c conda-forge pybamm
+
 
 Optional solvers
 ----------------

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -31,19 +31,21 @@ To install PyBaMM, you will need:
 - A C compiler (ex: ``gcc``).
 - A Fortran compiler (ex: ``gfortran``).
 
-On Ubuntu, you can install the above with
+You can install the above with
 
-.. code:: bash
+.. tab:: Ubuntu
 
-	  sudo apt install python3.X python3.X-dev libopenblas-dev gcc gfortran
+	.. code:: bash
 
-Where ``X`` is the version sub-number.
+		sudo apt install python3.X python3.X-dev libopenblas-dev gcc gfortran
 
-On MacOS,
+	Where ``X`` is the version sub-number.
 
-.. code:: bash
+.. tab:: MacOS
 
-	  brew install python openblas gcc gfortran libomp
+	.. code:: bash
+
+		brew install python openblas gcc gfortran libomp
 
 Finally, we recommend using `Tox <https://tox.readthedocs.io/en/latest/>`_.
 You can install it with
@@ -100,12 +102,19 @@ You should now have everything ready to build and install PyBaMM successfully.
 Using Tox (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code:: bash
+.. tab:: GNU/Linux and MacOS
 
-	  # in the PyBaMM/ directory
-	  tox -e dev # (GNU/Linux and MacOS)
-	  #
-	  python -m tox -e windows-dev # (Windows)
+	.. code:: bash
+
+		# in the PyBaMM/ directory
+		tox -e dev
+
+.. tab:: Windows
+
+	.. code:: bash
+
+		# in the PyBaMM/ directory
+	  	python -m tox -e windows-dev
 
 
 This creates a virtual environment ``.tox/dev`` (or ``windows-dev``) inside the ``PyBaMM/`` directory.
@@ -113,11 +122,17 @@ It comes ready with PyBaMM and some useful development tools like `pre-commit <h
 
 You can now activate the environment with
 
-.. code:: bash
+.. tab:: GNU/Linux and MacOS
 
-	  source .tox/dev/bin/activate # (GNU/Linux and MacOS)
-	  #
-	  .tox\windows-dev\Scripts\activate.bat # (Windows)
+	.. code:: bash
+
+		source .tox/dev/bin/activate
+
+.. tab:: Windows
+
+	.. code:: bash
+
+	  	.tox\windows-dev\Scripts\activate.bat # (Windows)
 
 and run the tests to check your installation.
 
@@ -130,12 +145,17 @@ From the ``PyBaMM/`` directory, you can install PyBaMM using ``python setup.py i
 
 	  pip install .
 
-
 If you intend to contribute to the development of PyBaMM, it is convenient to install in "editable mode", along with useful tools for development and documentation:
 
 .. code:: bash
 
 	  pip install -e .[dev,docs]
+
+If you are using ``zsh``, you would need to use different pattern matching:
+
+.. code:: bash
+
+	  pip install -e .'[dev,docs]'
 
 Running the tests
 --------------------
@@ -147,23 +167,34 @@ You can use Tox to run the unit tests and example notebooks in isolated virtual 
 
 The default command
 
-.. code:: bash
+.. tab:: GNU/Linux and MacOS
 
-	  tox -e tests # (GNU/Linux and MacOS)
-	  #
-	  python -m tox -e windows-tests # (Windows)
+	.. code:: bash
+
+		tox -e tests
+
+.. tab:: Windows
+
+	.. code:: bash
+
+	  	python -m tox -e windows-tests
 
 will run the full test suite (integration and unit tests).
 This can take several minutes.
 
 It is often sufficient to run the unit tests only. To do so, use
 
+.. tab:: GNU/Linux and MacOS
+
    .. code:: bash
 
-      tox -e unit # (GNU/Linux and MacOS)
-      #
-      python -m tox -e windows-unit # (Windows)
+    	tox -e unit
 
+.. tab:: Windows
+
+   .. code:: bash
+
+		python -m tox -e windows-unit
 
 Using the test runner 
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -206,23 +237,18 @@ The preview will be updated automatically following changes.
 Doctests, examples, style and coverage
 --------------------------------------
 
-- ``tox -e examples``: Run the example scripts in ``examples/scripts``.
-- ``tox -e doctests``: Run doctests.
-- ``tox -e coverage``: Measure current test coverage.
+.. tab:: GNU/Linux and MacOS
 
-Note for Windows users
-----------------------
+	``Tox`` can also be used to run the following commands:
 
-If you are running Windows, the following tox commands must be prefixed by ``windows-``:
+	- ``tox -e examples``: Run the example scripts in ``examples/scripts``.
+	- ``tox -e doctests``: Run doctests.
 
-- ``tests``
-- ``unit``
-- ``examples``
-- ``doctests``
-- ``dev``
+.. tab:: Windows
 
-For example, to run the full test suite on Windows you would type:
+	``Tox`` can also be used to run the following commands:
 
-.. code:: bash
+	- ``python -m tox -e windows-examples``: Run the example scripts in ``examples/scripts``.
+	- ``python -m tox -e windows-doctests``: Run doctests.
 
-	  python -m tox -e windows-tests  
+Use ``tox -e coverage`` to measure current test coverage on all platforms.

--- a/docs/source/user_guide/installation/windows.rst
+++ b/docs/source/user_guide/installation/windows.rst
@@ -42,7 +42,7 @@ type:
 
 You can then “activate” the environment using:
 
-.. code:: bash
+.. code:: cmd
 
    env\Scripts\activate.bat
 

--- a/setup.py
+++ b/setup.py
@@ -230,6 +230,7 @@ setup(
             "sphinx_design",
             "sphinx-copybutton",
             "myst-parser",
+            "sphinx-inline-tabs",
         ],  # For doc generation
         "dev": [
             "pre-commit",  # For code style checking

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
      doctests: sphinx_design
      doctests: sphinx-copybutton
      doctests: myst-parser
+     doctests: sphinx-inline-tabs
      !windows-!mac: scikits.odes
      examples: jupyter   # For example notebooks
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ deps =
      sphinx_design
      sphinx-copybutton
      myst-parser
+     sphinx-inline-tabs
 changedir = docs
 commands = sphinx-autobuild --open-browser -qT . {envtmpdir}/html
 


### PR DESCRIPTION
# Description

Adds the [sphinx-inline-tabs](https://github.com/pradyunsg/sphinx-inline-tabs) Sphinx extension to save space on installation instructions and remove redundant steps in the documentation for developer and user workflows.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
