### PR TITLE
#2954 turn off benchmark: ORegan2022 DFN solver with the casadi model

### DIFF
--- a/benchmarks/time_sims_experiments.py
+++ b/benchmarks/time_sims_experiments.py
@@ -17,7 +17,7 @@ class TimeSimulation:
             "Hold at 4.1 V until 10 mA",
             "Rest for 1 hour",
         ],
-        "GITT": [("Discharge at C/20 for 1 hour", "Rest for 1 hour")] * 20,
+        "GITT": [("Discharge at C/20 for 1 hour", "Rest for 1 hour")] * 10,
     }
 
     def setup(self, experiment, parameters, model_class, solver_class):

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -145,8 +145,7 @@ class TimeSolveDFN:
     )
 
     def setup(self, solve_first, parameters, solver_class):
-        if (solve_first, parameters, solver_class) == (
-            True,
+        if (parameters, solver_class) == (
             "ORegan2022",
             pybamm.CasadiSolver,
         ):


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2954

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
