### PR TITLE
Documentation suggestions for the installation and tutorials

### DIFF
--- a/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
@@ -24,7 +24,7 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.solvers.solution.Solution at 0x136d2fac0>"
+       "<pybamm.solvers.solution.Solution at 0x14c144a90>"
       ]
      },
      "execution_count": 1,
@@ -215,14 +215,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In some cases simulations might take a long time to run, so it is advisable to save in your computer. The output can be analysed later without re-running the simulation."
+    "In some cases simulations might take a long time to run, so it is advisable to save files to your computer. The output can be analysed later without re-running the simulation."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output files should be saved to a working directory where they can be recovered at a later time. Since this is only a tutorial, we will save the files to a temporary folder that will be discarded at the end."
+    "The output files should be saved to a working directory outside the PyBaMM project. Since this is only a tutorial, we will save the files to a temporary folder that can be discarded at the end."
    ]
   },
   {
@@ -259,12 +259,39 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you now check the root directory of your notebooks you will notice that a new file called `\"SPMe.pkl\"` has appeared. We can load the stored simulation doing"
+    "If you now check the output directory you will notice that a new file called `\"SPMe.pkl\"` has appeared."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['SPMe.pkl']"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.listdir(temp_folder.name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can load the stored simulation doing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,13 +307,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8f1fa742280c4e5d8f00ad80e65695ce",
+       "model_id": "7ea56723de29416895d03d7c5d867c26",
        "version_major": 2,
        "version_minor": 0
       },
@@ -300,10 +327,10 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x136d48310>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x14c2cc4c0>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -321,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,13 +365,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc70e659f14e47ed88a6f4753e824b56",
+       "model_id": "44804d087e41415ea60b63324ccf7bff",
        "version_major": 2,
        "version_minor": 0
       },
@@ -358,10 +385,10 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x152135eb0>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x14ed84a90>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -24,16 +22,9 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<pybamm.solvers.solution.Solution at 0x7f996c4a7e90>"
+       "<pybamm.solvers.solution.Solution at 0x136d2fac0>"
       ]
      },
      "execution_count": 1,
