### PR TITLE
Fix failing doctests

### DIFF
--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -35,3 +35,8 @@ def add_diagram(app, what, name, obj, options, lines):
 
 def setup(app):
     app.connect("autodoc-process-docstring", add_diagram)
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
# Description

A quick fix after #3074 and #3097 to declare the `inheritance_diagram.py` extension safe for parallel reads and writes, in order to suppress warnings that arise when running the doctests in the CI which are treated as errors.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
