### PR TITLE
Split Jupyter notebooks tests and example scripts tests into separate `nox` sessions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,9 @@ nox -s tests
 
 When you commit anything to PyBaMM, these checks will also be run automatically (see [infrastructure](#infrastructure)).
 
-### Testing notebooks
+### Testing the example notebooks
 
-To test all example scripts and notebooks, type
+To test all the example notebooks in the `docs/source/examples/` folder, type
 
 ```bash
 nox -s examples
@@ -169,6 +169,14 @@ If notebooks fail because of changes to PyBaMM, it can be a bit of a hassle to d
 
 ```bash
 python run-tests.py --debook docs/source/examples/notebooks/notebook-name.ipynb script.py
+```
+
+### Testing the example scripts
+
+To test all the example scripts in the `examples/` folder, type
+
+```bash
+nox -s scripts
 ```
 
 ### Debugging

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -236,7 +236,8 @@ Doctests, examples, and coverage
 
 ``Nox`` can also be used to run doctests, run examples, and generate a coverage report using:
 
-- ``nox -s examples``: Run the example scripts in ``examples/scripts``.
+- ``nox -s examples``: Run the Jupyter notebooks in ``docs/source/examples/notebooks/``.
+- ``nox -s scripts``: Run the example scripts in ``examples/scripts/``.
 - ``nox -s doctests``: Run doctests.
 - ``nox -s coverage``: Measure current test coverage and generate a coverage report.
 - ``nox -s quick``: Run integration tests, unit tests, and doctests sequentially.

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,12 +109,14 @@ def run_examples(session):
     session.run_always("pip", "install", "-e", ".[all]")
     session.run("python", "run-tests.py", "--examples")
 
+
 @nox.session(name="scripts")
 def run_scripts(session):
     """Run the scripts tests for Python scripts."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.run_always("pip", "install", "-e", ".[all]")
     session.run("python", "run-tests.py", "--scripts")
+
 
 @nox.session(name="dev")
 def set_dev(session):

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,11 +104,17 @@ def run_unit(session):
 
 @nox.session(name="examples")
 def run_examples(session):
-    """Run the examples tests for Jupyter notebooks and Python scripts."""
+    """Run the examples tests for Jupyter notebooks."""
     set_environment_variables(PYBAMM_ENV, session=session)
     session.run_always("pip", "install", "-e", ".[all]")
     session.run("python", "run-tests.py", "--examples")
 
+@nox.session(name="scripts")
+def run_scripts(session):
+    """Run the scripts tests for Python scripts."""
+    set_environment_variables(PYBAMM_ENV, session=session)
+    session.run_always("pip", "install", "-e", ".[all]")
+    session.run("python", "run-tests.py", "--scripts")
 
 @nox.session(name="dev")
 def set_dev(session):

--- a/run-tests.py
+++ b/run-tests.py
@@ -97,18 +97,27 @@ def run_doc_tests():
     shutil.rmtree("docs/build")
 
 
-def run_notebook_and_scripts(executable="python"):
+def run_notebooks(executable="python"):
     """
-    Runs Jupyter notebook and example scripts tests. Exits if they fail.
+    Runs Jupyter notebook tests. Exits if they fail.
     """
 
     # Scan and run
-    print("Testing notebooks and scripts with executable `" + str(executable) + "`")
+    print("Testing notebooks with executable `" + str(executable) + "`")
 
     # Test notebooks in docs/source/examples
     if not scan_for_notebooks("docs/source/examples", True, executable):
         print("\nErrors encountered in notebooks")
         sys.exit(1)
+    print("\nOK")
+
+def run_scripts(executable="python"):
+    """
+    Run example scripts tests. Exits if they fail.
+    """
+
+    # Scan and run
+    print("Testing scripts with executable `" + str(executable) + "`")
 
     # Test scripts in examples
     # TODO: add scripts to docs/source/examples
@@ -362,17 +371,24 @@ if __name__ == "__main__":
         action="store_true",
         help="Run unit tests without starting a subprocess.",
     )
-    # Notebook tests
+    # Example notebooks tests
     parser.add_argument(
         "--examples",
         action="store_true",
-        help="Test all Jupyter notebooks and scripts in `examples`.",
+        help="Test all Jupyter notebooks in `docs/source/examples/`.",
     )
     parser.add_argument(
         "-debook",
         nargs=2,
         metavar=("in", "out"),
         help="Export a Jupyter notebook to a Python file for manual testing.",
+    )
+    # Scripts tests
+    parser.add_argument(
+        "--scripts",
+        action="store_true",
+        help="Test all example scripts in `examples/`.",
+
     )
     # Doctests
     parser.add_argument(
@@ -422,10 +438,14 @@ if __name__ == "__main__":
     # Notebook tests
     elif args.examples:
         has_run = True
-        run_notebook_and_scripts(interpreter)
+        run_notebooks(interpreter)
     if args.debook:
         has_run = True
         export_notebook(*args.debook)
+    # Scripts tests
+    elif args.scripts:
+        has_run = True
+        run_scripts(interpreter)
     # Combined test sets
     if args.quick:
         has_run = True

--- a/run-tests.py
+++ b/run-tests.py
@@ -111,6 +111,7 @@ def run_notebooks(executable="python"):
         sys.exit(1)
     print("\nOK")
 
+
 def run_scripts(executable="python"):
     """
     Run example scripts tests. Exits if they fail.


### PR DESCRIPTION
# Description

See relevant discussions on Slack and on #3264. This PR adds a new `--scripts` argument to the `run-tests.py` parser and a new `nox` session for running the examples scripts tests with the `nox -s scripts` command.

> [!Note]  
> This PR should be merged in conjunction with #3264

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
