### PR TITLE
Issue 3328 correctly point notebook download URLs according to versions

### DIFF
--- a/.github/workflows/lychee_url_checker.yml
+++ b/.github/workflows/lychee_url_checker.yml
@@ -45,6 +45,7 @@ jobs:
             --accept 200,429
             --exclude-path ./CHANGELOG.md
             --exclude-path ./scripts/update_version.py
+            --exclude-path docs/conf.py
             './**/*.rst'
             './**/*.md'
             './**/*.py'

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,3 +11,7 @@ file:///home/runner/work/PyBaMM/PyBaMM/docs/source/user_guide/fundamentals/pybam
 
 # Errors in docs/source/user_guide/index.md
 file:///home/runner/work/PyBaMM/PyBaMM/docs/source/user_guide/api_docs
+
+# Ignore links in docs/conf.py
+https://github.com/pybamm-team/PyBaMM/blob/
+https://github.com/pybamm-team/PyBaMM/tree/v

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,7 +11,3 @@ file:///home/runner/work/PyBaMM/PyBaMM/docs/source/user_guide/fundamentals/pybam
 
 # Errors in docs/source/user_guide/index.md
 file:///home/runner/work/PyBaMM/PyBaMM/docs/source/user_guide/api_docs
-
-# Ignore links in docs/conf.py
-https://github.com/pybamm-team/PyBaMM/blob/
-https://github.com/pybamm-team/PyBaMM/tree/v

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -303,6 +303,41 @@ bibtex_tooltips = True
 # a conflict with the sphinx-docsearch extension for Algolia search
 
 nbsphinx_requirejs_path = ""
+
+# For notebook downloads (23.5 onwards), we get the version from the environment
+# variable READTHEDOCS_VERSION and set it accordingly.
+
+# If the version is set to "latest", then we are on the develop branch, and we
+# point to the notebook in the develop blob
+# If we are on "stable", we point to the notebook in the relevant release tree
+# for the PyBaMM version
+# On a PR build, we use READTHEDOCS_GIT_COMMIT_HASH which will always point to changes
+# made to a notebook, if any.
+# On local builds, the version is not set, so we use "latest".
+
+if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (os.environ.get("READTHEDOCS_VERSION") is None): # noqa: E501
+    notebooks_version = "develop"
+    github_download_url = (
+        "https://github.com/pybamm-team/PyBaMM/blob/" + notebooks_version
+    )
+if os.environ.get("READTHEDOCS_VERSION") == "stable":
+    notebooks_version = version
+    github_download_url = (
+        "https://github.com/pybamm-team/PyBaMM/tree/v" + notebooks_version
+    )
+if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
+    notebooks_version = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")
+    github_download_url = (
+        "https://github.com/pybamm-team/PyBaMM/blob/" + notebooks_version
+    )
+
+html_context.update(
+    {
+        "notebooks_version": notebooks_version,
+        "github_download_url": github_download_url,
+    }
+)
+
 nbsphinx_prolog = r"""
 
 {% set github_docname =

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -320,18 +320,17 @@ if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (
 ):
     notebooks_version = "develop"
     append_to_url = f"blob/{notebooks_version}"
-    )
+
 if os.environ.get("READTHEDOCS_VERSION") == "stable":
     notebooks_version = version
     append_to_url = f"tree/v{notebooks_version}"
-    )
+
 if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
     notebooks_version = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")
     append_to_url = f"blob/{notebooks_version}"
-    )
 
-google_colab_url = github_download_url.replace("github.com", "githubtocolab.com")
 github_download_url = f"https://github.com/pybamm-team/PyBaMM/{append_to_url}"
+google_colab_url = github_download_url.replace("github.com", "githubtocolab.com")
 
 html_context.update(
     {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -331,10 +331,13 @@ if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
         "https://github.com/pybamm-team/PyBaMM/blob/" + notebooks_version
     )
 
+google_colab_url = github_download_url.replace("github.com", "githubtocolab.com")
+
 html_context.update(
     {
         "notebooks_version": notebooks_version,
         "github_download_url": github_download_url,
+        "google_colab_url": google_colab_url,
     }
 )
 
@@ -346,6 +349,7 @@ env.doc2path(env.docname, base=None) %}
 
 {% set notebooks_version = env.config.html_context.notebooks_version %}
 {% set github_download_url = env.config.html_context.github_download_url %}
+{% set google_colab_url = env.config.html_context.google_colab_url %}
 
 {% set doc_path = env.doc2path(env.docname, base=None) %}
 
@@ -358,7 +362,7 @@ env.doc2path(env.docname, base=None) %}
         <p>
             An interactive online version of this notebook is available, which can be
             accessed via
-            <a href="https://colab.research.google.com/{{ github_docname | e }}"
+            <a href="{{ google_colab_url | e }}/docs/{{ doc_path | e }}"
             target="_blank">
             <img src="https://colab.research.google.com/assets/colab-badge.svg"
             alt="Open this notebook in Google Colab"/></a>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -315,7 +315,9 @@ nbsphinx_requirejs_path = ""
 # made to a notebook, if any.
 # On local builds, the version is not set, so we use "latest".
 
-if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (os.environ.get("READTHEDOCS_VERSION") is None): # noqa: E501
+if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (
+    os.environ.get("READTHEDOCS_VERSION") is None
+):
     notebooks_version = "develop"
     github_download_url = (
         "https://github.com/pybamm-team/PyBaMM/blob/" + notebooks_version

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -344,8 +344,8 @@ nbsphinx_prolog = r"""
 'github/pybamm-team/pybamm/blob/develop/docs/' +
 env.doc2path(env.docname, base=None) %}
 
-{% set readthedocs_download_url =
-'https://docs.pybamm.org/en/latest/' %}
+{% set notebooks_version = env.config.html_context.notebooks_version %}
+{% set github_download_url = env.config.html_context.github_download_url %}
 
 {% set doc_path = env.doc2path(env.docname, base=None) %}
 
@@ -366,7 +366,7 @@ env.doc2path(env.docname, base=None) %}
             <hr>
         <p>
             Alternatively, you may
-            <a href="{{ readthedocs_download_url | e }}{{ doc_path | e }}"
+            <a href="{{ github_download_url | e }}/docs/{{ doc_path | e }}"
             target="_blank" download>
             download this notebook</a> and run it offline.
         </p>


### PR DESCRIPTION
# Description

Closes #3328; ensures that users of the example notebooks can download the correct notebook from GitHub according to the latest version, stable versions starting from 23.5, and on PR builds. The Google Colab badge now points to the correct renditions of the notebooks, rather than the `develop` branch.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
