### PR TITLE
Add `blacken-docs` as pre-commit hook for code-blocks in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,10 @@ repos:
       - id: nbqa-ruff
         additional_dependencies: [ruff==0.0.276]
         args: ["--fix","--ignore=E501,E402"]
+
+  -   repo: https://github.com/adamchainz/blacken-docs
+      rev: "1.15.0"
+      hooks:
+      -   id: blacken-docs
+          additional_dependencies:
+          - black==22.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,4 @@ repos:
     rev: "1.15.0"
     hooks:
        - id: blacken-docs
-         additional_dependencies:
-           - black==22.12.0
+         additional_dependencies: [black==22.12.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,9 +21,9 @@ repos:
         additional_dependencies: [ruff==0.0.276]
         args: ["--fix","--ignore=E501,E402"]
 
-  -   repo: https://github.com/adamchainz/blacken-docs
-      rev: "1.15.0"
-      hooks:
-      -   id: blacken-docs
-          additional_dependencies:
-          - black==22.12.0
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: "1.15.0"
+    hooks:
+       - id: blacken-docs
+         additional_dependencies:
+           - black==22.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,13 +219,20 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
 2. Set break points, either in your IDE or using the Python debugging module. To use the latter, add the following line where you want to set the break point
 
    ```python
-   import ipdb; ipdb.set_trace()
+   import ipdb
+
+   ipdb.set_trace()
    ```
 
    This will start the [Python interactive debugger](https://gist.github.com/mono0926/6326015). If you want to be able to use magic commands from `ipython`, such as `%timeit`, then set
 
    ```python
-   from IPython import embed; embed(); import ipdb; ipdb.set_trace()
+   from IPython import embed
+
+   embed()
+   import ipdb
+
+   ipdb.set_trace()
    ```
 
    at the break point instead.
@@ -237,7 +244,9 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
       try:
           do_something_complicated()
       except ValueError:
-          import ipdb; ipdb.set_trace()
+          import ipdb
+
+          ipdb.set_trace()
       ```
 
       This will start the debugger at the point where the `ValueError` was raised, and allow you to investigate further. Sometimes, it is more informative to put the try-except block further up the call stack than exactly where the error is raised.
@@ -245,6 +254,7 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
 
       ```python
       import warnings
+
       warnings.simplefilter("error")
       ```
 
@@ -270,7 +280,12 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
 Sometimes, a bit of code will take much longer than you expect to run. In this case, you can set
 
 ```python
-from IPython import embed; embed(); import ipdb; ipdb.set_trace()
+from IPython import embed
+
+embed()
+import ipdb
+
+ipdb.set_trace()
 ```
 
 as above, and then use some of the profiling tools. In order of increasing detail:

--- a/docs/source/api/parameters/parameter_sets.rst
+++ b/docs/source/api/parameters/parameter_sets.rst
@@ -40,12 +40,13 @@ For an example, see the `Marquis2019`_ parameter sets.
 
     import pybamm
 
+
     def get_parameter_values():
-        """ Doc string for cell-alpha """
+        """Doc string for cell-alpha"""
         return {
             "chemistry": "lithium_ion",
             "citation": "@book{van1995python, title={Python reference manual}}",
-            ...
+            # ...
         }
 
 Then register ``get_parameter_values`` to ``pybamm_parameter_sets`` in ``pyproject.toml``:

--- a/docs/source/user_guide/fundamentals/index.md
+++ b/docs/source/user_guide/fundamentals/index.md
@@ -43,11 +43,13 @@ One of PyBaMM's unique features is the `Experiment` class, which allows users to
 ```python
 pybamm.Experiment(
     [
-        ("Discharge at C/10 for 10 hours or until 3.3 V",
-        "Rest for 1 hour",
-        "Charge at 1 A until 4.1 V",
-        "Hold at 4.1 V until 50 mA",
-        "Rest for 1 hour")
+        (
+            "Discharge at C/10 for 10 hours or until 3.3 V",
+            "Rest for 1 hour",
+            "Charge at 1 A until 4.1 V",
+            "Hold at 4.1 V until 50 mA",
+            "Rest for 1 hour",
+        )
     ]
     * 3,
 )

--- a/docs/source/user_guide/getting_started.md
+++ b/docs/source/user_guide/getting_started.md
@@ -4,6 +4,7 @@ The easiest way to use PyBaMM is to run a 1C constant-current discharge with a m
 
 ```python
 import pybamm
+
 model = pybamm.lithium_ion.DFN()  # Doyle-Fuller-Newman model
 sim = pybamm.Simulation(model)
 sim.solve([0, 3600])  # solve for 1 hour
@@ -14,13 +15,16 @@ or simulate an experiment such as a constant-current discharge followed by a con
 
 ```python
 import pybamm
+
 experiment = pybamm.Experiment(
     [
-        ("Discharge at C/10 for 10 hours or until 3.3 V",
-        "Rest for 1 hour",
-        "Charge at 1 A until 4.1 V",
-        "Hold at 4.1 V until 50 mA",
-        "Rest for 1 hour")
+        (
+            "Discharge at C/10 for 10 hours or until 3.3 V",
+            "Rest for 1 hour",
+            "Charge at 1 A until 4.1 V",
+            "Hold at 4.1 V until 50 mA",
+            "Rest for 1 hour",
+        )
     ]
     * 3,
 )

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -51,32 +51,25 @@ class IDAKLUSolver(pybamm.BaseSolver):
             options = {
                 # print statistics of the solver after every solve
                 "print_stats": False,
-
                 # jacobian form, can be "none", "dense",
                 # "banded", "sparse", "matrix-free"
                 "jacobian": "sparse",
-
                 # name of sundials linear solver to use options are: "SUNLinSol_KLU",
                 # "SUNLinSol_Dense", "SUNLinSol_Band", "SUNLinSol_SPBCGS",
                 # "SUNLinSol_SPFGMR", "SUNLinSol_SPGMR", "SUNLinSol_SPTFQMR",
                 "linear_solver": "SUNLinSol_KLU",
-
                 # preconditioner for iterative solvers, can be "none", "BBDP"
                 "preconditioner": "BBDP",
-
                 # for iterative linear solvers, max number of iterations
                 "linsol_max_iterations": 5,
-
                 # for iterative linear solver preconditioner, bandwidth of
                 # approximate jacobian
                 "precon_half_bandwidth": 5,
-
                 # for iterative linear solver preconditioner, bandwidth of
                 # approximate jacobian that is kept
-                "precon_half_bandwidth_keep": 5
-
+                "precon_half_bandwidth_keep": 5,
                 # Number of threads available for OpenMP
-                "num_threads": 1
+                "num_threads": 1,
             }
 
         Note: These options only have an effect if model.convert_to_format == 'casadi'


### PR DESCRIPTION
# Description

This PR aims to add [`blacken-docs`](https://github.com/adamchainz/blacken-docs) as pre-commit hook to auto format python code in docs.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
