### PR TITLE
Add an option to download Jupyter notebooks from readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,18 +267,14 @@ intersphinx_mapping = {
 
 nbsphinx_prolog = r"""
 
-{% set download_url =
-'https://raw.githubusercontent.com/pybamm-team/pybamm/develop/docs/' +
-env.doc2path(env.docname, base=None) %}
-
-{% set alternative_download_url =
-'https://docs.pybamm.org/en/latest/' %}
-
-{% set doc_path = env.doc2path(env.docname, base=None) %}
-
 {% set github_docname =
 'github/pybamm-team/pybamm/blob/develop/docs/' +
 env.doc2path(env.docname, base=None) %}
+
+{% set readthedocs_download_url =
+'https://docs.pybamm.org/en/latest/' %}
+
+{% set doc_path = env.doc2path(env.docname, base=None) %}
 
 .. raw:: html
 
@@ -297,7 +293,7 @@ env.doc2path(env.docname, base=None) %}
             <hr>
         <p>
             Alternatively, you may
-            <a href="{{ alternative_download_url | e }}{{ doc_path | e }}"
+            <a href="{{ readthedocs_download_url | e }}{{ doc_path | e }}"
             target="_blank" download>
             download this notebook</a> and run it offline.
         </p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,7 +267,16 @@ intersphinx_mapping = {
 
 nbsphinx_prolog = r"""
 
-{% set docname =
+{% set download_url =
+'https://raw.githubusercontent.com/pybamm-team/pybamm/develop/docs/' +
+env.doc2path(env.docname, base=None) %}
+
+{% set alternative_download_url =
+'https://docs.pybamm.org/en/latest/' %}
+
+{% set doc_path = env.doc2path(env.docname, base=None) %}
+
+{% set github_docname =
 'github/pybamm-team/pybamm/blob/develop/docs/' +
 env.doc2path(env.docname, base=None) %}
 
@@ -280,10 +289,17 @@ env.doc2path(env.docname, base=None) %}
         <p>
             An interactive online version of this notebook is available, which can be
             accessed via
-            <a href="https://colab.research.google.com/{{ docname | e }}" 
+            <a href="https://colab.research.google.com/{{ github_docname | e }}" 
             target="_blank">
             <img src="https://colab.research.google.com/assets/colab-badge.svg"
             alt="Open this notebook in Google Colab"/></a>
+        </p>
+            <hr>
+        <p>
+            Alternatively, you may
+            <a href="{{ alternative_download_url | e }}{{ doc_path | e }}"
+            target="_blank" download>
+            download this notebook</a> and run it offline.
         </p>
     </div>
 


### PR DESCRIPTION
# Description

Adds a link to download Jupyter notebooks in the PyBaMM documentation such that they can be run offline by users.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
