### PR TITLE
Fix periodic benchmarks and remove version cap on `asv`

### DIFF
--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
+          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy packaging
           python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS

--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -18,16 +18,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc libopenblas-dev
+
       - name: Install python dependencies
-      # Pin asv==0.5.1 to fix failing benchmarks. Related to https://github.com/airspeed-velocity/asv/issues/1323
         run: |
-          python -m pip install --upgrade pip wheel setuptools virtualenv asv==0.5.1 wget cmake casadi numpy
-      - name: Install SuiteSparse and Sundials
+          python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
+          python -m pip install asv
+
+      - name: Install SuiteSparse and SUNDIALS
         run: python scripts/install_KLU_Sundials.py
+
       - name: Fetch base branch
         run: |
           # This workflow also runs for merge commits
@@ -49,7 +53,8 @@ jobs:
           HEAD_COMMIT=$(git rev-parse HEAD)
           echo $BASE_COMMIT | tee commits_to_compare.txt
           echo $HEAD_COMMIT | tee -a commits_to_compare.txt
-          asv run HASHFILE:commits_to_compare.txt --m "GitHubRunner" --show-stderr --strict -v
+          asv run HASHFILE:commits_to_compare.txt --m "GitHubRunner" --show-stderr -v
+
       - name: Compare commits' benchmark results
         run: |
           BASE_COMMIT=$(head -1 commits_to_compare.txt)

--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.8
 
       - name: Install Linux system dependencies
         run: |

--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Linux system dependencies
         run: |
@@ -27,7 +27,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
-          python -m pip install asv
+          python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS
         run: python scripts/install_KLU_Sundials.py

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
+          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy packaging
           python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.8
 
       - name: Install Linux system dependencies
         run: |

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -20,26 +20,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install gfortran gcc libopenblas-dev
+
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools virtualenv asv wget cmake casadi numpy
-      - name: Install SuiteSparse and Sundials
+          python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
+          python -m pip install asv
+
+      - name: Install SuiteSparse and SUNDIALS
         run: python scripts/install_KLU_Sundials.py
+
       - name: Run benchmarks
         run: |
           asv machine --machine "GitHubRunner"
-          asv run --machine "GitHubRunner" NEW --show-stderr --strict -v
+          asv run --machine "GitHubRunner" NEW --show-stderr -v
         env:
           SUNDIALS_INST: $HOME/.local
           LD_LIBRARY_PATH: $HOME/.local/lib
+
       - name: Upload results as artifact
         uses: actions/upload-artifact@v3
         with:
@@ -55,18 +62,22 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
+
       - name: Install asv
         run: pip install asv
+
       - name: Checkout pybamm-bench repo
         uses: actions/checkout@v4
         with:
           repository: pybamm-team/pybamm-bench
           token: ${{ secrets.BENCH_PAT }}
+
       - name: Download results artifact
         uses: actions/download-artifact@v3
         with:
           name: asv_new_results
           path: new_results
+
       - name: Copy new results and push to pybamm-bench repo
         env:
           PUSH_BENCH_EMAIL: ${{ secrets.PUSH_BENCH_EMAIL }}
@@ -78,6 +89,7 @@ jobs:
           git add results
           git commit -am "Add new results"
           git push
+
       - name: Publish results
         run: |
           asv publish

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install Linux system dependencies
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools virtualenv wget cmake casadi numpy virtualenv packaging
-          python -m pip install asv
+          python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS
         run: python scripts/install_KLU_Sundials.py


### PR DESCRIPTION
# Description

The scheduled benchmarks suite was failing to run because the version was not pinned to 0.5.1. This PR resolves both benchmarks workflows and allows the benchmarks to run

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