@@ -50,7 +41,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -58,7 +48,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -75,7 +64,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -93,7 +81,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -108,26 +95,26 @@
     {
      "data": {
       "text/plain": [
-       "array([3.77047806, 3.75305182, 3.74567027, 3.74038822, 3.73581196,\n",
-       "       3.73153391, 3.72742393, 3.72343929, 3.71956623, 3.71580184,\n",
-       "       3.71214621, 3.7086004 , 3.70516561, 3.70184253, 3.69863121,\n",
-       "       3.69553118, 3.69254137, 3.68966018, 3.68688562, 3.68421526,\n",
-       "       3.68164637, 3.67917591, 3.6768006 , 3.67451688, 3.67232094,\n",
-       "       3.67020869, 3.66817572, 3.66621717, 3.66432762, 3.6625009 ,\n",
-       "       3.66072974, 3.65900536, 3.65731692, 3.65565066, 3.65398895,\n",
-       "       3.65230898, 3.65058135, 3.6487688 , 3.64682546, 3.64469798,\n",
-       "       3.64232968, 3.63966973, 3.63668796, 3.63339303, 3.62984711,\n",
-       "       3.62616692, 3.6225045 , 3.61901241, 3.61580868, 3.6129572 ,\n",
-       "       3.61046847, 3.60831405, 3.60644483, 3.60480596, 3.60334607,\n",
-       "       3.60202167, 3.60079822, 3.5996495 , 3.59855637, 3.59750531,\n",
-       "       3.59648723, 3.59549638, 3.59452954, 3.59358541, 3.59266405,\n",
-       "       3.59176646, 3.59089417, 3.59004885, 3.58923192, 3.58844407,\n",
-       "       3.58768477, 3.58695179, 3.58624057, 3.58554372, 3.58485045,\n",
-       "       3.58414611, 3.58341187, 3.58262441, 3.58175587, 3.58077378,\n",
-       "       3.57964098, 3.57831538, 3.5767492 , 3.57488745, 3.57266504,\n",
-       "       3.5700019 , 3.56679523, 3.56290766, 3.5581495 , 3.55225276,\n",
-       "       3.54483361, 3.53533853, 3.52296795, 3.50656968, 3.48449277,\n",
-       "       3.45439366, 3.41299182, 3.35578871, 3.27680072, 3.16842636])"
+       "array([3.77048098, 3.75309871, 3.74569826, 3.74040906, 3.73582978,\n",
+       "       3.73155017, 3.72743983, 3.72345507, 3.71958265, 3.71581858,\n",
+       "       3.71216287, 3.70861698, 3.7051823 , 3.70185947, 3.69864846,\n",
+       "       3.69554865, 3.69255894, 3.6896778 , 3.68690322, 3.68423281,\n",
+       "       3.68166383, 3.67919326, 3.67681781, 3.67453394, 3.67233783,\n",
+       "       3.6702254 , 3.66819225, 3.66623353, 3.66434383, 3.66251699,\n",
+       "       3.66074577, 3.65902141, 3.65733311, 3.65566717, 3.65400602,\n",
+       "       3.65232696, 3.6506007 , 3.64879012, 3.64684952, 3.64472566,\n",
+       "       3.64236191, 3.63970731, 3.63673126, 3.63344172, 3.62989992,\n",
+       "       3.62622171, 3.6225587 , 3.61906361, 3.61585516, 3.61299814,\n",
+       "       3.61050386, 3.60834443, 3.606471  , 3.60482876, 3.60336628,\n",
+       "       3.60203993, 3.60081505, 3.59966528, 3.59857137, 3.59751973,\n",
+       "       3.59650118, 3.59550993, 3.59454272, 3.59359821, 3.59267644,\n",
+       "       3.59177838, 3.59090556, 3.59005965, 3.58924208, 3.58845355,\n",
+       "       3.58769359, 3.58695999, 3.58624826, 3.58555109, 3.58485777,\n",
+       "       3.58415379, 3.5834204 , 3.58263444, 3.58176818, 3.58078926,\n",
+       "       3.57966067, 3.57834049, 3.57678113, 3.57492782, 3.57271582,\n",
+       "       3.57006555, 3.566875  , 3.56300793, 3.5582764 , 3.55241508,\n",
+       "       3.54504405, 3.53561555, 3.52333845, 3.50707266, 3.48518447,\n",
+       "       3.45535426, 3.41433385, 3.35766635, 3.27941791, 3.17203869])"
       ]
      },
      "execution_count": 4,
@@ -140,7 +127,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -192,7 +178,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -207,7 +192,7 @@
     {
      "data": {
       "text/plain": [
-       "array([3.72947892, 3.7086004 , 3.67810702, 3.65400557])"
+       "array([3.729495  , 3.70861698, 3.67812431, 3.65402263])"
       ]
      },
      "execution_count": 6,
@@ -220,7 +205,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -228,11 +212,17 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In some cases simulations might take a long time to run so it is advisable to save in your computer so it can be analysed later without re-running the simulation. You can save the whole simulation doing:"
+    "In some cases simulations might take a long time to run, so it is advisable to save in your computer. The output can be analysed later without re-running the simulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output files should be saved to a working directory where they can be recovered at a later time. Since this is only a tutorial, we will save the files to a temporary folder that will be discarded at the end."
    ]
   },
   {
@@ -241,15 +231,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.save(\"SPMe.pkl\")"
+    "import os\n",
+    "from tempfile import TemporaryDirectory\n",
+    "temp_folder = TemporaryDirectory()\n",
+    "\n",
+    "def temp_path_to(name):\n",
+    "    return os.path.join(temp_folder.name, name)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you now check the root directory of your notebooks you will notice that a new file called `\"SPMe.pkl\"` has appeared. We can load the stored simulation doing"
+    " You can save the whole simulation doing:"
    ]
   },
   {
@@ -258,11 +252,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim2 = pybamm.load(\"SPMe.pkl\")"
+    "sim.save(temp_path_to(\"SPMe.pkl\"))"
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you now check the root directory of your notebooks you will notice that a new file called `\"SPMe.pkl\"` has appeared. We can load the stored simulation doing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim2 = pybamm.load(temp_path_to(\"SPMe.pkl\"))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -271,63 +280,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "80a9bcfaa1264a6f80be4c12906f491e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=0.0, description='t', max=1.0, step=0.01), Output()), _dom_classes=('w…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "sim2.plot()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, we can just save the solution of the simulation in a similar way"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "sol = sim.solution\n",
-    "sol.save(\"SPMe_sol.pkl\")"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and load it in a similar way too"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1fc7b0729d6c40fe9e4f5921bb12b57d",
+       "model_id": "8f1fa742280c4e5d8f00ad80e65695ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -341,21 +300,78 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x7f995f4bd390>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x136d48310>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "sol2 = pybamm.load(\"SPMe_sol.pkl\")\n",
+    "sim2.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, we can just save the solution of the simulation in a similar way"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sol = sim.solution\n",
+    "sol.save(temp_path_to(\"SPMe_sol.pkl\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and load it in a similar way too"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc70e659f14e47ed88a6f4753e824b56",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=1.0, step=0.01), Output()), _dom_classes=('w…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x152135eb0>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sol2 = pybamm.load(temp_path_to(\"SPMe_sol.pkl\"))\n",
     "pybamm.dynamic_plot(sol2)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -364,15 +380,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol.save_data(\"sol_data.pkl\", [\"Current [A]\", \"Voltage [V]\"])"
+    "sol.save_data(temp_path_to(\"sol_data.pkl\"), [\"Current [A]\", \"Voltage [V]\"])"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -381,18 +396,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol.save_data(\"sol_data.csv\", [\"Current [A]\", \"Voltage [V]\"], to_format=\"csv\")\n",
+    "sol.save_data(temp_path_to(\"sol_data.csv\"), [\"Current [A]\", \"Voltage [V]\"], to_format=\"csv\")\n",
     "# matlab needs names without spaces\n",
-    "sol.save_data(\"sol_data.mat\", [\"Current [A]\", \"Voltage [V]\"], to_format=\"matlab\",\n",
+    "sol.save_data(temp_path_to(\"sol_data.mat\"), [\"Current [A]\", \"Voltage [V]\"], to_format=\"matlab\",\n",
     "              short_names={\"Current [A]\": \"I\", \"Voltage [V]\": \"V\"})"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -400,29 +414,22 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before finishing we will remove the data files we saved so that we leave the directory as we found it"
+    "Since the data is no longer needed, we will remove the files we saved."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "os.remove(\"SPMe.pkl\")\n",
-    "os.remove(\"SPMe_sol.pkl\")\n",
-    "os.remove(\"sol_data.pkl\")\n",
-    "os.remove(\"sol_data.csv\")\n",
-    "os.remove(\"sol_data.mat\")"
+    "temp_folder.cleanup()"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -433,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +450,7 @@
       "[1] Joel A. E. Andersson, Joris Gillis, Greg Horn, James B. Rawlings, and Moritz Diehl. CasADi – A software framework for nonlinear optimization and optimal control. Mathematical Programming Computation, 11(1):1–36, 2019. doi:10.1007/s12532-018-0139-4.\n",
       "[2] Charles R. Harris, K. Jarrod Millman, Stéfan J. van der Walt, Ralf Gommers, Pauli Virtanen, David Cournapeau, Eric Wieser, Julian Taylor, Sebastian Berg, Nathaniel J. Smith, and others. Array programming with NumPy. Nature, 585(7825):357–362, 2020. doi:10.1038/s41586-020-2649-2.\n",
       "[3] Scott G. Marquis, Valentin Sulzer, Robert Timms, Colin P. Please, and S. Jon Chapman. An asymptotic derivation of a single particle model with electrolyte. Journal of The Electrochemical Society, 166(15):A3693–A3706, 2019. doi:10.1149/2.0341915jes.\n",
-      "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). ECSarXiv. February, 2020. doi:10.1149/osf.io/67ckj.\n",
+      "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). Journal of Open Research Software, 9(1):14, 2021. doi:10.5334/jors.309.\n",
       "\n"
      ]
     }
@@ -455,7 +462,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.13 ('python39-pybamm')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -469,7 +476,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.18"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -22,9 +24,16 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "<pybamm.solvers.solution.Solution at 0x14c144a90>"
+       "<pybamm.solvers.solution.Solution at 0x7f996c4a7e90>"
       ]
      },
      "execution_count": 1,
@@ -41,6 +50,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,6 +58,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,6 +75,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -81,6 +93,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -95,26 +108,26 @@
     {
      "data": {
       "text/plain": [
-       "array([3.77048098, 3.75309871, 3.74569826, 3.74040906, 3.73582978,\n",
-       "       3.73155017, 3.72743983, 3.72345507, 3.71958265, 3.71581858,\n",
-       "       3.71216287, 3.70861698, 3.7051823 , 3.70185947, 3.69864846,\n",
-       "       3.69554865, 3.69255894, 3.6896778 , 3.68690322, 3.68423281,\n",
-       "       3.68166383, 3.67919326, 3.67681781, 3.67453394, 3.67233783,\n",
-       "       3.6702254 , 3.66819225, 3.66623353, 3.66434383, 3.66251699,\n",
-       "       3.66074577, 3.65902141, 3.65733311, 3.65566717, 3.65400602,\n",
-       "       3.65232696, 3.6506007 , 3.64879012, 3.64684952, 3.64472566,\n",
-       "       3.64236191, 3.63970731, 3.63673126, 3.63344172, 3.62989992,\n",
-       "       3.62622171, 3.6225587 , 3.61906361, 3.61585516, 3.61299814,\n",
-       "       3.61050386, 3.60834443, 3.606471  , 3.60482876, 3.60336628,\n",
-       "       3.60203993, 3.60081505, 3.59966528, 3.59857137, 3.59751973,\n",
-       "       3.59650118, 3.59550993, 3.59454272, 3.59359821, 3.59267644,\n",
-       "       3.59177838, 3.59090556, 3.59005965, 3.58924208, 3.58845355,\n",
-       "       3.58769359, 3.58695999, 3.58624826, 3.58555109, 3.58485777,\n",
-       "       3.58415379, 3.5834204 , 3.58263444, 3.58176818, 3.58078926,\n",
-       "       3.57966067, 3.57834049, 3.57678113, 3.57492782, 3.57271582,\n",
-       "       3.57006555, 3.566875  , 3.56300793, 3.5582764 , 3.55241508,\n",
-       "       3.54504405, 3.53561555, 3.52333845, 3.50707266, 3.48518447,\n",
-       "       3.45535426, 3.41433385, 3.35766635, 3.27941791, 3.17203869])"
+       "array([3.77047806, 3.75305182, 3.74567027, 3.74038822, 3.73581196,\n",
+       "       3.73153391, 3.72742393, 3.72343929, 3.71956623, 3.71580184,\n",
+       "       3.71214621, 3.7086004 , 3.70516561, 3.70184253, 3.69863121,\n",
+       "       3.69553118, 3.69254137, 3.68966018, 3.68688562, 3.68421526,\n",
+       "       3.68164637, 3.67917591, 3.6768006 , 3.67451688, 3.67232094,\n",
+       "       3.67020869, 3.66817572, 3.66621717, 3.66432762, 3.6625009 ,\n",
+       "       3.66072974, 3.65900536, 3.65731692, 3.65565066, 3.65398895,\n",
+       "       3.65230898, 3.65058135, 3.6487688 , 3.64682546, 3.64469798,\n",
+       "       3.64232968, 3.63966973, 3.63668796, 3.63339303, 3.62984711,\n",
+       "       3.62616692, 3.6225045 , 3.61901241, 3.61580868, 3.6129572 ,\n",
+       "       3.61046847, 3.60831405, 3.60644483, 3.60480596, 3.60334607,\n",
+       "       3.60202167, 3.60079822, 3.5996495 , 3.59855637, 3.59750531,\n",
+       "       3.59648723, 3.59549638, 3.59452954, 3.59358541, 3.59266405,\n",
+       "       3.59176646, 3.59089417, 3.59004885, 3.58923192, 3.58844407,\n",
+       "       3.58768477, 3.58695179, 3.58624057, 3.58554372, 3.58485045,\n",
+       "       3.58414611, 3.58341187, 3.58262441, 3.58175587, 3.58077378,\n",
+       "       3.57964098, 3.57831538, 3.5767492 , 3.57488745, 3.57266504,\n",
+       "       3.5700019 , 3.56679523, 3.56290766, 3.5581495 , 3.55225276,\n",
+       "       3.54483361, 3.53533853, 3.52296795, 3.50656968, 3.48449277,\n",
+       "       3.45439366, 3.41299182, 3.35578871, 3.27680072, 3.16842636])"
       ]
      },
      "execution_count": 4,
@@ -127,6 +140,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -178,6 +192,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -192,7 +207,7 @@
     {
      "data": {
       "text/plain": [
-       "array([3.729495  , 3.70861698, 3.67812431, 3.65402263])"
+       "array([3.72947892, 3.7086004 , 3.67810702, 3.65400557])"
       ]
      },
      "execution_count": 6,
@@ -205,6 +220,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -212,17 +228,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In some cases simulations might take a long time to run, so it is advisable to save files to your computer. The output can be analysed later without re-running the simulation."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The output files should be saved to a working directory outside the PyBaMM project. Since this is only a tutorial, we will save the files to a temporary folder that can be discarded at the end."
+    "In some cases simulations might take a long time to run so it is advisable to save in your computer so it can be analysed later without re-running the simulation. You can save the whole simulation doing:"
    ]
   },
   {
@@ -231,19 +241,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from tempfile import TemporaryDirectory\n",
-    "temp_folder = TemporaryDirectory()\n",
-    "\n",
-    "def temp_path_to(name):\n",
-    "    return os.path.join(temp_folder.name, name)"
+    "sim.save(\"SPMe.pkl\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " You can save the whole simulation doing:"
+    "If you now check the root directory of your notebooks you will notice that a new file called `\"SPMe.pkl\"` has appeared. We can load the stored simulation doing"
    ]
   },
   {
@@ -252,14 +258,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.save(temp_path_to(\"SPMe.pkl\"))"
+    "sim2 = pybamm.load(\"SPMe.pkl\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you now check the output directory you will notice that a new file called `\"SPMe.pkl\"` has appeared."
+    "which allows the same manipulation as the original simulation would allow"
    ]
   },
   {
@@ -269,24 +276,29 @@
    "outputs": [
     {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "80a9bcfaa1264a6f80be4c12906f491e",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "['SPMe.pkl']"
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=1.0, step=0.01), Output()), _dom_classes=('w…"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "os.listdir(temp_folder.name)"
+    "sim2.plot()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can load the stored simulation doing"
+    "Alternatively, we can just save the solution of the simulation in a similar way"
    ]
   },
   {
@@ -295,14 +307,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim2 = pybamm.load(temp_path_to(\"SPMe.pkl\"))"
+    "sol = sim.solution\n",
+    "sol.save(\"SPMe_sol.pkl\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "which allows the same manipulation as the original simulation would allow"
+    "and load it in a similar way too"
    ]
   },
   {
@@ -313,7 +327,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ea56723de29416895d03d7c5d867c26",
+       "model_id": "1fc7b0729d6c40fe9e4f5921bb12b57d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -327,7 +341,7 @@
     {
      "data": {
       "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x14c2cc4c0>"
+       "<pybamm.plotting.quick_plot.QuickPlot at 0x7f995f4bd390>"
       ]
      },
      "execution_count": 11,
@@ -336,69 +350,12 @@
     }
    ],
    "source": [
-    "sim2.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, we can just save the solution of the simulation in a similar way"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sol = sim.solution\n",
-    "sol.save(temp_path_to(\"SPMe_sol.pkl\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "and load it in a similar way too"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44804d087e41415ea60b63324ccf7bff",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(FloatSlider(value=0.0, description='t', max=1.0, step=0.01), Output()), _dom_classes=('w…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<pybamm.plotting.quick_plot.QuickPlot at 0x14ed84a90>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sol2 = pybamm.load(temp_path_to(\"SPMe_sol.pkl\"))\n",
+    "sol2 = pybamm.load(\"SPMe_sol.pkl\")\n",
     "pybamm.dynamic_plot(sol2)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -407,14 +364,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol.save_data(temp_path_to(\"sol_data.pkl\"), [\"Current [A]\", \"Voltage [V]\"])"
+    "sol.save_data(\"sol_data.pkl\", [\"Current [A]\", \"Voltage [V]\"])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -423,17 +381,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol.save_data(temp_path_to(\"sol_data.csv\"), [\"Current [A]\", \"Voltage [V]\"], to_format=\"csv\")\n",
+    "sol.save_data(\"sol_data.csv\", [\"Current [A]\", \"Voltage [V]\"], to_format=\"csv\")\n",
     "# matlab needs names without spaces\n",
-    "sol.save_data(temp_path_to(\"sol_data.mat\"), [\"Current [A]\", \"Voltage [V]\"], to_format=\"matlab\",\n",
+    "sol.save_data(\"sol_data.mat\", [\"Current [A]\", \"Voltage [V]\"], to_format=\"matlab\",\n",
     "              short_names={\"Current [A]\": \"I\", \"Voltage [V]\": \"V\"})"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -441,22 +400,29 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the data is no longer needed, we will remove the files we saved."
+    "Before finishing we will remove the data files we saved so that we leave the directory as we found it"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "temp_folder.cleanup()"
+    "import os\n",
+    "os.remove(\"SPMe.pkl\")\n",
+    "os.remove(\"SPMe_sol.pkl\")\n",
+    "os.remove(\"sol_data.pkl\")\n",
+    "os.remove(\"sol_data.csv\")\n",
+    "os.remove(\"sol_data.mat\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -467,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -477,7 +443,7 @@
       "[1] Joel A. E. Andersson, Joris Gillis, Greg Horn, James B. Rawlings, and Moritz Diehl. CasADi – A software framework for nonlinear optimization and optimal control. Mathematical Programming Computation, 11(1):1–36, 2019. doi:10.1007/s12532-018-0139-4.\n",
       "[2] Charles R. Harris, K. Jarrod Millman, Stéfan J. van der Walt, Ralf Gommers, Pauli Virtanen, David Cournapeau, Eric Wieser, Julian Taylor, Sebastian Berg, Nathaniel J. Smith, and others. Array programming with NumPy. Nature, 585(7825):357–362, 2020. doi:10.1038/s41586-020-2649-2.\n",
       "[3] Scott G. Marquis, Valentin Sulzer, Robert Timms, Colin P. Please, and S. Jon Chapman. An asymptotic derivation of a single particle model with electrolyte. Journal of The Electrochemical Society, 166(15):A3693–A3706, 2019. doi:10.1149/2.0341915jes.\n",
-      "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). Journal of Open Research Software, 9(1):14, 2021. doi:10.5334/jors.309.\n",
+      "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). ECSarXiv. February, 2020. doi:10.1149/osf.io/67ckj.\n",
       "\n"
      ]
     }
@@ -489,7 +455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.13 ('python39-pybamm')",
    "language": "python",
    "name": "python3"
   },
