### PR TITLE
Fix #3418 Allow pybamm-requires to return early if an existing SUNDIAL…

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -40,10 +40,59 @@ def set_environment_variables(env_dict, session):
 def run_pybamm_requires(session):
     """Download, compile, and install the build-time requirements for Linux and macOS: the SuiteSparse and SUNDIALS libraries."""  # noqa: E501
     set_environment_variables(PYBAMM_ENV, session=session)
+    force_rebuild = "--force" in session.posargs
+    sundials_so_path = [
+            Path("/path/to/sundials/libsundials_idas.so"),
+            Path("/path/to/sundials/libsundials_idas.dylib"),
+
+            Path("/path/to/sundials/libsundials_sunlinsolklu.so"),
+            Path("/path/to/sundials/libsundials_sunlinsolklu.dylib"),
+
+            Path("/path/to/sundials/libsundials_sunlinsoldense.so"),
+            Path("/path/to/sundials/libsundials_sunlinsoldense.dylib"),
+
+            Path("/path/to/sundials/libsundials_sunlinsolspbcgs.so"),
+            Path("/path/to/sundials/libsundials_sunlinsolspbcgs.dylib"),
+
+            Path("/path/to/sundials/libsundials_sunlinsollapackdense.so"),
+            Path("/path/to/sundials/libsundials_sunlinsollapackdense.dylib"),
+
+            Path("/path/to/sundials/libsundials_sunmatrixsparse.so"),
+            Path("/path/to/sundials/libsundials_sunmatrixsparse.dylib"),
+
+            Path("/path/to/sundials/libsundials_nvecserial.so"),
+            Path("/path/to/sundials/libsundials_nvecserial.dylib"),
+
+            Path("/path/to/sundials/libsundials_nvecopenmp.so"),
+            Path("/path/to/sundials/libsundials_nvecopenmp.dylib")
+        ]
+    klu_so_path = [
+            Path("/path/to/suitesparse/libsuitesparseconfig.so"),
+            Path("/path/to/suitesparse/libsuitesparseconfig.dylib"), # for MacOS
+            
+            Path("/path/to/suitesparse/libklu.so"),
+            Path("/path/to/suitesparse/libklu.dylib"),
+            
+            Path("/path/to/suitesparse/libamd.so"),
+            Path("/path/to/suitesparse/libamd.dylib"),
+            
+            Path("/path/to/suitesparse/libcolamd.so"),
+            Path("/path/to/suitesparse/libcolamd.dylib"),
+            
+            Path("/path/to/suitesparse/libbtf.so"),
+            Path("/path/to/suitesparse/libbtf.dylib"),
+        ]
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)
-        session.run("python", "scripts/install_KLU_Sundials.py")
-        if not os.path.exists("./pybind11"):
+        
+        if (sundials_so_path.exists() and 
+            klu_so_path.exists()) and not force_rebuild:
+            session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")  # noqa: E501
+            return
+            session.run("python", "scripts/install_Klu_Sundials.py")
+        elif os.path.exists("./pybind11"):
+            session.log("Found pybind11")
+            return
             session.run(
                 "git",
                 "clone",

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def run_pybamm_requires(session):
         "libsundials_nvecserial",
         "libsundials_nvecopenmp"
     ]
-    
+
     KLU_LIBS = [
         "libsuitesparseconfig",
         "libklu",
@@ -79,7 +79,7 @@ def run_pybamm_requires(session):
             Path(PYBAMM_ENV["LD_LIBRARY_PATH"], lib + ".dylib")
             for lib in KLU_LIBS
     ]
-    
+
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def run_pybamm_requires(session):
         "libsundials_nvecserial",
         "libsundials_nvecopenmp"
     ]
