### PR TITLE
Fix typo .all-contributorsrc

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -717,7 +717,7 @@
       "contributions": [
         "doc"
       ]
-    },
+    }
   ],
   "contributorsPerLine": 7,
   "projectName": "PyBaMM",


### PR DESCRIPTION
There's a typo in the .all-contributorsrc which causes the bot to fail. This hopefully fixes it.