### PR TITLE
Remove with clause in docs session for backwards compatibility

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -152,16 +152,16 @@ def build_docs(session):
     """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
     session.install("-e", ".[all,docs]")
-    with session.chdir("docs/"):
-        session.run(
-            "sphinx-autobuild",
-            "-j",
-            "auto",
-            "--open-browser",
-            "-qT",
-            ".",
-            f"{envbindir}/../tmp/html",
-        )
+    session.chdir("docs")
+    session.run(
+        "sphinx-autobuild",
+        "-j",
+        "auto",
+        "--open-browser",
+        "-qT",
+        ".",
+        f"{envbindir}/../tmp/html",
+    )
 
 
 @nox.session(name="pre-commit")


### PR DESCRIPTION
# Description

The "with" keyword in the ```nox -s docs``` session causes an AttributeError in older versions of Nox. This change makes the nox session backwards compatible.

Fixes #3319

## Type of change

Closest category is "bug fix", however, this is just a minor compatibility issue.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
