### PR TITLE
Do not generate notebooks in PDF builds on Read the Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,6 +203,15 @@ htmlhelp_basename = "PyBaMMdoc"
 
 # -- Options for LaTeX output ------------------------------------------------
 
+# Note: we exclude the examples directory from the LaTeX build because it has
+# problems with the creation of PDFs on Read the Docs
+# https://github.com/readthedocs/readthedocs.org/issues/2045
+
+# Detect if we are building LaTeX output through the invocation of the build commands
+if any("latex" in arg for arg in sys.argv) or any("latexmk" in arg for arg in sys.argv):
+    exclude_patterns.append("source/examples/*")
+    print("Skipping compilation of .ipynb files for LaTeX build.")
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -25,9 +25,13 @@ fundamentals/index
 
 # Example notebooks
 
-The notebooks below provide a good introduction to PyBaMM and how to use it. For more
-examples, see the [Examples](../examples/index.rst) section.
+PyBaMM ships with example notebooks that demonstrate how to use it and reveal some of its
+functionalities and its inner workings. For more examples, see the [Examples](../examples/index.rst) section.
 
+```{only} latex
+The notebooks are not included in PDF formats of the documentation. You may access them on PyBaMM's hosted
+documentation available at https://docs.pybamm.org/en/latest/source/examples/index.html
+```
 
 ```{nbgallery}
 ---


### PR DESCRIPTION
# Description

Please take a look at the discussion on Slack for more details. This PR removes the Jupyter notebooks when the Sphinx LaTeXBuilder is invoked and generates a singular PDF file. (Probably) fixes #3240

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
