### PR TITLE
Stop automatic version updating

### DIFF
--- a/.github/workflows/update_version.yml
+++ b/.github/workflows/update_version.yml
@@ -2,9 +2,6 @@ name: Update version
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run at 10 am UTC on 28th every month
-    - cron: 0 10 28 * *
 
 jobs:
   update-version:


### PR DESCRIPTION
Quick fix to stop the scheduled dispatch of the version update workflow (the one that opens the release PR). I have not deleted the workflow as the plan for #2881 is to update it, but this quick fix should prevent the PRs from being open in the meantime.