### PR TITLE
Re-enable PDF builds for Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@ sphinx:
   fail_on_warning: false
 
 formats:
+  - pdf
   - epub
   - htmlzip
 

--- a/docs/_static/pybamm.css
+++ b/docs/_static/pybamm.css
@@ -1,3 +1,11 @@
+/* Font */
+
+@import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap");
+
+body {
+  font-family: "Open Sans", sans-serif;
+}
+
 /* Main page overview cards */
 
 .sd-card {

--- a/docs/_static/pybamm.css
+++ b/docs/_static/pybamm.css
@@ -1,41 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap");
-
-.navbar-brand img {
-  height: 50px;
-}
-
-.navbar-brand {
-  height: 50px;
-}
-
-body {
-  font-family: "Open Sans", sans-serif;
-}
-
-pre,
-code {
-  font-size: 100%;
-  line-height: 155%;
-}
-
-h1 {
-  font-family: "Lato", sans-serif;
-  color: #013243;
-  /* warm black */
-}
-
-h2 {
-  color: #4d77cf;
-  /* han blue */
-  letter-spacing: -0.03em;
-}
-
-h3 {
-  color: #013243;
-  /* warm black */
-  letter-spacing: -0.03em;
-}
-
 /* Main page overview cards */
 
 .sd-card {
@@ -81,18 +43,18 @@ h3 {
 }
 
 /* Dark theme tweaking */
+
 html[data-theme="dark"] .sd-card img[src*=".svg"] {
   filter: invert(0.82) brightness(0.8) contrast(1.2);
 }
 
 /* Main index page overview cards */
+
 html[data-theme="dark"] .sd-card {
   background-color: var(--pst-color-background);
 }
 
-html[data-theme="dark"] .sd-shadow-sm {
-  box-shadow: 0 0.1rem 1rem rgba(250, 250, 250, 0.6) !important;
-}
+/* Inheritance diagram dropdown options */
 
 html[data-theme="dark"] .sd-card .sd-card-header {
   background-color: var(--pst-color-background);
@@ -103,12 +65,12 @@ html[data-theme="dark"] .sd-card .sd-card-footer {
   background-color: var(--pst-color-background);
 }
 
-html[data-theme="dark"] h1 {
-  color: var(--pst-color-primary);
+details.sd-dropdown {
+  box-shadow: none !important;
 }
 
-html[data-theme="dark"] h3 {
-  color: #0a6774;
+.sd-summary-content blockquote {
+  border-left: 0 !important;
 }
 
 /* Overrides for sphinx-hoverxref since it does not support a native dark theme, see */
@@ -158,6 +120,7 @@ kbd.DocSearch-Commands-Key {
 .DocSearch-Button-Key {
   width: 24px;
 }
+
 /* Do not add custom padding for keyboard buttons */
 
 kbd:not(.compound) {

--- a/docs/_static/pybamm.css
+++ b/docs/_static/pybamm.css
@@ -109,6 +109,12 @@ details.sd-dropdown {
 
 @import url("https://cdn.jsdelivr.net/npm/@docsearch/css@3");
 
+/* Remove the default PST search */
+
+div.search-button__wrapper.show {
+  visibility: hidden;
+}
+
 .DocSearch-Modal {
   margin: 150px auto auto;
   background: var(--pst-color-background);

--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -20,16 +20,21 @@ def add_diagram(app, what, name, obj, options, lines):
                 # do nothing if it is not a derived class
                 return
 
-            # Append the inheritance diagram to the docstring
+            # Append the inheritance diagram to the docstring. Note: we do this
+            # for HTML output only because SVG output creates multiple PDFs which
+            # are not supported by Read the Docs.
+            # https://github.com/readthedocs/readthedocs.org/issues/2045
             lines.append("\n")
-            lines.append(".. dropdown:: View inheritance diagram for this model")
-            lines.append("   :animate: fade-in-slide-down")
-            lines.append("   :icon: eye\n")
-            lines.append("   :class-title: sd-align-major-center sd-fs-6 \n")
-            lines.append("   :class-container: sd-text-info \n")
+            lines.append(".. only:: html\n")
             lines.append("\n")
-            lines.append("       .. inheritance-diagram:: " + cls_name)
-            lines.append("           :parts: 2\n")
+            lines.append("    .. dropdown:: View inheritance diagram for this model")
+            lines.append("        :animate: fade-in-slide-down")
+            lines.append("        :icon: eye\n")
+            lines.append("        :class-title: sd-align-major-center sd-fs-6 \n")
+            lines.append("        :class-container: sd-text-info \n")
+            lines.append("\n")
+            lines.append("            .. inheritance-diagram:: " + cls_name)
+            lines.append("                :parts: 2\n")
             lines.append("\n")
 
 

--- a/docs/sphinxext/inheritance_diagram.py
+++ b/docs/sphinxext/inheritance_diagram.py
@@ -25,7 +25,7 @@ def add_diagram(app, what, name, obj, options, lines):
             # are not supported by Read the Docs.
             # https://github.com/readthedocs/readthedocs.org/issues/2045
             lines.append("\n")
-            lines.append(".. only:: html\n")
+            lines.append(".. only:: not latex\n")
             lines.append("\n")
             lines.append("    .. dropdown:: View inheritance diagram for this model")
             lines.append("        :animate: fade-in-slide-down")


### PR DESCRIPTION
# Description

The SVG images generated by the `sphinxext/inheritance_diagram.py` extension create multiple PDFs upon LaTeX output with Sphinx's LaTeXBuilder. This PR makes them render on HTML output only, which is in-line with documentation for other projects that display inheritance diagrams for API components.

Closes #3240 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
