### PR TITLE
Resolve default imports for optional dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,9 @@ On the other hand... We _do_ want to compare several tools, to generate document
 
 Only 'core pybamm' is installed by default. The others have to be specified explicitly when running the installation command.
 
-### Matplotlib
+### Managing Optional Dependencies and Their Imports
 
-We use Matplotlib in PyBaMM, but with two caveats:
+PyBaMM utilizes optional dependencies to allow users to choose which additional libraries they want to use. Managing these optional dependencies and their imports is essential to provide flexibility to PyBaMM users.
 
 First, Matplotlib should only be used in plotting methods, and these should _never_ be called by other PyBaMM methods. So users who don't like Matplotlib will not be forced to use it in any way. Use in notebooks is OK and encouraged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ You now have everything you need to start making changes!
 10. [Test your code!](#testing)
 11. PyBaMM has online documentation at http://docs.pybamm.org/. To make sure any new methods or classes you added show up there, please read the [documentation](#documentation) section.
 12. If you added a major new feature, perhaps it should be showcased in an [example notebook](#example-notebooks).
-13. When you feel your code is finished, or at least warrants serious discussion, run the [pre-commit checks](#pre-commit-checks) and then create a [pull request](https://help.github.com/articles/about-pull-requests/) (PR) on [PyBaMM's GitHub page](https://github.com/pybamm-team/PyBaMM).
+13. When you feel your code is finished, or at least warrants serious discussion, run the [pre-commit checks](#pre-commit-checks) and then create a [pull request](https://help.github.com/articles/about-pull-requests/) (PR) on [PyBaMM&#39;s GitHub page](https://github.com/pybamm-team/PyBaMM).
 14. Once a PR has been created, it will be reviewed by any member of the community. Changes might be suggested which you can make by simply adding new commits to the branch. When everything's finished, someone with the right GitHub permissions will merge your changes into PyBaMM main repository.
 
 Finally, if you really, really, _really_ love developing PyBaMM, have a look at the current [project infrastructure](#infrastructure).
@@ -104,17 +104,25 @@ Only 'core pybamm' is installed by default. The others have to be specified expl
 
 PyBaMM utilizes optional dependencies to allow users to choose which additional libraries they want to use. Managing these optional dependencies and their imports is essential to provide flexibility to PyBaMM users.
 
-First, Matplotlib should only be used in plotting methods, and these should _never_ be called by other PyBaMM methods. So users who don't like Matplotlib will not be forced to use it in any way. Use in notebooks is OK and encouraged.
+PyBaMM provides a utility function `have_optional_dependency`, to check for the availability of optional dependencies within methods. This function can be used to conditionally import optional dependencies only if they are available. Here's how to use it:
 
-Second, Matplotlib should never be imported at the module level, but always inside methods. For example:
+Optional Dependencies should never be imported at the module level, but always inside methods. For example:
 
 ```
-def plot_great_things(self, x, y, z):
-    import matplotlib.pyplot as pl
+def use_pybtex(x,y,z):
+    pybtex = have_optional_dependency("pybtex")
     ...
 ```
 
-This allows people to (1) use PyBaMM without ever importing Matplotlib and (2) configure Matplotlib's back-end in their scripts, which _must_ be done before e.g. `pyplot` is first imported.
+While importing a specific attribute instead of whole module:
+
+```
+def use_parse_file(x,y,z):
+    parse_file = have_optional_dependency("pybtex.database","parse_file")
+    ...
+```
+
+This allows people to (1) use PyBaMM without importing Optional dependency by default and (2) configure module dependent functionality in their scripts, which _must_ be done before e.g. `print_citations` method is first imported.
 
 ## Testing
 
@@ -266,7 +274,6 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
       ```
 
       This will start the debugger at the point where the `ValueError` was raised, and allow you to investigate further. Sometimes, it is more informative to put the try-except block further up the call stack than exactly where the error is raised.
-
    2. Warnings. If functions are raising warnings instead of errors, it can be hard to pinpoint where this is coming from. Here, you can use the `warnings` module to convert warnings to errors:
 
       ```python
@@ -276,7 +283,6 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
       ```
 
       Then you can use a try-except block, as in a., but with, for example, `RuntimeWarning` instead of `ValueError`.
-
    3. Stepping through the expression tree. Most calls in PyBaMM are operations on [expression trees](https://github.com/pybamm-team/PyBaMM/blob/develop/docs/source/examples/notebooks/expression_tree/expression-tree.ipynb). To view an expression tree in ipython, you can use the `render` command:
 
       ```python
@@ -284,11 +290,8 @@ This also means that, if you can't fix the bug yourself, it will be much easier 
       ```
 
       You can then step through the expression tree, using the `children` attribute, to pinpoint exactly where a bug is coming from. For example, if `expression_tree.jac(y)` is failing, you can check `expression_tree.children[0].jac(y)`, then `expression_tree.children[0].children[0].jac(y)`, etc.
-
 3. To isolate whether a bug is in a model, its Jacobian or its simplified version, you can set the `use_jacobian` and/or `use_simplify` attributes of the model to `False` (they are both `True` by default for most models).
-
 4. If a model isn't giving the answer you expect, you can try comparing it to other models. For example, you can investigate parameter limits in which two models should give the same answer by setting some parameters to be small or zero. The `StandardOutputComparison` class can be used to compare some standard outputs from battery models.
-
 5. To get more information about what is going on under the hood, and hence understand what is causing the bug, you can set the [logging](https://realpython.com/python-logging/) level to `DEBUG` by adding the following line to your test or script:
 
    ```python3

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -52,7 +52,13 @@ from .util import (
 )
 from .logger import logger, set_logging_level, get_new_logger
 from .settings import settings
-from .citations import Citations, citations, print_citations
+try:
+    import pybtex
+
+    if pybtex is not None:
+        from .citations import Citations, citations, print_citations
+except ImportError:
+    pass
 
 #
 # Classes for the Expression Tree

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -47,6 +47,7 @@ from .util import (
     get_parameters_filepath,
     have_jax,
     install_jax,
+    have_optional_dependency,
     is_jax_compatible,
     get_git_commit_info,
 )

--- a/pybamm/__init__.py
+++ b/pybamm/__init__.py
@@ -53,14 +53,7 @@ from .util import (
 )
 from .logger import logger, set_logging_level, get_new_logger
 from .settings import settings
-try:
-    import pybtex
-
-    if pybtex is not None:
-        from .citations import Citations, citations, print_citations
-except ImportError:
-    pass
-
+from .citations import Citations, citations, print_citations
 #
 # Classes for the Expression Tree
 #

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -6,10 +6,10 @@
 import pybamm
 import os
 import warnings
-import pybtex
+# import pybtex
 from sys import _getframe
-from pybtex.database import parse_file, parse_string, Entry
-from pybtex.scanner import PybtexError
+# from pybtex.database import parse_file, parse_string, Entry
+# from pybtex.scanner import PybtexError
 
 
 class Citations:
@@ -76,6 +76,7 @@ class Citations:
         """Reads the citations in `pybamm.CITATIONS.bib`. Other works can be cited
         by passing a BibTeX citation to :meth:`register`.
         """
+        parse_file = pybamm.util.have_optional_dependency("pybtex.database","parse_file")
         citations_file = os.path.join(pybamm.root_dir(), "pybamm", "CITATIONS.bib")
         bib_data = parse_file(citations_file, bib_format="bibtex")
         for key, entry in bib_data.entries.items():
@@ -86,6 +87,7 @@ class Citations:
         previous entry is overwritten
         """
 
+        Entry = pybamm.util.have_optional_dependency("pybtex.database","Entry")
         # Check input types are correct
         if not isinstance(key, str) or not isinstance(entry, Entry):
             raise TypeError()
@@ -151,6 +153,8 @@ class Citations:
         key: str
             A BibTeX formatted citation
         """
+        PybtexError = pybamm.util.have_optional_dependency("pybtex.scanner","PybtexError")
+        parse_string = pybamm.util.have_optional_dependency("pybtex.database","parse_string")
         try:
             # Parse string as a bibtex citation, and check that a citation was found
             bib_data = parse_string(key, bib_format="bibtex")
@@ -177,7 +181,6 @@ class Citations:
             for key, entry in self._citation_tags.items():
                 print(f"{key} was cited due to the use of {entry}")
 
-    @pybamm.util.have_optional_dependency("pybtex")
     def print(self, filename=None, output_format="text", verbose=False):
         """Print all citations that were used for running simulations. The verbose
         option is provided to print tags for citations in the output such that it can
@@ -218,6 +221,7 @@ class Citations:
         """
         # Parse citations that were not known keys at registration, but do not
         # fail if they cannot be parsed
+        pybtex = pybamm.util.have_optional_dependency("pybtex")
         try:
             for key in self._unknown_citations:
                 self._parse_citation(key)

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -177,6 +177,7 @@ class Citations:
             for key, entry in self._citation_tags.items():
                 print(f"{key} was cited due to the use of {entry}")
 
+    @pybamm.util.have_optional_dependency("pybtex")
     def print(self, filename=None, output_format="text", verbose=False):
         """Print all citations that were used for running simulations. The verbose
         option is provided to print tags for citations in the output such that it can

--- a/pybamm/citations.py
+++ b/pybamm/citations.py
@@ -6,10 +6,8 @@
 import pybamm
 import os
 import warnings
-# import pybtex
 from sys import _getframe
-# from pybtex.database import parse_file, parse_string, Entry
-# from pybtex.scanner import PybtexError
+from pybamm.util import have_optional_dependency
 
 
 class Citations:
@@ -76,7 +74,7 @@ class Citations:
         """Reads the citations in `pybamm.CITATIONS.bib`. Other works can be cited
         by passing a BibTeX citation to :meth:`register`.
         """
-        parse_file = pybamm.util.have_optional_dependency("pybtex.database","parse_file")
+        parse_file = have_optional_dependency("pybtex.database","parse_file")
         citations_file = os.path.join(pybamm.root_dir(), "pybamm", "CITATIONS.bib")
         bib_data = parse_file(citations_file, bib_format="bibtex")
         for key, entry in bib_data.entries.items():
@@ -87,7 +85,7 @@ class Citations:
         previous entry is overwritten
         """
 
-        Entry = pybamm.util.have_optional_dependency("pybtex.database","Entry")
+        Entry = have_optional_dependency("pybtex.database","Entry")
         # Check input types are correct
         if not isinstance(key, str) or not isinstance(entry, Entry):
             raise TypeError()
@@ -153,8 +151,8 @@ class Citations:
         key: str
             A BibTeX formatted citation
         """
-        PybtexError = pybamm.util.have_optional_dependency("pybtex.scanner","PybtexError")
-        parse_string = pybamm.util.have_optional_dependency("pybtex.database","parse_string")
+        PybtexError = have_optional_dependency("pybtex.scanner","PybtexError")
+        parse_string = have_optional_dependency("pybtex.database","parse_string")
         try:
             # Parse string as a bibtex citation, and check that a citation was found
             bib_data = parse_string(key, bib_format="bibtex")
@@ -221,7 +219,7 @@ class Citations:
         """
         # Parse citations that were not known keys at registration, but do not
         # fail if they cannot be parsed
-        pybtex = pybamm.util.have_optional_dependency("pybtex")
+        pybtex = have_optional_dependency("pybtex")
         try:
             for key in self._unknown_citations:
                 self._parse_citation(key)

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -2,10 +2,10 @@
 # NumpyArray class
 #
 import numpy as np
-import sympy
 from scipy.sparse import csr_matrix, issparse
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class Array(pybamm.Symbol):
@@ -125,6 +125,7 @@ class Array(pybamm.Symbol):
 
     def to_equation(self):
         """Returns the value returned by the node when evaluated."""
+        sympy = have_optional_dependency("sympy")
         entries_list = self.entries.tolist()
         return sympy.Array(entries_list)
 

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -4,11 +4,11 @@
 import numbers
 
 import numpy as np
-import sympy
 from scipy.sparse import csr_matrix, issparse
 import functools
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 def _preprocess_binary(left, right):
@@ -147,6 +147,7 @@ class BinaryOperator(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -323,6 +324,7 @@ class MatrixMultiplication(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         left = sympy.Matrix(left)
         right = sympy.Matrix(right)
         return left * right
@@ -626,6 +628,7 @@ class Minimum(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         return sympy.Min(left, right)
 
 
@@ -662,6 +665,7 @@ class Maximum(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         return sympy.Max(left, right)
 
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -5,10 +5,10 @@ import copy
 from collections import defaultdict
 
 import numpy as np
-import sympy
 from scipy.sparse import issparse, vstack
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class Concatenation(pybamm.Symbol):
@@ -135,6 +135,7 @@ class Concatenation(pybamm.Symbol):
 
     def _sympy_operator(self, *children):
         """Apply appropriate SymPy operators."""
+        sympy = have_optional_dependency("sympy")
         self.concat_latex = tuple(map(sympy.latex, children))
 
         if self.print_name is not None:

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -4,7 +4,6 @@
 import numbers
 
 import numpy as np
-import sympy
 from scipy import special
 
 import pybamm
@@ -202,6 +201,7 @@ class Function(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -250,6 +250,7 @@ class SpecificFunction(Function):
 
     def _sympy_operator(self, child):
         """Apply appropriate SymPy operators."""
+        sympy = have_optional_dependency("sympy")
         class_name = self.__class__.__name__.lower()
         sympy_function = getattr(sympy, class_name)
         return sympy_function(child)
@@ -267,6 +268,7 @@ class Arcsinh(SpecificFunction):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.Function._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         return sympy.asinh(child)
 
 
@@ -287,6 +289,7 @@ class Arctan(SpecificFunction):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.Function._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         return sympy.atan(child)
 
 

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -3,7 +3,10 @@
 #
 import numbers
 
-import autograd
+try:
+    import autograd
+except ImportError:
+    pass
 import numpy as np
 import sympy
 from scipy import special

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -3,16 +3,12 @@
 #
 import numbers
 
-try:
-    import autograd
-except ImportError:
-    pass
 import numpy as np
 import sympy
 from scipy import special
 
 import pybamm
-
+from pybamm.util import have_optional_dependency
 
 class Function(pybamm.Symbol):
     """
@@ -99,6 +95,7 @@ class Function(pybamm.Symbol):
         Derivative with respect to child number 'idx'.
         See :meth:`pybamm.Symbol._diff()`.
         """
+        autograd = have_optional_dependency("autograd")
         # Store differentiated function, needed in case we want to convert to CasADi
         if self.derivative == "autograd":
             return Function(

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -1,9 +1,8 @@
 #
 # IndependentVariable class
 #
-import sympy
-
 import pybamm
+from pybamm.utili import have_optional_dependency
 
 KNOWN_COORD_SYS = ["cartesian", "cylindrical polar", "spherical polar"]
 
@@ -44,6 +43,7 @@ class IndependentVariable(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -77,6 +77,7 @@ class Time(IndependentVariable):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         return sympy.Symbol("t")
 
 

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -2,7 +2,7 @@
 # IndependentVariable class
 #
 import pybamm
-from pybamm.utili import have_optional_dependency
+from pybamm.util import have_optional_dependency
 
 KNOWN_COORD_SYS = ["cartesian", "cylindrical polar", "spherical polar"]
 

--- a/pybamm/expression_tree/operations/latexify.py
+++ b/pybamm/expression_tree/operations/latexify.py
@@ -5,10 +5,9 @@ import copy
 import re
 import warnings
 
-import sympy
-
 import pybamm
 from pybamm.expression_tree.printing.sympy_overrides import custom_print_func
+from pybamm.util import have_optional_dependency
 
 
 def get_rng_min_max_name(rng, min_or_max):
@@ -88,6 +87,7 @@ class Latexify:
         Returns a list of boundary condition equations with ranges in front of
         the equations.
         """
+        sympy = have_optional_dependency("sympy")
         bcs_eqn_list = []
         bcs = self.model.boundary_conditions.get(var, None)
 
@@ -118,6 +118,7 @@ class Latexify:
 
     def _get_param_var(self, node):
         """Returns a list of parameters and a list of variables."""
+        sympy = have_optional_dependency("sympy")
         param_list = []
         var_list = []
         dfs_nodes = [node]
@@ -160,6 +161,7 @@ class Latexify:
         return param_list, var_list
 
     def latexify(self, output_variables=None):
+        sympy = have_optional_dependency("sympy")
         # Voltage is the default output variable if it exists
         if output_variables is None:
             if "Voltage [V]" in self.model.variables:

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -5,9 +5,9 @@ import numbers
 import sys
 
 import numpy as np
-import sympy
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class Parameter(pybamm.Symbol):
@@ -44,6 +44,7 @@ class Parameter(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -217,6 +218,7 @@ class FunctionParameter(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/expression_tree/printing/sympy_overrides.py
+++ b/pybamm/expression_tree/printing/sympy_overrides.py
@@ -3,9 +3,10 @@
 #
 import re
 
-from sympy.printing.latex import LatexPrinter
+from pybamm.util import have_optional_dependency
 
 
+LatexPrinter = have_optional_dependency("sympy.printing.latex","LatexPrinter")
 class CustomPrint(LatexPrinter):
     """Override SymPy methods to match PyBaMM's requirements"""
 
@@ -21,4 +22,5 @@ class CustomPrint(LatexPrinter):
 
 
 def custom_print_func(expr, **settings):
+    have_optional_dependency("sympy.printing.latex","LatexPrinter")
     return CustomPrint().doprint(expr)

--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -2,10 +2,9 @@
 # Scalar class
 #
 import numpy as np
-import sympy
 
 import pybamm
-
+from pybamm.util import have_optional_dependency
 
 class Scalar(pybamm.Symbol):
     """
@@ -70,6 +69,7 @@ class Scalar(pybamm.Symbol):
 
     def to_equation(self):
         """Returns the value returned by the node when evaluated."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -3,20 +3,13 @@
 #
 import numbers
 
-
-try:
-    import anytree
-    from anytree.exporter import DotExporter
-except ImportError:
-    _has_anytree = False
-else:
-    _has_anytree = True
 import numpy as np
 import sympy
 from scipy.sparse import csr_matrix, issparse
 from functools import lru_cache, cached_property
 
 import pybamm
+from pybamm.util import have_optional_dependency
 from pybamm.expression_tree.printing.print_name import prettify_print_name
 
 DOMAIN_LEVELS = ["primary", "secondary", "tertiary", "quaternary"]
@@ -448,8 +441,7 @@ class Symbol:
         """
         Print out a visual representation of the tree (this node and its children)
         """
-        if not _has_anytree:
-            raise ImportError("Module 'anytree' is required to do this")
+        anytree = have_optional_dependency("anytree")
         for pre, _, node in anytree.RenderTree(self):
             if isinstance(node, pybamm.Scalar) and node.name != str(node.value):
                 print("{}{} = {}".format(pre, node.name, node.value))
@@ -467,9 +459,8 @@ class Symbol:
         filename : str
             filename to output, must end in ".png"
         """
-        if not _has_anytree:
-            raise ImportError("Module 'anytree' is required to do this")
 
+        DotExporter = have_optional_dependency("anytree.exporter","DotExporter")
         # check that filename ends in .png.
         if filename[-4:] != ".png":
             raise ValueError("filename should end in .png")
@@ -489,8 +480,7 @@ class Symbol:
         Finds all children of a symbol and assigns them a new id so that they can be
         visualised properly using the graphviz output
         """
-        if not _has_anytree:
-            raise ImportError("Module 'anytree' is required to do this")
+        anytree = have_optional_dependency("anytree")
         name = symbol.name
         if name == "div":
             name = "&nabla;&sdot;"
@@ -534,8 +524,7 @@ class Symbol:
         a
         b
         """
-        if not _has_anytree:
-            raise ImportError("Module 'anytree' is required to do this")
+        anytree = have_optional_dependency("anytree")
         return anytree.PreOrderIter(self)
 
     def __str__(self):

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -3,10 +3,14 @@
 #
 import numbers
 
-import anytree
+
+try:
+    import anytree
+    from anytree.exporter import DotExporter
+except ImportError:
+    pass
 import numpy as np
 import sympy
-from anytree.exporter import DotExporter
 from scipy.sparse import csr_matrix, issparse
 from functools import lru_cache, cached_property
 

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -4,7 +4,6 @@
 import numbers
 
 import numpy as np
-import sympy
 from scipy.sparse import csr_matrix, issparse
 from functools import lru_cache, cached_property
 
@@ -987,4 +986,5 @@ class Symbol:
         self._print_name = prettify_print_name(name)
 
     def to_equation(self):
+        sympy = have_optional_dependency("sympy")
         return sympy.Symbol(str(self.name))

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -8,7 +8,9 @@ try:
     import anytree
     from anytree.exporter import DotExporter
 except ImportError:
-    pass
+    _has_anytree = False
+else:
+    _has_anytree = True
 import numpy as np
 import sympy
 from scipy.sparse import csr_matrix, issparse
@@ -446,6 +448,8 @@ class Symbol:
         """
         Print out a visual representation of the tree (this node and its children)
         """
+        if not _has_anytree:
+            raise ImportError("Module 'anytree' is required to do this")
         for pre, _, node in anytree.RenderTree(self):
             if isinstance(node, pybamm.Scalar) and node.name != str(node.value):
                 print("{}{} = {}".format(pre, node.name, node.value))
@@ -463,6 +467,8 @@ class Symbol:
         filename : str
             filename to output, must end in ".png"
         """
+        if not _has_anytree:
+            raise ImportError("Module 'anytree' is required to do this")
 
         # check that filename ends in .png.
         if filename[-4:] != ".png":
@@ -483,6 +489,8 @@ class Symbol:
         Finds all children of a symbol and assigns them a new id so that they can be
         visualised properly using the graphviz output
         """
+        if not _has_anytree:
+            raise ImportError("Module 'anytree' is required to do this")
         name = symbol.name
         if name == "div":
             name = "&nabla;&sdot;"
@@ -526,6 +534,8 @@ class Symbol:
         a
         b
         """
+        if not _has_anytree:
+            raise ImportError("Module 'anytree' is required to do this")
         return anytree.PreOrderIter(self)
 
     def __str__(self):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -4,11 +4,9 @@
 import numbers
 
 import numpy as np
-import sympy
 from scipy.sparse import csr_matrix, issparse
-from sympy.vector.operators import Divergence as sympy_Divergence
-from sympy.vector.operators import Gradient as sympy_Gradient
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class UnaryOperator(pybamm.Symbol):
@@ -83,6 +81,7 @@ class UnaryOperator(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -368,6 +367,7 @@ class Gradient(SpatialOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        sympy_Gradient = have_optional_dependency("sympy.vector.operators","Gradient")
         return sympy_Gradient(child)
 
 
@@ -403,6 +403,7 @@ class Divergence(SpatialOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        sympy_Divergence = have_optional_dependency("sympy.vector.operators","Divergence")
         return sympy_Divergence(child)
 
 
@@ -579,6 +580,7 @@ class Integral(SpatialOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         return sympy.Integral(child, sympy.Symbol("xn"))
 
 
@@ -889,6 +891,7 @@ class BoundaryValue(BoundaryOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        sympy = have_optional_dependency("sympy")
         if (
             self.child.domain[0] in ["negative particle", "positive particle"]
             and self.side == "right"

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -3,9 +3,9 @@
 #
 
 import numpy as np
-import sympy
 import numbers
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class VariableBase(pybamm.Symbol):
@@ -124,6 +124,7 @@ class VariableBase(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
+        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/meshes/scikit_fem_submeshes.py
+++ b/pybamm/meshes/scikit_fem_submeshes.py
@@ -3,12 +3,9 @@
 #
 import pybamm
 from .meshes import SubMesh
-
-try:
-    import skfem
-except ImportError:
-    pass
 import numpy as np
+
+from pybamm.util import have_optional_dependency
 
 
 class ScikitSubMesh2D(SubMesh):
@@ -30,6 +27,7 @@ class ScikitSubMesh2D(SubMesh):
     """
 
     def __init__(self, edges, coord_sys, tabs):
+        skfem = have_optional_dependency("skfem")
         self.edges = edges
         self.nodes = dict.fromkeys(["y", "z"])
         for var in self.nodes.keys():

--- a/pybamm/meshes/scikit_fem_submeshes.py
+++ b/pybamm/meshes/scikit_fem_submeshes.py
@@ -4,7 +4,10 @@
 import pybamm
 from .meshes import SubMesh
 
-import skfem
+try:
+    import skfem
+except ImportError:
+    pass
 import numpy as np
 
 

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -8,10 +8,7 @@ import warnings
 import sys
 from functools import lru_cache
 from datetime import timedelta
-try:
-    import tqdm
-except ImportError:
-    pass
+from pybamm.util import have_optional_dependency
 
 
 def is_notebook():
@@ -535,6 +532,7 @@ class Simulation:
             Additional key-word arguments passed to `solver.solve`.
             See :meth:`pybamm.BaseSolver.solve`.
         """
+        tqdm = have_optional_dependency("tqdm")
         # Setup
         if solver is None:
             solver = self._solver

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -8,7 +8,10 @@ import warnings
 import sys
 from functools import lru_cache
 from datetime import timedelta
-import tqdm
+try:
+    import tqdm
+except ImportError:
+    pass
 
 
 def is_notebook():

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -6,10 +6,8 @@ import pybamm
 from scipy.sparse import csr_matrix, csc_matrix
 from scipy.sparse.linalg import inv
 import numpy as np
-try:
-    import skfem
-except ImportError:
-    pass
+
+from pybamm.util import have_optional_dependency
 
 
 class ScikitFiniteElement(pybamm.SpatialMethod):
@@ -90,6 +88,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
             to the y-component of the gradient and the second column corresponds
             to the z component of the gradient.
         """
+        skfem = have_optional_dependency("skfem")
         domain = symbol.domain[0]
         mesh = self.mesh[domain]
 
@@ -145,6 +144,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Matrix`
             The (sparse) finite element gradient matrix for the domain
         """
+        skfem = have_optional_dependency("skfem")
         # get primary domain mesh
         domain = symbol.domain[0]
         mesh = self.mesh[domain]
@@ -190,6 +190,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
             Contains the result of acting the discretised gradient on
             the child discretised_symbol
         """
+        skfem = have_optional_dependency("skfem")
         domain = symbol.domain[0]
         mesh = self.mesh[domain]
 
@@ -261,6 +262,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Matrix`
             The (sparse) finite element stiffness matrix for the domain
         """
+        skfem = have_optional_dependency("skfem")
         # get primary domain mesh
         domain = symbol.domain[0]
         mesh = self.mesh[domain]
@@ -323,6 +325,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Matrix`
             The finite element integral vector for the domain
         """
+        skfem = have_optional_dependency("skfem")
         # get primary domain mesh
         domain = child.domain[0]
         mesh = self.mesh[domain]
@@ -384,6 +387,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Matrix`
             The finite element integral vector for the domain
         """
+        skfem = have_optional_dependency("skfem")
         # get primary domain mesh
         mesh = self.mesh[domain[0]]
 
@@ -501,6 +505,7 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
         :class:`pybamm.Matrix`
             The (sparse) mass matrix for the spatial method.
         """
+        skfem = have_optional_dependency("skfem")
         # get primary domain mesh
         domain = symbol.domain[0]
         mesh = self.mesh[domain]

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -6,7 +6,10 @@ import pybamm
 from scipy.sparse import csr_matrix, csc_matrix
 from scipy.sparse.linalg import inv
 import numpy as np
-import skfem
+try:
+    import skfem
+except ImportError:
+    pass
 
 
 class ScikitFiniteElement(pybamm.SpatialMethod):

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -345,3 +345,12 @@ def install_jax(arguments=None):  # pragma: no cover
             f"jaxlib>={JAXLIB_VERSION}",
         ]
     )
+
+
+def have_optional_dependency(module):
+    try:
+        importlib.import_module(module)
+        _has_module = True
+    except ImportError:
+        _has_module = False
+    return _has_module

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -353,17 +353,13 @@ def have_optional_dependency(module_name, attribute=None):
         if attribute:
             if hasattr(module, attribute):
                 imported_attribute = getattr(module, attribute)
-                print(f"The {module_name}.{attribute} is available.")
                 return imported_attribute
             else:
-                print(f"The {module_name}.{attribute} is not available.")
-                return None
+                raise ImportError(f"{module_name}.{attribute} is not available.")
         else:
-            print(f"The {module_name} module is available.")
             return module
     except ImportError:
         if attribute:
-            print(f"The {module_name}.{attribute} is not available.")
+            raise ImportError(f"{module_name}.{attribute} is not available.")
         else:
-            print(f"The {module_name} module is not available.")
-        return None
+            raise ImportError(f"{module_name} module is not available.")

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -346,19 +346,26 @@ def install_jax(arguments=None):  # pragma: no cover
         ]
     )
 
-
+# https://docs.pybamm.org/en/latest/source/user_guide/contributing.html#managing-optional-dependencies-and-their-imports
 def have_optional_dependency(module_name, attribute=None):
     try:
+        # Attempt to import the specified module
         module = importlib.import_module(module_name)
+
         if attribute:
+            # If an attribute is specified, check if it's available
             if hasattr(module, attribute):
                 imported_attribute = getattr(module, attribute)
-                return imported_attribute
+                return imported_attribute  # Return the imported attribute
             else:
+                # Raise an ImportError if the attribute is not available
                 raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:
+            # Return the entire module if no attribute is specified
             return module
+
     except ImportError:
+        # Raise an ImportError if the module or attribute is not available
         if attribute:
             raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -347,10 +347,25 @@ def install_jax(arguments=None):  # pragma: no cover
     )
 
 
-def have_optional_dependency(module):
-    try:
-        importlib.import_module(module)
-        _has_module = True
-    except ImportError:
-        _has_module = False
-    return _has_module
+def have_optional_dependency(module_name, attribute=None):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            try:
+                module = importlib.import_module(module_name)
+                if attribute:
+                    if hasattr(module, attribute):
+                        imported_attribute = getattr(module, attribute)
+                        print(f"The {module_name}.{attribute} is available.")
+                        kwargs[attribute] = imported_attribute
+                    else:
+                        print(f"The {module_name}.{attribute} is not available.")
+                else:
+                    print(f"The {module_name} module is available.")
+                return func(*args, **kwargs)
+            except ImportError:
+                if attribute:
+                    print(f"The {module_name}.{attribute} is not available.")
+                else:
+                    print(f"The {module_name} module is not available.")
+        return wrapper
+    return decorator

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -355,11 +355,11 @@ def have_optional_dependency(module_name, attribute=None):
                 imported_attribute = getattr(module, attribute)
                 return imported_attribute
             else:
-                raise ImportError(f"{module_name}.{attribute} is not available.")
+                raise ImportError(f"Optional dependency {module_name}.{attribute} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:
             return module
     except ImportError:
         if attribute:
-            raise ImportError(f"{module_name}.{attribute} is not available.")
+            raise ImportError(f"Optional dependency {module_name}.{attribute} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:
-            raise ImportError(f"{module_name} module is not available.")
+            raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -348,24 +348,22 @@ def install_jax(arguments=None):  # pragma: no cover
 
 
 def have_optional_dependency(module_name, attribute=None):
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            try:
-                module = importlib.import_module(module_name)
-                if attribute:
-                    if hasattr(module, attribute):
-                        imported_attribute = getattr(module, attribute)
-                        print(f"The {module_name}.{attribute} is available.")
-                        kwargs[attribute] = imported_attribute
-                    else:
-                        print(f"The {module_name}.{attribute} is not available.")
-                else:
-                    print(f"The {module_name} module is available.")
-                return func(*args, **kwargs)
-            except ImportError:
-                if attribute:
-                    print(f"The {module_name}.{attribute} is not available.")
-                else:
-                    print(f"The {module_name} module is not available.")
-        return wrapper
-    return decorator
+    try:
+        module = importlib.import_module(module_name)
+        if attribute:
+            if hasattr(module, attribute):
+                imported_attribute = getattr(module, attribute)
+                print(f"The {module_name}.{attribute} is available.")
+                return imported_attribute
+            else:
+                print(f"The {module_name}.{attribute} is not available.")
+                return None
+        else:
+            print(f"The {module_name} module is available.")
+            return module
+    except ImportError:
+        if attribute:
+            print(f"The {module_name}.{attribute} is not available.")
+        else:
+            print(f"The {module_name} module is not available.")
+        return None

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -355,11 +355,11 @@ def have_optional_dependency(module_name, attribute=None):
                 imported_attribute = getattr(module, attribute)
                 return imported_attribute
             else:
-                raise ImportError(f"Optional dependency {module_name}.{attribute} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
+                raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:
             return module
     except ImportError:
         if attribute:
-            raise ImportError(f"Optional dependency {module_name}.{attribute} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
+            raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")
         else:
             raise ImportError(f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details.")

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -5,10 +5,10 @@ from tests import TestCase
 import unittest
 
 import numpy as np
-import sympy
 from scipy.sparse import coo_matrix
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class TestBinaryOperators(TestCase):
@@ -746,6 +746,7 @@ class TestBinaryOperators(TestCase):
         self.assertEqual(pybamm.inner(a3, a3).evaluate(), 9)
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         # Test print_name
         pybamm.Addition.print_name = "test"
         self.assertEqual(pybamm.Addition(1, 2).to_equation(), sympy.Symbol("test"))

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -5,9 +5,9 @@ import unittest
 from tests import TestCase
 
 import numpy as np
-import sympy
 
 import pybamm
+from pybamm.util import have_optional_dependency
 from tests import get_discretisation_for_testing, get_mesh_for_testing
 
 
@@ -370,6 +370,7 @@ class TestConcatenations(TestCase):
         )
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         a = pybamm.Symbol("a", domain="test a")
         b = pybamm.Symbol("b", domain="test b")
         func_symbol = sympy.Symbol(r"\begin{cases}a\\b\end{cases}")

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -5,10 +5,10 @@ from tests import TestCase
 import unittest
 
 import numpy as np
-import sympy
 from scipy import special
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 def test_function(arg):
@@ -120,6 +120,7 @@ class TestFunction(TestCase):
         self.assertEqual(fun.name, "function (cos)")
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         a = pybamm.Symbol("a", domain="test")
 
         # Test print_name

--- a/tests/unit/test_expression_tree/test_independent_variable.py
+++ b/tests/unit/test_expression_tree/test_independent_variable.py
@@ -4,9 +4,9 @@
 from tests import TestCase
 import unittest
 
-import sympy
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class TestIndependentVariable(TestCase):
@@ -64,6 +64,7 @@ class TestIndependentVariable(TestCase):
         self.assertTrue(x.evaluates_on_edges("primary"))
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         # Test print_name
         func = pybamm.IndependentVariable("a")
         func.print_name = "test"

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -5,9 +5,8 @@ from tests import TestCase
 import numbers
 import unittest
 
-import sympy
-
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class TestParameter(TestCase):
@@ -21,6 +20,7 @@ class TestParameter(TestCase):
         self.assertIsInstance(a.evaluate_for_shape(), numbers.Number)
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         func = pybamm.Parameter("test_string")
         func1 = pybamm.Parameter("test_name")
 
@@ -98,6 +98,7 @@ class TestFunctionParameter(TestCase):
         self.assertEqual(_myfun(x).print_name, None)
 
     def test_function_parameter_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         func = pybamm.FunctionParameter("test", {"x": pybamm.Scalar(1)})
         func1 = pybamm.FunctionParameter("func", {"var": pybamm.Variable("var")})
 

--- a/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
+++ b/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
@@ -4,14 +4,14 @@ Tests for the sympy_overrides.py
 from tests import TestCase
 import unittest
 
-import sympy
-
 import pybamm
 from pybamm.expression_tree.printing.sympy_overrides import custom_print_func
+from pybamm.util import have_optional_dependency
 
 
 class TestCustomPrint(TestCase):
     def test_print_Derivative(self):
+        sympy = have_optional_dependency("sympy")
         # Test force_partial
         der1 = sympy.Derivative("y", "x")
         der1.force_partial = True

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -8,10 +8,10 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 from scipy.sparse import csr_matrix, coo_matrix
-import sympy
 
 import pybamm
 from pybamm.expression_tree.binary_operators import _Heaviside
+from pybamm.util import have_optional_dependency
 
 
 class TestSymbol(TestCase):
@@ -484,6 +484,7 @@ class TestSymbol(TestCase):
             (y1 + y2).test_shape()
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         self.assertEqual(pybamm.Symbol("test").to_equation(), sympy.Symbol("test"))
 
     def test_numpy_array_ufunc(self):

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -5,12 +5,10 @@ import unittest
 from tests import TestCase
 
 import numpy as np
-import sympy
 from scipy.sparse import diags
-from sympy.vector.operators import Divergence as sympy_Divergence
-from sympy.vector.operators import Gradient as sympy_Gradient
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class TestUnaryOperators(TestCase):
@@ -613,6 +611,11 @@ class TestUnaryOperators(TestCase):
         self.assertFalse((2 * a).is_constant())
 
     def test_to_equation(self):
+
+        sympy = have_optional_dependency("sympy")
+        sympy_Divergence = have_optional_dependency("sympy.vector.operators","Divergence")
+        sympy_Gradient = have_optional_dependency("sympy.vector.operators","Gradient")
+
         a = pybamm.Symbol("a", domain="negative particle")
         b = pybamm.Symbol("b", domain="current collector")
         c = pybamm.Symbol("c", domain="test")

--- a/tests/unit/test_expression_tree/test_variable.py
+++ b/tests/unit/test_expression_tree/test_variable.py
@@ -5,9 +5,9 @@ from tests import TestCase
 import unittest
 
 import numpy as np
-import sympy
 
 import pybamm
+from pybamm.util import have_optional_dependency
 
 
 class TestVariable(TestCase):
@@ -55,6 +55,7 @@ class TestVariable(TestCase):
             pybamm.Variable("var", bounds=(1, 1))
 
     def test_to_equation(self):
+        sympy = have_optional_dependency("sympy")
         # Test print_name
         func = pybamm.Variable("test_string")
         func.print_name = "test"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,6 +88,10 @@ class TestUtil(TestCase):
         self.assertIsInstance(git_commit_info, str)
         self.assertEqual(git_commit_info[:2], "v2")
 
+    def test_have_optional_dependency(self):
+        with self.assertRaisesRegex(ImportError,"Optional dependency pybtex is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details."):
+            pybamm.print_citations()
+
 
 class TestSearch(TestCase):
     def test_url_gets_to_stdout(self):


### PR DESCRIPTION
# Description

With this PR i'm trying to fix the error getting while importing `pybamm` without any extra dependencies for `pybamm=23.9rc0`

Fixes #3473 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
