### PR TITLE
Remove x-lumped in benchmarks

### DIFF
--- a/benchmarks/different_model_options.py
+++ b/benchmarks/different_model_options.py
@@ -215,7 +215,7 @@ class TimeBuildModelThermal:
     param_names = ["model", "model option"]
     params = (
         [pybamm.lithium_ion.SPM, pybamm.lithium_ion.DFN],
-        ["isothermal", "lumped", "x-lumped", "x-full"],
+        ["isothermal", "lumped", "x-full"],
     )
 
     def time_setup_model(self, model, params):
@@ -226,7 +226,7 @@ class TimeSolveThermal:
     param_names = ["model", "model option", "solver class"]
     params = (
         [pybamm.lithium_ion.SPM, pybamm.lithium_ion.DFN],
-        ["isothermal", "lumped", "x-lumped", "x-full"],
+        ["isothermal", "lumped", "x-full"],
         [pybamm.CasadiSolver, pybamm.IDAKLUSolver],
     )
 


### PR DESCRIPTION
# Description

Current benchmarks do not include current collector models, so x-lumped and lumped end up solving the same model (plus x-lumped was failing). I have removed the x-lumped from the list of options.

Fixes #3357

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
