### PR TITLE
Fix hysteresis option bug

### DIFF
--- a/pybamm/models/submodels/interface/base_interface.py
+++ b/pybamm/models/submodels/interface/base_interface.py
@@ -110,9 +110,10 @@ class BaseInterface(pybamm.BaseSubModel):
                     c_e = c_e.orphans[0]
                     T = T.orphans[0]
             # Get main reaction exchange-current density (may have empirical hysteresis)
-            if domain_options["exchange-current density"] == "single":
+            j0_option = getattr(domain_options, self.phase)["exchange-current density"]
+            if j0_option == "single":
                 j0 = phase_param.j0(c_e, c_s_surf, T)
-            elif domain_options["exchange-current density"] == "current sigmoid":
+            elif j0_option == "current sigmoid":
                 current = variables["Total current density [A.m-2]"]
                 k = 100
                 if Domain == "Positive":

--- a/pybamm/models/submodels/particle/base_particle.py
+++ b/pybamm/models/submodels/particle/base_particle.py
@@ -35,9 +35,10 @@ class BaseParticle(pybamm.BaseSubModel):
         domain_options = getattr(self.options, domain)
 
         # Get diffusivity (may have empirical hysteresis)
-        if domain_options["diffusivity"] == "single":
+        diffusivity_option = getattr(domain_options, self.phase)["diffusivity"]
+        if diffusivity_option == "single":
             D = phase_param.D(c, T)
-        elif domain_options["diffusivity"] == "current sigmoid":
+        elif diffusivity_option == "current sigmoid":
             k = 100
             if Domain == "Positive":
                 lithiation_current = current

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -393,7 +393,7 @@ class BaseUnitTestLithiumIon:
     def test_well_posed_composite_kinetic_hysteresis(self):
         options = {
             "particle phases": ("2", "1"),
-            "exchange current density": (
+            "exchange-current density": (
                 ("current sigmoid", "single"),
                 "current sigmoid",
             ),

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -389,3 +389,22 @@ class BaseUnitTestLithiumIon:
     def test_well_posed_psd(self):
         options = {"particle size": "distribution", "surface form": "algebraic"}
         self.check_well_posedness(options)
+
+    def test_well_posed_composite_kinetic_hysteresis(self):
+        options = {
+            "particle phases": ("2", "1"),
+            "exchange current density": (
+                ("current sigmoid", "single"),
+                "current sigmoid",
+            ),
+            "open-circuit potential": (("current sigmoid", "single"), "single"),
+        }
+        self.check_well_posedness(options)
+
+    def test_well_posed_composite_diffusion_hysteresis(self):
+        options = {
+            "particle phases": ("2", "1"),
+            "diffusivity": (("current sigmoid", "current sigmoid"), "current sigmoid"),
+            "open-circuit potential": (("current sigmoid", "single"), "single"),
+        }
+        self.check_well_posedness(options)

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_newman_tobias.py
@@ -22,6 +22,12 @@ class TestNewmanTobias(BaseUnitTestLithiumIon, TestCase):
     def test_well_posed_particle_phases_sei(self):
         pass  # skip this test
 
+    def test_well_posed_composite_kinetic_hysteresis(self):
+        pass  # skip this test
+
+    def test_well_posed_composite_diffusion_hysteresis(self):
+        pass  # skip this test
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description
Fixes a bug when using exchange-current or diffusivity hysteresis with composite electrodes.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
