### PR TITLE
Cache `nox` environments and refactor unit tests in CI

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -87,13 +87,13 @@ jobs:
       - name: Install standard python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools nox
-  
-      - name: Install SuiteSparse and Sundials
+
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
         run: nox -s pybamm-requires
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10, and for macOS and Windows with all Python versions
+        if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
         run: nox -s unit
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
@@ -106,10 +106,6 @@ jobs:
 
       - name: Run integration tests
         run: nox -s integration
-
-      - name: Run unit tests for Windows and MacOS
-        if: matrix.os != 'ubuntu-latest'
-        run: nox -s unit
 
       - name: Install docs dependencies and run doctests
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -111,7 +111,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         with:
           path: ${{ github.workspace }}/.nox/unit/
-          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py') }}-${{ hashFiles('**/setup.py') }}
+          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -60,7 +60,7 @@ jobs:
           execute_install_scripts: true
 
       # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TexLive for Linux
+      - name: Install OpenBLAS and TeXLive for Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
@@ -105,6 +105,13 @@ jobs:
       - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
         if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         run: nox -s unit
+
+      - name: Cache unit tests nox environment for GNU/Linux with Python 3.8, 3.9, and 3.10
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+        with:
+          path: ${{ github.workspace }}/.nox/unit/
+          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py') }}-${{ hashFiles('**/setup.py') }}
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: choco install graphviz --version=2.38.0.20190211
+        run: choco install graphviz --version=8.0.5
 
       - name: Install standard Python dependencies
         run: |

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -70,7 +70,7 @@ jobs:
       # Added fixes to homebrew installs:
       # rm -f /usr/local/bin/2to3
       # (see https://github.com/actions/virtual-environments/issues/2322)
-      - name: Install MacOS system dependencies
+      - name: Install macOS system dependencies
         if: matrix.os == 'macos-latest'
         env:
           # Homebrew environment variables
@@ -125,9 +125,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: nox -s integration
 
-      - name: Run unit tests for Windows and MacOS with all Python versions
+      - name: Run unit tests for Windows and macOS with all Python versions
         if: matrix.os != 'ubuntu-latest'
         run: nox -s unit
+
+      - name: Cache unit tests nox environment for Windows and macOS with all Python versions
+        uses: actions/cache@v3
+        if: matrix.os != 'ubuntu-latest'
+        with:
+          path: ${{ github.workspace }}/.nox/unit/
+          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -125,16 +125,17 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: nox -s integration
 
-      - name: Run unit tests for Windows and macOS with all Python versions
-        if: matrix.os != 'ubuntu-latest'
-        run: nox -s unit
-
       - name: Cache unit tests nox environment for Windows and macOS with all Python versions
         uses: actions/cache@v3
         if: matrix.os != 'ubuntu-latest'
         with:
           path: ${{ github.workspace }}/.nox/unit/
           key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
+          restore-keys: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-
+
+      - name: Run unit tests for Windows and macOS with all Python versions
+        if: matrix.os != 'ubuntu-latest'
+        run: nox -s unit
 
       - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -64,7 +64,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo dot -c 
+          sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       # Added fixes to homebrew installs:
@@ -86,8 +86,7 @@ jobs:
           rm -f /usr/local/bin/pydoc3*
           rm -f /usr/local/bin/python3*
           brew update
-          brew install graphviz
-          brew install openblas
+          brew install graphviz openblas
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
@@ -128,6 +127,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         run: nox -s unit
 
+      - name: Cache coverage nox environment for GNU/Linux with Python 3.11
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        with:
+          path: ${{ github.workspace }}/.nox/coverage/
+          key: ${{ runner.os }}-nox-coverage-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/.coveragerc') }}
+
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: nox -s coverage
@@ -135,6 +141,13 @@ jobs:
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         uses: codecov/codecov-action@v2.1.0
+
+      - name: Cache integration tests nox environment for GNU/Linux with Python 3.11
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        with:
+          path: ${{ github.workspace }}/.nox/integration/
+          key: ${{ runner.os }}-nox-integration-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Run integration tests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
@@ -151,9 +164,23 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         run: nox -s unit
 
+      - name: Cache doctests nox environment for GNU/Linux with Python 3.11
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        with:
+          path: ${{ github.workspace }}/.nox/doctests/
+          key: ${{ runner.os }}-nox-doctests-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/docs/requirements.txt') }}
+
       - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: nox -s doctests
