### PR TITLE
Rename parameter "Exchange-current density for plating" to "Exchange-current density for lithium metal electrode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ## Breaking changes
 
+- The parameter "Exchange-current density for plating \[A.m-2]" has been renamed to "Exchange-current density for lithium-metal electrode \[A.m-2]" ([#3429](https://github.com/pybamm-team/PyBaMM/pull/3429))
 - Dropped support for i686 (32-bit) architectures on GNU/Linux distributions ([#3412](https://github.com/pybamm-team/PyBaMM/pull/3412))
 - The class `pybamm.thermal.OneDimensionalX` has been moved to `pybamm.thermal.pouch_cell.OneDimensionalX` to reflect the fact that the model formulation implicitly assumes a pouch cell geometry ([#3257](https://github.com/pybamm-team/PyBaMM/pull/3257))
 - The "lumped" thermal option now always used the parameters "Cell cooling surface area [m2]", "Cell volume [m3]" and "Total heat transfer coefficient [W.m-2.K-1]" to compute the cell cooling regardless of the chosen "cell geometry" option. The user must now specify the correct values for these parameters instead of them being calculated based on e.g. a pouch cell. An `OptionWarning` is raised to let users know to update their parameters ([#3257](https://github.com/pybamm-team/PyBaMM/pull/3257))

--- a/pybamm/input/parameters/lithium_ion/Mohtat2020.py
+++ b/pybamm/input/parameters/lithium_ion/Mohtat2020.py
@@ -342,7 +342,7 @@ def get_parameter_values():
         "chemistry": "lithium_ion",
         # lithium plating
         "Lithium metal partial molar volume [m3.mol-1]": 1.3e-05,
-        "Exchange-current density for plating [A.m-2]": 0.001,
+        "Exchange-current density for lithium-metal electrode [A.m-2]": 0.001,
         "Initial plated lithium concentration [mol.m-3]": 0.0,
         "Typical plated lithium concentration [mol.m-3]": 1000.0,
         "Lithium plating transfer coefficient": 0.7,

--- a/pybamm/input/parameters/lithium_ion/OKane2022.py
+++ b/pybamm/input/parameters/lithium_ion/OKane2022.py
@@ -515,7 +515,7 @@ def get_parameter_values():
         # lithium plating
         "Lithium metal partial molar volume [m3.mol-1]": 1.3e-05,
         "Lithium plating kinetic rate constant [m.s-1]": 1e-09,
-        "Exchange-current density for plating [A.m-2]"
+        "Exchange-current density for lithium-metal electrode [A.m-2]"
         "": plating_exchange_current_density_OKane2020,
         "Exchange-current density for stripping [A.m-2]"
         "": stripping_exchange_current_density_OKane2020,

--- a/pybamm/input/parameters/lithium_ion/OKane2022_graphite_SiOx_halfcell.py
+++ b/pybamm/input/parameters/lithium_ion/OKane2022_graphite_SiOx_halfcell.py
@@ -399,7 +399,7 @@ def get_parameter_values():
         # lithium plating
         "Lithium metal partial molar volume [m3.mol-1]": 1.3e-05,
         "Lithium plating kinetic rate constant [m.s-1]": 1e-09,
-        "Exchange-current density for plating [A.m-2]"
+        "Exchange-current density for lithium-metal electrode [A.m-2]"
         "": plating_exchange_current_density_OKane2020,
         "Exchange-current density for stripping [A.m-2]"
         "": stripping_exchange_current_density_OKane2020,

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -199,14 +199,14 @@ class LithiumIonParameters(BaseParameters):
         )
 
     def j0_plating(self, c_e, c_Li, T):
-        """Dimensional exchange-current density for plating [A.m-2]"""
+        """Dimensional exchange-current density for lithium-metal electrode [A.m-2]"""
         inputs = {
             "Electrolyte concentration [mol.m-3]": c_e,
             "Plated lithium concentration [mol.m-3]": c_Li,
             "Temperature [K]": T,
         }
         return pybamm.FunctionParameter(
-            "Exchange-current density for plating [A.m-2]", inputs
+            "Exchange-current density for lithium-metal electrode [A.m-2]", inputs
         )
 
     def dead_lithium_decay_rate(self, L_sei):

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -324,6 +324,11 @@ class ParameterValues:
                 raise ValueError(
                     f"parameter '{param}' has been renamed to " "'Thermodynamic factor'"
                 )
+            if "Exchange-current density for plating [A.m-2]" in param:
+                raise ValueError(
+                    f"parameter '{param}' has been renamed to "
+                    "'Exchange-current density for lithium-metal electrode [A.m-2]'"
+                )
 
     def process_model(self, unprocessed_model, inplace=True):
         """Assign parameter values to a model.

--- a/tests/unit/test_parameters/test_parameter_sets/test_OKane2022.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_OKane2022.py
@@ -14,7 +14,9 @@ class TestOKane2022(TestCase):
 
         fun_test = {
             # Lithium plating
-            "Exchange-current density for plating [A.m-2]": ([1e3, 1e4, T], 9.6485e-2),
+            "Exchange-current density for lithium-metal electrode [A.m-2]": (
+                [1e3, 1e4, T], 9.6485e-2
+            ),
             "Exchange-current density for stripping [A.m-2]": (
                 [1e3, 1e4, T],
                 9.6485e-1,

--- a/tests/unit/test_parameters/test_parameter_sets/test_OKane2022_negative_halfcell.py
+++ b/tests/unit/test_parameters/test_parameter_sets/test_OKane2022_negative_halfcell.py
@@ -14,7 +14,9 @@ class TestOKane2022_graphite_SiOx_halfcell(TestCase):
 
         fun_test = {
             # Lithium plating
-            "Exchange-current density for plating [A.m-2]": ([1e3, 1e4, T], 9.6485e-2),
+            "Exchange-current density for lithium-metal electrode [A.m-2]": (
+                [1e3, 1e4, T], 9.6485e-2
+            ),
             "Exchange-current density for stripping [A.m-2]": (
                 [1e3, 1e4, T],
                 9.6485e-1,

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -147,6 +147,10 @@ class TestParameterValues(TestCase):
             # since + has other meanings in regex
         with self.assertRaisesRegex(ValueError, "Thermodynamic factor"):
             pybamm.ParameterValues({"1 + dlnf/dlnc": 1})
+        with self.assertRaisesRegex(
+            ValueError, "Exchange-current density for lithium-metal electrode"):
+            pybamm.ParameterValues(
+                {"Exchange-current density for plating": 0.001})
 
     def test_process_symbol(self):
         parameter_values = pybamm.ParameterValues({"a": 4, "b": 2, "c": 3})

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -148,9 +148,9 @@ class TestParameterValues(TestCase):
         with self.assertRaisesRegex(ValueError, "Thermodynamic factor"):
             pybamm.ParameterValues({"1 + dlnf/dlnc": 1})
         with self.assertRaisesRegex(
-            ValueError, "Exchange-current density for lithium-metal electrode"):
+            ValueError, "Exchange-current density for plating [A.m-2]"):
             pybamm.ParameterValues(
-                {"Exchange-current density for plating": 0.001})
+                {"Exchange-current density for lithium-metal electrode [A.m-2]": 0.001})
 
     def test_process_symbol(self):
         parameter_values = pybamm.ParameterValues({"a": 4, "b": 2, "c": 3})

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -148,9 +148,9 @@ class TestParameterValues(TestCase):
         with self.assertRaisesRegex(ValueError, "Thermodynamic factor"):
             pybamm.ParameterValues({"1 + dlnf/dlnc": 1})
         with self.assertRaisesRegex(
-            ValueError, "Exchange-current density for plating [A.m-2]"):
+            ValueError, "Exchange-current density for lithium-metal electrode [A.m-2]"):
             pybamm.ParameterValues(
-                {"Exchange-current density for lithium-metal electrode [A.m-2]": 0.001})
+                {"Exchange-current density for plating [A.m-2]": 0.001})
 
     def test_process_symbol(self):
         parameter_values = pybamm.ParameterValues({"a": 4, "b": 2, "c": 3})

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -147,8 +147,8 @@ class TestParameterValues(TestCase):
             # since + has other meanings in regex
         with self.assertRaisesRegex(ValueError, "Thermodynamic factor"):
             pybamm.ParameterValues({"1 + dlnf/dlnc": 1})
-        with self.assertRaisesRegex(
-            ValueError, "Exchange-current density for lithium-metal electrode [A.m-2]"):
+        # renamed to "Exchange-current density for lithium-metal electrode [A.m-2]"
+        with self.assertRaises(ValueError):
             pybamm.ParameterValues(
                 {"Exchange-current density for plating [A.m-2]": 0.001})
 


### PR DESCRIPTION
# Description

Closes #3428, adds a check for the use of the "Exchange-current density for plating [A.m-2]" parameter because it is to be renamed to "Exchange-current density for lithium-metal electrode [A.m-2]"

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
