### PR TITLE
Remove backport `importlib_metadata` from required dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Test `JaxSolver`'s compatibility with Python `3.8`, `3.9`, `3.10`, and `3.11` ([#2958](https://github.com/pybamm-team/PyBaMM/pull/2958))
 - Update Jax (0.4.8) and JaxLib (0.4.7) compatibility ([#2927](https://github.com/pybamm-team/PyBaMM/pull/2927))
+- Removed `importlib_metadata` as a required dependency for user installations ([#3050](https://github.com/pybamm-team/PyBaMM/pull/3050))
 
 ## Bug fixes
 

--- a/pybamm/parameters/parameter_sets.py
+++ b/pybamm/parameters/parameter_sets.py
@@ -1,5 +1,5 @@
 import warnings
-import importlib_metadata
+import importlib.metadata
 import textwrap
 from collections.abc import Mapping
 
@@ -36,7 +36,7 @@ class ParameterSets(Mapping):
     def __init__(self):
         # Dict of entry points for parameter sets, lazily load entry points as
         self.__all_parameter_sets = dict()
-        for entry_point in importlib_metadata.entry_points(
+        for entry_point in importlib.metadata.entry_points(
             group="pybamm_parameter_sets"
         ):
             self.__all_parameter_sets[entry_point.name] = entry_point

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,6 @@ setup(
         "scikit-fem>=0.2.0",
         "casadi>=3.6.0",
         "imageio>=2.9.0",
-        "importlib-metadata",
         "pybtex>=0.24.0",
         "sympy>=1.8",
         "xarray",


### PR DESCRIPTION
# Description

A quick fix to replace the dependency on the backported module `importlib_metadata` with the standard module `importlib.metadata`, since we had dropped support for Python 3.7 and below in #2370 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
