### PR TITLE
fix energy calculation

### DIFF
--- a/examples/scripts/cycling_ageing.py
+++ b/examples/scripts/cycling_ageing.py
@@ -1,7 +1,7 @@
 import pybamm as pb
 
 pb.set_logging_level("NOTICE")
-model = pb.lithium_ion.DFN(
+model = pb.lithium_ion.SPM(
     {
         "SEI": "ec reaction limited",
         "SEI film resistance": "distributed",

--- a/noxfile.py
+++ b/noxfile.py
@@ -114,13 +114,13 @@ def set_dev(session):
     session.install("cmake")
     if sys.platform == "linux" or sys.platform == "darwin":
         session.run(
-        "echo",
-        "export",
-        f"LD_LIBRARY_PATH={PYBAMM_ENV['LD_LIBRARY_PATH']}",
-        ">>",
-        f"{envbindir}/activate",
-        external=True,  # silence warning about echo being an external command
-    )
+            "echo",
+            "export",
+            f"LD_LIBRARY_PATH={PYBAMM_ENV['LD_LIBRARY_PATH']}",
+            ">>",
+            f"{envbindir}/activate",
+            external=True,  # silence warning about echo being an external command
+        )
 
 
 @nox.session(name="tests")

--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -268,12 +268,8 @@ class ElectrodeSOHSolver:
         sol_dict = {key: sol[key].data[0] for key in sol.all_models[0].variables.keys()}
 
         # Calculate theoretical energy
-        x_0 = sol_dict["x_0"]
-        y_0 = sol_dict["y_0"]
-        x_100 = sol_dict["x_100"]
-        y_100 = sol_dict["y_100"]
         energy = pybamm.lithium_ion.electrode_soh.theoretical_energy_integral(
-            self.parameter_values, x_100, x_0, y_100, y_0
+            self.parameter_values, sol_dict
         )
         sol_dict.update({"Maximum theoretical energy [W.h]": energy})
         return sol_dict
@@ -598,7 +594,7 @@ def get_min_max_stoichiometries(
     return esoh_solver.get_min_max_stoichiometries()
 
 
-def theoretical_energy_integral(parameter_values, n_i, n_f, p_i, p_f, points=100):
+def theoretical_energy_integral(parameter_values, inputs, points=100):
     """
     Calculate maximum energy possible from a cell given OCV, initial soc, and final soc
     given voltage limits, open-circuit potentials, etc defined by parameter_values
@@ -618,20 +614,25 @@ def theoretical_energy_integral(parameter_values, n_i, n_f, p_i, p_f, points=100
     E
         The total energy of the cell in Wh
     """
-    n_vals = np.linspace(n_i, n_f, num=points)
-    p_vals = np.linspace(p_i, p_f, num=points)
+    x_0 = inputs["x_0"]
+    y_0 = inputs["y_0"]
+    x_100 = inputs["x_100"]
+    y_100 = inputs["y_100"]
+    Q_p = inputs["Q_p"]
+    x_vals = np.linspace(x_100, x_0, num=points)
+    y_vals = np.linspace(y_100, y_0, num=points)
     # Calculate OCV at each stoichiometry
     param = pybamm.LithiumIonParameters()
     T = param.T_amb(0)
-    Vs = np.empty(n_vals.shape)
-    for i in range(n_vals.size):
+    Vs = np.empty(x_vals.shape)
+    for i in range(x_vals.size):
         Vs[i] = (
-            parameter_values.evaluate(param.p.prim.U(p_vals[i], T)).item()
-            - parameter_values.evaluate(param.n.prim.U(n_vals[i], T)).item()
+            parameter_values.evaluate(param.p.prim.U(y_vals[i], T)).item()
+            - parameter_values.evaluate(param.n.prim.U(x_vals[i], T)).item()
         )
     # Calculate dQ
-    Q_p = parameter_values.evaluate(param.p.prim.Q_init) * (p_f - p_i)
-    dQ = Q_p / (points - 1)
+    Q = Q_p * (y_0 - y_100)
+    dQ = Q / (points - 1)
     # Integrate and convert to W-h
     E = np.trapz(Vs, dx=dQ)
     return E
@@ -663,7 +664,10 @@ def calculate_theoretical_energy(
     # Get initial and final stoichiometric values.
     x_100, y_100 = get_initial_stoichiometries(initial_soc, parameter_values)
     x_0, y_0 = get_initial_stoichiometries(final_soc, parameter_values)
+    Q_p = parameter_values.evaluate(pybamm.LithiumIonParameters().p.prim.Q_init)
     E = theoretical_energy_integral(
-        parameter_values, x_100, x_0, y_100, y_0, points=points
+        parameter_values,
+        {"x_100": x_100, "x_0": x_0, "y_100": y_100, "y_0": y_0, "Q_p": Q_p},
+        points=points,
     )
     return E

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -36,12 +36,12 @@ class TestElectrodeSOH(TestCase):
                 self.assertAlmostEqual(sol[key], sol_split[key].data[0], places=5)
             else:
                 # theoretical_energy is not present in sol_split
-                x_0 = sol_split["x_0"].data[0]
-                y_0 = sol_split["y_0"].data[0]
-                x_100 = sol_split["x_100"].data[0]
-                y_100 = sol_split["y_100"].data[0]
+                inputs = {
+                    k: sol_split[k].data[0]
+                    for k in ["x_0", "y_0", "x_100", "y_100", "Q_p"]
+                }
                 energy = pybamm.lithium_ion.electrode_soh.theoretical_energy_integral(
-                    parameter_values, x_100, x_0, y_100, y_0
+                    parameter_values, inputs
                 )
                 self.assertAlmostEqual(sol[key], energy, places=5)
 


### PR DESCRIPTION
# Description

The theoretical energy calculation was using `param.p.prim.Q_init` in all cases, when it should have been using the value of "Q_p" from the solution of the esoh solver, which can change from the initial value as the cell degrades

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all`
- [ ] The documentation builds: `$ python run-tests.py --doctest`

You can run unit and doctests together at once, using `$ python run-tests.py --quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
