### PR TITLE
Ensure `setup-python` outputs are always included in `nox` cache keys

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -46,7 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
+      - id: setup-python
+        name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
@@ -110,7 +111,7 @@ jobs:
             ${{ env.HOME }}/.local/lib/
             ${{ env.HOME }}/.local/include/
             ${{ env.HOME }}/.local/examples/
-          key: nox-pybamm-requires-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}
+          key: nox-pybamm-requires-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/install_KLU_Sundials.py') }}
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
@@ -121,7 +122,7 @@ jobs:
         if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
         with:
           path: ${{ github.workspace }}/.nox/unit/
-          key: ${{ runner.os }}-nox-unit-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
+          key: ${{ runner.os }}-nox-unit-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10 and for macOS and Windows with all Python versions
         if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
@@ -132,7 +133,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         with:
           path: ${{ github.workspace }}/.nox/coverage/
-          key: ${{ runner.os }}-nox-coverage-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/.coveragerc') }}
+          key: ${{ runner.os }}-nox-coverage-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/.coveragerc') }}
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
@@ -147,7 +148,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         with:
           path: ${{ github.workspace }}/.nox/integration/
-          key: ${{ runner.os }}-nox-integration-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
+          key: ${{ runner.os }}-nox-integration-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Run integration tests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
@@ -158,7 +159,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         with:
           path: ${{ github.workspace }}/.nox/doctests/
-          key: ${{ runner.os }}-nox-doctests-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/docs/requirements.txt') }}
+          key: ${{ runner.os }}-nox-doctests-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py', '**/docs/requirements.txt') }}
 
       - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
@@ -169,7 +170,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         with:
           path: ${{ github.workspace }}/.nox/examples/
-          key: ${{ runner.os }}-nox-examples-${{ matrix.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
+          key: ${{ runner.os }}-nox-examples-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/noxfile.py', '**/setup.py') }}
 
       - name: Install dev dependencies and run example tests for GNU/Linux with Python 3.11
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11


### PR DESCRIPTION
# Description

A follow-up to #3079 and fixes the failing Windows tests with Python 3.11 on #3108. This PR ensures that the Python version (including sub-versions and patch releases) from the outputs of the `setup-python` action is used to build the cache keys and invalidates previously built caches when there is a version change (i.e., from Python 3.11.3 to Python 3.11.4), making the caching more robust. See https://github.com/actions/setup-python/issues/330#issuecomment-1126638275 for more details.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
