### PR TITLE
Fix #3303 Added Better Option Checking

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -481,12 +481,28 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 )
 
         # Options not yet compatible with particle-size distributions
-        if options["particle size"] == "distribution":
-            if options["lithium plating"] != "none":
-                raise NotImplementedError(
+        particle_size = options.get("particle size")
+        if isinstance(particle_size, tuple):
+            if particle_size[0] == "distribution":
+                lithium_plating = options.get("lithium plating")
+    
+                if isinstance(lithium_plating, tuple):
+                    lithium_plating = lithium_plating[0]
+
+                if lithium_plating != "none":
+                    raise NotImplementedError(
+                        "Lithium plating submodels do not yet support particle-size "
+                        "distributions."
+                        )
+        else:
+            if particle_size == "distribution":
+                lithium_plating = options["lithium plating"]
+
+                if lithium_plating != "none":
+                    raise NotImplementedError(
                     "Lithium plating submodels do not yet support particle-size "
-                    "distributions."
-                )
+                    "distributions."  
+                    )
             if options["particle"] in ["quadratic profile", "quartic profile"]:
                 raise NotImplementedError(
                     "'quadratic' and 'quartic' concentration profiles have not yet "

--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -485,7 +485,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         if isinstance(particle_size, tuple):
             if particle_size[0] == "distribution":
                 lithium_plating = options.get("lithium plating")
-    
+
                 if isinstance(lithium_plating, tuple):
                     lithium_plating = lithium_plating[0]
 
@@ -501,7 +501,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 if lithium_plating != "none":
                     raise NotImplementedError(
                     "Lithium plating submodels do not yet support particle-size "
-                    "distributions."  
+                    "distributions."
                     )
             if options["particle"] in ["quadratic profile", "quartic profile"]:
                 raise NotImplementedError(


### PR DESCRIPTION
Fixes #3303 

The key changes:

- Use .get() instead of direct indexing to handle cases where the key is missing
- Check if the value is a tuple using isinstance()
- If it's a tuple, use the first index
- Handle lithium plating the same way

# Description

This allows the code to work regardless of whether the options are single values or tuples.
