### PR TITLE
Bug fix: Make examples more compatible with Mac

### DIFF
--- a/docs/source/examples/notebooks/batch_study.ipynb
+++ b/docs/source/examples/notebooks/batch_study.ipynb
@@ -224,7 +224,7 @@
    "source": [
     "# using less number of images in the example\n",
     "# for a smoother GIF use more images\n",
-    "batch_study.create_gif(number_of_images=5, duration=0.2)"
+    "batch_study.create_gif(number_of_images=5, duration=0.2, output_filename="batch.gif")"
    ]
   },
   {

--- a/docs/source/examples/notebooks/batch_study.ipynb
+++ b/docs/source/examples/notebooks/batch_study.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
     "# loading up 3 models to compare\n",

--- a/docs/source/examples/notebooks/batch_study.ipynb
+++ b/docs/source/examples/notebooks/batch_study.ipynb
@@ -224,7 +224,7 @@
    "source": [
     "# using less number of images in the example\n",
     "# for a smoother GIF use more images\n",
-    "batch_study.create_gif(number_of_images=5, duration=0.2, output_filename="batch.gif")"
+    "batch_study.create_gif(number_of_images=5, duration=0.2, output_filename=\"batch.gif\")"
    ]
   },
   {

--- a/docs/source/examples/notebooks/callbacks.ipynb
+++ b/docs/source/examples/notebooks/callbacks.ipynb
@@ -48,7 +48,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q\n",
+    "%pip install \"pybamm[plot,cite]\" -q\n",
     "import pybamm\n",
     "\n",
     "model = pybamm.lithium_ion.DFN()\n",

--- a/docs/source/examples/notebooks/change-settings.ipynb
+++ b/docs/source/examples/notebooks/change-settings.ipynb
@@ -43,7 +43,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/creating_models/1-an-ode-model.ipynb
+++ b/docs/source/examples/notebooks/creating_models/1-an-ode-model.ipynb
@@ -36,7 +36,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"

--- a/docs/source/examples/notebooks/creating_models/2-a-pde-model.ipynb
+++ b/docs/source/examples/notebooks/creating_models/2-a-pde-model.ipynb
@@ -41,7 +41,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"

--- a/docs/source/examples/notebooks/creating_models/3-negative-particle-problem.ipynb
+++ b/docs/source/examples/notebooks/creating_models/3-negative-particle-problem.ipynb
@@ -58,7 +58,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/creating_models/4-comparing-full-and-reduced-order-models.ipynb
+++ b/docs/source/examples/notebooks/creating_models/4-comparing-full-and-reduced-order-models.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/creating_models/5-half-cell-model.ipynb
+++ b/docs/source/examples/notebooks/creating_models/5-half-cell-model.ipynb
@@ -71,7 +71,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "\n",

--- a/docs/source/examples/notebooks/creating_models/6-a-simple-SEI-model.ipynb
+++ b/docs/source/examples/notebooks/creating_models/6-a-simple-SEI-model.ipynb
@@ -123,7 +123,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/experiments-start-time.ipynb
+++ b/docs/source/examples/notebooks/experiments-start-time.ipynb
@@ -36,7 +36,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "from datetime import datetime"
    ]

--- a/docs/source/examples/notebooks/expression_tree/broadcasts.ipynb
+++ b/docs/source/examples/notebooks/expression_tree/broadcasts.ipynb
@@ -24,7 +24,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"
    ]

--- a/docs/source/examples/notebooks/expression_tree/expression-tree.ipynb
+++ b/docs/source/examples/notebooks/expression_tree/expression-tree.ipynb
@@ -35,7 +35,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "\n",

--- a/docs/source/examples/notebooks/getting_started/tutorial-1-how-to-run-a-model.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-1-how-to-run-a-model.ipynb
@@ -34,7 +34,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-10-creating-a-model.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-10-creating-a-model.ipynb
@@ -40,7 +40,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-11-creating-a-submodel.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-11-creating-a-submodel.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-2-compare-models.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-2-compare-models.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-3-basic-plotting.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-3-basic-plotting.ipynb
@@ -40,7 +40,7 @@
         }
       ],
       "source": [
-        "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
         "import pybamm\n",
         "import matplotlib.pyplot as plt\n",
         "\n",

--- a/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "os.chdir(pybamm.__path__[0]+'/..')"

--- a/docs/source/examples/notebooks/getting_started/tutorial-5-run-experiments.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-5-run-experiments.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"
    ]

--- a/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-6-managing-simulation-outputs.ipynb
@@ -42,7 +42,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "model = pybamm.lithium_ion.SPMe()\n",
     "sim = pybamm.Simulation(model)\n",

