### PR TITLE
Multi-architecture Docker images and parallel builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
+      fail-fast: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
-    # if: github.repository_owner == 'pybamm-team'
+    if: github.repository_owner == 'pybamm-team'
     name: Image (${{ matrix.build-args }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
-        architectures: [amd64, arm64]
 
     steps:
       - name: Checkout
@@ -58,7 +57,7 @@ jobs:
           tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
           push: false # temporary
           build-args: ${{ matrix.build-args }}
-          platforms: linux/${{ matrix.architectures }}
+          platforms: linux/amd64, linux/arm64
 
       - name: List built image(s)
         run: docker images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
     # if: github.repository_owner == 'pybamm-team'
-    name: Build image ({{ matrix.build-args }})
+    name: Build image (${{ matrix.build-args }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,75 +1,64 @@
-name: Build & Push Docker Images
+name: Build and push Docker images to Docker Hub
 
 on:
   workflow_dispatch:
   push:
     branches:
     - develop
+  # temporary
+  pull_request:
 
 jobs:
-  pre_job:
+  build_docker_images:
+    # This workflow is only of value to PyBaMM and would always be skipped in forks
+    if: github.repository_owner == 'pybamm-team'
+    name: Build image ({{ matrix.build-args }} / {{ matrix.architectures }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
+        architectures: [amd64, arm64]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: List built images
+      - name: Create tags for Docker images based on build-time arguments
+        id: tags
+        run: |
+          if [ "${{ matrix.build-args }}" = "" ]; then
+            echo "::set-output name=tag::latest" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.build-args }}" = "JAX=true" ]; then
+            echo "::set-output name=tag::jax" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.build-args }}" = "ODES=true" ]; then
+            echo "::set-output name=tag::odes" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.build-args }}" = "IDAKLU=true" ]; then
+            echo "::set-output name=tag::idaklu" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.build-args }}" = "ALL=true" ]; then
+            echo "::set-output name=tag::all" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push Docker image to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: scripts/Dockerfile
+          tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
+          push: false # temporary
+          build-args: ${{ matrix.build-args }}
+          platforms: linux/${{ matrix.architectures }}
+
+      - name: List built image(s)
         run: docker images
-
-      - name: Build and Push Docker Image (Without Solvers)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: scripts/Dockerfile
-          tags: pybamm/pybamm:latest
-          push: true
-
-      - name: Build and Push Docker Image (With JAX Solver)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: scripts/Dockerfile
-          tags: pybamm/pybamm:jax
-          push: true
-          build-args: |
-            JAX=true
-
-      - name: Build and Push Docker Image (With ODES & DAE Solver)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: scripts/Dockerfile
-          tags: pybamm/pybamm:odes
-          push: true
-          build-args: |
-            ODES=true
-
-      - name: Build and Push Docker Image (With IDAKLU Solver)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: scripts/Dockerfile
-          tags: pybamm/pybamm:idaklu
-          push: true
-          build-args: |
-            IDAKLU=true
-
-      - name: Build and Push Docker Image (With All Solvers)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: scripts/Dockerfile
-          tags: pybamm/pybamm:latest
-          push: true
-          build-args: |
-            ALL=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
-      fail-fast: true
+      fail-fast: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
-    if: github.repository_owner == 'pybamm-team'
+    # if: github.repository_owner == 'pybamm-team'
     name: Build image ({{ matrix.build-args }} / {{ matrix.architectures }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,11 +10,11 @@ jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
     # if: github.repository_owner == 'pybamm-team'
-    name: Build image (${{ matrix.build-args }})
+    name: Image (${{ matrix.build-args }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
+        build-args: ["No solvers", "JAX", "ODES", "IDAKLU", "ALL"]
       fail-fast: true
 
     steps:
@@ -36,27 +36,51 @@ jobs:
       - name: Create tags for Docker images based on build-time arguments
         id: tags
         run: |
-          if [ "${{ matrix.build-args }}" = "" ]; then
+          if [ "${{ matrix.build-args }}" = "No solvers" ]; then
             echo "tag=latest" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "JAX=true" ]; then
+          elif [ "${{ matrix.build-args }}" = "JAX" ]; then
             echo "tag=jax" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "ODES=true" ]; then
+          elif [ "${{ matrix.build-args }}" = "ODES" ]; then
             echo "tag=odes" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "IDAKLU=true" ]; then
+          elif [ "${{ matrix.build-args }}" = "IDAKLU" ]; then
             echo "tag=idaklu" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "ALL=true" ]; then
