### PR TITLE
Raise error for unknown parameter_values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 - Parameters in `Prada2013` have been updated to better match those given in the paper, which is a 2.3 Ah cell, instead of the mix-and-match with the 1.1 Ah cell from Lain2019.
+- Error generated when invalid parameter values are passed.
 
 # [v23.5](https://github.com/pybamm-team/PyBaMM/tree/v23.5) - 2023-06-18
 

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -65,7 +65,7 @@ class ParameterValues:
                 values.pop("chemistry", None)
                 self.update(values, check_already_exists=False)
             else:
-                print("Invalid Parameter Set Value")
+                raise ValueError("Invalid Parameter Value")
 
         # Initialise empty _processed_symbols dict (for caching)
         self._processed_symbols = {}

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -65,7 +65,7 @@ class ParameterValues:
                 values.pop("chemistry", None)
                 self.update(values, check_already_exists=False)
             else:
-                print('Invalid Parameter Set Value')
+                print("Invalid Parameter Set Value")
 
         # Initialise empty _processed_symbols dict (for caching)
         self._processed_symbols = {}

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -60,10 +60,12 @@ class ParameterValues:
             self.update(values, check_already_exists=False)
         else:
             # Check if values is a named parameter set
-            if isinstance(values, str) and values in pybamm.parameter_sets:
+            if isinstance(values, str) and values in pybamm.parameter_sets.keys():
                 values = pybamm.parameter_sets[values]
                 values.pop("chemistry", None)
                 self.update(values, check_already_exists=False)
+            else:
+                print('Invalid Parameter Set Value')
 
         # Initialise empty _processed_symbols dict (for caching)
         self._processed_symbols = {}

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -43,7 +43,7 @@ class TestParameterValues(TestCase):
 
         # junk param values rejected
         with self.assertRaisesRegex(ValueError, "Invalid Parameter Value"):
-            pybamm.ParameterValues("Junk", chemistry="lithium-ion")
+            pybamm.ParameterValues("Junk")
 
     def test_repr(self):
         param = pybamm.ParameterValues({"a": 1})

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -41,6 +41,10 @@ class TestParameterValues(TestCase):
         ):
             pybamm.ParameterValues(None, chemistry="lithium-ion")
 
+        # junk param values rejected
+        with self.assertRaisesRegex(ValueError, "Invalid Parameter Value"):
+            pybamm.ParameterValues("Junk", chemistry="lithium-ion")
+
     def test_repr(self):
         param = pybamm.ParameterValues({"a": 1})
         self.assertEqual(


### PR DESCRIPTION
added else statement to inform user of an invalid parameter set

# Description

Added else statement to inform user of an invalid parameter set in parameter_values.py

In response to #3063 - Raise error for unknown parameter sets


Fixes # (3063)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