--- a/docs/source/examples/notebooks/getting_started/tutorial-7-model-options.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-7-model-options.ipynb
@@ -24,7 +24,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-8-solver-options.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-8-solver-options.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/getting_started/tutorial-9-changing-the-mesh.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-9-changing-the-mesh.ipynb
@@ -28,7 +28,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/initialize-model-with-solution.ipynb
+++ b/docs/source/examples/notebooks/initialize-model-with-solution.ipynb
@@ -23,14 +23,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[33mWARNING: You are using pip version 21.0.1; however, version 21.1 is available.\n",
-      "You should consider upgrading via the '/Users/vsulzer/Documents/Energy_storage/PyBaMM/.tox/dev/bin/python -m pip install --upgrade pip' command.\u001b[0m\n",
+      "\u001B[33mWARNING: You are using pip version 21.0.1; however, version 21.1 is available.\n",
+      "You should consider upgrading via the '/Users/vsulzer/Documents/Energy_storage/PyBaMM/.tox/dev/bin/python -m pip install --upgrade pip' command.\u001B[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "\n",
     "import pybamm\n",
     "import pandas as pd\n",

--- a/docs/source/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
+++ b/docs/source/examples/notebooks/models/DFN-with-particle-size-distributions.ipynb
@@ -42,7 +42,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/models/DFN.ipynb
+++ b/docs/source/examples/notebooks/models/DFN.ipynb
@@ -128,7 +128,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np"
    ]

--- a/docs/source/examples/notebooks/models/MPM.ipynb
+++ b/docs/source/examples/notebooks/models/MPM.ipynb
@@ -103,7 +103,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/models/MSMR.ipynb
+++ b/docs/source/examples/notebooks/models/MSMR.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/models/SEI-on-cracks.ipynb
+++ b/docs/source/examples/notebooks/models/SEI-on-cracks.ipynb
@@ -21,14 +21,14 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip available: \u001b[0m\u001b[31;49m22.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.0.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip available: \u001B[0m\u001B[31;49m22.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m23.0.1\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/models/SPM.ipynb
+++ b/docs/source/examples/notebooks/models/SPM.ipynb
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/models/SPMe.ipynb
+++ b/docs/source/examples/notebooks/models/SPMe.ipynb
@@ -126,7 +126,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
+++ b/docs/source/examples/notebooks/models/Validating_mechanical_models_Enertech_DFN.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
+++ b/docs/source/examples/notebooks/models/compare-comsol-discharge-curve.ipynb
@@ -32,7 +32,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/models/compare-ecker-data.ipynb
+++ b/docs/source/examples/notebooks/models/compare-ecker-data.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import pandas as pd\n",

--- a/docs/source/examples/notebooks/models/compare-lithium-ion.ipynb
+++ b/docs/source/examples/notebooks/models/compare-lithium-ion.ipynb
@@ -48,7 +48,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "os.chdir(pybamm.__path__[0]+'/..')\n",

--- a/docs/source/examples/notebooks/models/compare-particle-diffusion-models.ipynb
+++ b/docs/source/examples/notebooks/models/compare-particle-diffusion-models.ipynb
@@ -35,7 +35,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import numpy as np\n",

--- a/docs/source/examples/notebooks/models/composite_particle.ipynb
+++ b/docs/source/examples/notebooks/models/composite_particle.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "#%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/docs/source/examples/notebooks/models/coupled-degradation.ipynb
+++ b/docs/source/examples/notebooks/models/coupled-degradation.ipynb
@@ -29,7 +29,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/models/electrode-state-of-health.ipynb
+++ b/docs/source/examples/notebooks/models/electrode-state-of-health.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"

--- a/docs/source/examples/notebooks/models/jelly-roll-model.ipynb
+++ b/docs/source/examples/notebooks/models/jelly-roll-model.ipynb
@@ -56,7 +56,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np \n",
     "from numpy import pi\n",

--- a/docs/source/examples/notebooks/models/latexify.ipynb
+++ b/docs/source/examples/notebooks/models/latexify.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/models/lead-acid.ipynb
+++ b/docs/source/examples/notebooks/models/lead-acid.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/models/lithium-plating.ipynb
+++ b/docs/source/examples/notebooks/models/lithium-plating.ipynb
@@ -24,7 +24,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/models/loss_of_active_materials.ipynb
+++ b/docs/source/examples/notebooks/models/loss_of_active_materials.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
     "model = pybamm.lithium_ion.DFN(\n",

--- a/docs/source/examples/notebooks/models/pouch-cell-model.ipynb
+++ b/docs/source/examples/notebooks/models/pouch-cell-model.ipynb
@@ -55,7 +55,7 @@
                         }
                   ],
                   "source": [
-                        "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+                        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
                         "import pybamm\n",
                         "import pickle\n",
                         "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/models/rate-capability.ipynb
+++ b/docs/source/examples/notebooks/models/rate-capability.ipynb
@@ -30,7 +30,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"

--- a/docs/source/examples/notebooks/models/simulating-ORegan-2022-parameter-set.ipynb
+++ b/docs/source/examples/notebooks/models/simulating-ORegan-2022-parameter-set.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
+++ b/docs/source/examples/notebooks/models/submodel_cracking_DFN_or_SPM.ipynb
@@ -23,7 +23,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "import matplotlib.pyplot as plt\n",

--- a/docs/source/examples/notebooks/models/thermal-models.ipynb
+++ b/docs/source/examples/notebooks/models/thermal-models.ipynb
@@ -27,7 +27,7 @@
         }
       ],
       "source": [
-        "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
         "import pybamm"
       ]
     },

