### PR TITLE
Fix failing windows wheel builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
+if(NOT MSVC)
+    # MSVC does not support variable length arrays (vla)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=vla")
+endif()
 
 # casadi seems to compile without the newer versions of std::string
 add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)

--- a/pybamm/solvers/c_solvers/idaklu/CasadiSolverOpenMP.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/CasadiSolverOpenMP.cpp
@@ -275,7 +275,7 @@ Solution CasadiSolverOpenMP::solve(
 
   // set inputs
   auto p_inputs = inputs.unchecked<2>();
-  for (uint i = 0; i < functions->inputs.size(); i++)
+  for (int i = 0; i < functions->inputs.size(); i++)
     functions->inputs[i] = p_inputs(i, 0);
 
   // set initial conditions

--- a/pybamm/solvers/c_solvers/idaklu/casadi_functions.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_functions.hpp
@@ -21,7 +21,7 @@
  */
 template<typename T1, typename T2>
 void csc_csr(const realtype f[], const T1 c[], const T1 r[], realtype nf[], T2 nc[], T2 nr[], int N, int cols) {
-  int nn[cols+1];
+  std::vector<int> nn(cols+1);
   std::vector<int> rr(N);
   for (int i=0; i<cols+1; i++)
     nc[i] = 0;

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -219,7 +219,7 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
         jac_colptrs[i] = p_jac_times_cjmass_colptrs[i];
       }
     } else if (SUNSparseMatrix_SparseType(JJ) == CSR_MAT) {
-      realtype newjac[SUNSparseMatrix_NNZ(JJ)];
+      std::vector<realtype> newjac(SUNSparseMatrix_NNZ(JJ));
       sunindextype *jac_ptrs = SUNSparseMatrix_IndexPointers(JJ);
       sunindextype *jac_vals = SUNSparseMatrix_IndexValues(JJ);
 
@@ -229,7 +229,7 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
       p_python_functions->jac_times_cjmass.m_arg[2] =
         p_python_functions->inputs.data();
       p_python_functions->jac_times_cjmass.m_arg[3] = &cj;
-      p_python_functions->jac_times_cjmass.m_res[0] = newjac;
+      p_python_functions->jac_times_cjmass.m_res[0] = newjac.data();
       p_python_functions->jac_times_cjmass();
 
       // convert (casadi's) CSC format to CSR
@@ -237,7 +237,7 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
           std::remove_pointer_t<decltype(p_python_functions->jac_times_cjmass_rowvals.data())>,
           std::remove_pointer_t<decltype(jac_vals)>
       >(
-        newjac,
+        newjac.data(),
         p_python_functions->jac_times_cjmass_rowvals.data(),
         p_python_functions->jac_times_cjmass_colptrs.data(),
         jac_data,

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -219,7 +219,8 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
         jac_colptrs[i] = p_jac_times_cjmass_colptrs[i];
       }
     } else if (SUNSparseMatrix_SparseType(JJ) == CSR_MAT) {
-      realtype newjac[SUNSparseMatrix_NNZ(JJ)];
+      const int JJ_nnz = SUNSparseMatrix_NNZ(JJ);
+      realtype newjac[JJ_nnz];
       sunindextype *jac_ptrs = SUNSparseMatrix_IndexPointers(JJ);
       sunindextype *jac_vals = SUNSparseMatrix_IndexValues(JJ);
 

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -219,7 +219,7 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
         jac_colptrs[i] = p_jac_times_cjmass_colptrs[i];
       }
     } else if (SUNSparseMatrix_SparseType(JJ) == CSR_MAT) {
-      realtype newjac[SM_NNZ_S(JJ)];
+      realtype newjac[SUNSparseMatrix_NNZ(JJ)];
       sunindextype *jac_ptrs = SUNSparseMatrix_IndexPointers(JJ);
       sunindextype *jac_vals = SUNSparseMatrix_IndexValues(JJ);
 

--- a/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/casadi_sundials_functions.cpp
@@ -219,8 +219,7 @@ int jacobian_casadi(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
         jac_colptrs[i] = p_jac_times_cjmass_colptrs[i];
       }
     } else if (SUNSparseMatrix_SparseType(JJ) == CSR_MAT) {
-      const int JJ_nnz = SUNSparseMatrix_NNZ(JJ);
-      realtype newjac[JJ_nnz];
+      realtype newjac[SM_NNZ_S(JJ)];
       sunindextype *jac_ptrs = SUNSparseMatrix_IndexPointers(JJ);
       sunindextype *jac_vals = SUNSparseMatrix_IndexValues(JJ);
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/pybamm-team/sundials-vcpkg-registry.git",
-      "baseline": "5a6a8c4daf1e898809a19e60ea6e6cece85fe08e",
+      "baseline": "7d19be6c0713589465e2eb67ef3f5ffbf9f5d5c1",
       "packages": ["sundials"]
     },
     {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/pybamm-team/sundials-vcpkg-registry.git",
-      "baseline": "2aaffb6bba7bc0b50cb74ddad636832d673851a1",
+      "baseline": "5a6a8c4daf1e898809a19e60ea6e6cece85fe08e",
       "packages": ["sundials"]
     },
     {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,7 +7,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/pybamm-team/sundials-vcpkg-registry.git",
-      "baseline": "7d19be6c0713589465e2eb67ef3f5ffbf9f5d5c1",
+      "baseline": "af9f5e4bc730bf2361c47f809dcfb733e7951faa",
       "packages": ["sundials"]
     },
     {


### PR DESCRIPTION
# Description

Windows wheels were failing to build. This was due to differences in c++ compiler specifications across operating systems. Additional compiler flags have been added to harmonise build specifications across operating systems going forwards.

Fixes #3431 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [X] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [X] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [X] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
