### PR TITLE
Extract single element from `np.ndarray` when converting to scalar

### DIFF
--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -37,9 +37,14 @@ class Scalar(pybamm.Symbol):
         """The value returned by the node when evaluated."""
         return self._value
 
+    # address numpy 1.25 deprecation warning: array should have ndim=0 before conversion
     @value.setter
     def value(self, value):
-        self._value = np.float64(value)
+        self._value = (
+            np.float64(value.item())
+            if isinstance(value, np.ndarray)
+            else np.float64(value)
+        )
 
     def set_id(self):
         """See :meth:`pybamm.Symbol.set_id()`."""

--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -422,11 +422,13 @@ class ElectrodeSOHSolver:
 
         # Check that the min and max achievable voltages span wider than the desired
         # voltage range
+        # address numpy 1.25 deprecation warning: array should have ndim=0
+        # before conversion
         V_lower_bound = float(
-            self.OCV_function.evaluate(inputs={"x": x0_min, "y": y0_max})
+            self.OCV_function.evaluate(inputs={"x": x0_min, "y": y0_max}).item()
         )
         V_upper_bound = float(
-            self.OCV_function.evaluate(inputs={"x": x100_max, "y": y100_min})
+            self.OCV_function.evaluate(inputs={"x": x100_max, "y": y100_min}).item()
         )
         if V_lower_bound > self.V_min:
             raise (
@@ -622,9 +624,10 @@ def theoretical_energy_integral(parameter_values, n_i, n_f, p_i, p_f, points=100
     T = param.T_amb(0)
     Vs = np.empty(n_vals.shape)
     for i in range(n_vals.size):
-        Vs[i] = parameter_values.evaluate(
-            param.p.prim.U(p_vals[i], T)
-        ) - parameter_values.evaluate(param.n.prim.U(n_vals[i], T))
+        Vs[i] = (
+            parameter_values.evaluate(param.p.prim.U(p_vals[i], T)).item()
+            - parameter_values.evaluate(param.n.prim.U(n_vals[i], T)).item()
+        )
     # Calculate dQ
     Q_p = parameter_values.evaluate(param.p.prim.Q_init) * (p_f - p_i)
     dQ = Q_p / (points - 1)

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -647,7 +647,9 @@ class ParameterValues:
             new_symbol._scale = self.process_symbol(symbol.scale)
             reference = self.process_symbol(symbol.reference)
             if isinstance(reference, pybamm.Vector):
-                reference = pybamm.Scalar(float(reference.evaluate()))
+                # address numpy 1.25 deprecation warning: array should have ndim=0
+                # before conversion
+                reference = pybamm.Scalar((reference.evaluate()).item())
             new_symbol._reference = reference
             new_symbol.bounds = tuple([self.process_symbol(b) for b in symbol.bounds])
             return new_symbol

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -502,8 +502,12 @@ class BaseSolver(object):
                     # We only need to do this if the model is a DAE model
                     # see #1082
                     k = 20
+                    # address numpy 1.25 deprecation warning: array should have
+                    # ndim=0 before conversion
                     init_sign = float(
-                        np.sign(event.evaluate(0, model.y0.full(), inputs=inputs))
+                        np.sign(
+                            event.evaluate(0, model.y0.full(), inputs=inputs)
+                        ).item()
                     )
                     # We create a sigmoid for each event which will multiply the
                     # rhs. Doing * 2 - 1 ensures that when the event is crossed,

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -40,8 +40,9 @@ def errors(pts, function, method_options, bcs=None):
     left_extrap_processed = disc.process_symbol(left_extrap)
     right_extrap_processed = disc.process_symbol(right_extrap)
 
-    l_error = np.abs(l_true - left_extrap_processed.evaluate(None, y))
-    r_error = np.abs(r_true - right_extrap_processed.evaluate(None, y))
+    # address numpy 1.25 deprecation warning: array should have ndim=0 before conversion
+    l_error = np.abs(l_true - left_extrap_processed.evaluate(None, y)).item()
+    r_error = np.abs(r_true - right_extrap_processed.evaluate(None, y)).item()
 
     return l_error, r_error
 


### PR DESCRIPTION
# Description

Extracts singular element from NumPy arrays with `ndim` > 0 using [`numpy.ndarray.item()`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.item.html) before conversion to Python/NumPy scalars (`float` data types)

Fixes #3052 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