-    
+
     KLU_LIBS = [
         "libsuitesparseconfig",
         "libklu",
@@ -64,7 +64,7 @@ def run_pybamm_requires(session):
         fileext = ".so"
     elif sys.platform == "darwin":
         fileext = ".dylib"
-    
+
     sundials_so_path = [
         Path(PYBAMM_ENV["LD_LIBRARY_PATH"], lib + fileext)
         for lib in SUNDIALS_LIBS
@@ -81,7 +81,7 @@ def run_pybamm_requires(session):
             session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")
         else:
             session.run("python", "scripts/install_KLU_Sundials.py")
-        
+
         if os.path.exists("./pybind11"):
             session.log("Found pybind11")
             return

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def run_pybamm_requires(session):
         "libsundials_nvecserial",
         "libsundials_nvecopenmp"
     ]
-    
+
     KLU_LIBS = [
         "libsuitesparseconfig",
         "libklu",
@@ -64,7 +64,7 @@ def run_pybamm_requires(session):
         fileext = ".so"
     elif sys.platform == "darwin":
         fileext = ".dylib"
-    
+
     sundials_so_path = [
         Path(PYBAMM_ENV["LD_LIBRARY_PATH"], lib + fileext)
         for lib in SUNDIALS_LIBS

--- a/noxfile.py
+++ b/noxfile.py
@@ -82,9 +82,7 @@ def run_pybamm_requires(session):
         else:
             session.run("python", "scripts/install_KLU_Sundials.py")
 
-        if os.path.exists("./pybind11"):
-            session.log("Found pybind11")
-            return
+        if not os.path.exists("./pybind11"):
             session.run(
                 "git",
                 "clone",

--- a/noxfile.py
+++ b/noxfile.py
@@ -69,23 +69,23 @@ def run_pybamm_requires(session):
     klu_so_path = [
             Path("/path/to/suitesparse/libsuitesparseconfig.so"),
             Path("/path/to/suitesparse/libsuitesparseconfig.dylib"), # for MacOS
-            
+
             Path("/path/to/suitesparse/libklu.so"),
             Path("/path/to/suitesparse/libklu.dylib"),
-            
+
             Path("/path/to/suitesparse/libamd.so"),
             Path("/path/to/suitesparse/libamd.dylib"),
-            
+
             Path("/path/to/suitesparse/libcolamd.so"),
             Path("/path/to/suitesparse/libcolamd.dylib"),
-            
+
             Path("/path/to/suitesparse/libbtf.so"),
             Path("/path/to/suitesparse/libbtf.dylib"),
         ]
     if sys.platform != "win32":
         session.install("wget", "cmake", silent=False)
-        
-        if (sundials_so_path.exists() and 
+
+        if (sundials_so_path.exists() and
             klu_so_path.exists()) and not force_rebuild:
             session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")  # noqa: E501
             return

--- a/noxfile.py
+++ b/noxfile.py
@@ -51,7 +51,7 @@ def run_pybamm_requires(session):
         "libsundials_nvecserial",
         "libsundials_nvecopenmp"
     ]
-
+    
     KLU_LIBS = [
         "libsuitesparseconfig",
         "libklu",
@@ -64,7 +64,7 @@ def run_pybamm_requires(session):
         fileext = ".so"
     elif sys.platform == "darwin":
         fileext = ".dylib"
-
+    
     sundials_so_path = [
         Path(PYBAMM_ENV["LD_LIBRARY_PATH"], lib + fileext)
         for lib in SUNDIALS_LIBS
@@ -81,7 +81,9 @@ def run_pybamm_requires(session):
             session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")
         else:
             session.run("python", "scripts/install_KLU_Sundials.py")
-            if not os.path.exists("./pybind11"):
+            if os.path.exists("./pybind11"):
+                session.log("Found pybind11")
+            elif not os.path.exists("./pybind11"):
                 session.run(
                     "git",
                     "clone",

--- a/noxfile.py
+++ b/noxfile.py
@@ -81,17 +81,16 @@ def run_pybamm_requires(session):
             session.warn("Found existing build-time requirements, skipping installation. Note: run with the --force flag (nox -s pybamm-requires -- --force) to invoke re-installation.")
         else:
             session.run("python", "scripts/install_KLU_Sundials.py")
-
-        if not os.path.exists("./pybind11"):
-            session.run(
-                "git",
-                "clone",
-                "https://github.com/pybind/pybind11.git",
-                "pybind11/",
-                external=True,
+            if not os.path.exists("./pybind11"):
+                session.run(
+                    "git",
+                    "clone",
+                    "https://github.com/pybind/pybind11.git",
+                    "pybind11/",
+                    external=True,
             )
-        else:
-            session.error("nox -s pybamm-requires is only available on Linux & macOS.")
+            else:
+                session.error("nox -s pybamm-requires is only available on Linux & macOS.")
 
 
 @nox.session(name="coverage")


### PR DESCRIPTION

Users can skip the re-installation of the build-time components if already present but still factor in the cases where it is necessary for them to reinstall for debugging purposes.

The key aspects are:
-Checking for existing Sundials and KLU installations before installing
-Breaking out the install scripts for each dependency
-Allowing a force rebuild with --force
-Keeping the pybind11 install logic the same

Fixes #3418 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
