### PR TITLE
Enable downloadable PDF, EPUB, and zipped HTML formats on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,11 @@ sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
 
+formats:
+  - pdf
+  - epub
+  - htmlzip
+
 # Set the version of Python and other tools you might need
 build:
   # Install Graphviz to build SVG files


### PR DESCRIPTION


# Description

According to the [documentation](https://docs.readthedocs.io/en/stable/guides/enable-offline-formats.html). This PR will build PyBaMM's documentation in more formats and make it available for download for subsequent versions.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
