### PR TITLE
Fix bug with identical steps with different end times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- Fixed bug that made identical Experiment steps with different end times crash ([#3516](https://github.com/pybamm-team/PyBaMM/pull/3516))
 - Fixed bug in calculation of theoretical energy that made it very slow ([#3506](https://github.com/pybamm-team/PyBaMM/pull/3506))
 
 # [v23.9rc0](https://github.com/pybamm-team/PyBaMM/tree/v23.9rc0) - 2023-10-31

--- a/pybamm/experiment/experiment.py
+++ b/pybamm/experiment/experiment.py
@@ -78,7 +78,7 @@ class Experiment:
         self.operating_conditions_cycles = operating_conditions_cycles
         self.cycle_lengths = [len(cycle) for cycle in operating_conditions_cycles]
 
-        operating_conditions_steps_unprocessed = self._set_next_start_time(
+        self.operating_conditions_steps_unprocessed = self._set_next_start_time(
             [cond for cycle in operating_conditions_cycles for cond in cycle]
         )
 
@@ -89,7 +89,7 @@ class Experiment:
         self.temperature = _convert_temperature_to_kelvin(temperature)
 
         processed_steps = {}
-        for step in operating_conditions_steps_unprocessed:
+        for step in self.operating_conditions_steps_unprocessed:
             if repr(step) in processed_steps:
                 continue
             elif isinstance(step, str):
@@ -106,7 +106,7 @@ class Experiment:
 
         self.operating_conditions_steps = [
             processed_steps[repr(step)]
-            for step in operating_conditions_steps_unprocessed
+            for step in self.operating_conditions_steps_unprocessed
         ]
 
         # Save the processed unique steps and the processed operating conditions

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -169,10 +169,8 @@ class Simulation:
         # Update experiment using capacity
         capacity = self._parameter_values["Nominal cell capacity [A.h]"]
         for op_conds in self.experiment.operating_conditions_steps:
-            print(op_conds.type)
             if op_conds.type == "C-rate":
                 op_conds.type = "current"
-                print("    ", op_conds.type)
                 op_conds.value = op_conds.value * capacity
 
             # Update terminations
@@ -209,12 +207,9 @@ class Simulation:
         reduces simulation time since the model formulation is efficient.
         """
         self.experiment_unique_steps_to_model = {}
-        for op_number, op in enumerate(set(self.experiment.operating_conditions_steps)):
+        for op_number, op in enumerate(self.experiment.unique_steps):
             new_model = self._model.new_copy()
             new_parameter_values = self._parameter_values.copy()
-
-            if op.type == "C-rate":
-                print(op)
 
             if op.type != "current":
                 # Voltage or power control

--- a/pybamm/simulation.py
+++ b/pybamm/simulation.py
@@ -777,7 +777,7 @@ class Simulation:
                     start_time = current_solution.t[-1]
 
                     # If step has an end time, dt must take that into account
-                    if op_conds_unproc.end_time:
+                    if getattr(op_conds_unproc, "end_time", None):
                         dt = min(
                             op_conds.duration,
                             (
@@ -834,7 +834,7 @@ class Simulation:
                     step_termination = step_solution.termination
 
                     # Add a padding rest step if necessary
-                    if op_conds_unproc.next_start_time is not None:
+                    if getattr(op_conds_unproc, "next_start_time", None) is not None:
                         rest_time = (
                             op_conds_unproc.next_start_time
                             - (

--- a/pybamm/step/_steps_util.py
+++ b/pybamm/step/_steps_util.py
@@ -70,6 +70,7 @@ class _Step:
         description=None,
     ):
         self.type = typ
+        self.raw_termination = termination
 
         # Record all the args for repr and hash
         self.repr_args = f"{typ}, {value}"
@@ -170,6 +171,19 @@ class _Step:
         used for hashing.
         """
         return f"_Step({self.hash_args})"
+
+    def copy(self):
+        return _Step(
+            typ=self.type,
+            value=self.value,
+            duration=self.duration,
+            termination=self.raw_termination,
+            period=self.period,
+            temperature=self.temperature,
+            tags=self.tags,
+            start_time=self.start_time,
+            description=self.description,
+        )
 
     def to_dict(self):
         """

--- a/pybamm/step/_steps_util.py
+++ b/pybamm/step/_steps_util.py
@@ -172,19 +172,6 @@ class _Step:
         """
         return f"_Step({self.hash_args})"
 
-    def copy(self):
-        return _Step(
-            typ=self.type,
-            value=self.value,
-            duration=self.duration,
-            termination=self.raw_termination,
-            period=self.period,
-            temperature=self.temperature,
-            tags=self.tags,
-            start_time=self.start_time,
-            description=self.description,
-        )
-
     def to_dict(self):
         """
         Convert the step to a dictionary.

--- a/pybamm/step/_steps_util.py
+++ b/pybamm/step/_steps_util.py
@@ -70,7 +70,6 @@ class _Step:
         description=None,
     ):
         self.type = typ
-        self.raw_termination = termination
 
         # Record all the args for repr and hash
         self.repr_args = f"{typ}, {value}"

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -183,24 +183,27 @@ class TestExperiment(TestCase):
             )
 
     def test_set_next_start_time(self):
-        # Defined dummy experiment to access _set_next_start_time
-        experiment = pybamm.Experiment(["Rest for 1 hour"])
         raw_op = [
             pybamm.step._Step(
                 "current", 1, duration=3600, start_time=datetime(2023, 1, 1, 8, 0)
             ),
+            pybamm.step._Step("voltage", 2.5, duration=3600, start_time=None),
             pybamm.step._Step(
                 "current", 1, duration=3600, start_time=datetime(2023, 1, 1, 12, 0)
             ),
             pybamm.step._Step("current", 1, duration=3600, start_time=None),
+            pybamm.step._Step("voltage", 2.5, duration=3600, start_time=None),
             pybamm.step._Step(
                 "current", 1, duration=3600, start_time=datetime(2023, 1, 1, 15, 0)
             ),
         ]
+        experiment = pybamm.Experiment(raw_op)
         processed_op = experiment._set_next_start_time(raw_op)
 
         expected_next = [
+            None,
             datetime(2023, 1, 1, 12, 0),
+            None,
             None,
             datetime(2023, 1, 1, 15, 0),
             None,
@@ -208,16 +211,21 @@ class TestExperiment(TestCase):
 
         expected_end = [
             datetime(2023, 1, 1, 12, 0),
+            datetime(2023, 1, 1, 12, 0),
+            datetime(2023, 1, 1, 15, 0),
             datetime(2023, 1, 1, 15, 0),
             datetime(2023, 1, 1, 15, 0),
             None,
         ]
 
+        # Test method directly
         for next, end, op in zip(expected_next, expected_end, processed_op):
             # useful form for debugging
             self.assertEqual(op.next_start_time, next)
             self.assertEqual(op.end_time, end)
 
+        # TODO: once #3176 is completed, the test should pass for
+        # operating_conditions_steps (or equivalent) as well
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

Fixes a bug in which identical steps but with different end times could not be distinguished, and thus crashed the simulation by using a wrong end time.

It is a hacky fix, a more robust one should be implemented as part of the refactor in #3176.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
