### PR TITLE
Remove redundant `packaging` dependency install

### DIFF
--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy packaging
+          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy
           python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy packaging
+          python -m pip install --upgrade pip wheel setuptools wget cmake casadi numpy
           python -m pip install asv[virtualenv]
 
       - name: Install SuiteSparse and SUNDIALS


### PR DESCRIPTION
# Description

Removes the `packaging` dependency from the explicit list of packages on two Github actions activities, since it's already included within `asv[virtualenv]`.

Fixes #3383

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] CI change

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ N/A ] Code is commented, particularly in hard-to-understand areas
- [  N/A ] Tests added that prove fix is effective or that feature works
