### PR TITLE
Add floating window tooltips for cross-references in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_gallery.load_style",
+    "hoverxref.extension",
 ]
 
 # -- sphinxcontrib-bibtex configuration --------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -302,6 +302,27 @@ env.doc2path(env.docname, base=None) %}
 
 """
 
+# -- Options for sphinx-hoverxref --------------------------------------------
+
+# Hoverxref settings
+
+hoverxref_default_type = "tooltip"
+hoverxref_auto_ref = True
+
+hoverxref_roles = ["class", "meth", "func", "ref", "autoclass", "autofunction", "term"]
+hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
+
+hoverxref_domains = ["py"]
+
+# Currently, only projects that are hosted on readthedocs + CPython, NumPy, and
+# SymPy are supported
+hoverxref_intersphinx = list(intersphinx_mapping.keys())
+
+# Tooltips settings
+hoverxref_tooltip_lazy = False
+# TODO: configure theme and sizing for tooltips
+
+
 # -- Jinja templating --------------------------------------------------------
 # Credit to: https://ericholscher.com/blog/2016/jul/25/integrating-jinja-rst-sphinx/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,7 +323,7 @@ hoverxref_tooltip_lazy = False
 hoverxref_tooltip_maxwidth = 750
 hoverxref_tooltip_animation = "swing"
 hoverxref_tooltip_content = "Loading information..."
-hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-punk"]
+hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-shadow-custom"]
 
 
 # -- Jinja templating --------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -323,7 +323,6 @@ hoverxref_tooltip_lazy = False
 hoverxref_tooltip_maxwidth = 750
 hoverxref_tooltip_animation = "swing"
 hoverxref_tooltip_content = "Loading information..."
-hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-shadow-custom"]
 
 
 # -- Jinja templating --------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -309,7 +309,7 @@ env.doc2path(env.docname, base=None) %}
 hoverxref_default_type = "tooltip"
 hoverxref_auto_ref = True
 
-hoverxref_roles = ["class", "meth", "func", "ref", "autoclass", "autofunction", "term"]
+hoverxref_roles = ["class", "meth", "func", "ref", "term"]
 hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
 
 hoverxref_domains = ["py"]
@@ -320,7 +320,10 @@ hoverxref_intersphinx = list(intersphinx_mapping.keys())
 
 # Tooltips settings
 hoverxref_tooltip_lazy = False
-# TODO: configure theme and sizing for tooltips
+hoverxref_tooltip_maxwidth = 750
+hoverxref_tooltip_animation = "swing"
+hoverxref_tooltip_content = "Loading information..."
+hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-punk"]
 
 
 # -- Jinja templating --------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,8 +321,10 @@ hoverxref_intersphinx = list(intersphinx_mapping.keys())
 # Tooltips settings
 hoverxref_tooltip_lazy = False
 hoverxref_tooltip_maxwidth = 750
-hoverxref_tooltip_animation = "swing"
+hoverxref_tooltip_animation = "fade"
+hoverxref_tooltip_animation_duration = 1
 hoverxref_tooltip_content = "Loading information..."
+hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-shadow-custom"]
 
 
 # -- Jinja templating --------------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,3 +29,4 @@ ipython
 ipykernel
 ipywidgets
 sphinx-gallery
+sphinx-hoverxref

--- a/docs/source/_static/pybamm.css
+++ b/docs/source/_static/pybamm.css
@@ -155,7 +155,7 @@ html[data-theme="dark"] h3 {
 }
 
 .tooltipster-sidetip.tooltipster-shadow .tooltipster-arrow {
-  background: var(--pst-color-background) !important;
+  background: none !important;
   overflow: hidden;
   position: absolute;
 }

--- a/docs/source/_static/pybamm.css
+++ b/docs/source/_static/pybamm.css
@@ -144,3 +144,14 @@ html[data-theme="dark"] h1 {
 html[data-theme="dark"] h3 {
   color: #0a6774;
 }
+
+/* Overrides for sphinx-hoverxref since it does not support a native dark theme, see */
+/* https://github.com/readthedocs/sphinx-hoverxref/issues/231 */
+
+html[data-theme="dark"] .tooltipster-sidetip.tooltipster-shadow .tooltipster-box
+.tooltipster-arrow .tooltipster-right .tooltipster-left .tooltipster-arrow-border {
+  border: none;
+  border-radius: 5px;
+  background-color: var(--pst-color-background);
+  box-shadow: 0 0 10px 6px rgba(0,0,0,.1);
+}

--- a/docs/source/_static/pybamm.css
+++ b/docs/source/_static/pybamm.css
@@ -148,10 +148,22 @@ html[data-theme="dark"] h3 {
 /* Overrides for sphinx-hoverxref since it does not support a native dark theme, see */
 /* https://github.com/readthedocs/sphinx-hoverxref/issues/231 */
 
-html[data-theme="dark"] .tooltipster-sidetip.tooltipster-shadow .tooltipster-box
-.tooltipster-arrow .tooltipster-right .tooltipster-left .tooltipster-arrow-border {
-  border: none;
-  border-radius: 5px;
-  background-color: var(--pst-color-background);
-  box-shadow: 0 0 10px 6px rgba(0,0,0,.1);
+/* These will ensure that the tooltip inherits the PyData colours */
+
+.tooltipster-sidetip.tooltipster-shadow .tooltipster-box {
+  background: var(--pst-color-background) !important;
+}
+
+.tooltipster-sidetip.tooltipster-shadow .tooltipster-arrow {
+  background: var(--pst-color-background) !important;
+  overflow: hidden;
+  position: absolute;
+}
+
+.tooltipster-sidetip.tooltipster-shadow.tooltipster-right .tooltipster-arrow-border {
+  border-right-color: var(--pst-color-background) !important;
+}
+
+.tooltipster-sidetip.tooltipster-shadow.tooltipster-left .tooltipster-arrow-border {
+  border-left-color: var(--pst-color-background) !important;
 }

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -1,4 +1,4 @@
-(user)=
+(user_guide)=
 
 # PyBaMM user guide
 

--- a/setup.py
+++ b/setup.py
@@ -236,6 +236,7 @@ setup(
             "ipykernel",
             "ipywidgets",
             "sphinx-gallery",
+            "sphinx-hoverxref",
         ],  # For doc generation
         "dev": [
             "pre-commit",  # For code style checking


### PR DESCRIPTION
# Description

This PR adds and configures support for [sphinx-hoverxref](https://sphinx-hoverxref.readthedocs.io/en/latest/index.html), which enables hovering over classes, methods, and other links to directly display their results within the same page

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