+
+      - name: Cache examples nox environment for GNU/Linux with Python 3.11
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
+        with:
+          path: ${{ github.workspace }}/.nox/examples/
+          key: ${{ runner.os }}-nox-examples-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Install dev dependencies and run example tests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -108,7 +108,6 @@ jobs:
             ${{ github.workspace }}/pybind11/
             ${{ github.workspace }}/install_KLU_Sundials/
             # Headers and dynamic library files for SuiteSparse and SUNDIALS
-            ${{ env.HOME }}/.local/lib/
             ${{ env.HOME }}/.local/include/
             ${{ env.HOME }}/.local/examples/
           key: nox-pybamm-requires-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -117,16 +117,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: nox -s pybamm-requires
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
-        run: nox -s unit
-
       - name: Cache unit tests nox environment for GNU/Linux with Python 3.8, 3.9, and 3.10
         uses: actions/cache@v3
         if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
         with:
           path: ${{ github.workspace }}/.nox/unit/
           key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
+
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+        run: nox -s unit
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
@@ -146,7 +146,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/.nox/unit/
           key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
-          restore-keys: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-
 
       - name: Run unit tests for Windows and macOS with all Python versions
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -108,6 +108,7 @@ jobs:
             ${{ github.workspace }}/pybind11/
             ${{ github.workspace }}/install_KLU_Sundials/
             # Headers and dynamic library files for SuiteSparse and SUNDIALS
+            ${{ env.HOME }}/.local/lib/
             ${{ env.HOME }}/.local/include/
             ${{ env.HOME }}/.local/examples/
           key: nox-pybamm-requires-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -98,7 +98,22 @@ jobs:
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install nox
 
-      - name: Install SuiteSparse and Sundials
+      - name: Cache pybamm-requires nox environment for GNU/Linux
+        uses: actions/cache@v3
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          path: |
+            # Repository files
+            ${{ github.workspace }}/.nox/pybamm-requires/
+            ${{ github.workspace }}/pybind11/
+            ${{ github.workspace }}/install_KLU_Sundials/
+            # Headers and dynamic library files for SuiteSparse and SUNDIALS
+            ${{ env.HOME }}/.local/lib/
+            ${{ env.HOME }}/.local/include/
+            ${{ env.HOME }}/.local/examples/
+          key: nox-pybamm-requires-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}
+
+      - name: Install SuiteSparse and SUNDIALS
         if: matrix.os == 'ubuntu-latest'
         run: nox -s pybamm-requires
 

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -112,19 +112,19 @@ jobs:
             ${{ env.HOME }}/.local/examples/
           key: nox-pybamm-requires-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}
 
-      - name: Install SuiteSparse and SUNDIALS
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
         run: nox -s pybamm-requires
 
-      - name: Cache unit tests nox environment for GNU/Linux with Python 3.8, 3.9, and 3.10
+      - name: Cache unit tests nox environment for GNU/Linux with Python 3.8, 3.9, and 3.10, and for macOS and Windows with all Python versions
         uses: actions/cache@v3
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+        if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
         with:
           path: ${{ github.workspace }}/.nox/unit/
           key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
-      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11
+      - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10 and for macOS and Windows with all Python versions
+        if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
         run: nox -s unit
 
       - name: Cache coverage nox environment for GNU/Linux with Python 3.11
@@ -152,17 +152,6 @@ jobs:
       - name: Run integration tests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         run: nox -s integration
-
-      - name: Cache unit tests nox environment for Windows and macOS with all Python versions
-        uses: actions/cache@v3
-        if: matrix.os != 'ubuntu-latest'
-        with:
-          path: ${{ github.workspace }}/.nox/unit/
-          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
-
-      - name: Run unit tests for Windows and macOS with all Python versions
-        if: matrix.os != 'ubuntu-latest'
-        run: nox -s unit
 
       - name: Cache doctests nox environment for GNU/Linux with Python 3.11
         uses: actions/cache@v3

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Check style
         run: |


### PR DESCRIPTION
# Description

This PR caches `nox` test environments in order to speed up the CI. Environments are matched with a key that corresponds to relevant files that are subject to change, and the Python version (including the subversion) to avoid mismatch constraints. It also refactors the unit tests to run in a single step for Linux, macOS, and Windows; closes #3095 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