--- a/docs/source/examples/notebooks/models/unsteady-heat-equation.ipynb
+++ b/docs/source/examples/notebooks/models/unsteady-heat-equation.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"

--- a/docs/source/examples/notebooks/models/using-model-options_thermal-example.ipynb
+++ b/docs/source/examples/notebooks/models/using-model-options_thermal-example.ipynb
@@ -32,7 +32,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import os\n",
     "os.chdir(pybamm.__path__[0]+'/..')"

--- a/docs/source/examples/notebooks/models/using-submodels.ipynb
+++ b/docs/source/examples/notebooks/models/using-submodels.ipynb
@@ -34,7 +34,7 @@
         }
       ],
       "source": [
-        "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
         "import pybamm"
       ]
     },

--- a/docs/source/examples/notebooks/parameterization/change-input-current.ipynb
+++ b/docs/source/examples/notebooks/parameterization/change-input-current.ipynb
@@ -41,7 +41,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/parameterization/parameter-values.ipynb
+++ b/docs/source/examples/notebooks/parameterization/parameter-values.ipynb
@@ -31,7 +31,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/parameterization/parameterization.ipynb
+++ b/docs/source/examples/notebooks/parameterization/parameterization.ipynb
@@ -41,7 +41,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"

--- a/docs/source/examples/notebooks/plotting/customize-quick-plot.ipynb
+++ b/docs/source/examples/notebooks/plotting/customize-quick-plot.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
     "models = [pybamm.lithium_ion.SPM(), pybamm.lithium_ion.SPMe(), pybamm.lithium_ion.DFN()]\n",

--- a/docs/source/examples/notebooks/plotting/plot-voltage-components.ipynb
+++ b/docs/source/examples/notebooks/plotting/plot-voltage-components.ipynb
@@ -116,7 +116,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "\n",
     "model = pybamm.lithium_ion.DFN()\n",

--- a/docs/source/examples/notebooks/simulating-long-experiments.ipynb
+++ b/docs/source/examples/notebooks/simulating-long-experiments.ipynb
@@ -33,7 +33,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/source/examples/notebooks/simulation-class.ipynb
+++ b/docs/source/examples/notebooks/simulation-class.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "# using less number of images in the example\n",
     "# for a smoother GIF use more images\n",
-    "simulation.create_gif(number_of_images=5, duration=0.2)"
+    "simulation.create_gif(number_of_images=5, duration=0.2, output_filename="simulation.gif")"
    ]
   },
   {

--- a/docs/source/examples/notebooks/simulation-class.ipynb
+++ b/docs/source/examples/notebooks/simulation-class.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm"
    ]
   },

--- a/docs/source/examples/notebooks/simulation-class.ipynb
+++ b/docs/source/examples/notebooks/simulation-class.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "# using less number of images in the example\n",
     "# for a smoother GIF use more images\n",