+          elif [ "${{ matrix.build-args }}" = "ALL" ]; then
             echo "tag=all" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build and push Docker image to Docker Hub
+      - name: Build and push Docker image to Docker Hub (no solvers)
+        if: matrix.build-args == 'No solvers'
         uses: docker/build-push-action@v5
         with:
           context: .
           file: scripts/Dockerfile
           tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
           push: true
-          build-args: ${{ matrix.build-args }}
           platforms: linux/amd64, linux/arm64
+
+      - name: Build and push Docker image to Docker Hub (with ODES and IDAKLU solvers)
+        if: matrix.build-args == 'ODES' || matrix.build-args == 'IDAKLU'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: scripts/Dockerfile
+          tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
+          push: true
+          build-args: ${{ matrix.build-args }}=true
+          platforms: linux/amd64, linux/arm64
+
+      - name: Build and push Docker image to Docker Hub (with ALL and JAX solvers)
+        if: matrix.build-args == 'ALL' || matrix.build-args == 'JAX'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: scripts/Dockerfile
+          tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
+          push: true
+          build-args: ${{ matrix.build-args }}=true
+          # exclude arm64 for JAX and ALL builds for now, see
+          # https://github.com/google/jax/issues/13608
+          platforms: linux/amd64
 
       - name: List built image(s)
         run: docker images

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,15 +39,15 @@ jobs:
         id: tags
         run: |
           if [ "${{ matrix.build-args }}" = "" ]; then
-            echo "::set-output name=tag::latest" >> $GITHUB_OUTPUT
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           elif [ "${{ matrix.build-args }}" = "JAX=true" ]; then
-            echo "::set-output name=tag::jax" >> $GITHUB_OUTPUT
+            echo "tag=jax" >> "$GITHUB_OUTPUT"
           elif [ "${{ matrix.build-args }}" = "ODES=true" ]; then
-            echo "::set-output name=tag::odes" >> $GITHUB_OUTPUT
+            echo "tag=odes" >> "$GITHUB_OUTPUT"
           elif [ "${{ matrix.build-args }}" = "IDAKLU=true" ]; then
-            echo "::set-output name=tag::idaklu" >> $GITHUB_OUTPUT
+            echo "tag=idaklu" >> "$GITHUB_OUTPUT"
           elif [ "${{ matrix.build-args }}" = "ALL=true" ]; then
-            echo "::set-output name=tag::all" >> $GITHUB_OUTPUT
+            echo "tag=all" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push Docker image to Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
     - develop
-  # temporary
-  pull_request:
 
 jobs:
   build_docker_images:
@@ -17,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build-args: ["", "JAX=true", "ODES=true", "IDAKLU=true", "ALL=true"]
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - name: Checkout
@@ -56,7 +54,7 @@ jobs:
           context: .
           file: scripts/Dockerfile
           tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
-          push: false # temporary
+          push: true
           build-args: ${{ matrix.build-args }}
           platforms: linux/amd64, linux/arm64
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
     # if: github.repository_owner == 'pybamm-team'
-    name: Build image ({{ matrix.build-args }} / {{ matrix.architectures }})
+    name: Build image ({{ matrix.build-args }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
# Description

This PR uses QEMU to build images for aarch64/arm64 platforms besides amd64, and fixes the error in https://github.com/pybamm-team/PyBaMM/pull/3316#discussion_r1349778849 about an improper tag for one of the images by using a build-matrix setup to create images. Related to #3312.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
