### PR TITLE
Added support for tuples in option checking. Fixes #3303

### DIFF
--- a/pybamm/models/full_battery_models/base_battery_model.py
+++ b/pybamm/models/full_battery_models/base_battery_model.py
@@ -481,9 +481,25 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 )
 
         # Options not yet compatible with particle-size distributions
-        if options["particle size"] == "distribution":
-            if options["lithium plating"] != "none":
-                raise NotImplementedError(
+        particle_size = options.get("particle size")
+        if isinstance(particle_size, tuple):
+            if particle_size[0] == "distribution":
+                lithium_plating = options.get("lithium plating")
+
+                if isinstance(lithium_plating, tuple):
+                    lithium_plating = lithium_plating[0]
+
+                if lithium_plating != "none":
+                    raise NotImplementedError(
+                        "Lithium plating submodels do not yet support particle-size "
+                        "distributions."
+                        )
+        else:
+            if particle_size == "distribution":
+                lithium_plating = options["lithium plating"]
+
+                if lithium_plating != "none":
+                    raise NotImplementedError(
                     "Lithium plating submodels do not yet support particle-size "
                     "distributions."
                 )


### PR DESCRIPTION
# Description

Earlier:
<img width="621" alt="Screenshot 2023-09-29 at 9 24 25 PM" src="https://github.com/pybamm-team/PyBaMM/assets/111041731/42bdd196-f403-4d18-b31e-926862fdd6d2">

Earlier "particle size" was not treated as a tuple and this caused problem as explained in Issue #3303.

Now:

<img width="658" alt="Screenshot 2023-09-29 at 9 33 27 PM" src="https://github.com/pybamm-team/PyBaMM/assets/111041731/386f42d0-eb02-4186-b60e-24c6e99fe34e">

Now, there is added compatibility for "particle size" to be either a tuple or a single value.

Fixes #3303 

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)
