### PR TITLE
Fix Windows unit and integration tests failures

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -84,44 +84,44 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: choco install graphviz --version=2.38.0.20190211
 
-      - name: Install standard python dependencies
+      - name: Install standard Python dependencies
         run: |
-          python -m pip install --upgrade pip wheel setuptools nox
+          python -m pip install --upgrade pip wheel setuptools
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Run unit tests for GNU/Linux with Python 3.8, 3.9, and 3.10, and for macOS and Windows with all Python versions
         if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
-        run: nox -s unit
+        run: pipx run nox -s unit
 
       - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-        run: nox -s coverage
+        run: pipx run nox -s coverage
 
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
         uses: codecov/codecov-action@v3.1.4
 
       - name: Run integration tests
-        run: nox -s integration
+        run: pipx run nox -s integration
 
       - name: Install docs dependencies and run doctests
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s doctests
+        run: pipx run nox -s doctests
 
       - name: Check if the documentation can be built
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s docs
+        run: pipx run nox -s docs
 
       - name: Install dev dependencies and run example tests
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s examples
+        run: pipx run nox -s examples
 
       - name: Run example scripts tests
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s scripts
+        run: pipx run nox -s scripts
 
   #M-series Mac Mini
   build-apple-mseries:

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Install PyBaMM dependencies
         run: |
-          pip install --upgrade pip wheel setuptools nox
+          pip install --upgrade pip wheel setuptools
           pip install -e .[all,docs]
 
       - name: Cache pybamm-requires nox environment for GNU/Linux
@@ -111,10 +111,10 @@ jobs:
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Run unit tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
-        run: nox -s unit
+        run: pipx run nox -s unit
 
   # Runs only on Ubuntu with Python 3.11
   check_coverage:
@@ -169,10 +169,10 @@ jobs:
           key: nox-pybamm-requires-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/install_KLU_Sundials.py') }}
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Run unit tests for Ubuntu with Python 3.11 and generate coverage report
-        run: nox -s coverage
+        run: pipx run nox -s coverage
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3.1.4
@@ -235,7 +235,7 @@ jobs:
 
       - name: Install PyBaMM dependencies
         run: |
-          pip install --upgrade pip wheel setuptools nox
+          pip install --upgrade pip wheel setuptools
           pip install -e .[all,docs]
 
       - name: Cache pybamm-requires nox environment for GNU/Linux
@@ -254,10 +254,10 @@ jobs:
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
         if: matrix.os == 'ubuntu-latest'
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Run integration tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
-        run: nox -s integration
+        run: pipx run nox -s integration
 
 # Runs only on Ubuntu with Python 3.11. Skips IDAKLU module compilation
 # for speedups, which is already tested in other jobs.
@@ -296,14 +296,14 @@ jobs:
 
       - name: Install PyBaMM dependencies
         run: |
-          pip install --upgrade pip wheel setuptools nox
+          pip install --upgrade pip wheel setuptools
           pip install -e .[all,docs]
 
       - name: Install docs dependencies and run doctests for GNU/Linux with Python 3.11
-        run: nox -s doctests
+        run: pipx run nox -s doctests
 
       - name: Check if the documentation can be built for GNU/Linux with Python 3.11
-        run: nox -s docs
+        run: pipx run nox -s docs
 
   # Runs only on Ubuntu with Python 3.11
   run_example_tests:
@@ -341,7 +341,7 @@ jobs:
 
       - name: Install PyBaMM dependencies
         run: |
-          pip install --upgrade pip wheel setuptools nox
+          pip install --upgrade pip wheel setuptools
           pip install -e .[all,docs]
 
       - name: Cache pybamm-requires nox environment for GNU/Linux
@@ -358,10 +358,10 @@ jobs:
           key: nox-pybamm-requires-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/install_KLU_Sundials.py') }}
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Install dev dependencies and run example tests for GNU/Linux with Python 3.11
-        run: nox -s examples
+        run: pipx run nox -s examples
 
   # Runs only on Ubuntu with Python 3.11
   run_scripts_tests:
@@ -399,7 +399,7 @@ jobs:
 
       - name: Install PyBaMM dependencies
         run: |
-          pip install --upgrade pip wheel setuptools nox
+          pip install --upgrade pip wheel setuptools
           pip install -e .[all,docs]
 
       - name: Cache pybamm-requires nox environment for GNU/Linux
@@ -416,7 +416,7 @@ jobs:
           key: nox-pybamm-requires-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/install_KLU_Sundials.py') }}
 
       - name: Install SuiteSparse and SUNDIALS on GNU/Linux
-        run: nox -s pybamm-requires
+        run: pipx run nox -s pybamm-requires
 
       - name: Install dev dependencies and run example scripts tests for GNU/Linux with Python 3.11
-        run: nox -s scripts
+        run: pipx run nox -s scripts


### PR DESCRIPTION
# Description

Uses `pipx` to run `nox` in the workflows (since it is installed by default on GitHub Actions runners) so that `nox` can be found as a command-line application without Python executable invocation

See https://github.com/pybamm-team/PyBaMM/pull/3406#issuecomment-1763497185, #3452,  #3408
## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
