### PR TITLE
Drop support for i686 manylinux

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -105,7 +105,7 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install openblas-devel lapack-devel &&
-            bash build_manylinux_wheels/install_sundials.sh 5.8.1 6.5.0
+            bash build_manylinux_wheels/install_sundials.sh 6.0.3 6.5.0
 
           CIBW_BEFORE_BUILD_LINUX: "python -m pip install cmake casadi numpy"
           CIBW_BEFORE_BUILD_MACOS: >

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -102,6 +102,8 @@ jobs:
       - name: Build wheels on Linux and MacOS
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+          # NumPy requires BLAS now which is no longer available on manylinux2014 i686, so skip it
+          CIBW_ARCHS_LINUX: x86_64
           # TODO: openblas no longer available on centos 7 i686 image, use blas instead for now
           CIBW_BEFORE_ALL_LINUX: >
             yum -y install blas-devel lapack-devel &&
@@ -135,13 +137,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
-        run: pip install wheel
+        run: pip install --upgrade pip setuptools wheel build
 
       - name: Build sdist
-        run: python setup.py sdist --formats=gztar
+        run: python -m build --sdist
 
       - name: Upload sdist
         uses: actions/upload-artifact@v3
@@ -171,7 +173,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          packages_dir: files/
+          packages-dir: files/
 
       - name: Publish on TestPyPI
         if: github.event.inputs.target == 'testpypi'
@@ -179,5 +181,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TESTPYPI_TOKEN }}
-          packages_dir: files/
-          repository_url: https://test.pypi.org/legacy/
+          packages-dir: files/
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -102,11 +102,9 @@ jobs:
       - name: Build wheels on Linux and MacOS
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # NumPy requires BLAS now which is no longer available on manylinux2014 i686, so skip it
           CIBW_ARCHS_LINUX: x86_64
-          # TODO: openblas no longer available on centos 7 i686 image, use blas instead for now
           CIBW_BEFORE_ALL_LINUX: >
-            yum -y install blas-devel lapack-devel &&
+            yum -y install openblas-devel lapack-devel &&
             bash build_manylinux_wheels/install_sundials.sh 5.8.1 6.5.0
 
           CIBW_BEFORE_BUILD_LINUX: "python -m pip install cmake casadi numpy"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ## Breaking changes
 
+- Dropped support for i686 (32-bit) architectures on GNU/Linux distributions ([#3412](https://github.com/pybamm-team/PyBaMM/pull/3412))
 - The class `pybamm.thermal.OneDimensionalX` has been moved to `pybamm.thermal.pouch_cell.OneDimensionalX` to reflect the fact that the model formulation implicitly assumes a pouch cell geometry ([#3257](https://github.com/pybamm-team/PyBaMM/pull/3257))
 - The "lumped" thermal option now always used the parameters "Cell cooling surface area [m2]", "Cell volume [m3]" and "Total heat transfer coefficient [W.m-2.K-1]" to compute the cell cooling regardless of the chosen "cell geometry" option. The user must now specify the correct values for these parameters instead of them being calculated based on e.g. a pouch cell. An `OptionWarning` is raised to let users know to update their parameters ([#3257](https://github.com/pybamm-team/PyBaMM/pull/3257))
 - Numpy functions now work with PyBaMM symbols (e.g. `np.exp(pybamm.Symbol("a"))` returns `pybamm.Exp(pybamm.Symbol("a"))`). This means that parameter functions can be specified using numpy functions instead of pybamm functions. Additionally, combining numpy arrays with pybamm objects now works (the numpy array is converted to a pybamm array) ([#3205](https://github.com/pybamm-team/PyBaMM/pull/3205))

--- a/build_manylinux_wheels/install_sundials.sh
+++ b/build_manylinux_wheels/install_sundials.sh
@@ -65,8 +65,8 @@ yum -y install openblas-devel
 
 mkdir -p build_sundials
 cd build_sundials
-KLU_INCLUDE_DIR=/usr/include
-KLU_LIBRARY_DIR=/usr/lib
+KLU_INCLUDE_DIR=/usr/local/include
+KLU_LIBRARY_DIR=/usr/local/lib
 SUNDIALS_DIR=sundials-$SUNDIALS_VERSION
 cmake -DENABLE_LAPACK=ON\
       -DSUNDIALS_INDEX_SIZE=32\


### PR DESCRIPTION
# Description

Drops support for 32-bit wheels on Linux platforms due to NumPy's recent BLAS requirement and uses an updated method, i.e., `python -m build` for building the source distribution

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