@@ -503,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -42,16 +42,16 @@ You can install the above with
 
 	Where ``X`` is the version sub-number.
 
+	.. note::
+
+		On Windows, you can install ``graphviz`` using the `Chocolatey <https://chocolatey.org/>`_ package manager, or
+		follow the instructions on the `graphviz website <https://graphviz.org/download/>`_.
+
 .. tab:: MacOS
 
 	.. code:: bash
 
 		brew install python openblas gcc gfortran graphviz libomp
-
-.. note::
-
-	On Windows, you can install ``graphviz`` using the `Chocolatey <https://chocolatey.org/>`_ package manager, or
-	follow the instructions on the `graphviz website <https://graphviz.org/download/>`_.
 
 Finally, we recommend using `Nox <https://nox.thea.codes/en/stable/>`_.
 You can install it with
@@ -114,7 +114,7 @@ Using Nox (recommended)
 	nox -s dev
 
 .. note::
-    It is recommended to use ``--verbose`` or ``-v`` to see outputs of all commands run.
+	It is recommended to use ``--verbose`` or ``-v`` to see outputs of all commands run.
 
 This creates a virtual environment ``.nox/dev`` inside the ``PyBaMM/`` directory.
 It comes ready with PyBaMM and some useful development tools like `pre-commit <https://pre-commit.com/>`_ and `ruff <https://beta.ruff.rs/docs/>`_.
