### PR TITLE
Fix #3418 Allow pybamm-requires to return early if an existing SUNDIALS installation is found

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,11 +36,19 @@ def set_environment_variables(env_dict, session):
 
 @nox.session(name="pybamm-requires")
 def run_pybamm_requires(session):
-    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  # noqa: E501
-    set_environment_variables(PYBAMM_ENV, session=session)
+    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  
+    force_rebuild = "--force" in session.posargs
+    sundials_path = Path("/path/to/sundials")
+    suitesparse_path = Path("/path/to/suitesparse")
+    if (sundials_path.exists() and suitesparse_path.exists()) and not force_rebuild:
+        session.log("Found existing build dependencies")
+        return
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)
-        session.run("python", "scripts/install_KLU_Sundials.py")
+        if not os.path.exists("/path/to/klu"):
+            session.run("python", "scripts/install_klu.py") 
+        if not os.path.exists(sundials_path):
+            session.run("python", "scripts/install_sundials.py")
         if not os.path.exists("./pybind11"):
             session.run(
                 "git",

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import nox
 import os
 import sys
@@ -36,7 +37,7 @@ def set_environment_variables(env_dict, session):
 
 @nox.session(name="pybamm-requires")
 def run_pybamm_requires(session):
-    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""
+    """Download, compile, and install the build-time requirements for Linux and macOS"""
     force_rebuild = "--force" in session.posargs
     sundials_path = Path("/path/to/sundials")
     suitesparse_path = Path("/path/to/suitesparse")

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def set_environment_variables(env_dict, session):
 
 @nox.session(name="pybamm-requires")
 def run_pybamm_requires(session):
-    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  
+    """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""
     force_rebuild = "--force" in session.posargs
     sundials_path = Path("/path/to/sundials")
     suitesparse_path = Path("/path/to/suitesparse")
@@ -46,7 +46,7 @@ def run_pybamm_requires(session):
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)
         if not os.path.exists("/path/to/klu"):
-            session.run("python", "scripts/install_klu.py") 
+            session.run("python", "scripts/install_klu.py")
         if not os.path.exists(sundials_path):
             session.run("python", "scripts/install_sundials.py")
         if not os.path.exists("./pybind11"):

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ def run_pybamm_requires(session):
     sundials_path = Path("/path/to/sundials")
     suitesparse_path = Path("/path/to/suitesparse")
     if (sundials_path.exists() and suitesparse_path.exists()) and not force_rebuild:
-        session.log("Found existing build dependencies")
+        session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")
         return
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)


### PR DESCRIPTION
# Description

Users can skip the re-installation of the build-time components if already present but still factor in the cases where it is necessary for them to reinstall for debugging purposes.

The key aspects are:
-Checking for existing Sundials and KLU installations before installing
-Breaking out the install scripts for each dependency
-Allowing a force rebuild with --force
-Keeping the pybind11 install logic the same

Fixes #3418 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
