### PR TITLE
Fix need_reply workflows

### DIFF
--- a/.github/workflows/need_reply_remove.yml
+++ b/.github/workflows/need_reply_remove.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.comment.author_association != 'OWNER' &&
       github.event.comment.author_association != 'COLLABORATOR' &&
-      github.repository-owner == 'pybamm-team'
+      github.repository_owner == 'pybamm-team'
     steps:
       - name: Remove needs-reply label
         uses: octokit/request-action@v2.x

--- a/.github/workflows/needs_reply.yml
+++ b/.github/workflows/needs_reply.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository-owner == 'pybamm-team'
+    if: github.repository_owner == 'pybamm-team'
     steps:
       - name: Close old issues that need reply
         uses: dwieeb/needs-reply@v2


### PR DESCRIPTION
# Description

Should be `repository_owner` and not `repository-owner` - https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