@@ -131,7 +131,7 @@ You can now activate the environment with
 
 	.. code:: bash
 
-	  	.nox\dev\Scripts\activate.bat
+		.nox\dev\Scripts\activate.bat
 
 and run the tests to check your installation.
 

--- a/docs/source/user_guide/installation/windows.rst
+++ b/docs/source/user_guide/installation/windows.rst
@@ -82,4 +82,4 @@ Installation using WSL
 
 If you want to install the optional PyBaMM solvers, you have to use the
 Windows Subsystem for Linux (WSL). You can find the installation
-instructions `here <INSTALL-WINDOWS-WSL.md>`__.
+instructions `here <windows-wsl.html>`__.


### PR DESCRIPTION
# Description

Minor updates to the documentation pages.

Changes:
 - Fixes a broken link between the windows installation page and the windows WSL installation page. The broken link was caused by having the incorrect name for the windows WSL page.
 - Removes a note about using chocolatey from the MacOS install from source tab. I left the note in the Linux install from source tab for the use-case where a windows installation is done with Cygwin. I can remove the note from both MacOS and Linux if desired.
 - Tutorial 6 now uses a temporary folder to write the pickle files. I feel it is cleaner to write output to a specific folder rather than the current working directory. Since this is my opinion and it does add a small amount of complexity, I can remove this change if it is unwanted.

## Type of change

Documentation and notebook changes only. No additional features or updates to the library.

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
