### PR TITLE
Document other useful `nox` commands

### DIFF
--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -228,3 +228,18 @@ Doctests, examples, style and coverage
 
 
 Use ``nox -s coverage`` to measure current test coverage on all platforms.
+
+Extra tips while using Nox
+--------------------------
+Here are some additional useful commands you can run with Nox:
+
+- ``nox -v``: Enables verbose mode, providing more detailed output during the execution of Nox sessions.
+- ``nox -l``: Lists all available Nox sessions and their descriptions.
+- ``nox -p <python.version>``: Runs only sessions with the specified Python version. Replace ``python.version`` with the desired Python version.
+- ``nox -k "<keyword_expression>"``: Runs test sessions that match the specified pytest-style keyword expression.
+- ``nox -t "<tag1>" "<tag2>"``: Runs test sessions that have the specified tags.
+- ``nox --stop-on-first-error``: Stops the execution of Nox sessions immediately after the first error or failure occurs.
+- ``nox --envdir <path>``: Specifies the directory where Nox creates and manages the virtual environments used by the sessions. In this case, the directory is set to ``<path>``.
+- ``nox --install-only``: Skips the test execution and only performs the installation step defined in the Nox sessions.
+- ``nox --nocolor``: Disables the color output in the console during the execution of Nox sessions.
+- ``nox --report output.json``: Generates a JSON report of the Nox session execution and saves it to the specified file, in this case, "output.json".

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -107,7 +107,7 @@ Using Nox (recommended)
 	.. code:: bash
 
 		# in the PyBaMM/ directory
-		nox -s dev
+		nox -s dev --verbose
 
 This creates a virtual environment ``.nox/dev`` inside the ``PyBaMM/`` directory.
 It comes ready with PyBaMM and some useful development tools like `pre-commit <https://pre-commit.com/>`_ and `black <https://black.readthedocs.io/en/stable/>`_.

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -235,7 +235,6 @@ Here are some additional useful commands you can run with Nox:
 
 - ``--verbose or -v``: Enables verbose mode, providing more detailed output during the execution of Nox sessions.
 - ``--list or -l``: Lists all available Nox sessions and their descriptions.
-- ``--python <python.version> or -p <python.version>``: Runs only sessions with the specified Python version. Replace ``python.version`` with the desired Python version.
 - ``-k "<keyword_expression>"``: Runs test sessions that match the specified pytest-style keyword expression.
 - ``-t "<tag1>" "<tag2>"``: Runs test sessions that have the specified tags.
 - ``--stop-on-first-error``: Stops the execution of Nox sessions immediately after the first error or failure occurs.

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -109,7 +109,8 @@ Using Nox (recommended)
 		# in the PyBaMM/ directory
 		nox -s dev
 
-**Note** : It is recommended to use ``--verbose`` or ``-v`` to see outputs of all commands run.
+.. note::
+    It is recommended to use ``--verbose`` or ``-v`` to see outputs of all commands run.
 
 This creates a virtual environment ``.nox/dev`` inside the ``PyBaMM/`` directory.
 It comes ready with PyBaMM and some useful development tools like `pre-commit <https://pre-commit.com/>`_ and `black <https://black.readthedocs.io/en/stable/>`_.

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -107,7 +107,9 @@ Using Nox (recommended)
 	.. code:: bash
 
 		# in the PyBaMM/ directory
-		nox -s dev --verbose
+		nox -s dev
+
+**Note** : It is recommended to use ``--verbose`` or ``-v`` to see outputs of all commands run.
 
 This creates a virtual environment ``.nox/dev`` inside the ``PyBaMM/`` directory.
 It comes ready with PyBaMM and some useful development tools like `pre-commit <https://pre-commit.com/>`_ and `black <https://black.readthedocs.io/en/stable/>`_.

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -233,13 +233,13 @@ Extra tips while using Nox
 --------------------------
 Here are some additional useful commands you can run with Nox:
 
-- ``nox -v``: Enables verbose mode, providing more detailed output during the execution of Nox sessions.
-- ``nox -l``: Lists all available Nox sessions and their descriptions.
-- ``nox -p <python.version>``: Runs only sessions with the specified Python version. Replace ``python.version`` with the desired Python version.
-- ``nox -k "<keyword_expression>"``: Runs test sessions that match the specified pytest-style keyword expression.
-- ``nox -t "<tag1>" "<tag2>"``: Runs test sessions that have the specified tags.
-- ``nox --stop-on-first-error``: Stops the execution of Nox sessions immediately after the first error or failure occurs.
-- ``nox --envdir <path>``: Specifies the directory where Nox creates and manages the virtual environments used by the sessions. In this case, the directory is set to ``<path>``.
-- ``nox --install-only``: Skips the test execution and only performs the installation step defined in the Nox sessions.
-- ``nox --nocolor``: Disables the color output in the console during the execution of Nox sessions.
-- ``nox --report output.json``: Generates a JSON report of the Nox session execution and saves it to the specified file, in this case, "output.json".
+- ``--verbose or -v``: Enables verbose mode, providing more detailed output during the execution of Nox sessions.
+- ``--list or -l``: Lists all available Nox sessions and their descriptions.
+- ``--python <python.version> or -p <python.version>``: Runs only sessions with the specified Python version. Replace ``python.version`` with the desired Python version.
+- ``-k "<keyword_expression>"``: Runs test sessions that match the specified pytest-style keyword expression.
+- ``-t "<tag1>" "<tag2>"``: Runs test sessions that have the specified tags.
+- ``--stop-on-first-error``: Stops the execution of Nox sessions immediately after the first error or failure occurs.
+- ``--envdir <path>``: Specifies the directory where Nox creates and manages the virtual environments used by the sessions. In this case, the directory is set to ``<path>``.
+- ``--install-only``: Skips the test execution and only performs the installation step defined in the Nox sessions.
+- ``--nocolor``: Disables the color output in the console during the execution of Nox sessions.
+- ``--report output.json``: Generates a JSON report of the Nox session execution and saves it to the specified file, in this case, "output.json".

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -235,8 +235,6 @@ Here are some additional useful commands you can run with Nox:
 
 - ``--verbose or -v``: Enables verbose mode, providing more detailed output during the execution of Nox sessions.
 - ``--list or -l``: Lists all available Nox sessions and their descriptions.
-- ``-k "<keyword_expression>"``: Runs test sessions that match the specified pytest-style keyword expression.
-- ``-t "<tag1>" "<tag2>"``: Runs test sessions that have the specified tags.
 - ``--stop-on-first-error``: Stops the execution of Nox sessions immediately after the first error or failure occurs.
 - ``--envdir <path>``: Specifies the directory where Nox creates and manages the virtual environments used by the sessions. In this case, the directory is set to ``<path>``.
 - ``--install-only``: Skips the test execution and only performs the installation step defined in the Nox sessions.


### PR DESCRIPTION
# Description

Make nox -s dev run like nox -s dev --verbose to so that all commands run is shown.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
