### PR TITLE
fix: Add warning when existing parameters are updated

### DIFF
--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -221,9 +221,8 @@ class ParameterValues:
                     )
             else:
                 if name in self._dict_items:
-                    warnings.warn(
-                        message=f"Parameter '{name}' already exists in the parameters.",
-                        category=UserWarning,
+                    pybamm.logger.warning(
+                        f"Parameter '{name}' already exists in the parameters."
                     )
             # if no conflicts, update
             if isinstance(value, str):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -221,7 +221,9 @@ class ParameterValues:
             else:
                 if name in self._dict_items:
                     pybamm.logger.warning(
-                        f"Parameter '{name}' already exists in the parameters."
+                        f"Parameter '{name}' already exists in the parameters. "
+                        + "Updating parameters should be done by setting "
+                        + "check_already_exists=True"
                     )
             # if no conflicts, update
             if isinstance(value, str):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -188,8 +188,6 @@ class ParameterValues:
             update it. This is to avoid cases where an intended change in the parameters
             is ignored due a typo in the parameter name, and is True by default but can
             be manually overridden.
-        path : string, optional
-            Path from which to load functions
         """
         # check if values is not a dictionary
         if not isinstance(values, dict):
@@ -210,15 +208,22 @@ class ParameterValues:
                     )
                 )
             # check parameter already exists (for updating parameters)
-            if check_already_exists is True:
+            if check_already_exists:
                 try:
                     self._dict_items[name]
                 except KeyError as err:
                     raise KeyError(
-                        "Cannot update parameter '{}' as it does not ".format(name)
-                        + "have a default value. ({}). If you are ".format(err.args[0])
+                        f"Cannot update parameter '{name}' as it does not "
+                        + f"have a default value. ({err.args[0]}). If you are "
                         + "sure you want to update this parameter, use "
                         + "param.update({{name: value}}, check_already_exists=False)"
+                    )
+            else:
+                if name in self._dict_items:
+                    raise KeyError(
+                        f"Parameter '{name}' already exists in that parameters. "
+                        + "If you want to update this parameter, use "
+                        + "param.update({{name: value}}, check_already_exists=True)"
                     )
             # if no conflicts, update
             if isinstance(value, str):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -4,7 +4,6 @@
 import numpy as np
 import pybamm
 import numbers
-import warnings
 from pprint import pformat
 from collections import defaultdict
 

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -221,7 +221,7 @@ class ParameterValues:
             else:
                 if name in self._dict_items:
                     pybamm.logger.warning(
-                        f"Parameter '{name}' already exists in the parameters. "
+                        f"Key '{name}' already exists in the parameter set. "
                         + "Updating parameters should be done by setting "
                         + "check_already_exists=True"
                     )

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -4,6 +4,7 @@
 import numpy as np
 import pybamm
 import numbers
+import warnings
 from pprint import pformat
 from collections import defaultdict
 
@@ -220,10 +221,9 @@ class ParameterValues:
                     )
             else:
                 if name in self._dict_items:
-                    raise KeyError(
-                        f"Parameter '{name}' already exists in that parameters. "
-                        + "If you want to update this parameter, use "
-                        + "param.update({{name: value}}, check_already_exists=True)"
+                    warnings.warn(
+                        message=f"Parameter '{name}' already exists in the parameters.",
+                        category=UserWarning,
                     )
             # if no conflicts, update
             if isinstance(value, str):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -170,7 +170,7 @@ class ParameterValues:
         """
         return self._dict_items.search(key, print_values)
 
-    def update(self, values, check_conflict=False, check_already_exists=True, path=""):
+    def update(self, values, check_conflict=False, check_already_exists=True):
         """
         Update parameter dictionary, while also performing some basic checks.
 


### PR DESCRIPTION
# Description

I was looking at #2265 and saw that a lot of tests (34) and examples (22) would be affected by making it an error to update parameters with check_already_exists=False. This makes it seem like a larger change. As an intermediate I propose to implement a warning so users and developers can adjust their scripts before it becomes an error. Similar to adding a deprecation warning.

If this change makes it in before the next release, then users can start adapting their code before the errors begin.

Related #2265

## Type of change

Minor change to the way parameters are updated.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
