### PR TITLE
Remove notebook outputs from main directory

### DIFF
--- a/docs/source/examples/notebooks/solution-data-and-processed-variables.ipynb
+++ b/docs/source/examples/notebooks/solution-data-and-processed-variables.ipynb
@@ -1,536 +1,557 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# A look at solution data and processed variables"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Once you have run a simulation the first thing you want to do is have a look at the data. Most of the examples so far have made use of PyBaMM's handy QuickPlot function but there are other ways to access the data and this notebook will explore them. First off we will generate a standard SPMe model and use QuickPlot to view the default variables."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Note: you may need to restart the kernel to use updated packages.\n"
-          ]
-        },
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "9ad1d544145646a3ae6c71a74f1dd41d",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "interactive(children=(FloatSlider(value=0.0, description='t', max=3510.0, step=35.1), Output()), _dom_classes=…"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
-        "import pybamm\n",
-        "import numpy as np\n",
-        "import os\n",
-        "import matplotlib.pyplot as plt\n",
-        "os.chdir(pybamm.__path__[0]+'/..')\n",
-        "\n",
-        "# load model\n",
-        "model = pybamm.lithium_ion.SPMe()\n",
-        "\n",
-        "# set up and solve simulation\n",
-        "simulation = pybamm.Simulation(model)\n",
-        "dt = 90\n",
-        "t_eval = np.arange(0, 3600, dt)  # time in seconds\n",
-        "solution = simulation.solve(t_eval)\n",
-        "\n",
-        "quick_plot = pybamm.QuickPlot(solution)\n",
-        "quick_plot.dynamic_plot();"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Behind the scenes the QuickPlot classed has created some processed variables which can interpolate the model variables for our solution and has also stored the results for the solution steps"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "dict_keys(['Negative particle surface concentration [mol.m-3]', 'Electrolyte concentration [mol.m-3]', 'Positive particle surface concentration [mol.m-3]', 'Current [A]', 'Negative electrode potential [V]', 'Electrolyte potential [V]', 'Positive electrode potential [V]', 'Voltage [V]'])"
-            ]
-          },
-          "execution_count": 2,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution.data.keys()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "(20, 40)"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution.data['Negative particle surface concentration [mol.m-3]'].shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "(40,)"
-            ]
-          },
-          "execution_count": 4,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution.t.shape"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Notice that the dictionary keys are in the same order as the subplots in the QuickPlot figure. We can add new processed variables to the solution by simply using it like a dictionary. First let's find a few more variables to look at. As you will see there are quite a few:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "tags": [
-          "outputPrepend"
-        ]
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "['Ambient temperature', 'Ambient temperature [K]', 'Average negative particle concentration', 'Average negative particle concentration [mol.m-3]', 'Average positive particle concentration', 'Average positive particle concentration [mol.m-3]', 'Battery voltage [V]', 'C-rate', 'Cell temperature', 'Cell temperature [K]', 'Change in measured open-circuit voltage', 'Change in measured open-circuit voltage [V]', 'Current [A]', 'Current collector current density', 'Current collector current density [A.m-2]', 'Discharge capacity [A.h]', 'Electrode current density', 'Electrode tortuosity', 'Electrolyte concentration', 'Electrolyte concentration [Molar]', 'Electrolyte concentration [mol.m-3]', 'Electrolyte current density', 'Electrolyte current density [A.m-2]', 'Electrolyte flux', 'Electrolyte flux [mol.m-2.s-1]', 'Electrolyte potential', 'Electrolyte potential [V]', 'Electrolyte tortuosity', 'Exchange current density', 'Exchange current density [A.m-2]', 'Exchange current density per volume [A.m-3]', 'Gradient of electrolyte potential', 'Gradient of negative electrode potential', 'Gradient of negative electrolyte potential', 'Gradient of positive electrode potential', 'Gradient of positive electrolyte potential', 'Gradient of separator electrolyte potential', 'Inner SEI concentration [mol.m-3]', 'Inner SEI interfacial current density', 'Inner SEI interfacial current density [A.m-2]', 'Inner SEI thickness', 'Inner SEI thickness [m]', 'Inner positive electrode SEI concentration [mol.m-3]', 'Inner positive electrode SEI interfacial current density', 'Inner positive electrode SEI interfacial current density [A.m-2]', 'Inner positive electrode SEI thickness', 'Inner positive electrode SEI thickness [m]', 'Interfacial current density', 'Interfacial current density [A.m-2]', 'Interfacial current density per volume [A.m-3]', 'Irreversible electrochemical heating', 'Irreversible electrochemical heating [W.m-3]', 'Leading-order current collector current density', 'Leading-order electrode tortuosity', 'Leading-order electrolyte tortuosity', 'Leading-order negative electrode porosity', 'Leading-order negative electrode tortuosity', 'Leading-order negative electrolyte tortuosity', 'Leading-order porosity', 'Leading-order positive electrode porosity', 'Leading-order positive electrode tortuosity', 'Leading-order positive electrolyte tortuosity', 'Leading-order separator porosity', 'Leading-order separator tortuosity', 'Leading-order x-averaged negative electrode porosity', 'Leading-order x-averaged negative electrode porosity change', 'Leading-order x-averaged negative electrode tortuosity', 'Leading-order x-averaged negative electrolyte tortuosity', 'Leading-order x-averaged positive electrode porosity', 'Leading-order x-averaged positive electrode porosity change', 'Leading-order x-averaged positive electrode tortuosity', 'Leading-order x-averaged positive electrolyte tortuosity', 'Leading-order x-averaged separator porosity', 'Leading-order x-averaged separator porosity change', 'Leading-order x-averaged separator tortuosity', 'Local ECM resistance', 'Local ECM resistance [Ohm]', 'Local voltage', 'Local voltage [V]', 'Loss of lithium to SEI [mol]', 'Loss of lithium to positive electrode SEI [mol]', 'Maximum negative particle concentration', 'Maximum negative particle concentration [mol.m-3]', 'Maximum negative particle surface concentration', 'Maximum negative particle surface concentration [mol.m-3]', 'Maximum positive particle concentration', 'Maximum positive particle concentration [mol.m-3]', 'Maximum positive particle surface concentration', 'Maximum positive particle surface concentration [mol.m-3]', 'Measured battery open-circuit voltage [V]', 'Measured open-circuit voltage', 'Measured open-circuit voltage [V]', 'Minimum negative particle concentration', 'Minimum negative particle concentration [mol.m-3]', 'Minimum negative particle surface concentration', 'Minimum negative particle surface concentration [mol.m-3]', 'Minimum positive particle concentration', 'Minimum positive particle concentration [mol.m-3]', 'Minimum positive particle surface concentration', 'Minimum positive particle surface concentration [mol.m-3]', 'Negative current collector potential', 'Negative current collector potential [V]', 'Negative current collector temperature', 'Negative current collector temperature [K]', 'Negative electrode active material volume fraction', 'Negative electrode active material volume fraction change', 'Negative electrode current density', 'Negative electrode current density [A.m-2]', 'Negative electrode entropic change', 'Negative electrode exchange current density', 'Negative electrode exchange current density [A.m-2]', 'Negative electrode exchange current density per volume [A.m-3]', 'Negative electrode extent of lithiation', 'Negative electrode interfacial current density', 'Negative electrode interfacial current density [A.m-2]', 'Negative electrode interfacial current density per volume [A.m-3]', 'Negative electrode ohmic losses', 'Negative electrode ohmic losses [V]', 'Negative electrode open-circuit potential', 'Negative electrode open-circuit potential [V]', 'Negative electrode oxygen exchange current density', 'Negative electrode oxygen exchange current density [A.m-2]', 'Negative electrode oxygen exchange current density per volume [A.m-3]', 'Negative electrode oxygen interfacial current density', 'Negative electrode oxygen interfacial current density [A.m-2]', 'Negative electrode oxygen interfacial current density per volume [A.m-3]', 'Negative electrode oxygen open-circuit potential', 'Negative electrode oxygen open-circuit potential [V]', 'Negative electrode oxygen reaction overpotential', 'Negative electrode oxygen reaction overpotential [V]', 'Negative electrode porosity', 'Negative electrode porosity change', 'Negative electrode potential', 'Negative electrode potential [V]', 'Negative electrode pressure', 'Negative electrode reaction overpotential', 'Negative electrode reaction overpotential [V]', 'SEI film overpotential', 'SEI film overpotential [V]', 'SEI interfacial current density', 'SEI interfacial current density [A.m-2]', 'Negative electrode surface area to volume ratio', 'Negative electrode surface area to volume ratio [m-1]', 'Negative electrode surface potential difference', 'Negative electrode surface potential difference [V]', 'Negative electrode temperature', 'Negative electrode temperature [K]', 'Negative electrode tortuosity', 'Negative electrode transverse volume-averaged acceleration', 'Negative electrode transverse volume-averaged acceleration [m.s-2]', 'Negative electrode transverse volume-averaged velocity', 'Negative electrode transverse volume-averaged velocity [m.s-2]', 'Negative electrode volume-averaged acceleration', 'Negative electrode volume-averaged acceleration [m.s-1]', 'Negative electrode volume-averaged concentration', 'Negative electrode volume-averaged concentration [mol.m-3]', 'Negative electrode volume-averaged velocity', 'Negative electrode volume-averaged velocity [m.s-1]', 'Negative electrolyte concentration', 'Negative electrolyte concentration [Molar]', 'Negative electrolyte concentration [mol.m-3]', 'Negative electrolyte current density', 'Negative electrolyte current density [A.m-2]', 'Negative electrolyte potential', 'Negative electrolyte potential [V]', 'Negative electrolyte tortuosity', 'Negative particle concentration', 'Negative particle concentration [mol.m-3]', 'Negative particle flux', 'Negative particle radius', 'Negative particle radius [m]', 'Negative particle surface concentration', 'Negative particle surface concentration [mol.m-3]', 'Negative SEI concentration [mol.m-3]', 'Ohmic heating', 'Ohmic heating [W.m-3]', 'Outer SEI concentration [mol.m-3]', 'Outer SEI interfacial current density', 'Outer SEI interfacial current density [A.m-2]', 'Outer SEI thickness', 'Outer SEI thickness [m]', 'Outer positive electrode SEI concentration [mol.m-3]', 'Outer positive electrode SEI interfacial current density', 'Outer positive electrode SEI interfacial current density [A.m-2]', 'Outer positive electrode SEI thickness', 'Outer positive electrode SEI thickness [m]', 'Oxygen exchange current density', 'Oxygen exchange current density [A.m-2]', 'Oxygen exchange current density per volume [A.m-3]', 'Oxygen interfacial current density', 'Oxygen interfacial current density [A.m-2]', 'Oxygen interfacial current density per volume [A.m-3]', 'Porosity', 'Porosity change', 'Positive current collector potential', 'Positive current collector potential [V]', 'Positive current collector temperature', 'Positive current collector temperature [K]', 'Positive electrode active material volume fraction', 'Positive electrode active material volume fraction change', 'Positive electrode current density', 'Positive electrode current density [A.m-2]', 'Positive electrode entropic change', 'Positive electrode exchange current density', 'Positive electrode exchange current density [A.m-2]', 'Positive electrode exchange current density per volume [A.m-3]', 'Positive electrode extent of lithiation', 'Positive electrode interfacial current density', 'Positive electrode interfacial current density [A.m-2]', 'Positive electrode interfacial current density per volume [A.m-3]', 'Positive electrode ohmic losses', 'Positive electrode ohmic losses [V]', 'Positive electrode open-circuit potential', 'Positive electrode open-circuit potential [V]', 'Positive electrode oxygen exchange current density', 'Positive electrode oxygen exchange current density [A.m-2]', 'Positive electrode oxygen exchange current density per volume [A.m-3]', 'Positive electrode oxygen interfacial current density', 'Positive electrode oxygen interfacial current density [A.m-2]', 'Positive electrode oxygen interfacial current density per volume [A.m-3]', 'Positive electrode oxygen open-circuit potential', 'Positive electrode oxygen open-circuit potential [V]', 'Positive electrode oxygen reaction overpotential', 'Positive electrode oxygen reaction overpotential [V]', 'Positive electrode porosity', 'Positive electrode porosity change', 'Positive electrode potential', 'Positive electrode potential [V]', 'Positive electrode pressure', 'Positive electrode reaction overpotential', 'Positive electrode reaction overpotential [V]', 'Positive electrode SEI film overpotential', 'Positive electrode SEI film overpotential [V]', 'Positive electrode SEI interfacial current density', 'Positive electrode SEI interfacial current density [A.m-2]', 'Positive electrode surface area to volume ratio', 'Positive electrode surface area to volume ratio [m-1]', 'Positive electrode surface potential difference', 'Positive electrode surface potential difference [V]', 'Positive electrode temperature', 'Positive electrode temperature [K]', 'Positive electrode tortuosity', 'Positive electrode transverse volume-averaged acceleration', 'Positive electrode transverse volume-averaged acceleration [m.s-2]', 'Positive electrode transverse volume-averaged velocity', 'Positive electrode transverse volume-averaged velocity [m.s-2]', 'Positive electrode volume-averaged acceleration', 'Positive electrode volume-averaged acceleration [m.s-1]', 'Positive electrode volume-averaged concentration', 'Positive electrode volume-averaged concentration [mol.m-3]', 'Positive electrode volume-averaged velocity', 'Positive electrode volume-averaged velocity [m.s-1]', 'Positive electrolyte concentration', 'Positive electrolyte concentration [Molar]', 'Positive electrolyte concentration [mol.m-3]', 'Positive electrolyte current density', 'Positive electrolyte current density [A.m-2]', 'Positive electrolyte potential', 'Positive electrolyte potential [V]', 'Positive electrolyte tortuosity', 'Positive particle concentration', 'Positive particle concentration [mol.m-3]', 'Positive particle flux', 'Positive particle radius', 'Positive particle radius [m]', 'Positive particle surface concentration', 'Positive particle surface concentration [mol.m-3]', 'Positive SEI concentration [mol.m-3]', 'Pressure', 'R-averaged negative particle concentration', 'R-averaged negative particle concentration [mol.m-3]', 'R-averaged positive particle concentration', 'R-averaged positive particle concentration [mol.m-3]', 'Reversible heating', 'Reversible heating [W.m-3]', 'Sei interfacial current density', 'Sei interfacial current density [A.m-2]', 'Sei interfacial current density per volume [A.m-3]', 'Separator electrolyte concentration', 'Separator electrolyte concentration [Molar]', 'Separator electrolyte concentration [mol.m-3]', 'Separator electrolyte potential', 'Separator electrolyte potential [V]', 'Separator porosity', 'Separator porosity change', 'Separator pressure', 'Separator temperature', 'Separator temperature [K]', 'Separator tortuosity', 'Separator transverse volume-averaged acceleration', 'Separator transverse volume-averaged acceleration [m.s-2]', 'Separator transverse volume-averaged velocity', 'Separator transverse volume-averaged velocity [m.s-2]', 'Separator volume-averaged acceleration', 'Separator volume-averaged acceleration [m.s-1]', 'Separator volume-averaged velocity', 'Separator volume-averaged velocity [m.s-1]', 'Sum of electrolyte reaction source terms', 'Sum of interfacial current densities', 'Sum of negative electrode electrolyte reaction source terms', 'Sum of negative electrode interfacial current densities', 'Sum of positive electrode electrolyte reaction source terms', 'Sum of positive electrode interfacial current densities', 'Sum of x-averaged negative electrode electrolyte reaction source terms', 'Sum of x-averaged negative electrode interfacial current densities', 'Sum of x-averaged positive electrode electrolyte reaction source terms', 'Sum of x-averaged positive electrode interfacial current densities', 'Terminal power [W]', 'Voltage', 'Voltage [V]', 'Time', 'Time [h]', 'Time [min]', 'Time [s]', 'Total concentration in electrolyte [mol]', 'Total current density', 'Total current density [A.m-2]', 'Total heating', 'Total heating [W.m-3]', 'Total lithium in negative electrode [mol]', 'Total lithium in positive electrode [mol]', 'Total SEI thickness', 'Total SEI thickness [m]', 'Total positive electrode SEI thickness', 'Total positive electrode SEI thickness [m]', 'Transverse volume-averaged acceleration', 'Transverse volume-averaged acceleration [m.s-2]', 'Transverse volume-averaged velocity', 'Transverse volume-averaged velocity [m.s-2]', 'Volume-averaged Ohmic heating', 'Volume-averaged Ohmic heating [W.m-3]', 'Volume-averaged acceleration', 'Volume-averaged acceleration [m.s-1]', 'Volume-averaged cell temperature', 'Volume-averaged cell temperature [K]', 'Volume-averaged irreversible electrochemical heating', 'Volume-averaged irreversible electrochemical heating[W.m-3]', 'Volume-averaged reversible heating', 'Volume-averaged reversible heating [W.m-3]', 'Volume-averaged total heating', 'Volume-averaged total heating [W.m-3]', 'Volume-averaged velocity', 'Volume-averaged velocity [m.s-1]', 'X-averaged Ohmic heating', 'X-averaged Ohmic heating [W.m-3]', 'X-averaged battery concentration overpotential [V]', 'X-averaged battery electrolyte ohmic losses [V]', 'X-averaged battery open-circuit voltage [V]', 'X-averaged battery reaction overpotential [V]', 'X-averaged battery solid phase ohmic losses [V]', 'X-averaged cell temperature', 'X-averaged cell temperature [K]', 'X-averaged concentration overpotential', 'X-averaged concentration overpotential [V]', 'X-averaged electrolyte concentration', 'X-averaged electrolyte concentration [Molar]', 'X-averaged electrolyte concentration [mol.m-3]', 'X-averaged electrolyte ohmic losses', 'X-averaged electrolyte ohmic losses [V]', 'X-averaged electrolyte overpotential', 'X-averaged electrolyte overpotential [V]', 'X-averaged electrolyte potential', 'X-averaged electrolyte potential [V]', 'X-averaged inner SEI concentration [mol.m-3]', 'X-averaged inner SEI interfacial current density', 'X-averaged inner SEI interfacial current density [A.m-2]', 'X-averaged inner SEI thickness', 'X-averaged inner SEI thickness [m]', 'X-averaged inner positive electrode SEI concentration [mol.m-3]', 'X-averaged inner positive electrode SEI interfacial current density', 'X-averaged inner positive electrode SEI interfacial current density [A.m-2]', 'X-averaged inner positive electrode SEI thickness', 'X-averaged inner positive electrode SEI thickness [m]', 'X-averaged irreversible electrochemical heating', 'X-averaged irreversible electrochemical heating [W.m-3]', 'X-averaged negative electrode active material volume fraction', 'X-averaged negative electrode active material volume fraction change', 'X-averaged negative electrode entropic change', 'X-averaged negative electrode exchange current density', 'X-averaged negative electrode exchange current density [A.m-2]', 'X-averaged negative electrode exchange current density per volume [A.m-3]', 'X-averaged negative electrode extent of lithiation', 'X-averaged negative electrode interfacial current density', 'X-averaged negative electrode interfacial current density [A.m-2]', 'X-averaged negative electrode interfacial current density per volume [A.m-3]', 'X-averaged negative electrode ohmic losses', 'X-averaged negative electrode ohmic losses [V]', 'X-averaged negative electrode open-circuit potential', 'X-averaged negative electrode open-circuit potential [V]', 'X-averaged negative electrode oxygen exchange current density', 'X-averaged negative electrode oxygen exchange current density [A.m-2]', 'X-averaged negative electrode oxygen exchange current density per volume [A.m-3]', 'X-averaged negative electrode oxygen interfacial current density', 'X-averaged negative electrode oxygen interfacial current density [A.m-2]', 'X-averaged negative electrode oxygen interfacial current density per volume [A.m-3]', 'X-averaged negative electrode oxygen open-circuit potential', 'X-averaged negative electrode oxygen open-circuit potential [V]', 'X-averaged negative electrode oxygen reaction overpotential', 'X-averaged negative electrode oxygen reaction overpotential [V]', 'X-averaged negative electrode porosity', 'X-averaged negative electrode porosity change', 'X-averaged negative electrode potential', 'X-averaged negative electrode potential [V]', 'X-averaged negative electrode pressure', 'X-averaged negative electrode reaction overpotential', 'X-averaged negative electrode reaction overpotential [V]', 'X-averaged negative electrode resistance [Ohm.m2]', 'X-averaged SEI concentration [mol.m-3]', 'X-averaged SEI film overpotential', 'X-averaged SEI film overpotential [V]', 'X-averaged SEI interfacial current density', 'X-averaged SEI interfacial current density [A.m-2]', 'X-averaged negative electrode surface area to volume ratio', 'X-averaged negative electrode surface area to volume ratio [m-1]', 'X-averaged negative electrode surface potential difference', 'X-averaged negative electrode surface potential difference [V]', 'X-averaged negative electrode temperature', 'X-averaged negative electrode temperature [K]', 'X-averaged negative electrode tortuosity', 'X-averaged negative electrode total interfacial current density', 'X-averaged negative electrode total interfacial current density [A.m-2]', 'X-averaged negative electrode total interfacial current density per volume [A.m-3]', 'X-averaged negative electrode transverse volume-averaged acceleration', 'X-averaged negative electrode transverse volume-averaged acceleration [m.s-2]', 'X-averaged negative electrode transverse volume-averaged velocity', 'X-averaged negative electrode transverse volume-averaged velocity [m.s-2]', 'X-averaged negative electrode volume-averaged acceleration', 'X-averaged negative electrode volume-averaged acceleration [m.s-1]', 'X-averaged negative electrolyte concentration', 'X-averaged negative electrolyte concentration [mol.m-3]', 'X-averaged negative electrolyte potential', 'X-averaged negative electrolyte potential [V]', 'X-averaged negative electrolyte tortuosity', 'X-averaged negative particle concentration', 'X-averaged negative particle concentration [mol.m-3]', 'X-averaged negative particle flux', 'X-averaged negative particle surface concentration', 'X-averaged negative particle surface concentration [mol.m-3]', 'X-averaged open-circuit voltage', 'X-averaged open-circuit voltage [V]', 'X-averaged outer SEI concentration [mol.m-3]', 'X-averaged outer SEI interfacial current density', 'X-averaged outer SEI interfacial current density [A.m-2]', 'X-averaged outer SEI thickness', 'X-averaged outer SEI thickness [m]', 'X-averaged outer positive electrode SEI concentration [mol.m-3]', 'X-averaged outer positive electrode SEI interfacial current density', 'X-averaged outer positive electrode SEI interfacial current density [A.m-2]', 'X-averaged outer positive electrode SEI thickness', 'X-averaged outer positive electrode SEI thickness [m]', 'X-averaged positive electrode active material volume fraction', 'X-averaged positive electrode active material volume fraction change', 'X-averaged positive electrode entropic change', 'X-averaged positive electrode exchange current density', 'X-averaged positive electrode exchange current density [A.m-2]', 'X-averaged positive electrode exchange current density per volume [A.m-3]', 'X-averaged positive electrode extent of lithiation', 'X-averaged positive electrode interfacial current density', 'X-averaged positive electrode interfacial current density [A.m-2]', 'X-averaged positive electrode interfacial current density per volume [A.m-3]', 'X-averaged positive electrode ohmic losses', 'X-averaged positive electrode ohmic losses [V]', 'X-averaged positive electrode open-circuit potential', 'X-averaged positive electrode open-circuit potential [V]', 'X-averaged positive electrode oxygen exchange current density', 'X-averaged positive electrode oxygen exchange current density [A.m-2]', 'X-averaged positive electrode oxygen exchange current density per volume [A.m-3]', 'X-averaged positive electrode oxygen interfacial current density', 'X-averaged positive electrode oxygen interfacial current density [A.m-2]', 'X-averaged positive electrode oxygen interfacial current density per volume [A.m-3]', 'X-averaged positive electrode oxygen open-circuit potential', 'X-averaged positive electrode oxygen open-circuit potential [V]', 'X-averaged positive electrode oxygen reaction overpotential', 'X-averaged positive electrode oxygen reaction overpotential [V]', 'X-averaged positive electrode porosity', 'X-averaged positive electrode porosity change', 'X-averaged positive electrode potential', 'X-averaged positive electrode potential [V]', 'X-averaged positive electrode pressure', 'X-averaged positive electrode reaction overpotential', 'X-averaged positive electrode reaction overpotential [V]', 'X-averaged positive electrode resistance [Ohm.m2]', 'X-averaged positive electrode SEI concentration [mol.m-3]', 'X-averaged positive electrode SEI film overpotential', 'X-averaged positive electrode SEI film overpotential [V]', 'X-averaged positive electrode SEI interfacial current density', 'X-averaged positive electrode SEI interfacial current density [A.m-2]', 'X-averaged positive electrode surface area to volume ratio', 'X-averaged positive electrode surface area to volume ratio [m-1]', 'X-averaged positive electrode surface potential difference', 'X-averaged positive electrode surface potential difference [V]', 'X-averaged positive electrode temperature', 'X-averaged positive electrode temperature [K]', 'X-averaged positive electrode tortuosity', 'X-averaged positive electrode total interfacial current density', 'X-averaged positive electrode total interfacial current density [A.m-2]', 'X-averaged positive electrode total interfacial current density per volume [A.m-3]', 'X-averaged positive electrode transverse volume-averaged acceleration', 'X-averaged positive electrode transverse volume-averaged acceleration [m.s-2]', 'X-averaged positive electrode transverse volume-averaged velocity', 'X-averaged positive electrode transverse volume-averaged velocity [m.s-2]', 'X-averaged positive electrode volume-averaged acceleration', 'X-averaged positive electrode volume-averaged acceleration [m.s-1]', 'X-averaged positive electrolyte concentration', 'X-averaged positive electrolyte concentration [mol.m-3]', 'X-averaged positive electrolyte potential', 'X-averaged positive electrolyte potential [V]', 'X-averaged positive electrolyte tortuosity', 'X-averaged positive particle concentration', 'X-averaged positive particle concentration [mol.m-3]', 'X-averaged positive particle flux', 'X-averaged positive particle surface concentration', 'X-averaged positive particle surface concentration [mol.m-3]', 'X-averaged reaction overpotential', 'X-averaged reaction overpotential [V]', 'X-averaged reversible heating', 'X-averaged reversible heating [W.m-3]', 'X-averaged SEI film overpotential', 'X-averaged SEI film overpotential [V]', 'X-averaged separator electrolyte concentration', 'X-averaged separator electrolyte concentration [mol.m-3]', 'X-averaged separator electrolyte potential', 'X-averaged separator electrolyte potential [V]', 'X-averaged separator porosity', 'X-averaged separator porosity change', 'X-averaged separator pressure', 'X-averaged separator temperature', 'X-averaged separator temperature [K]', 'X-averaged separator tortuosity', 'X-averaged separator transverse volume-averaged acceleration', 'X-averaged separator transverse volume-averaged acceleration [m.s-2]', 'X-averaged separator transverse volume-averaged velocity', 'X-averaged separator transverse volume-averaged velocity [m.s-2]', 'X-averaged separator volume-averaged acceleration', 'X-averaged separator volume-averaged acceleration [m.s-1]', 'X-averaged solid phase ohmic losses', 'X-averaged solid phase ohmic losses [V]', 'X-averaged total heating', 'X-averaged total heating [W.m-3]', 'X-averaged total SEI thickness', 'X-averaged total SEI thickness [m]', 'X-averaged total positive electrode SEI thickness', 'X-averaged total positive electrode SEI thickness [m]', 'X-averaged volume-averaged acceleration', 'X-averaged volume-averaged acceleration [m.s-1]', 'r_n', 'r_n [m]', 'r_p', 'r_p [m]', 'x', 'x [m]', 'x_n', 'x_n [m]', 'x_p', 'x_p [m]', 'x_s', 'x_s [m]']\n"
-          ]
-        }
-      ],
-      "source": [
-        "keys = list(model.variables.keys())\n",
-        "keys.sort()\n",
-        "print(keys)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "If you want to find a particular variable you can search the variables dictionary"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Time\n",
-            "Time [h]\n",
-            "Time [min]\n",
-            "Time [s]\n"
-          ]
-        }
-      ],
-      "source": [
-        "model.variables.search(\"time\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We'll use the time in hours"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "<pybamm.solvers.processed_variable.ProcessedVariable at 0x7f69966b6210>"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution['Time [h]']"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "This created a new processed variable and stored it on the solution object"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "dict_keys(['Negative particle surface concentration [mol.m-3]', 'Electrolyte concentration [mol.m-3]', 'Positive particle surface concentration [mol.m-3]', 'Current [A]', 'Negative electrode potential [V]', 'Electrolyte potential [V]', 'Positive electrode potential [V]', 'Voltage [V]', 'Time [h]'])"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution.data.keys()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can see the data by simply accessing the entries attribute of the processed variable"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "array([0.   , 0.025, 0.05 , 0.075, 0.1  , 0.125, 0.15 , 0.175, 0.2  ,\n",
-              "       0.225, 0.25 , 0.275, 0.3  , 0.325, 0.35 , 0.375, 0.4  , 0.425,\n",
-              "       0.45 , 0.475, 0.5  , 0.525, 0.55 , 0.575, 0.6  , 0.625, 0.65 ,\n",
-              "       0.675, 0.7  , 0.725, 0.75 , 0.775, 0.8  , 0.825, 0.85 , 0.875,\n",
-              "       0.9  , 0.925, 0.95 , 0.975])"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution['Time [h]'].entries"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can also call the method with specified time(s) in SI units of seconds"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "time_in_seconds = np.array([0, 600, 900, 1700, 3000 ])"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "array([0.        , 0.16666667, 0.25      , 0.47222222, 0.83333333])"
-            ]
-          },
-          "execution_count": 11,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "solution['Time [h]'](time_in_seconds)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "If the variable has not already been processed it will be created behind the scenes"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "array([298.15, 298.15, 298.15, 298.15, 298.15])"
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "var = 'X-averaged negative electrode temperature [K]'\n",
-        "solution[var](time_in_seconds)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "In this example the simulation was isothermal, so the temperature remains unchanged."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Saving the solution\n",
-        "\n",
-        "The solution can be saved in a number of ways:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# to a pickle file (default)\n",
-        "solution.save_data(\n",
-        "    \"outputs.pickle\", [\"Time [h]\", \"Current [A]\", \"Voltage [V]\", \"Electrolyte concentration [mol.m-3]\"]\n",
-        ")\n",
-        "# to a matlab file\n",
-        "# need to give variable names without space\n",
-        "solution.save_data(\n",
-        "    \"outputs.mat\", \n",
-        "    [\"Time [h]\", \"Current [A]\", \"Voltage [V]\", \"Electrolyte concentration [mol.m-3]\"], \n",
-        "    to_format=\"matlab\",\n",
-        "    short_names={\n",
-        "        \"Time [h]\": \"t\", \"Current [A]\": \"I\", \"Voltage [V]\": \"V\", \"Electrolyte concentration [mol.m-3]\": \"c_e\",\n",
-        "    }\n",
-        ")\n",
-        "# to a csv file (time-dependent outputs only, no spatial dependence allowed)\n",
-        "solution.save_data(\n",
-        "    \"outputs.csv\", [\"Time [h]\", \"Current [A]\", \"Voltage [V]\"], to_format=\"csv\"\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Stepping the solver\n",
-        "\n",
-        "The previous solution was created in one go with the solve method, but it is also possible to step the solution and look at the results as we go. In doing so, the results are automatically updated at each step."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Time 0\n",
-            "[3.77047806 3.71250693]\n",
-            "Time 360\n",
-            "[3.77047806 3.71250693 3.68215218]\n",
-            "Time 720\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574]\n",
-            "Time 1080\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942]\n",
-            "Time 1440\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857]\n",
-            "Time 1800\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
-            " 3.59709451]\n",
-            "Time 2160\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
-            " 3.59709451 3.58821334]\n",
-            "Time 2520\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
-            " 3.59709451 3.58821334 3.58056055]\n",
-            "Time 2880\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
-            " 3.59709451 3.58821334 3.58056055 3.55158694]\n",
-            "Time 3240\n",
-            "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
-            " 3.59709451 3.58821334 3.58056055 3.55158694 3.16842636]\n"
-          ]
-        }
-      ],
-      "source": [
-        "dt = 360\n",
-        "time = 0\n",
-        "end_time = solution[\"Time [s]\"].entries[-1]\n",
-        "step_simulation = pybamm.Simulation(model)\n",
-        "while time < end_time:\n",
-        "    step_solution = step_simulation.step(dt)\n",
-        "    print('Time', time)\n",
-        "    print(step_solution[\"Voltage [V]\"].entries)\n",
-        "    time += dt"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can plot the voltages and see that the solutions are the same"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "<matplotlib.legend.Legend at 0x7f69964178d0>"
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAp9ElEQVR4nO3de3xU1bn/8c+TcBcUlaBcTCIFrQghQkRUIhdRqXjwyq2hgrXiHY9WWpUeKxZ+R62tPVpPlfZU0MYCWtsiWkUrCKKAgFy8ICggcpGbgIKCkDy/P1YSkjAhE5hkksn3/Xrt18zee83sZ5PhmTVrr72WuTsiIlLzJcU7ABERiQ0ldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQ5SZ0M2tgZvPNbImZfWBmYyKUSTWzGWb2npktNbOLKydcEREpi5XXD93MDDjK3XeZWV3gLeA2d59brMx44D13/4OZtQdedvf0SoxbRERKqVNeAQ8Zf1fBat2CpfS3gANHFzw/BtgQqwBFRCQ65dbQAcwsGVgItAUed/efl9rfApgOHAscBfRx94WHes9mzZp5enr6YYYtIlI7LVy4cKu7p0TaV24NHcDd84BMM2sK/N3MOrj7+8WKDAEmuPtvzOxs4JmCMvnF38fMRgAjAFJTU1mwYMFhnI6ISO1lZp+Vta9CvVzcfQcwA+hbate1wJSCMu8ADYBmEV4/3t2z3D0rJSXiF4yIiBymaHq5pBTUzDGzhsAFwPJSxdYC5xeUOY2Q0LfENFIRETmkaJpcWgATC9rRk4Ap7j7NzO4HFrj7VOCnwB/N7HbCBdLhrmEcRUSqVDS9XJYCZ0TYfm+x5x8C58Y2NJHqY9++faxbt449e/bEOxSpJRo0aEDr1q2pW7du1K+J6qKoSG23bt06mjRpQnp6OuHWDJHK4+5s27aNdevWcfLJJ0f9upp1639uLqSnQ1JSeMzNjXdEUkvs2bOH448/XslcqoSZcfzxx1f4F2HNqaHn5sKIEfDNN2H9s8/COkBOTvziklpDyVyq0uF83mpODX306APJvNA334TtIiJSgxL62rUV2y4iUsvUnISemlqx7SIJZty4cZx++ulkZGSQmZnJvHnzAOjZsyennnoqnTp14txzz+Xjjz8u2p6amkrxHsSXXXYZjRs3rtBx3Z3evXvz1Vdfxexc1qxZw7PPPlu0vmDBAkaOHBmz969qw4cP5/nnnz+s1w4ePJiVK1fGJI6ak9DHjYNGjUps2k0jPrlmXJwCEqk677zzDtOmTWPRokUsXbqU119/nZNOOqlof25uLkuWLGHYsGGMGjWqaHvTpk2ZM2cOADt27GDjxo0VPvbLL79Mp06dOProo8svHKXSCT0rK4tHH300Zu9fk9x444089NBDMXmvmpPQc3Jg/HhISwMz8lqnMbrZeM793xw+K3NkA5HY+8//hJ49Y7v8538e+pgbN26kWbNm1K9fH4BmzZrRsmXLg8qdd955fPLJJ0XrgwcPZtKkSQC88MILXHHFFSXK//rXv+bMM88kIyODX/7ylxGPnZuby6WXXlq0/vTTT5ORkUGnTp340Y9+BIQE3bt3bzIyMjj//PNZW9AUOnz4cEaOHMk555xDmzZtimqxd911F7NnzyYzM5NHHnmEmTNncskllwBw33338eMf/5iePXvSpk2bokS/Zs0aOnToUBTHww8/zH333QfA4sWL6datGxkZGVx++eVs374dCL9SCseM2rp1K4UDAn7wwQd07dqVzMxMMjIyDqoh5+XlMXz4cDp06EDHjh155JFHDnmcQq+88goDBgwoWi9+XtOnT+fss8+mc+fODBgwgF27wiC22dnZvP766+zfvz/iv39F1JyEDiGpr1kD+fkkf76GEW/msGcP/Md/wNdfxzs4kcpz4YUX8vnnn3PKKadw00038eabb0Ys9+KLL9KxY8ei9fPPP59Zs2aRl5fHpEmTGDRoUNG+6dOns3LlSubPn8/ixYtZuHAhs2bNOug958yZQ5cuXYCQCMeOHcsbb7zBkiVL+J//+R8Abr31VoYNG8bSpUvJyckp0XyyceNG3nrrLaZNm8Zdd90FwAMPPEB2djaLFy/m9ttvP+iYy5cv59VXX2X+/PmMGTOGffv2HfLf5+qrr+bBBx9k6dKldOzYkTFjDpqHp4QnnniC2267jcWLF7NgwQJat25dYv/ixYtZv34977//PsuWLeOaa66J6jh9+vRh3rx57N69G4DJkyczePBgtm7dytixY3n99ddZtGgRWVlZ/Pa3vwUgKSmJtm3bsmTJkkPGHI2a020xgvbt4bnn4OKLYcgQ+Oc/ITk53lFJovvd76r+mI0bN2bhwoXMnj2bGTNmMGjQIB544AGGDx8OQE5ODg0bNiQ9PZ3HHnus6HXJycl0796dSZMm8e2331J8yOrp06czffp0zjgj3Ai+a9cuVq5cyXnnnVfi2F9++SVNmjQB4I033mDAgAE0axbG3jvuuOOA0CT0wgsvAPCjH/2In/3sZ0Wvv+yyy0hKSqJ9+/Zs2rQpqvPt168f9evXp379+jRv3vyQr9u5cyc7duygR48eAAwbNqxELTmSs88+m3HjxrFu3TquuOIK2rVrV2J/mzZtWLVqFbfeeiv9+vXjwgsvjOo4derUoW/fvrz44otcddVVvPTSSzz00EO8+eabfPjhh5x7brih/rvvvuPss88uel3z5s3ZsGFD0Rfn4arRCR3gwgvhscfgpptg1Cgo+NITSTjJycn07NmTnj170rFjRyZOnFiU0HNzc8nKyor4usGDB3P55ZcXNU8Ucnfuvvturr/++kMet06dOuTn55OUdHg/6AubiQqPWdHXJCcns3///qI4CkVz003x1xQv/8Mf/pCzzjqLl156iYsvvpgnn3yS3r17F+0/9thjWbJkCa+++ipPPPEEU6ZMKWp2Kc/gwYP5/e9/z3HHHUdWVhZNmjTB3bngggv461//GvE1e/bsoWHDhlG9/6HUrCaXMtx4I4wcCY88Ak8+Ge9oRGLv448/LtHOu3jxYtLS0qJ6bXZ2NnfffTdDhgwpsf2iiy7iz3/+c1Fb7vr169m8efNBrz/11FNZtWoVAL179+a5555j27ZtQKi9A5xzzjlFbfW5ublkZ2cfMqYmTZrwdQXbSU844QQ2b97Mtm3b2Lt3L9OmTQPgmGOO4dhjj2X27NkAPPPMM0W16PT0dBYuDHPtFO+FsmrVKtq0acPIkSO59NJLWbp0aYljbd26lfz8fK688krGjh3LokWLDnmc4nr06MGiRYv44x//yODBgwHo1q0bc+bMKbq+sXv3blasWFH0mhUrVpS4PnC4anwNvdBvfgMrV8LNN8Oxx8KAAaAb+yRR7Nq1i1tvvZUdO3ZQp04d2rZty/jx46N6rZlx5513HrT9wgsv5KOPPir66d+4cWP+8pe/0Lx58xLl+vXrx8yZM2nbti2nn346o0ePpkePHiQnJ3PGGWcwYcIEHnvsMa655hp+/etfk5KSwlNPPXXImDIyMkhOTqZTp04MHz68qNnnUOrWrcu9995L165dadWqFd///veL9k2cOJEbbriBb775hjZt2hQd/84772TgwIGMHz+efv36FZWfMmUKzzzzDHXr1uXEE0/knnvuKXGs9evXc8011xTV7v/7v//7kMcpLjk5mUsuuYQJEyYwceJEAFJSUpgwYQJDhgxh7969AIwdO5ZTTjmFTZs20bBhQ0488cRy/w3KE9UUdJUhKyvLYz1j0VdfQY8esHgxdO4Mv/gFXHppGPpF5Eh89NFHnHbaafEOIy42btzI1VdfzWuvvRbvUBLSI488wtFHH82111570L5InzszW+juEdvXEirVHX00zJsHf/oT7NwJV1wBnTrB5MmQlxfv6ERqphYtWnDdddfF9MYiOaBp06YMGzYsJu+VUAkdoF49uPZaWL4cnnkG9u+HwYPh9NPh6afDuohUzMCBA2N6Y5EccM0111CnTmxavxMuoReqUweGDoX334cpU6B+fRg2DE49FR59NDTPiIgkkoRN6IWSk8MF0vfeC/3UTzgBbrsNWrUKPWOKXWgWEanREj6hF0pKgv794e23Yf58uPxyeOKJUGO/+GJ45RUo1sVVRKTGqTUJvbgzzwzt6WvXwpgxofb+gx/AaaeF5pgdO+IdocjBqvNoi7/73e/4pvR8BVXoSEY7LDRhwgRuueWWw3rt73//e/785z8f0fFjoVYm9EInngj33hsmP8rNhaZNQ3NMy5YwfDi88w4U/V/Q9HdSETH+vFT30RbjndDj7cc//nGJIRfipVYn9EL16sEPfxi6PC5cCFdfDX/7G5xzDmRkwCtX5+LXjQiZ3/3A9HdK6hJJ4XSJMfy8VJfRFnfv3k2/fv3o1KkTHTp0YPLkyTz66KNs2LCBXr160atXL6DskQXT09P52c9+RseOHenatWtRrMOHD+eGG24gKyuLU045pegu0Ly8PEaNGlUU45MFt4K7O7fccgunnnoqffr0iXiHK8Cjjz5K+/btycjIKLpr88svv+Syyy4jIyODbt26HXSX6M6dO0lLSyu6qWj37t2cdNJJ7Nu3j08//ZS+ffvSpUsXsrOzWb58OQCNGjUiPT2d+fPnR4yjyrh7XJYuXbp4dfb11+7jx7tnZbmvJs09/NcsuaSlxTtMqSIffvhh9IXT0mL+efn666+9U6dO3q5dO7/xxht95syZRft69Ojh7777rru7P/TQQz5w4MCi7XPnzvWOHTv6/v37/YILLvDVq1f7UUcd5e7ur776ql933XWen5/veXl53q9fP3/zzTcPOnZqaqp/9dVX7u7+/PPP+09+8pOifTt27Cg45TTfsmWLu7tv2bLFs7OzfdeuXe7u/sADD/iYMWOKyo0dO9bd3SdOnOj9+vVzd/dhw4b5RRdd5Hl5eb5ixQpv1aqVf/vtt/7kk0/6r371K3d337Nnj3fp0sVXrVrlf/vb37xPnz6+f/9+X79+vR9zzDH+3HPPHRR7ixYtfM+ePe7uvn37dnd3v+WWW/y+++5zd/d///vf3qlTJ3d3f+qpp/zmm292d/f+/fv7G2+84e7ukyZN8muvvdbd3Xv37u0rVqxwd/e5c+d6r169io41duxYf/jhhyP9+Q5bpM8dsMDLyKuqoZehcWO47jp4911Is8jT3Lmmv5NIKmG6xMLRFsePH09KSgqDBg1iwoQJRftzcnLIzMxkzpw5PPzww0Xbox1tsXPnzixfvjzizDnFR1vs2LEjr732Gj//+c+ZPXs2xxxzzEHl586dWzSyYGZmJhMnTuSzYpMWFI4pM2TIEN55552i7QMHDiQpKYl27drRpk0bli9fzvTp03n66afJzMzkrLPOYtu2baxcuZJZs2YxZMgQkpOTadmyZYmBtYrLyMggJyeHv/zlL0V9vd96662icdx79+7Ntm3bDro+MGjQICZPngxQNOzwrl27ePvttxkwYACZmZlcf/31JZqwCkdMjKdye7ObWQNgFlC/oPzz7v7LUmUeAXoVrDYCmrt709iGGj+WmkqkWTQ+81SG9Qj926+6KtypKkIZn5cjnS6xOoy2eMopp7Bo0SJefvllfvGLX3D++edz7733HvS+hxpZsPhs9mU9L1x3dx577DEuuuiiEvtefvnlQ8Zc6KWXXmLWrFm8+OKLjBs3jmXLlkX1uv79+3PPPffw5ZdfsnDhQnr37s3u3btp2rQpixcvjviaWI2YeCSiqaHvBXq7eycgE+hrZt2KF3D32909090zgceAF2IdaFxFmP4uv2EjFg8YxxdfhDtTTzwxzL8xbRp8912c4pTqIcLnhUaNwvbDVF1GW9ywYQONGjVi6NChjBo1ikWLFgElR08sb2TBwprv5MmTS4wJ/txzz5Gfn8+nn37KqlWrOPXUU7nooov4wx/+UDTBxYoVK9i9ezfnnXcekydPJi8vj40bNzJjxoyD4s7Pz+fzzz+nV69ePPjgg+zcuZNdu3aRnZ1NbsH1jJkzZ9KsWbODLvg2btyYM888k9tuu41LLrmE5ORkjj76aE4++WSee+45IHxxFZ+UIlYjJh6JcmvoBW02uwpW6xYshxrRawgQ+epKTZWTEx5Hjw4/m1NTSRo3jstycrjUw8XUiRPDmDHPPht6y1xxRRhyoFevcNeq1CIRPi+MG3dg+2GoLqMtLlu2jFGjRpGUlETdunX5wx/+AMCIESPo27cvLVu2ZMaMGWWOLAiwfft2MjIyqF+/folafGpqKl27duWrr77iiSeeoEGDBvzkJz9hzZo1dO7cGXcnJSWFf/zjH1x++eW88cYbtG/fntTU1BJfDIXy8vIYOnQoO3fuxN0ZOXIkTZs2LZriLiMjg0aNGhWNiFjaoEGDGDBgADNnzizalpuby4033sjYsWPZt28fgwcPplOnTkCY2an0r6AqV1bjevEFSAYWExL7g4colwZsBJLL2D8CWAAsSE1NjeGlg+ph7173adPcf/Qj9yZNwnWwlBT3G25wnznTff/+eEcoh6tCF0UTzIYNG7xPnz4xea/iF0+LGzZsWMSLmjXFokWLfOjQoTF/30q5KOrueR6aU1oDXc2srN8Vgwlt7BHHNnT38e6e5e5ZKSkp0X3j1CD16kG/fuGmpc2b4YUXoHfvsN6zZxhuYMQIePlliGKyFZFqQaMtlm/r1q386le/incYFR8P3czuBb5x94cj7HsPuNnd3y7vfSpjPPTqavfu0Lb+97+HZP7116EXzQ9+AJddFoYeaNo03lHKodTm8dAlfmI+HrqZpZhZ04LnDYELgOURyn0fOBZ4p/S+2u6oo2DQIJg0CbZsgX/9KzSnzp4dHlNS4IILwuTDH39c7O5U0B2q1UhFKz8iR+JwPm/RNLm0AGaY2VLgXeA1d59mZvebWf9i5QYDk1yf+kOqXx/69g0Dg61fH4YX+OlPYd06uP12+P734XvfC1PpLbpTd6hWFw0aNGDbtm1K6lIl3J1t27bRoEGDCr0uoaagq+lWrw6jPv7rX/Dvf8MH36STToT+zGlpsGZNlcdXm+3bt49169ZFNdO8SCw0aNCA1q1bU7du3RLbD9XkooReTe3dC/UaJmER/j75GE88nk/v3mH4X02GLVJ7HCqhq4d0NVW/PmXecbghOZWbbw7PW7YMPWnOOw+6dw9NNkrwIrWTxnKpzsq447DVxHF88gmMHx8S+fTpoWm9fftwgfXSS+Hhh2HuXN21KlKbqIZenZVxx6Hl5PA9wsXT664L10tXroS33jqwTJ0aXtqgAXTtCmeddWBp1Uq1eJFEpDb0BLVpE8yZE5L7nDmwePGB2nqLFiGxFyb6rKwyBhbLzY3p7esicuR0UVTYuxeWLAnjzsyfHx6Lj5Tati107nxg6bYqlyZ3jIDis9A0ahTaeZTUReJGCV0i+vLLkNwXLTqwrF4d9q0mcpdJT03DPltTtYGKSBH1cpGIjjsu3OTUt++BbV9+GZpn0s4ve1KP7O7QqVNYMjKgQ4cwlIGIxJcSupRw3HGhGyRpkbtMbm+cSlIS/OUv8L//e2B7mzYhuXfseOCxbVtITq662EVqOyV0iWzcuNAXslQb+vFPjGNWzoGRCJYsgWXLwrJ0aehdUzC3Lg0ahMSemXlgychQbV6ksqgNXcp2GL1cvv0WPvooJPelS0PCf+892L497DeDdu1Ccj/jDOjWDc48MwxgdiTHFaktdFFU4so9DD723nuhfb5wKbwAm5wcEvw558DgvFy6PTWCpG/Vu0YkEiV0qZa+/DLczfr222GZN08DkomUR71cpFo67rgwucfFF4f1/fshud7aiDPW5n+2locegEsugdNP152uIpFoLBepNurUAUtNjbjvi7qp3H13uMianh7Gi589u9RkICK1nBK6VC9lDEjW8qlxrFsXmtIzM2HChDAwWdu2MGbMgfZ4kdpMCV2ql5yckLXT0kK7Slpa0QXRVq3CYGT//GcYq2bixFBbHzMm9IPv2ROeeirM2SpSG+miqNR4a9fCM8+EWvsnn4QK/pVXwo9/DD16qL1dEssRTRItUt2lpoZu6ytWhJElhw4NtfhevUKf93HjQrdJkUSnhC4Jwyz0ZX/ySdi4MdTaU1PhF78ILTcXXwzPPx9GnhRJRErokpAaNQo19TfeCM0w99wThicYMCBM8HHjjWGmpxIzOuXmhkb5pKTwmJsbp+hFDo/a0KXWyMuD114LF06nTQvD1Bx9NPTrB7cen0u3/xuB6Q5VqeZ0p6hIKd9+C6+/Dv/4RxhQ7N2tukNVagbdKSpSSsOG8B//EZa8PEiqW/Ydqv9vLJx9dpiyr0mTqo9VJFrlJnQzawDMAuoXlH/e3X8ZodxA4D7Cf4sl7v7D2IYqUjmSkwlXTyOM//5F3VT+67/C86SkcKdqVha0bw+nnRYeTzop7BOJt2hq6HuB3u6+y8zqAm+Z2b/cfW5hATNrB9wNnOvu282seSXFK1I5yhj/veX4cWzvFwYOe+edMIjY1Knwf/9XohinnXZgadsWTj45LMcfH2U/eA0ZLDFQbkL30Mi+q2C1bsFS+sfpdcDj7r694DWbYxmkSKUrTJ4RkmpT4KKLwlJo69Yw7vtHH8GHH4bHmTPDTE7FNWkSOswUJviTTw41+tTU8JiSAkl/zS35ZfLZZ2G9eFwiUYjqoqiZJQMLgbaExP3zUvv/AawAzgWSgfvc/ZUI7zMCGAGQmpra5bMIP3FFarKvvw7jyqxeDatWHXheuBT/AQBQrx6syk+n1f6D/y/sPTGNbQvXcMIJmspPDohZLxczawr8HbjV3d8vtn0asA8YCLQmtLl3dPcdZb2XerlIbeMeavaffx5+BHz+eVge+HUSSRGuyOZjJJNPUhKceGLoP9+yZVhatDj4MSXlMNry1dRT48Ssl4u77zCzGUBf4P1iu9YB89x9H7DazFYA7YB3DzNmkYRjFpJuSgp07lxsx5TIF2T3pKTyv2Ng/foDy6efwltvwbZtB79/cjI0bx6S/wknhMfiz084Iexv3jyMRZ88SU09iSaaXi4pwL6CZN4QuAB4sFSxfwBDgKfMrBlwCrAqxrGKJKYyLsg2emQcN5aRV/fuhS++gA0bwjAHhY+bNoXtmzbB+++H5/v3H/z6pCRYw2hOyi/VBvTNN3x162heTs6hWTNKLA0axO6UpXJEU0NvAUwsaEdPAqa4+zQzux9Y4O5TgVeBC83sQyAPGOXuEeoQInKQQ1yQLUv9+uGep7S0Q791fn6YoPuLL2Dz5pJL67FrI76m8fa1DBly8PaGDUOvncKlWbOSz5s1C78+in8JlB7avgQ198Sc7hQVqa3S0yM29eS1TuPjV9ewdStFy7ZtYSn+vHDZvj18cUTSsGFo4mnRomR7/7lrcun+zAjq7NVQCxWlO0VF5GBlNPUkPzCO9u2jf5u8PNix40Dy37KFEl8GmzaF5qCPPw5dO7dvh9WMpg4HN/dsvX40j3+SQ9u2Yejjdu3g2GNjcbK1g2roIrVZHJo9vv0WGhyVhEXIPfkYdSy/xFyx3/senHXWgSUzMzQ51VYanEtEqpcymntIS+Pbj9awenUY9vjDD2H+fJg7N9TyIfTdP+OMkNx79YK+fWvXBVsldBGpXnJzIzb3lNWG7h5mnZo378CyYEGo7TdpApdeCgMHwoUXJn7tXQldRKqfI2zu2bcPZsyAyZPh738PbfPHHAOXXx6Se58+ULduJcYfJ0roIpLQvvsujG8/ZUoY437nznDz1B13wO23l9N9sobRJNEiktDq1Qtzxk6YEHrVTJ0K3buH+WRPPRWefrrsrpWJRAldRBJK/fph4pJ//hNmzQr93ocNgy5dwhyziTx3rBK6iCSs7OzQQ+bZZ0Mb+5/Oz2XPsBGhh437gfFrEiSpqw1dRGqFPXtgb4t0jtlRs+eO1Z2iIlLrNWgADXZGHr+GtWVsr2HU5CIitUdqasTNflLk7TWNErqI1B7jxh3Uh3E3jfhd83F8912cYoohJXQRqT1ycsLdqGlpYcaRtDRmDR3PHQtyGDiQGp/UldBFpHbJyQkXQPPzYc0afvBMDo89Fro5XnVVmDykplJCF5Fa75Zb4PHH4cUX4cora25SV0IXEQFuugmeeAJeegmuuCJ0c6xplNBFRApcf31oYn/55TAOTE2jhC4iUsx114Xa+h//CKtXxzuailFCFxEp5Z57IDkZxo6NdyQVo4QuIlJKq1Zwww0wcWKYOammUEIXEYngrrvCsLz33x/vSKKnhC4iEsGJJ4bujLm5sHx5vKOJjhK6iEgZRo2Chg3hvvviHUl0yk3oZtbAzOab2RIz+8DMxkQoM9zMtpjZ4oLlJ5UTrohI1UlJgdtuC1PbLVsW72jKF00NfS/Q2907AZlAXzPrFqHcZHfPLFj+FMsgRUTi5ac/hSZNakYtvdyE7sGugtW6BUt8ZsUQEalixx0XJpp+4QV47714R3NoUbWhm1mymS0GNgOvufu8CMWuNLOlZva8mZ1UxvuMMLMFZrZgy5Ythx+1iEgVuv12aNoUfvnLeEdyaFEldHfPc/dMoDXQ1cw6lCryIpDu7hnAa8DEMt5nvLtnuXtWSkrKEYQtIlJ1jjkG7rwzDN717rvxjqZsFerl4u47gBlA31Lbt7l74fhkfwK6xCQ6EZFqYuRIOP54uPfeeEdStmh6uaSYWdOC5w2BC4Dlpcq0KLbaH/gohjGKiMRdkybw85/DK6/A22/HO5rIoqmhtwBmmNlS4F1CG/o0M7vfzPoXlBlZ0KVxCTASGF454YqIxM9NN0Hz5tW3lm7u8emwkpWV5QsWLIjLsUVEDtcjj4ShdZcsgYyMqj++mS1096xI+3SnqIhIBVx1VXicOTOuYUSkhC4iUgEnnRTmmH7rrXhHcjAldBGRCureHWbPhji1WJdJCV1EpIKys+GLL2DVqnhHUpISuohIBXXvHh5nz45vHKUpoYuIVNBpp4UxXpTQRURquKSkUEuvbhdGldBFRA5D9+6wYgVs2hTvSA5QQhcROQzZ2eFxzpz4xlGcErqIyGHo3DlMT1ed2tGV0EVEDkO9enDWWUroIiIJITs7zGL09dfxjiRQQhcROUzdu0N+PsydG+9IAiV0EZHDdPbZoQtjdem+qIQuInKYmjSBzMzq046uhC4icgSys0OTy7598Y5ECV1E5IhkZ8O338KiRfGORAldROSIVKeBupTQRUSOwAknQLt21ePCqBK6iMgRKhyoKz8/vnEooYuIHKHsbNi2DT7+OL5xKKGLiByh6tKOroQuInKE2rYNbenxbkdXQhcROUJmodml2tfQzayBmc03syVm9oGZjTlE2SvNzM0sK7ZhiohUb927w5o1sG5d/GKIpoa+F+jt7p2ATKCvmXUrXcjMmgC3AfNiGqGISA1QOOFFPJtdyk3oHuwqWK1bsHiEor8CHgT2xC48EZGaISMDGjeOb7NLVG3oZpZsZouBzcBr7j6v1P7OwEnu/lI57zPCzBaY2YItW7YcbswiItVOnTpwzjnVvIYO4O557p4JtAa6mlmHwn1mlgT8FvhpFO8z3t2z3D0rJSXlMEMWEamesrNh2TLYsSM+x69QLxd33wHMAPoW29wE6ADMNLM1QDdgqi6Mikht0707uMdv4uhoermkmFnTgucNgQuA5YX73X2nuzdz93R3TwfmAv3dfUHlhCwiUj117Qp168av2SWaGnoLYIaZLQXeJbShTzOz+82sf+WGJyJSczRqBF26xO/CaJ3yCrj7UuCMCNvvLaN8zyMPS0SkZrrjDtgTp75+5SZ0ERGJ3oAB8Tu2bv0XEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIMpN6GbWwMzmm9kSM/vAzMZEKHODmS0zs8Vm9paZta+ccEVEpCzR1ND3Ar3dvROQCfQ1s26lyjzr7h3dPRN4CPhtTKMUEZFy1SmvgLs7sKtgtW7B4qXKfFVs9ajS+0VEpPKVm9ABzCwZWAi0BR5393kRytwM3AHUA3rHMkgRESlfVBdF3T2voDmlNdDVzDpEKPO4u38P+Dnwi0jvY2YjzGyBmS3YsmXLEYQtIiKlVaiXi7vvAGYAfQ9RbBJwWRmvH+/uWe6elZKSUpFDi4hIOaLp5ZJiZk0LnjcELgCWlyrTrthqP2BlDGMUEZEoRNOG3gKYWNCOngRMcfdpZnY/sMDdpwK3mFkfYB+wHRhWaRGLiEhE0fRyWQqcEWH7vcWe3xbjuEREpIJ0p6iISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBJEuQndzBqY2XwzW2JmH5jZmAhl7jCzD81sqZn928zSKidcEREpSzQ19L1Ab3fvBGQCfc2sW6ky7wFZ7p4BPA88FNMoRUSkXOUmdA92FazWLVi8VJkZ7v5NwepcoHVMoxQRkXJF1YZuZslmthjYDLzm7vMOUfxa4F8xiE1ERCogqoTu7nnunkmoeXc1sw6RypnZUCAL+HUZ+0eY2QIzW7Bly5bDDFlERCKpUC8Xd98BzAD6lt5nZn2A0UB/d99bxuvHu3uWu2elpKQcRrgiIlKWaHq5pJhZ04LnDYELgOWlypwBPElI5psrIU4RESlHnSjKtAAmmlky4QtgirtPM7P7gQXuPpXQxNIYeM7MANa6e//KClpERA5WbkJ396XAGRG231vseZ8YxyUiIhWkO0VFRBKEErqISIJQQhcRqSq5uZCeDklJ4TE3N6ZvH81FUREROVK5uTBiBHxTcFP9Z5+FdYCcnJgcQjV0EZGqMHr0gWRe6JtvwvYYUUIXEakKa9dWbPthUEIXEakKqakV234YlNBFRKrCuHHQqFHJbY0ahe0xooQuIlIVcnJg/HhISwOz8Dh+fMwuiIJ6uYiIVJ2cnJgm8NJUQxcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEYe4enwObbQE+O8yXNwO2xjCcmkDnXDvonGuHIznnNHePOIdn3BL6kTCzBe6eFe84qpLOuXbQOdcOlXXOanIREUkQSugiIgmipib08fEOIA50zrWDzrl2qJRzrpFt6CIicrCaWkMXEZFSqnVCN7O+ZvaxmX1iZndF2F/fzCYX7J9nZulxCDOmojjnO8zsQzNbamb/NrO0eMQZS+Wdc7FyV5qZm1mN7xERzTmb2cCCv/UHZvZsVccYa1F8tlPNbIaZvVfw+b44HnHGipn92cw2m9n7Zew3M3u04N9jqZl1PuKDunu1XIBk4FOgDVAPWAK0L1XmJuCJgueDgcnxjrsKzrkX0Kjg+Y214ZwLyjUBZgFzgax4x10Ff+d2wHvAsQXrzeMddxWc83jgxoLn7YE18Y77CM/5PKAz8H4Z+y8G/gUY0A2Yd6THrM419K7AJ+6+yt2/AyYBl5YqcykwseD588D5ZmZVGGOslXvO7j7D3QsnJpwLtK7iGGMtmr8zwK+AB4E9VRlcJYnmnK8DHnf37QDuvrmKY4y1aM7ZgaMLnh8DbKjC+GLO3WcBXx6iyKXA0x7MBZqaWYsjOWZ1TuitgM+Lra8r2BaxjLvvB3YCx1dJdJUjmnMu7lrCN3xNVu45F/wUPcndX6rKwCpRNH/nU4BTzGyOmc01s75VFl3liOac7wOGmtk64GXg1qoJLW4q+v+9XJrgooYys6FAFtAj3rFUJjNLAn4LDI9zKFWtDqHZpSfhV9gsM+vo7jviGVQlGwJMcPffmNnZwDNm1sHd8+MdWE1RnWvo64GTiq23LtgWsYyZ1SH8TNtWJdFVjmjOGTPrA4wG+rv73iqKrbKUd85NgA7ATDNbQ2hrnFrDL4xG83deB0x1933uvhpYQUjwNVU053wtMAXA3d8BGhDGPElUUf1/r4jqnNDfBdqZ2clmVo9w0XNqqTJTgWEFz68C3vCCqw01VLnnbGZnAE8SknlNb1eFcs7Z3Xe6ezN3T3f3dMJ1g/7uviA+4cZENJ/tfxBq55hZM0ITzKoqjDHWojnntcD5AGZ2GiGhb6nSKKvWVODqgt4u3YCd7r7xiN4x3leCy7lKfDGhZvIpMLpg2/2E/9AQ/uDPAZ8A84E28Y65Cs75dWATsLhgmRrvmCv7nEuVnUkN7+US5d/ZCE1NHwLLgMHxjrkKzrk9MIfQA2YxcGG8Yz7C8/0rsBHYR/jFdS1wA3BDsb/x4wX/Hsti8bnWnaIiIgmiOje5iIhIBSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCeL/AxAdFsZB2aDwAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          },
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "voltage = solution[\"Voltage [V]\"].entries\n",
-        "step_voltage = step_solution[\"Voltage [V]\"].entries\n",
-        "plt.figure()\n",
-        "plt.plot(solution[\"Time [h]\"].entries, voltage, \"b-\", label=\"SPMe (continuous solve)\")\n",
-        "plt.plot(\n",
-        "    step_solution[\"Time [h]\"].entries, step_voltage, \"ro\", label=\"SPMe (stepped solve)\"\n",
-        ")\n",
-        "plt.legend()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## References\n",
-        "\n",
-        "The relevant papers for this notebook are:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 16,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[1] Joel A. E. Andersson, Joris Gillis, Greg Horn, James B. Rawlings, and Moritz Diehl. CasADi – A software framework for nonlinear optimization and optimal control. Mathematical Programming Computation, 11(1):1–36, 2019. doi:10.1007/s12532-018-0139-4.\n",
-            "[2] Charles R. Harris, K. Jarrod Millman, Stéfan J. van der Walt, Ralf Gommers, Pauli Virtanen, David Cournapeau, Eric Wieser, Julian Taylor, Sebastian Berg, Nathaniel J. Smith, and others. Array programming with NumPy. Nature, 585(7825):357–362, 2020. doi:10.1038/s41586-020-2649-2.\n",
-            "[3] Scott G. Marquis, Valentin Sulzer, Robert Timms, Colin P. Please, and S. Jon Chapman. An asymptotic derivation of a single particle model with electrolyte. Journal of The Electrochemical Society, 166(15):A3693–A3706, 2019. doi:10.1149/2.0341915jes.\n",
-            "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). ECSarXiv. February, 2020. doi:10.1149/osf.io/67ckj.\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "pybamm.print_citations()"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A look at solution data and processed variables"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once you have run a simulation the first thing you want to do is have a look at the data. Most of the examples so far have made use of PyBaMM's handy QuickPlot function but there are other ways to access the data and this notebook will explore them. First off we will generate a standard SPMe model and use QuickPlot to view the default variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9ad1d544145646a3ae6c71a74f1dd41d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(FloatSlider(value=0.0, description='t', max=3510.0, step=35.1), Output()), _dom_classes=…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%pip install \"pybamm[plot,cite]\" -q    # install PyBaMM if it is not installed\n",
+    "import pybamm\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "os.chdir(pybamm.__path__[0]+'/..')\n",
+    "\n",
+    "# load model\n",
+    "model = pybamm.lithium_ion.SPMe()\n",
+    "\n",
+    "# set up and solve simulation\n",
+    "simulation = pybamm.Simulation(model)\n",
+    "dt = 90\n",
+    "t_eval = np.arange(0, 3600, dt)  # time in seconds\n",
+    "solution = simulation.solve(t_eval)\n",
+    "\n",
+    "quick_plot = pybamm.QuickPlot(solution)\n",
+    "quick_plot.dynamic_plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Behind the scenes the QuickPlot classed has created some processed variables which can interpolate the model variables for our solution and has also stored the results for the solution steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['Negative particle surface concentration [mol.m-3]', 'Electrolyte concentration [mol.m-3]', 'Positive particle surface concentration [mol.m-3]', 'Current [A]', 'Negative electrode potential [V]', 'Electrolyte potential [V]', 'Positive electrode potential [V]', 'Voltage [V]'])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution.data.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(20, 40)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution.data['Negative particle surface concentration [mol.m-3]'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(40,)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution.t.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the dictionary keys are in the same order as the subplots in the QuickPlot figure. We can add new processed variables to the solution by simply using it like a dictionary. First let's find a few more variables to look at. As you will see there are quite a few:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": [
+     "outputPrepend"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Ambient temperature', 'Ambient temperature [K]', 'Average negative particle concentration', 'Average negative particle concentration [mol.m-3]', 'Average positive particle concentration', 'Average positive particle concentration [mol.m-3]', 'Battery voltage [V]', 'C-rate', 'Cell temperature', 'Cell temperature [K]', 'Change in measured open-circuit voltage', 'Change in measured open-circuit voltage [V]', 'Current [A]', 'Current collector current density', 'Current collector current density [A.m-2]', 'Discharge capacity [A.h]', 'Electrode current density', 'Electrode tortuosity', 'Electrolyte concentration', 'Electrolyte concentration [Molar]', 'Electrolyte concentration [mol.m-3]', 'Electrolyte current density', 'Electrolyte current density [A.m-2]', 'Electrolyte flux', 'Electrolyte flux [mol.m-2.s-1]', 'Electrolyte potential', 'Electrolyte potential [V]', 'Electrolyte tortuosity', 'Exchange current density', 'Exchange current density [A.m-2]', 'Exchange current density per volume [A.m-3]', 'Gradient of electrolyte potential', 'Gradient of negative electrode potential', 'Gradient of negative electrolyte potential', 'Gradient of positive electrode potential', 'Gradient of positive electrolyte potential', 'Gradient of separator electrolyte potential', 'Inner SEI concentration [mol.m-3]', 'Inner SEI interfacial current density', 'Inner SEI interfacial current density [A.m-2]', 'Inner SEI thickness', 'Inner SEI thickness [m]', 'Inner positive electrode SEI concentration [mol.m-3]', 'Inner positive electrode SEI interfacial current density', 'Inner positive electrode SEI interfacial current density [A.m-2]', 'Inner positive electrode SEI thickness', 'Inner positive electrode SEI thickness [m]', 'Interfacial current density', 'Interfacial current density [A.m-2]', 'Interfacial current density per volume [A.m-3]', 'Irreversible electrochemical heating', 'Irreversible electrochemical heating [W.m-3]', 'Leading-order current collector current density', 'Leading-order electrode tortuosity', 'Leading-order electrolyte tortuosity', 'Leading-order negative electrode porosity', 'Leading-order negative electrode tortuosity', 'Leading-order negative electrolyte tortuosity', 'Leading-order porosity', 'Leading-order positive electrode porosity', 'Leading-order positive electrode tortuosity', 'Leading-order positive electrolyte tortuosity', 'Leading-order separator porosity', 'Leading-order separator tortuosity', 'Leading-order x-averaged negative electrode porosity', 'Leading-order x-averaged negative electrode porosity change', 'Leading-order x-averaged negative electrode tortuosity', 'Leading-order x-averaged negative electrolyte tortuosity', 'Leading-order x-averaged positive electrode porosity', 'Leading-order x-averaged positive electrode porosity change', 'Leading-order x-averaged positive electrode tortuosity', 'Leading-order x-averaged positive electrolyte tortuosity', 'Leading-order x-averaged separator porosity', 'Leading-order x-averaged separator porosity change', 'Leading-order x-averaged separator tortuosity', 'Local ECM resistance', 'Local ECM resistance [Ohm]', 'Local voltage', 'Local voltage [V]', 'Loss of lithium to SEI [mol]', 'Loss of lithium to positive electrode SEI [mol]', 'Maximum negative particle concentration', 'Maximum negative particle concentration [mol.m-3]', 'Maximum negative particle surface concentration', 'Maximum negative particle surface concentration [mol.m-3]', 'Maximum positive particle concentration', 'Maximum positive particle concentration [mol.m-3]', 'Maximum positive particle surface concentration', 'Maximum positive particle surface concentration [mol.m-3]', 'Measured battery open-circuit voltage [V]', 'Measured open-circuit voltage', 'Measured open-circuit voltage [V]', 'Minimum negative particle concentration', 'Minimum negative particle concentration [mol.m-3]', 'Minimum negative particle surface concentration', 'Minimum negative particle surface concentration [mol.m-3]', 'Minimum positive particle concentration', 'Minimum positive particle concentration [mol.m-3]', 'Minimum positive particle surface concentration', 'Minimum positive particle surface concentration [mol.m-3]', 'Negative current collector potential', 'Negative current collector potential [V]', 'Negative current collector temperature', 'Negative current collector temperature [K]', 'Negative electrode active material volume fraction', 'Negative electrode active material volume fraction change', 'Negative electrode current density', 'Negative electrode current density [A.m-2]', 'Negative electrode entropic change', 'Negative electrode exchange current density', 'Negative electrode exchange current density [A.m-2]', 'Negative electrode exchange current density per volume [A.m-3]', 'Negative electrode extent of lithiation', 'Negative electrode interfacial current density', 'Negative electrode interfacial current density [A.m-2]', 'Negative electrode interfacial current density per volume [A.m-3]', 'Negative electrode ohmic losses', 'Negative electrode ohmic losses [V]', 'Negative electrode open-circuit potential', 'Negative electrode open-circuit potential [V]', 'Negative electrode oxygen exchange current density', 'Negative electrode oxygen exchange current density [A.m-2]', 'Negative electrode oxygen exchange current density per volume [A.m-3]', 'Negative electrode oxygen interfacial current density', 'Negative electrode oxygen interfacial current density [A.m-2]', 'Negative electrode oxygen interfacial current density per volume [A.m-3]', 'Negative electrode oxygen open-circuit potential', 'Negative electrode oxygen open-circuit potential [V]', 'Negative electrode oxygen reaction overpotential', 'Negative electrode oxygen reaction overpotential [V]', 'Negative electrode porosity', 'Negative electrode porosity change', 'Negative electrode potential', 'Negative electrode potential [V]', 'Negative electrode pressure', 'Negative electrode reaction overpotential', 'Negative electrode reaction overpotential [V]', 'SEI film overpotential', 'SEI film overpotential [V]', 'SEI interfacial current density', 'SEI interfacial current density [A.m-2]', 'Negative electrode surface area to volume ratio', 'Negative electrode surface area to volume ratio [m-1]', 'Negative electrode surface potential difference', 'Negative electrode surface potential difference [V]', 'Negative electrode temperature', 'Negative electrode temperature [K]', 'Negative electrode tortuosity', 'Negative electrode transverse volume-averaged acceleration', 'Negative electrode transverse volume-averaged acceleration [m.s-2]', 'Negative electrode transverse volume-averaged velocity', 'Negative electrode transverse volume-averaged velocity [m.s-2]', 'Negative electrode volume-averaged acceleration', 'Negative electrode volume-averaged acceleration [m.s-1]', 'Negative electrode volume-averaged concentration', 'Negative electrode volume-averaged concentration [mol.m-3]', 'Negative electrode volume-averaged velocity', 'Negative electrode volume-averaged velocity [m.s-1]', 'Negative electrolyte concentration', 'Negative electrolyte concentration [Molar]', 'Negative electrolyte concentration [mol.m-3]', 'Negative electrolyte current density', 'Negative electrolyte current density [A.m-2]', 'Negative electrolyte potential', 'Negative electrolyte potential [V]', 'Negative electrolyte tortuosity', 'Negative particle concentration', 'Negative particle concentration [mol.m-3]', 'Negative particle flux', 'Negative particle radius', 'Negative particle radius [m]', 'Negative particle surface concentration', 'Negative particle surface concentration [mol.m-3]', 'Negative SEI concentration [mol.m-3]', 'Ohmic heating', 'Ohmic heating [W.m-3]', 'Outer SEI concentration [mol.m-3]', 'Outer SEI interfacial current density', 'Outer SEI interfacial current density [A.m-2]', 'Outer SEI thickness', 'Outer SEI thickness [m]', 'Outer positive electrode SEI concentration [mol.m-3]', 'Outer positive electrode SEI interfacial current density', 'Outer positive electrode SEI interfacial current density [A.m-2]', 'Outer positive electrode SEI thickness', 'Outer positive electrode SEI thickness [m]', 'Oxygen exchange current density', 'Oxygen exchange current density [A.m-2]', 'Oxygen exchange current density per volume [A.m-3]', 'Oxygen interfacial current density', 'Oxygen interfacial current density [A.m-2]', 'Oxygen interfacial current density per volume [A.m-3]', 'Porosity', 'Porosity change', 'Positive current collector potential', 'Positive current collector potential [V]', 'Positive current collector temperature', 'Positive current collector temperature [K]', 'Positive electrode active material volume fraction', 'Positive electrode active material volume fraction change', 'Positive electrode current density', 'Positive electrode current density [A.m-2]', 'Positive electrode entropic change', 'Positive electrode exchange current density', 'Positive electrode exchange current density [A.m-2]', 'Positive electrode exchange current density per volume [A.m-3]', 'Positive electrode extent of lithiation', 'Positive electrode interfacial current density', 'Positive electrode interfacial current density [A.m-2]', 'Positive electrode interfacial current density per volume [A.m-3]', 'Positive electrode ohmic losses', 'Positive electrode ohmic losses [V]', 'Positive electrode open-circuit potential', 'Positive electrode open-circuit potential [V]', 'Positive electrode oxygen exchange current density', 'Positive electrode oxygen exchange current density [A.m-2]', 'Positive electrode oxygen exchange current density per volume [A.m-3]', 'Positive electrode oxygen interfacial current density', 'Positive electrode oxygen interfacial current density [A.m-2]', 'Positive electrode oxygen interfacial current density per volume [A.m-3]', 'Positive electrode oxygen open-circuit potential', 'Positive electrode oxygen open-circuit potential [V]', 'Positive electrode oxygen reaction overpotential', 'Positive electrode oxygen reaction overpotential [V]', 'Positive electrode porosity', 'Positive electrode porosity change', 'Positive electrode potential', 'Positive electrode potential [V]', 'Positive electrode pressure', 'Positive electrode reaction overpotential', 'Positive electrode reaction overpotential [V]', 'Positive electrode SEI film overpotential', 'Positive electrode SEI film overpotential [V]', 'Positive electrode SEI interfacial current density', 'Positive electrode SEI interfacial current density [A.m-2]', 'Positive electrode surface area to volume ratio', 'Positive electrode surface area to volume ratio [m-1]', 'Positive electrode surface potential difference', 'Positive electrode surface potential difference [V]', 'Positive electrode temperature', 'Positive electrode temperature [K]', 'Positive electrode tortuosity', 'Positive electrode transverse volume-averaged acceleration', 'Positive electrode transverse volume-averaged acceleration [m.s-2]', 'Positive electrode transverse volume-averaged velocity', 'Positive electrode transverse volume-averaged velocity [m.s-2]', 'Positive electrode volume-averaged acceleration', 'Positive electrode volume-averaged acceleration [m.s-1]', 'Positive electrode volume-averaged concentration', 'Positive electrode volume-averaged concentration [mol.m-3]', 'Positive electrode volume-averaged velocity', 'Positive electrode volume-averaged velocity [m.s-1]', 'Positive electrolyte concentration', 'Positive electrolyte concentration [Molar]', 'Positive electrolyte concentration [mol.m-3]', 'Positive electrolyte current density', 'Positive electrolyte current density [A.m-2]', 'Positive electrolyte potential', 'Positive electrolyte potential [V]', 'Positive electrolyte tortuosity', 'Positive particle concentration', 'Positive particle concentration [mol.m-3]', 'Positive particle flux', 'Positive particle radius', 'Positive particle radius [m]', 'Positive particle surface concentration', 'Positive particle surface concentration [mol.m-3]', 'Positive SEI concentration [mol.m-3]', 'Pressure', 'R-averaged negative particle concentration', 'R-averaged negative particle concentration [mol.m-3]', 'R-averaged positive particle concentration', 'R-averaged positive particle concentration [mol.m-3]', 'Reversible heating', 'Reversible heating [W.m-3]', 'Sei interfacial current density', 'Sei interfacial current density [A.m-2]', 'Sei interfacial current density per volume [A.m-3]', 'Separator electrolyte concentration', 'Separator electrolyte concentration [Molar]', 'Separator electrolyte concentration [mol.m-3]', 'Separator electrolyte potential', 'Separator electrolyte potential [V]', 'Separator porosity', 'Separator porosity change', 'Separator pressure', 'Separator temperature', 'Separator temperature [K]', 'Separator tortuosity', 'Separator transverse volume-averaged acceleration', 'Separator transverse volume-averaged acceleration [m.s-2]', 'Separator transverse volume-averaged velocity', 'Separator transverse volume-averaged velocity [m.s-2]', 'Separator volume-averaged acceleration', 'Separator volume-averaged acceleration [m.s-1]', 'Separator volume-averaged velocity', 'Separator volume-averaged velocity [m.s-1]', 'Sum of electrolyte reaction source terms', 'Sum of interfacial current densities', 'Sum of negative electrode electrolyte reaction source terms', 'Sum of negative electrode interfacial current densities', 'Sum of positive electrode electrolyte reaction source terms', 'Sum of positive electrode interfacial current densities', 'Sum of x-averaged negative electrode electrolyte reaction source terms', 'Sum of x-averaged negative electrode interfacial current densities', 'Sum of x-averaged positive electrode electrolyte reaction source terms', 'Sum of x-averaged positive electrode interfacial current densities', 'Terminal power [W]', 'Voltage', 'Voltage [V]', 'Time', 'Time [h]', 'Time [min]', 'Time [s]', 'Total concentration in electrolyte [mol]', 'Total current density', 'Total current density [A.m-2]', 'Total heating', 'Total heating [W.m-3]', 'Total lithium in negative electrode [mol]', 'Total lithium in positive electrode [mol]', 'Total SEI thickness', 'Total SEI thickness [m]', 'Total positive electrode SEI thickness', 'Total positive electrode SEI thickness [m]', 'Transverse volume-averaged acceleration', 'Transverse volume-averaged acceleration [m.s-2]', 'Transverse volume-averaged velocity', 'Transverse volume-averaged velocity [m.s-2]', 'Volume-averaged Ohmic heating', 'Volume-averaged Ohmic heating [W.m-3]', 'Volume-averaged acceleration', 'Volume-averaged acceleration [m.s-1]', 'Volume-averaged cell temperature', 'Volume-averaged cell temperature [K]', 'Volume-averaged irreversible electrochemical heating', 'Volume-averaged irreversible electrochemical heating[W.m-3]', 'Volume-averaged reversible heating', 'Volume-averaged reversible heating [W.m-3]', 'Volume-averaged total heating', 'Volume-averaged total heating [W.m-3]', 'Volume-averaged velocity', 'Volume-averaged velocity [m.s-1]', 'X-averaged Ohmic heating', 'X-averaged Ohmic heating [W.m-3]', 'X-averaged battery concentration overpotential [V]', 'X-averaged battery electrolyte ohmic losses [V]', 'X-averaged battery open-circuit voltage [V]', 'X-averaged battery reaction overpotential [V]', 'X-averaged battery solid phase ohmic losses [V]', 'X-averaged cell temperature', 'X-averaged cell temperature [K]', 'X-averaged concentration overpotential', 'X-averaged concentration overpotential [V]', 'X-averaged electrolyte concentration', 'X-averaged electrolyte concentration [Molar]', 'X-averaged electrolyte concentration [mol.m-3]', 'X-averaged electrolyte ohmic losses', 'X-averaged electrolyte ohmic losses [V]', 'X-averaged electrolyte overpotential', 'X-averaged electrolyte overpotential [V]', 'X-averaged electrolyte potential', 'X-averaged electrolyte potential [V]', 'X-averaged inner SEI concentration [mol.m-3]', 'X-averaged inner SEI interfacial current density', 'X-averaged inner SEI interfacial current density [A.m-2]', 'X-averaged inner SEI thickness', 'X-averaged inner SEI thickness [m]', 'X-averaged inner positive electrode SEI concentration [mol.m-3]', 'X-averaged inner positive electrode SEI interfacial current density', 'X-averaged inner positive electrode SEI interfacial current density [A.m-2]', 'X-averaged inner positive electrode SEI thickness', 'X-averaged inner positive electrode SEI thickness [m]', 'X-averaged irreversible electrochemical heating', 'X-averaged irreversible electrochemical heating [W.m-3]', 'X-averaged negative electrode active material volume fraction', 'X-averaged negative electrode active material volume fraction change', 'X-averaged negative electrode entropic change', 'X-averaged negative electrode exchange current density', 'X-averaged negative electrode exchange current density [A.m-2]', 'X-averaged negative electrode exchange current density per volume [A.m-3]', 'X-averaged negative electrode extent of lithiation', 'X-averaged negative electrode interfacial current density', 'X-averaged negative electrode interfacial current density [A.m-2]', 'X-averaged negative electrode interfacial current density per volume [A.m-3]', 'X-averaged negative electrode ohmic losses', 'X-averaged negative electrode ohmic losses [V]', 'X-averaged negative electrode open-circuit potential', 'X-averaged negative electrode open-circuit potential [V]', 'X-averaged negative electrode oxygen exchange current density', 'X-averaged negative electrode oxygen exchange current density [A.m-2]', 'X-averaged negative electrode oxygen exchange current density per volume [A.m-3]', 'X-averaged negative electrode oxygen interfacial current density', 'X-averaged negative electrode oxygen interfacial current density [A.m-2]', 'X-averaged negative electrode oxygen interfacial current density per volume [A.m-3]', 'X-averaged negative electrode oxygen open-circuit potential', 'X-averaged negative electrode oxygen open-circuit potential [V]', 'X-averaged negative electrode oxygen reaction overpotential', 'X-averaged negative electrode oxygen reaction overpotential [V]', 'X-averaged negative electrode porosity', 'X-averaged negative electrode porosity change', 'X-averaged negative electrode potential', 'X-averaged negative electrode potential [V]', 'X-averaged negative electrode pressure', 'X-averaged negative electrode reaction overpotential', 'X-averaged negative electrode reaction overpotential [V]', 'X-averaged negative electrode resistance [Ohm.m2]', 'X-averaged SEI concentration [mol.m-3]', 'X-averaged SEI film overpotential', 'X-averaged SEI film overpotential [V]', 'X-averaged SEI interfacial current density', 'X-averaged SEI interfacial current density [A.m-2]', 'X-averaged negative electrode surface area to volume ratio', 'X-averaged negative electrode surface area to volume ratio [m-1]', 'X-averaged negative electrode surface potential difference', 'X-averaged negative electrode surface potential difference [V]', 'X-averaged negative electrode temperature', 'X-averaged negative electrode temperature [K]', 'X-averaged negative electrode tortuosity', 'X-averaged negative electrode total interfacial current density', 'X-averaged negative electrode total interfacial current density [A.m-2]', 'X-averaged negative electrode total interfacial current density per volume [A.m-3]', 'X-averaged negative electrode transverse volume-averaged acceleration', 'X-averaged negative electrode transverse volume-averaged acceleration [m.s-2]', 'X-averaged negative electrode transverse volume-averaged velocity', 'X-averaged negative electrode transverse volume-averaged velocity [m.s-2]', 'X-averaged negative electrode volume-averaged acceleration', 'X-averaged negative electrode volume-averaged acceleration [m.s-1]', 'X-averaged negative electrolyte concentration', 'X-averaged negative electrolyte concentration [mol.m-3]', 'X-averaged negative electrolyte potential', 'X-averaged negative electrolyte potential [V]', 'X-averaged negative electrolyte tortuosity', 'X-averaged negative particle concentration', 'X-averaged negative particle concentration [mol.m-3]', 'X-averaged negative particle flux', 'X-averaged negative particle surface concentration', 'X-averaged negative particle surface concentration [mol.m-3]', 'X-averaged open-circuit voltage', 'X-averaged open-circuit voltage [V]', 'X-averaged outer SEI concentration [mol.m-3]', 'X-averaged outer SEI interfacial current density', 'X-averaged outer SEI interfacial current density [A.m-2]', 'X-averaged outer SEI thickness', 'X-averaged outer SEI thickness [m]', 'X-averaged outer positive electrode SEI concentration [mol.m-3]', 'X-averaged outer positive electrode SEI interfacial current density', 'X-averaged outer positive electrode SEI interfacial current density [A.m-2]', 'X-averaged outer positive electrode SEI thickness', 'X-averaged outer positive electrode SEI thickness [m]', 'X-averaged positive electrode active material volume fraction', 'X-averaged positive electrode active material volume fraction change', 'X-averaged positive electrode entropic change', 'X-averaged positive electrode exchange current density', 'X-averaged positive electrode exchange current density [A.m-2]', 'X-averaged positive electrode exchange current density per volume [A.m-3]', 'X-averaged positive electrode extent of lithiation', 'X-averaged positive electrode interfacial current density', 'X-averaged positive electrode interfacial current density [A.m-2]', 'X-averaged positive electrode interfacial current density per volume [A.m-3]', 'X-averaged positive electrode ohmic losses', 'X-averaged positive electrode ohmic losses [V]', 'X-averaged positive electrode open-circuit potential', 'X-averaged positive electrode open-circuit potential [V]', 'X-averaged positive electrode oxygen exchange current density', 'X-averaged positive electrode oxygen exchange current density [A.m-2]', 'X-averaged positive electrode oxygen exchange current density per volume [A.m-3]', 'X-averaged positive electrode oxygen interfacial current density', 'X-averaged positive electrode oxygen interfacial current density [A.m-2]', 'X-averaged positive electrode oxygen interfacial current density per volume [A.m-3]', 'X-averaged positive electrode oxygen open-circuit potential', 'X-averaged positive electrode oxygen open-circuit potential [V]', 'X-averaged positive electrode oxygen reaction overpotential', 'X-averaged positive electrode oxygen reaction overpotential [V]', 'X-averaged positive electrode porosity', 'X-averaged positive electrode porosity change', 'X-averaged positive electrode potential', 'X-averaged positive electrode potential [V]', 'X-averaged positive electrode pressure', 'X-averaged positive electrode reaction overpotential', 'X-averaged positive electrode reaction overpotential [V]', 'X-averaged positive electrode resistance [Ohm.m2]', 'X-averaged positive electrode SEI concentration [mol.m-3]', 'X-averaged positive electrode SEI film overpotential', 'X-averaged positive electrode SEI film overpotential [V]', 'X-averaged positive electrode SEI interfacial current density', 'X-averaged positive electrode SEI interfacial current density [A.m-2]', 'X-averaged positive electrode surface area to volume ratio', 'X-averaged positive electrode surface area to volume ratio [m-1]', 'X-averaged positive electrode surface potential difference', 'X-averaged positive electrode surface potential difference [V]', 'X-averaged positive electrode temperature', 'X-averaged positive electrode temperature [K]', 'X-averaged positive electrode tortuosity', 'X-averaged positive electrode total interfacial current density', 'X-averaged positive electrode total interfacial current density [A.m-2]', 'X-averaged positive electrode total interfacial current density per volume [A.m-3]', 'X-averaged positive electrode transverse volume-averaged acceleration', 'X-averaged positive electrode transverse volume-averaged acceleration [m.s-2]', 'X-averaged positive electrode transverse volume-averaged velocity', 'X-averaged positive electrode transverse volume-averaged velocity [m.s-2]', 'X-averaged positive electrode volume-averaged acceleration', 'X-averaged positive electrode volume-averaged acceleration [m.s-1]', 'X-averaged positive electrolyte concentration', 'X-averaged positive electrolyte concentration [mol.m-3]', 'X-averaged positive electrolyte potential', 'X-averaged positive electrolyte potential [V]', 'X-averaged positive electrolyte tortuosity', 'X-averaged positive particle concentration', 'X-averaged positive particle concentration [mol.m-3]', 'X-averaged positive particle flux', 'X-averaged positive particle surface concentration', 'X-averaged positive particle surface concentration [mol.m-3]', 'X-averaged reaction overpotential', 'X-averaged reaction overpotential [V]', 'X-averaged reversible heating', 'X-averaged reversible heating [W.m-3]', 'X-averaged SEI film overpotential', 'X-averaged SEI film overpotential [V]', 'X-averaged separator electrolyte concentration', 'X-averaged separator electrolyte concentration [mol.m-3]', 'X-averaged separator electrolyte potential', 'X-averaged separator electrolyte potential [V]', 'X-averaged separator porosity', 'X-averaged separator porosity change', 'X-averaged separator pressure', 'X-averaged separator temperature', 'X-averaged separator temperature [K]', 'X-averaged separator tortuosity', 'X-averaged separator transverse volume-averaged acceleration', 'X-averaged separator transverse volume-averaged acceleration [m.s-2]', 'X-averaged separator transverse volume-averaged velocity', 'X-averaged separator transverse volume-averaged velocity [m.s-2]', 'X-averaged separator volume-averaged acceleration', 'X-averaged separator volume-averaged acceleration [m.s-1]', 'X-averaged solid phase ohmic losses', 'X-averaged solid phase ohmic losses [V]', 'X-averaged total heating', 'X-averaged total heating [W.m-3]', 'X-averaged total SEI thickness', 'X-averaged total SEI thickness [m]', 'X-averaged total positive electrode SEI thickness', 'X-averaged total positive electrode SEI thickness [m]', 'X-averaged volume-averaged acceleration', 'X-averaged volume-averaged acceleration [m.s-1]', 'r_n', 'r_n [m]', 'r_p', 'r_p [m]', 'x', 'x [m]', 'x_n', 'x_n [m]', 'x_p', 'x_p [m]', 'x_s', 'x_s [m]']\n"
+     ]
+    }
+   ],
+   "source": [
+    "keys = list(model.variables.keys())\n",
+    "keys.sort()\n",
+    "print(keys)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to find a particular variable you can search the variables dictionary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time\n",
+      "Time [h]\n",
+      "Time [min]\n",
+      "Time [s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.variables.search(\"time\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the time in hours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pybamm.solvers.processed_variable.ProcessedVariable at 0x7f69966b6210>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution['Time [h]']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This created a new processed variable and stored it on the solution object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['Negative particle surface concentration [mol.m-3]', 'Electrolyte concentration [mol.m-3]', 'Positive particle surface concentration [mol.m-3]', 'Current [A]', 'Negative electrode potential [V]', 'Electrolyte potential [V]', 'Positive electrode potential [V]', 'Voltage [V]', 'Time [h]'])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution.data.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see the data by simply accessing the entries attribute of the processed variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.   , 0.025, 0.05 , 0.075, 0.1  , 0.125, 0.15 , 0.175, 0.2  ,\n",
+       "       0.225, 0.25 , 0.275, 0.3  , 0.325, 0.35 , 0.375, 0.4  , 0.425,\n",
+       "       0.45 , 0.475, 0.5  , 0.525, 0.55 , 0.575, 0.6  , 0.625, 0.65 ,\n",
+       "       0.675, 0.7  , 0.725, 0.75 , 0.775, 0.8  , 0.825, 0.85 , 0.875,\n",
+       "       0.9  , 0.925, 0.95 , 0.975])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution['Time [h]'].entries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also call the method with specified time(s) in SI units of seconds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_in_seconds = np.array([0, 600, 900, 1700, 3000 ])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.        , 0.16666667, 0.25      , 0.47222222, 0.83333333])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "solution['Time [h]'](time_in_seconds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the variable has not already been processed it will be created behind the scenes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([298.15, 298.15, 298.15, 298.15, 298.15])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "var = 'X-averaged negative electrode temperature [K]'\n",
+    "solution[var](time_in_seconds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example the simulation was isothermal, so the temperature remains unchanged."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Saving the solution\n",
+    "\n",
+    "The solution can be saved in a number of ways:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# to a pickle file (default)\n",
+    "solution.save_data(\n",
+    "    \"outputs.pickle\", [\"Time [h]\", \"Current [A]\", \"Voltage [V]\", \"Electrolyte concentration [mol.m-3]\"]\n",
+    ")\n",
+    "# to a matlab file\n",
+    "# need to give variable names without space\n",
+    "solution.save_data(\n",
+    "    \"outputs.mat\", \n",
+    "    [\"Time [h]\", \"Current [A]\", \"Voltage [V]\", \"Electrolyte concentration [mol.m-3]\"], \n",
+    "    to_format=\"matlab\",\n",
+    "    short_names={\n",
+    "        \"Time [h]\": \"t\", \"Current [A]\": \"I\", \"Voltage [V]\": \"V\", \"Electrolyte concentration [mol.m-3]\": \"c_e\",\n",
+    "    }\n",
+    ")\n",
+    "# to a csv file (time-dependent outputs only, no spatial dependence allowed)\n",
+    "solution.save_data(\n",
+    "    \"outputs.csv\", [\"Time [h]\", \"Current [A]\", \"Voltage [V]\"], to_format=\"csv\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stepping the solver\n",
+    "\n",
+    "The previous solution was created in one go with the solve method, but it is also possible to step the solution and look at the results as we go. In doing so, the results are automatically updated at each step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Time 0\n",
+      "[3.77047806 3.71250693]\n",
+      "Time 360\n",
+      "[3.77047806 3.71250693 3.68215218]\n",
+      "Time 720\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574]\n",
+      "Time 1080\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942]\n",
+      "Time 1440\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857]\n",
+      "Time 1800\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
+      " 3.59709451]\n",
+      "Time 2160\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
+      " 3.59709451 3.58821334]\n",
+      "Time 2520\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
+      " 3.59709451 3.58821334 3.58056055]\n",
+      "Time 2880\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
+      " 3.59709451 3.58821334 3.58056055 3.55158694]\n",
+      "Time 3240\n",
+      "[3.77047806 3.71250693 3.68215218 3.66125574 3.64330942 3.61166857\n",
+      " 3.59709451 3.58821334 3.58056055 3.55158694 3.16842636]\n"
+     ]
+    }
+   ],
+   "source": [
+    "dt = 360\n",
+    "time = 0\n",
+    "end_time = solution[\"Time [s]\"].entries[-1]\n",
+    "step_simulation = pybamm.Simulation(model)\n",
+    "while time < end_time:\n",
+    "    step_solution = step_simulation.step(dt)\n",
+    "    print('Time', time)\n",
+    "    print(step_solution[\"Voltage [V]\"].entries)\n",
+    "    time += dt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot the voltages and see that the solutions are the same"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f69964178d0>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD8CAYAAABn919SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAp9ElEQVR4nO3de3xU1bn/8c+TcBcUlaBcTCIFrQghQkRUIhdRqXjwyq2hgrXiHY9WWpUeKxZ+R62tPVpPlfZU0MYCWtsiWkUrCKKAgFy8ICggcpGbgIKCkDy/P1YSkjAhE5hkksn3/Xrt18zee83sZ5PhmTVrr72WuTsiIlLzJcU7ABERiQ0ldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQ5SZ0M2tgZvPNbImZfWBmYyKUSTWzGWb2npktNbOLKydcEREpi5XXD93MDDjK3XeZWV3gLeA2d59brMx44D13/4OZtQdedvf0SoxbRERKqVNeAQ8Zf1fBat2CpfS3gANHFzw/BtgQqwBFRCQ65dbQAcwsGVgItAUed/efl9rfApgOHAscBfRx94WHes9mzZp5enr6YYYtIlI7LVy4cKu7p0TaV24NHcDd84BMM2sK/N3MOrj7+8WKDAEmuPtvzOxs4JmCMvnF38fMRgAjAFJTU1mwYMFhnI6ISO1lZp+Vta9CvVzcfQcwA+hbate1wJSCMu8ADYBmEV4/3t2z3D0rJSXiF4yIiBymaHq5pBTUzDGzhsAFwPJSxdYC5xeUOY2Q0LfENFIRETmkaJpcWgATC9rRk4Ap7j7NzO4HFrj7VOCnwB/N7HbCBdLhrmEcRUSqVDS9XJYCZ0TYfm+x5x8C58Y2NJHqY9++faxbt449e/bEOxSpJRo0aEDr1q2pW7du1K+J6qKoSG23bt06mjRpQnp6OuHWDJHK4+5s27aNdevWcfLJJ0f9upp1639uLqSnQ1JSeMzNjXdEUkvs2bOH448/XslcqoSZcfzxx1f4F2HNqaHn5sKIEfDNN2H9s8/COkBOTvziklpDyVyq0uF83mpODX306APJvNA334TtIiJSgxL62rUV2y4iUsvUnISemlqx7SIJZty4cZx++ulkZGSQmZnJvHnzAOjZsyennnoqnTp14txzz+Xjjz8u2p6amkrxHsSXXXYZjRs3rtBx3Z3evXvz1Vdfxexc1qxZw7PPPlu0vmDBAkaOHBmz969qw4cP5/nnnz+s1w4ePJiVK1fGJI6ak9DHjYNGjUps2k0jPrlmXJwCEqk677zzDtOmTWPRokUsXbqU119/nZNOOqlof25uLkuWLGHYsGGMGjWqaHvTpk2ZM2cOADt27GDjxo0VPvbLL79Mp06dOProo8svHKXSCT0rK4tHH300Zu9fk9x444089NBDMXmvmpPQc3Jg/HhISwMz8lqnMbrZeM793xw+K3NkA5HY+8//hJ49Y7v8538e+pgbN26kWbNm1K9fH4BmzZrRsmXLg8qdd955fPLJJ0XrgwcPZtKkSQC88MILXHHFFSXK//rXv+bMM88kIyODX/7ylxGPnZuby6WXXlq0/vTTT5ORkUGnTp340Y9+BIQE3bt3bzIyMjj//PNZW9AUOnz4cEaOHMk555xDmzZtimqxd911F7NnzyYzM5NHHnmEmTNncskllwBw33338eMf/5iePXvSpk2bokS/Zs0aOnToUBTHww8/zH333QfA4sWL6datGxkZGVx++eVs374dCL9SCseM2rp1K4UDAn7wwQd07dqVzMxMMjIyDqoh5+XlMXz4cDp06EDHjh155JFHDnmcQq+88goDBgwoWi9+XtOnT+fss8+mc+fODBgwgF27wiC22dnZvP766+zfvz/iv39F1JyEDiGpr1kD+fkkf76GEW/msGcP/Md/wNdfxzs4kcpz4YUX8vnnn3PKKadw00038eabb0Ys9+KLL9KxY8ei9fPPP59Zs2aRl5fHpEmTGDRoUNG+6dOns3LlSubPn8/ixYtZuHAhs2bNOug958yZQ5cuXYCQCMeOHcsbb7zBkiVL+J//+R8Abr31VoYNG8bSpUvJyckp0XyyceNG3nrrLaZNm8Zdd90FwAMPPEB2djaLFy/m9ttvP+iYy5cv59VXX2X+/PmMGTOGffv2HfLf5+qrr+bBBx9k6dKldOzYkTFjDpqHp4QnnniC2267jcWLF7NgwQJat25dYv/ixYtZv34977//PsuWLeOaa66J6jh9+vRh3rx57N69G4DJkyczePBgtm7dytixY3n99ddZtGgRWVlZ/Pa3vwUgKSmJtm3bsmTJkkPGHI2a020xgvbt4bnn4OKLYcgQ+Oc/ITk53lFJovvd76r+mI0bN2bhwoXMnj2bGTNmMGjQIB544AGGDx8OQE5ODg0bNiQ9PZ3HHnus6HXJycl0796dSZMm8e2331J8yOrp06czffp0zjgj3Ai+a9cuVq5cyXnnnVfi2F9++SVNmjQB4I033mDAgAE0axbG3jvuuOOA0CT0wgsvAPCjH/2In/3sZ0Wvv+yyy0hKSqJ9+/Zs2rQpqvPt168f9evXp379+jRv3vyQr9u5cyc7duygR48eAAwbNqxELTmSs88+m3HjxrFu3TquuOIK2rVrV2J/mzZtWLVqFbfeeiv9+vXjwgsvjOo4derUoW/fvrz44otcddVVvPTSSzz00EO8+eabfPjhh5x7brih/rvvvuPss88uel3z5s3ZsGFD0Rfn4arRCR3gwgvhscfgpptg1Cgo+NITSTjJycn07NmTnj170rFjRyZOnFiU0HNzc8nKyor4usGDB3P55ZcXNU8Ucnfuvvturr/++kMet06dOuTn55OUdHg/6AubiQqPWdHXJCcns3///qI4CkVz003x1xQv/8Mf/pCzzjqLl156iYsvvpgnn3yS3r17F+0/9thjWbJkCa+++ipPPPEEU6ZMKWp2Kc/gwYP5/e9/z3HHHUdWVhZNmjTB3bngggv461//GvE1e/bsoWHDhlG9/6HUrCaXMtx4I4wcCY88Ak8+Ge9oRGLv448/LtHOu3jxYtLS0qJ6bXZ2NnfffTdDhgwpsf2iiy7iz3/+c1Fb7vr169m8efNBrz/11FNZtWoVAL179+a5555j27ZtQKi9A5xzzjlFbfW5ublkZ2cfMqYmTZrwdQXbSU844QQ2b97Mtm3b2Lt3L9OmTQPgmGOO4dhjj2X27NkAPPPMM0W16PT0dBYuDHPtFO+FsmrVKtq0acPIkSO59NJLWbp0aYljbd26lfz8fK688krGjh3LokWLDnmc4nr06MGiRYv44x//yODBgwHo1q0bc+bMKbq+sXv3blasWFH0mhUrVpS4PnC4anwNvdBvfgMrV8LNN8Oxx8KAAaAb+yRR7Nq1i1tvvZUdO3ZQp04d2rZty/jx46N6rZlx5513HrT9wgsv5KOPPir66d+4cWP+8pe/0Lx58xLl+vXrx8yZM2nbti2nn346o0ePpkePHiQnJ3PGGWcwYcIEHnvsMa655hp+/etfk5KSwlNPPXXImDIyMkhOTqZTp04MHz68qNnnUOrWrcu9995L165dadWqFd///veL9k2cOJEbbriBb775hjZt2hQd/84772TgwIGMHz+efv36FZWfMmUKzzzzDHXr1uXEE0/knnvuKXGs9evXc8011xTV7v/7v//7kMcpLjk5mUsuuYQJEyYwceJEAFJSUpgwYQJDhgxh7969AIwdO5ZTTjmFTZs20bBhQ0488cRy/w3KE9UUdJUhKyvLYz1j0VdfQY8esHgxdO4Mv/gFXHppGPpF5Eh89NFHnHbaafEOIy42btzI1VdfzWuvvRbvUBLSI488wtFHH82111570L5InzszW+juEdvXEirVHX00zJsHf/oT7NwJV1wBnTrB5MmQlxfv6ERqphYtWnDdddfF9MYiOaBp06YMGzYsJu+VUAkdoF49uPZaWL4cnnkG9u+HwYPh9NPh6afDuohUzMCBA2N6Y5EccM0111CnTmxavxMuoReqUweGDoX334cpU6B+fRg2DE49FR59NDTPiIgkkoRN6IWSk8MF0vfeC/3UTzgBbrsNWrUKPWOKXWgWEanREj6hF0pKgv794e23Yf58uPxyeOKJUGO/+GJ45RUo1sVVRKTGqTUJvbgzzwzt6WvXwpgxofb+gx/AaaeF5pgdO+IdocjBqvNoi7/73e/4pvR8BVXoSEY7LDRhwgRuueWWw3rt73//e/785z8f0fFjoVYm9EInngj33hsmP8rNhaZNQ3NMy5YwfDi88w4U/V/Q9HdSETH+vFT30RbjndDj7cc//nGJIRfipVYn9EL16sEPfxi6PC5cCFdfDX/7G5xzDmRkwCtX5+LXjQiZ3/3A9HdK6hJJ4XSJMfy8VJfRFnfv3k2/fv3o1KkTHTp0YPLkyTz66KNs2LCBXr160atXL6DskQXT09P52c9+RseOHenatWtRrMOHD+eGG24gKyuLU045pegu0Ly8PEaNGlUU45MFt4K7O7fccgunnnoqffr0iXiHK8Cjjz5K+/btycjIKLpr88svv+Syyy4jIyODbt26HXSX6M6dO0lLSyu6qWj37t2cdNJJ7Nu3j08//ZS+ffvSpUsXsrOzWb58OQCNGjUiPT2d+fPnR4yjyrh7XJYuXbp4dfb11+7jx7tnZbmvJs09/NcsuaSlxTtMqSIffvhh9IXT0mL+efn666+9U6dO3q5dO7/xxht95syZRft69Ojh7777rru7P/TQQz5w4MCi7XPnzvWOHTv6/v37/YILLvDVq1f7UUcd5e7ur776ql933XWen5/veXl53q9fP3/zzTcPOnZqaqp/9dVX7u7+/PPP+09+8pOifTt27Cg45TTfsmWLu7tv2bLFs7OzfdeuXe7u/sADD/iYMWOKyo0dO9bd3SdOnOj9+vVzd/dhw4b5RRdd5Hl5eb5ixQpv1aqVf/vtt/7kk0/6r371K3d337Nnj3fp0sVXrVrlf/vb37xPnz6+f/9+X79+vR9zzDH+3HPPHRR7ixYtfM+ePe7uvn37dnd3v+WWW/y+++5zd/d///vf3qlTJ3d3f+qpp/zmm292d/f+/fv7G2+84e7ukyZN8muvvdbd3Xv37u0rVqxwd/e5c+d6r169io41duxYf/jhhyP9+Q5bpM8dsMDLyKuqoZehcWO47jp4911Is8jT3Lmmv5NIKmG6xMLRFsePH09KSgqDBg1iwoQJRftzcnLIzMxkzpw5PPzww0Xbox1tsXPnzixfvjzizDnFR1vs2LEjr732Gj//+c+ZPXs2xxxzzEHl586dWzSyYGZmJhMnTuSzYpMWFI4pM2TIEN55552i7QMHDiQpKYl27drRpk0bli9fzvTp03n66afJzMzkrLPOYtu2baxcuZJZs2YxZMgQkpOTadmyZYmBtYrLyMggJyeHv/zlL0V9vd96662icdx79+7Ntm3bDro+MGjQICZPngxQNOzwrl27ePvttxkwYACZmZlcf/31JZqwCkdMjKdye7ObWQNgFlC/oPzz7v7LUmUeAXoVrDYCmrt709iGGj+WmkqkWTQ+81SG9Qj926+6KtypKkIZn5cjnS6xOoy2eMopp7Bo0SJefvllfvGLX3D++edz7733HvS+hxpZsPhs9mU9L1x3dx577DEuuuiiEvtefvnlQ8Zc6KWXXmLWrFm8+OKLjBs3jmXLlkX1uv79+3PPPffw5ZdfsnDhQnr37s3u3btp2rQpixcvjviaWI2YeCSiqaHvBXq7eycgE+hrZt2KF3D32909090zgceAF2IdaFxFmP4uv2EjFg8YxxdfhDtTTzwxzL8xbRp8912c4pTqIcLnhUaNwvbDVF1GW9ywYQONGjVi6NChjBo1ikWLFgElR08sb2TBwprv5MmTS4wJ/txzz5Gfn8+nn37KqlWrOPXUU7nooov4wx/+UDTBxYoVK9i9ezfnnXcekydPJi8vj40bNzJjxoyD4s7Pz+fzzz+nV69ePPjgg+zcuZNdu3aRnZ1NbsH1jJkzZ9KsWbODLvg2btyYM888k9tuu41LLrmE5ORkjj76aE4++WSee+45IHxxFZ+UIlYjJh6JcmvoBW02uwpW6xYshxrRawgQ+epKTZWTEx5Hjw4/m1NTSRo3jstycrjUw8XUiRPDmDHPPht6y1xxRRhyoFevcNeq1CIRPi+MG3dg+2GoLqMtLlu2jFGjRpGUlETdunX5wx/+AMCIESPo27cvLVu2ZMaMGWWOLAiwfft2MjIyqF+/folafGpqKl27duWrr77iiSeeoEGDBvzkJz9hzZo1dO7cGXcnJSWFf/zjH1x++eW88cYbtG/fntTU1BJfDIXy8vIYOnQoO3fuxN0ZOXIkTZs2LZriLiMjg0aNGhWNiFjaoEGDGDBgADNnzizalpuby4033sjYsWPZt28fgwcPplOnTkCY2an0r6AqV1bjevEFSAYWExL7g4colwZsBJLL2D8CWAAsSE1NjeGlg+ph7173adPcf/Qj9yZNwnWwlBT3G25wnznTff/+eEcoh6tCF0UTzIYNG7xPnz4xea/iF0+LGzZsWMSLmjXFokWLfOjQoTF/30q5KOrueR6aU1oDXc2srN8Vgwlt7BHHNnT38e6e5e5ZKSkp0X3j1CD16kG/fuGmpc2b4YUXoHfvsN6zZxhuYMQIePlliGKyFZFqQaMtlm/r1q386le/incYFR8P3czuBb5x94cj7HsPuNnd3y7vfSpjPPTqavfu0Lb+97+HZP7116EXzQ9+AJddFoYeaNo03lHKodTm8dAlfmI+HrqZpZhZ04LnDYELgOURyn0fOBZ4p/S+2u6oo2DQIJg0CbZsgX/9KzSnzp4dHlNS4IILwuTDH39c7O5U0B2q1UhFKz8iR+JwPm/RNLm0AGaY2VLgXeA1d59mZvebWf9i5QYDk1yf+kOqXx/69g0Dg61fH4YX+OlPYd06uP12+P734XvfC1PpLbpTd6hWFw0aNGDbtm1K6lIl3J1t27bRoEGDCr0uoaagq+lWrw6jPv7rX/Dvf8MH36STToT+zGlpsGZNlcdXm+3bt49169ZFNdO8SCw0aNCA1q1bU7du3RLbD9XkooReTe3dC/UaJmER/j75GE88nk/v3mH4X02GLVJ7HCqhq4d0NVW/PmXecbghOZWbbw7PW7YMPWnOOw+6dw9NNkrwIrWTxnKpzsq447DVxHF88gmMHx8S+fTpoWm9fftwgfXSS+Hhh2HuXN21KlKbqIZenZVxx6Hl5PA9wsXT664L10tXroS33jqwTJ0aXtqgAXTtCmeddWBp1Uq1eJFEpDb0BLVpE8yZE5L7nDmwePGB2nqLFiGxFyb6rKwyBhbLzY3p7esicuR0UVTYuxeWLAnjzsyfHx6Lj5Tati107nxg6bYqlyZ3jIDis9A0ahTaeZTUReJGCV0i+vLLkNwXLTqwrF4d9q0mcpdJT03DPltTtYGKSBH1cpGIjjsu3OTUt++BbV9+GZpn0s4ve1KP7O7QqVNYMjKgQ4cwlIGIxJcSupRw3HGhGyRpkbtMbm+cSlIS/OUv8L//e2B7mzYhuXfseOCxbVtITq662EVqOyV0iWzcuNAXslQb+vFPjGNWzoGRCJYsgWXLwrJ0aehdUzC3Lg0ahMSemXlgychQbV6ksqgNXcp2GL1cvv0WPvooJPelS0PCf+892L497DeDdu1Ccj/jDOjWDc48MwxgdiTHFaktdFFU4so9DD723nuhfb5wKbwAm5wcEvw558DgvFy6PTWCpG/Vu0YkEiV0qZa+/DLczfr222GZN08DkomUR71cpFo67rgwucfFF4f1/fshud7aiDPW5n+2locegEsugdNP152uIpFoLBepNurUAUtNjbjvi7qp3H13uMianh7Gi589u9RkICK1nBK6VC9lDEjW8qlxrFsXmtIzM2HChDAwWdu2MGbMgfZ4kdpMCV2ql5yckLXT0kK7Slpa0QXRVq3CYGT//GcYq2bixFBbHzMm9IPv2ROeeirM2SpSG+miqNR4a9fCM8+EWvsnn4QK/pVXwo9/DD16qL1dEssRTRItUt2lpoZu6ytWhJElhw4NtfhevUKf93HjQrdJkUSnhC4Jwyz0ZX/ySdi4MdTaU1PhF78ILTcXXwzPPx9GnhRJRErokpAaNQo19TfeCM0w99wThicYMCBM8HHjjWGmpxIzOuXmhkb5pKTwmJsbp+hFDo/a0KXWyMuD114LF06nTQvD1Bx9NPTrB7cen0u3/xuB6Q5VqeZ0p6hIKd9+C6+/Dv/4RxhQ7N2tukNVagbdKSpSSsOG8B//EZa8PEiqW/Ydqv9vLJx9dpiyr0mTqo9VJFrlJnQzawDMAuoXlH/e3X8ZodxA4D7Cf4sl7v7D2IYqUjmSkwlXTyOM//5F3VT+67/C86SkcKdqVha0bw+nnRYeTzop7BOJt2hq6HuB3u6+y8zqAm+Z2b/cfW5hATNrB9wNnOvu282seSXFK1I5yhj/veX4cWzvFwYOe+edMIjY1Knwf/9XohinnXZgadsWTj45LMcfH2U/eA0ZLDFQbkL30Mi+q2C1bsFS+sfpdcDj7r694DWbYxmkSKUrTJ4RkmpT4KKLwlJo69Yw7vtHH8GHH4bHmTPDTE7FNWkSOswUJviTTw41+tTU8JiSAkl/zS35ZfLZZ2G9eFwiUYjqoqiZJQMLgbaExP3zUvv/AawAzgWSgfvc/ZUI7zMCGAGQmpra5bMIP3FFarKvvw7jyqxeDatWHXheuBT/AQBQrx6syk+n1f6D/y/sPTGNbQvXcMIJmspPDohZLxczawr8HbjV3d8vtn0asA8YCLQmtLl3dPcdZb2XerlIbeMeavaffx5+BHz+eVge+HUSSRGuyOZjJJNPUhKceGLoP9+yZVhatDj4MSXlMNry1dRT48Ssl4u77zCzGUBf4P1iu9YB89x9H7DazFYA7YB3DzNmkYRjFpJuSgp07lxsx5TIF2T3pKTyv2Ng/foDy6efwltvwbZtB79/cjI0bx6S/wknhMfiz084Iexv3jyMRZ88SU09iSaaXi4pwL6CZN4QuAB4sFSxfwBDgKfMrBlwCrAqxrGKJKYyLsg2emQcN5aRV/fuhS++gA0bwjAHhY+bNoXtmzbB+++H5/v3H/z6pCRYw2hOyi/VBvTNN3x162heTs6hWTNKLA0axO6UpXJEU0NvAUwsaEdPAqa4+zQzux9Y4O5TgVeBC83sQyAPGOXuEeoQInKQQ1yQLUv9+uGep7S0Q791fn6YoPuLL2Dz5pJL67FrI76m8fa1DBly8PaGDUOvncKlWbOSz5s1C78+in8JlB7avgQ198Sc7hQVqa3S0yM29eS1TuPjV9ewdStFy7ZtYSn+vHDZvj18cUTSsGFo4mnRomR7/7lrcun+zAjq7NVQCxWlO0VF5GBlNPUkPzCO9u2jf5u8PNix40Dy37KFEl8GmzaF5qCPPw5dO7dvh9WMpg4HN/dsvX40j3+SQ9u2Yejjdu3g2GNjcbK1g2roIrVZHJo9vv0WGhyVhEXIPfkYdSy/xFyx3/senHXWgSUzMzQ51VYanEtEqpcymntIS+Pbj9awenUY9vjDD2H+fJg7N9TyIfTdP+OMkNx79YK+fWvXBVsldBGpXnJzIzb3lNWG7h5mnZo378CyYEGo7TdpApdeCgMHwoUXJn7tXQldRKqfI2zu2bcPZsyAyZPh738PbfPHHAOXXx6Se58+ULduJcYfJ0roIpLQvvsujG8/ZUoY437nznDz1B13wO23l9N9sobRJNEiktDq1Qtzxk6YEHrVTJ0K3buH+WRPPRWefrrsrpWJRAldRBJK/fph4pJ//hNmzQr93ocNgy5dwhyziTx3rBK6iCSs7OzQQ+bZZ0Mb+5/Oz2XPsBGhh437gfFrEiSpqw1dRGqFPXtgb4t0jtlRs+eO1Z2iIlLrNWgADXZGHr+GtWVsr2HU5CIitUdqasTNflLk7TWNErqI1B7jxh3Uh3E3jfhd83F8912cYoohJXQRqT1ycsLdqGlpYcaRtDRmDR3PHQtyGDiQGp/UldBFpHbJyQkXQPPzYc0afvBMDo89Fro5XnVVmDykplJCF5Fa75Zb4PHH4cUX4cora25SV0IXEQFuugmeeAJeegmuuCJ0c6xplNBFRApcf31oYn/55TAOTE2jhC4iUsx114Xa+h//CKtXxzuailFCFxEp5Z57IDkZxo6NdyQVo4QuIlJKq1Zwww0wcWKYOammUEIXEYngrrvCsLz33x/vSKKnhC4iEsGJJ4bujLm5sHx5vKOJjhK6iEgZRo2Chg3hvvviHUl0yk3oZtbAzOab2RIz+8DMxkQoM9zMtpjZ4oLlJ5UTrohI1UlJgdtuC1PbLVsW72jKF00NfS/Q2907AZlAXzPrFqHcZHfPLFj+FMsgRUTi5ac/hSZNakYtvdyE7sGugtW6BUt8ZsUQEalixx0XJpp+4QV47714R3NoUbWhm1mymS0GNgOvufu8CMWuNLOlZva8mZ1UxvuMMLMFZrZgy5Ythx+1iEgVuv12aNoUfvnLeEdyaFEldHfPc/dMoDXQ1cw6lCryIpDu7hnAa8DEMt5nvLtnuXtWSkrKEYQtIlJ1jjkG7rwzDN717rvxjqZsFerl4u47gBlA31Lbt7l74fhkfwK6xCQ6EZFqYuRIOP54uPfeeEdStmh6uaSYWdOC5w2BC4Dlpcq0KLbaH/gohjGKiMRdkybw85/DK6/A22/HO5rIoqmhtwBmmNlS4F1CG/o0M7vfzPoXlBlZ0KVxCTASGF454YqIxM9NN0Hz5tW3lm7u8emwkpWV5QsWLIjLsUVEDtcjj4ShdZcsgYyMqj++mS1096xI+3SnqIhIBVx1VXicOTOuYUSkhC4iUgEnnRTmmH7rrXhHcjAldBGRCureHWbPhji1WJdJCV1EpIKys+GLL2DVqnhHUpISuohIBXXvHh5nz45vHKUpoYuIVNBpp4UxXpTQRURquKSkUEuvbhdGldBFRA5D9+6wYgVs2hTvSA5QQhcROQzZ2eFxzpz4xlGcErqIyGHo3DlMT1ed2tGV0EVEDkO9enDWWUroIiIJITs7zGL09dfxjiRQQhcROUzdu0N+PsydG+9IAiV0EZHDdPbZoQtjdem+qIQuInKYmjSBzMzq046uhC4icgSys0OTy7598Y5ECV1E5IhkZ8O338KiRfGORAldROSIVKeBupTQRUSOwAknQLt21ePCqBK6iMgRKhyoKz8/vnEooYuIHKHsbNi2DT7+OL5xKKGLiByh6tKOroQuInKE2rYNbenxbkdXQhcROUJmodml2tfQzayBmc03syVm9oGZjTlE2SvNzM0sK7ZhiohUb927w5o1sG5d/GKIpoa+F+jt7p2ATKCvmXUrXcjMmgC3AfNiGqGISA1QOOFFPJtdyk3oHuwqWK1bsHiEor8CHgT2xC48EZGaISMDGjeOb7NLVG3oZpZsZouBzcBr7j6v1P7OwEnu/lI57zPCzBaY2YItW7YcbswiItVOnTpwzjnVvIYO4O557p4JtAa6mlmHwn1mlgT8FvhpFO8z3t2z3D0rJSXlMEMWEamesrNh2TLYsSM+x69QLxd33wHMAPoW29wE6ADMNLM1QDdgqi6Mikht0707uMdv4uhoermkmFnTgucNgQuA5YX73X2nuzdz93R3TwfmAv3dfUHlhCwiUj117Qp168av2SWaGnoLYIaZLQXeJbShTzOz+82sf+WGJyJSczRqBF26xO/CaJ3yCrj7UuCMCNvvLaN8zyMPS0SkZrrjDtgTp75+5SZ0ERGJ3oAB8Tu2bv0XEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIJTQRUQShBK6iEiCUEIXEUkQSugiIglCCV1EJEEooYuIJAgldBGRBKGELiKSIMpN6GbWwMzmm9kSM/vAzMZEKHODmS0zs8Vm9paZta+ccEVEpCzR1ND3Ar3dvROQCfQ1s26lyjzr7h3dPRN4CPhtTKMUEZFy1SmvgLs7sKtgtW7B4qXKfFVs9ajS+0VEpPKVm9ABzCwZWAi0BR5393kRytwM3AHUA3rHMkgRESlfVBdF3T2voDmlNdDVzDpEKPO4u38P+Dnwi0jvY2YjzGyBmS3YsmXLEYQtIiKlVaiXi7vvAGYAfQ9RbBJwWRmvH+/uWe6elZKSUpFDi4hIOaLp5ZJiZk0LnjcELgCWlyrTrthqP2BlDGMUEZEoRNOG3gKYWNCOngRMcfdpZnY/sMDdpwK3mFkfYB+wHRhWaRGLiEhE0fRyWQqcEWH7vcWe3xbjuEREpIJ0p6iISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEoYQuIpIglNBFRBJEuQndzBqY2XwzW2JmH5jZmAhl7jCzD81sqZn928zSKidcEREpSzQ19L1Ab3fvBGQCfc2sW6ky7wFZ7p4BPA88FNMoRUSkXOUmdA92FazWLVi8VJkZ7v5NwepcoHVMoxQRkXJF1YZuZslmthjYDLzm7vMOUfxa4F8xiE1ERCogqoTu7nnunkmoeXc1sw6RypnZUCAL+HUZ+0eY2QIzW7Bly5bDDFlERCKpUC8Xd98BzAD6lt5nZn2A0UB/d99bxuvHu3uWu2elpKQcRrgiIlKWaHq5pJhZ04LnDYELgOWlypwBPElI5psrIU4RESlHnSjKtAAmmlky4QtgirtPM7P7gQXuPpXQxNIYeM7MANa6e//KClpERA5WbkJ396XAGRG231vseZ8YxyUiIhWkO0VFRBKEErqISIJQQhcRqSq5uZCeDklJ4TE3N6ZvH81FUREROVK5uTBiBHxTcFP9Z5+FdYCcnJgcQjV0EZGqMHr0gWRe6JtvwvYYUUIXEakKa9dWbPthUEIXEakKqakV234YlNBFRKrCuHHQqFHJbY0ahe0xooQuIlIVcnJg/HhISwOz8Dh+fMwuiIJ6uYiIVJ2cnJgm8NJUQxcRSRBK6CIiCUIJXUQkQSihi4gkCCV0EZEEYe4enwObbQE+O8yXNwO2xjCcmkDnXDvonGuHIznnNHePOIdn3BL6kTCzBe6eFe84qpLOuXbQOdcOlXXOanIREUkQSugiIgmipib08fEOIA50zrWDzrl2qJRzrpFt6CIicrCaWkMXEZFSqnVCN7O+ZvaxmX1iZndF2F/fzCYX7J9nZulxCDOmojjnO8zsQzNbamb/NrO0eMQZS+Wdc7FyV5qZm1mN7xERzTmb2cCCv/UHZvZsVccYa1F8tlPNbIaZvVfw+b44HnHGipn92cw2m9n7Zew3M3u04N9jqZl1PuKDunu1XIBk4FOgDVAPWAK0L1XmJuCJgueDgcnxjrsKzrkX0Kjg+Y214ZwLyjUBZgFzgax4x10Ff+d2wHvAsQXrzeMddxWc83jgxoLn7YE18Y77CM/5PKAz8H4Z+y8G/gUY0A2Yd6THrM419K7AJ+6+yt2/AyYBl5YqcykwseD588D5ZmZVGGOslXvO7j7D3QsnJpwLtK7iGGMtmr8zwK+AB4E9VRlcJYnmnK8DHnf37QDuvrmKY4y1aM7ZgaMLnh8DbKjC+GLO3WcBXx6iyKXA0x7MBZqaWYsjOWZ1TuitgM+Lra8r2BaxjLvvB3YCx1dJdJUjmnMu7lrCN3xNVu45F/wUPcndX6rKwCpRNH/nU4BTzGyOmc01s75VFl3liOac7wOGmtk64GXg1qoJLW4q+v+9XJrgooYys6FAFtAj3rFUJjNLAn4LDI9zKFWtDqHZpSfhV9gsM+vo7jviGVQlGwJMcPffmNnZwDNm1sHd8+MdWE1RnWvo64GTiq23LtgWsYyZ1SH8TNtWJdFVjmjOGTPrA4wG+rv73iqKrbKUd85NgA7ATDNbQ2hrnFrDL4xG83deB0x1933uvhpYQUjwNVU053wtMAXA3d8BGhDGPElUUf1/r4jqnNDfBdqZ2clmVo9w0XNqqTJTgWEFz68C3vCCqw01VLnnbGZnAE8SknlNb1eFcs7Z3Xe6ezN3T3f3dMJ1g/7uviA+4cZENJ/tfxBq55hZM0ITzKoqjDHWojnntcD5AGZ2GiGhb6nSKKvWVODqgt4u3YCd7r7xiN4x3leCy7lKfDGhZvIpMLpg2/2E/9AQ/uDPAZ8A84E28Y65Cs75dWATsLhgmRrvmCv7nEuVnUkN7+US5d/ZCE1NHwLLgMHxjrkKzrk9MIfQA2YxcGG8Yz7C8/0rsBHYR/jFdS1wA3BDsb/x4wX/Hsti8bnWnaIiIgmiOje5iIhIBSihi4gkCCV0EZEEoYQuIpIglNBFRBKEErqISIJQQhcRSRBK6CIiCeL/AxAdFsZB2aDwAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "voltage = solution[\"Voltage [V]\"].entries\n",
+    "step_voltage = step_solution[\"Voltage [V]\"].entries\n",
+    "plt.figure()\n",
+    "plt.plot(solution[\"Time [h]\"].entries, voltage, \"b-\", label=\"SPMe (continuous solve)\")\n",
+    "plt.plot(\n",
+    "    step_solution[\"Time [h]\"].entries, step_voltage, \"ro\", label=\"SPMe (stepped solve)\"\n",
+    ")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "As a final step, we will clean up the output files created by this notebook:"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "os.remove(\"outputs.csv\")\n",
+    "os.remove(\"outputs.mat\")\n",
+    "os.remove(\"outputs.pickle\")"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "The relevant papers for this notebook are:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1] Joel A. E. Andersson, Joris Gillis, Greg Horn, James B. Rawlings, and Moritz Diehl. CasADi – A software framework for nonlinear optimization and optimal control. Mathematical Programming Computation, 11(1):1–36, 2019. doi:10.1007/s12532-018-0139-4.\n",
+      "[2] Charles R. Harris, K. Jarrod Millman, Stéfan J. van der Walt, Ralf Gommers, Pauli Virtanen, David Cournapeau, Eric Wieser, Julian Taylor, Sebastian Berg, Nathaniel J. Smith, and others. Array programming with NumPy. Nature, 585(7825):357–362, 2020. doi:10.1038/s41586-020-2649-2.\n",
+      "[3] Scott G. Marquis, Valentin Sulzer, Robert Timms, Colin P. Please, and S. Jon Chapman. An asymptotic derivation of a single particle model with electrolyte. Journal of The Electrochemical Society, 166(15):A3693–A3706, 2019. doi:10.1149/2.0341915jes.\n",
+      "[4] Valentin Sulzer, Scott G. Marquis, Robert Timms, Martin Robinson, and S. Jon Chapman. Python Battery Mathematical Modelling (PyBaMM). ECSarXiv. February, 2020. doi:10.1149/osf.io/67ckj.\n"
+     ]
+    }
+   ],
+   "source": [
+    "pybamm.print_citations()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
# Description

The notebook **solution-data-and-processed-variables.ipynb** left some files behind [outputs.csv, outputs.mat, outputs.pickle]. These files were missed in #3377 

## Type of change

Minor fix, does not break anything.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
