### PR TITLE
fix esoh bug

### DIFF
--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh_half_cell.py
@@ -21,7 +21,7 @@ class ElectrodeSOHHalfCell(pybamm.BaseModel):
 
     """
 
-    def __init__(self, name="Electrode-specific SOH model"):
+    def __init__(self, name="ElectrodeSOH model"):
         pybamm.citations.register("Mohtat2019")
         super().__init__(name)
         param = pybamm.LithiumIonParameters({"working electrode": "positive"})
@@ -140,7 +140,7 @@ def get_min_max_stoichiometries(
     parameter_values : pybamm.ParameterValues
         The parameter values to use in the calculation
     """
-    esoh_model = pybamm.lithium_ion.ElectrodeSOHHalfCell(options)
+    esoh_model = pybamm.lithium_ion.ElectrodeSOHHalfCell("ElectrodeSOH")
     param = pybamm.LithiumIonParameters(options)
     esoh_sim = pybamm.Simulation(esoh_model, parameter_values=parameter_values)
     Q_w = parameter_values.evaluate(param.p.Q_init)

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -552,7 +552,7 @@ class Simulation:
                 )
             if (
                 self.operating_mode == "without experiment"
-                or self._model.name == "ElectrodeSOH model"
+                or "ElectrodeSOH" in self._model.name
             ):
                 if t_eval is None:
                     raise pybamm.SolverError(


### PR DESCRIPTION
# Description

There was a slight bug in #3456 that caused `initial_soc` to error when using a drive cycle for half-cell models. This PR fixes that bug. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
