### PR TITLE
Add docstrings for `nox` sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,6 +33,7 @@ def set_environment_variables(env_dict, session):
 
 @nox.session(name="pybamm-requires", reuse_venv=True)
 def run_pybamm_requires(session):
+    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  # noqa: E501
     set_environment_variables(PYBAMM_ENV, session=session)
     if sys.platform != "win32":
         session.install("wget", "cmake")
@@ -51,6 +52,7 @@ def run_pybamm_requires(session):
 
 @nox.session(name="coverage", reuse_venv=True)
 def run_coverage(session):
+    """Run the coverage tests and generate an XML report."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("coverage")
     session.install("-e", ".[all]")
@@ -64,6 +66,7 @@ def run_coverage(session):
 
 @nox.session(name="integration", reuse_venv=True)
 def run_integration(session):
+    """Run the integration tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("-e", ".[all]")
     if sys.platform == "linux":
@@ -73,12 +76,14 @@ def run_integration(session):
 
 @nox.session(name="doctests", reuse_venv=True)
 def run_doctests(session):
+    """Run the doctests and generate the output(s) in the docs/build/ directory."""
     session.install("-e", ".[all,docs]")
     session.run("python", "run-tests.py", "--doctest")
 
 
 @nox.session(name="unit", reuse_venv=True)
 def run_unit(session):
+    """Run the unit tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("-e", ".[all]")
     if sys.platform == "linux":
@@ -89,27 +94,32 @@ def run_unit(session):
 
 @nox.session(name="examples", reuse_venv=True)
 def run_examples(session):
+    """Run the examples tests for Jupyter notebooks and Python scripts."""
     session.install("-e", ".[all]")
     session.run("python", "run-tests.py", "--examples")
 
 
 @nox.session(name="dev", reuse_venv=True)
 def set_dev(session):
+    """Install PyBaMM in editable mode."""
     set_environment_variables(PYBAMM_ENV, session=session)
     envbindir = session.bin
     session.install("-e", ".[all]")
     session.install("cmake")
-    session.run(
+    if sys.platform == "linux" or sys.platform == "darwin":
+        session.run(
         "echo",
         "export",
         f"LD_LIBRARY_PATH={PYBAMM_ENV['LD_LIBRARY_PATH']}",
         ">>",
         f"{envbindir}/activate",
+        external=True,  # silence warning about echo being an external command
     )
 
 
 @nox.session(name="tests", reuse_venv=True)
 def run_tests(session):
+    """Run the unit tests and integration tests sequentially."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("-e", ".[all]")
     if sys.platform == "linux" or sys.platform == "darwin":
@@ -120,6 +130,7 @@ def run_tests(session):
 
 @nox.session(name="docs", reuse_venv=True)
 def build_docs(session):
+    """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
     session.install("-e", ".[all,docs]")
     with session.chdir("docs/"):
@@ -136,5 +147,6 @@ def build_docs(session):
 
 @nox.session(name="pre-commit", reuse_venv=True)
 def lint(session):
+    """Check all files against the defined pre-commit hooks."""
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files")

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,9 @@ import nox
 import os
 import sys
 
+
+# Options to modify nox behaviour
+nox.options.reuse_existing_virtualenvs = True
 if sys.platform == "linux":
     nox.options.sessions = ["pre-commit", "pybamm-requires", "unit"]
 else:
@@ -31,7 +34,7 @@ def set_environment_variables(env_dict, session):
         session.env[key] = value
 
 
-@nox.session(name="pybamm-requires", reuse_venv=True)
+@nox.session(name="pybamm-requires")
 def run_pybamm_requires(session):
     """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  # noqa: E501
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -50,7 +53,7 @@ def run_pybamm_requires(session):
         session.error("nox -s pybamm-requires is only available on Linux & MacOS.")
 
 
-@nox.session(name="coverage", reuse_venv=True)
+@nox.session(name="coverage")
 def run_coverage(session):
     """Run the coverage tests and generate an XML report."""
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -64,7 +67,7 @@ def run_coverage(session):
     session.run("coverage", "xml")
 
 
-@nox.session(name="integration", reuse_venv=True)
+@nox.session(name="integration")
 def run_integration(session):
     """Run the integration tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -74,14 +77,14 @@ def run_integration(session):
     session.run("python", "run-tests.py", "--integration")
 
 
-@nox.session(name="doctests", reuse_venv=True)
+@nox.session(name="doctests")
 def run_doctests(session):
     """Run the doctests and generate the output(s) in the docs/build/ directory."""
     session.install("-e", ".[all,docs]")
     session.run("python", "run-tests.py", "--doctest")
 
 
-@nox.session(name="unit", reuse_venv=True)
+@nox.session(name="unit")
 def run_unit(session):
     """Run the unit tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -92,14 +95,14 @@ def run_unit(session):
     session.run("python", "run-tests.py", "--unit")
 
 
-@nox.session(name="examples", reuse_venv=True)
+@nox.session(name="examples")
 def run_examples(session):
     """Run the examples tests for Jupyter notebooks and Python scripts."""
     session.install("-e", ".[all]")
     session.run("python", "run-tests.py", "--examples")
 
 
-@nox.session(name="dev", reuse_venv=True)
+@nox.session(name="dev")
 def set_dev(session):
     """Install PyBaMM in editable mode."""
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -117,7 +120,7 @@ def set_dev(session):
     )
 
 
-@nox.session(name="tests", reuse_venv=True)
+@nox.session(name="tests")
 def run_tests(session):
     """Run the unit tests and integration tests sequentially."""
     set_environment_variables(PYBAMM_ENV, session=session)
@@ -128,7 +131,7 @@ def run_tests(session):
     session.run("python", "run-tests.py", "--all")
 
 
-@nox.session(name="docs", reuse_venv=True)
+@nox.session(name="docs")
 def build_docs(session):
     """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
@@ -145,7 +148,7 @@ def build_docs(session):
         )
 
 
-@nox.session(name="pre-commit", reuse_venv=True)
+@nox.session(name="pre-commit")
 def lint(session):
     """Check all files against the defined pre-commit hooks."""
     session.install("pre-commit")

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,9 @@ PYBAMM_ENV = {
     "SUNDIALS_INST": f"{homedir}/.local",
     "LD_LIBRARY_PATH": f"{homedir}/.local/lib:",
 }
+# Do not stdout ANSI colours on GitHub Actions
+if os.getenv("CI") == "true":
+    os.environ["NO_COLOR"] = "1"
 
 
 def set_environment_variables(env_dict, session):


### PR DESCRIPTION
# Description

Adds descriptive docstrings for `nox` sessions, which can be listed with the `nox --list` or `nox -l` commands, and some general improvements. Closes #3048

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all`
- [x] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