-    "simulation.create_gif(number_of_images=5, duration=0.2, output_filename="simulation.gif")"
+    "simulation.create_gif(number_of_images=5, duration=0.2, output_filename=\"simulation.gif\")"
    ]
   },
   {

--- a/docs/source/examples/notebooks/solution-data-and-processed-variables.ipynb
+++ b/docs/source/examples/notebooks/solution-data-and-processed-variables.ipynb
@@ -42,7 +42,7 @@
         }
       ],
       "source": [
-        "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
         "import pybamm\n",
         "import numpy as np\n",
         "import os\n",

--- a/docs/source/examples/notebooks/solvers/dae-solver.ipynb
+++ b/docs/source/examples/notebooks/solvers/dae-solver.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/solvers/ode-solver.ipynb
+++ b/docs/source/examples/notebooks/solvers/ode-solver.ipynb
@@ -25,7 +25,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/source/examples/notebooks/solvers/speed-up-solver.ipynb
+++ b/docs/source/examples/notebooks/solvers/speed-up-solver.ipynb
@@ -29,7 +29,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np"

--- a/docs/source/examples/notebooks/spatial_methods/finite-volumes.ipynb
+++ b/docs/source/examples/notebooks/spatial_methods/finite-volumes.ipynb
@@ -62,7 +62,7 @@
     }
    ],
    "source": [
-    "%pip install pybamm[plot,cite] -q    # install PyBaMM if it is not installed\n",
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
     "import pybamm\n",
     "import numpy as np\n",
     "import os\n",

--- a/pybamm/callbacks.py
+++ b/pybamm/callbacks.py
@@ -3,7 +3,7 @@
 # Callbacks are used to perform actions (e.g. logging, saving)
 # at certain points in the simulation
 # Inspired by Keras callbacks
-# https://github.com/keras-team/keras/blob/master/keras/callbacks.py
+# https://github.com/keras-team/keras
 #
 import pybamm
 import numpy as np

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -781,10 +781,12 @@ class QuickPlot(object):
         images = []
 
         # create images/plots
+        stub_name = output_filename.split(".")[0]
         for val in time_array:
             self.plot(val)
-            images.append("plot" + str(val) + ".png")
-            self.fig.savefig("plot" + str(val) + ".png", dpi=300)
+            temp_name = f"{stub_name}{val}.png"
+            images.append(temp_name)
+            self.fig.savefig(temp_name, dpi=300)
             plt.close()
 
         # compile the images/plots to create a GIF

--- a/tests/unit/test_batch_study.py
+++ b/tests/unit/test_batch_study.py
@@ -93,14 +93,18 @@ class TestBatchStudy(TestCase):
         bs = pybamm.BatchStudy({"spm": pybamm.lithium_ion.SPM()})
         bs.solve([0, 10])
 
+        # Create a temporary file name
+        test_stub = "batch_study_test"
+        test_file = f"{test_stub}.gif"
+
         # create a GIF before calling the plot method
-        bs.create_gif(number_of_images=3, duration=1)
+        bs.create_gif(number_of_images=3, duration=1, output_filename=test_file)
 
         # create a GIF after calling the plot method
         bs.plot(testing=True)
-        bs.create_gif(number_of_images=3, duration=1)
+        bs.create_gif(number_of_images=3, duration=1, output_filename=test_file)
 
-        os.remove("plot.gif")
+        os.remove(test_file)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -290,11 +290,12 @@ class TestQuickPlot(TestCase):
         quick_plot.plot(0)
 
         # test creating a GIF
-        quick_plot.create_gif(number_of_images=3, duration=3)
-        assert not os.path.exists("plot*.png")
-        assert os.path.exists("plot.gif")
-        os.remove("plot.gif")
-
+        test_stub = "spm_sim_test"
+        test_file = f"{test_stub}.gif"
+        quick_plot.create_gif(number_of_images=3, duration=3, output_filename=test_file)
+        assert not os.path.exists(f"{test_stub}*.png")
+        assert os.path.exists(test_file)
+        os.remove(test_file)
         pybamm.close_plots()
 
     def test_loqs_spme(self):

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -343,14 +343,18 @@ class TestSimulation(TestCase):
         sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
         sim.solve(t_eval=[0, 10])
 
+        # Create a temporary file name
+        test_stub = "test_sim"
+        test_file = f"{test_stub}.gif"
+
         # create a GIF without calling the plot method
-        sim.create_gif(number_of_images=3, duration=1)
+        sim.create_gif(number_of_images=3, duration=1, output_filename=test_file)
 
         # call the plot method before creating the GIF
         sim.plot(testing=True)
-        sim.create_gif(number_of_images=3, duration=1)
+        sim.create_gif(number_of_images=3, duration=1, output_filename=test_file)
 
-        os.remove("plot.gif")
+        os.remove(test_file)
 
     def test_drive_cycle_interpolant(self):
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Fixing some issues in the notebooks that caused failures on MacOS and in Nox sessions.

Changes:
- Changed ```%pip install pybamm[plot,cite] -q``` to ```%pip install "pybamm[plot,cite]" -q``` in the notebooks. This prevents failures on MacOS.
- Fixed the temporary file name in the quick plot function create_gif() function. Running ```nox -s examples``` had failures due to "file not found" errors. The function would use the same file names on different threads creating a race condition.
- Fixed the link to keras' callbacks.py file. The files moved and the link no longer functioned.

## Type of change

Minor bug fixes in the notebooks.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
