### PR TITLE
Display when pages were last updated in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "sphinx_extend_parent",
     "sphinx_inline_tabs",
     "sphinxcontrib.bibtex",
+    "sphinx_last_updated_by_git",
     "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_gallery.load_style",

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ setup(
     ],
     extras_require={
         "docs": [
-            "sphinx>=1.5",
+            "sphinx>=6",
             "pydata-sphinx-theme",
             "sphinx_design",
             "sphinx-copybutton",
@@ -232,6 +232,7 @@ setup(
             "sphinx-inline-tabs",
             "sphinxcontrib-bibtex",
             "sphinx-autobuild",
+            "sphinx-last-updated-by-git",
             "nbsphinx",
             "ipykernel",
             "ipywidgets",


### PR DESCRIPTION
# Description

Adds the [sphinx-last-updated-by-git extension](https://github.com/mgeier/sphinx-last-updated-by-git) to display last-updated dates at the end of a source page

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
