### PR TITLE
Fix installation bug with `nox`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ PYBAMM_ENV = {
     "SUNDIALS_INST": f"{homedir}/.local",
     "LD_LIBRARY_PATH": f"{homedir}/.local/lib:",
 }
-VENV_DIR = Path('./venv').resolve()
+VENV_DIR = Path("./venv").resolve()
 
 
 def set_environment_variables(env_dict, session):
@@ -121,13 +121,25 @@ def set_dev(session):
     session.install("virtualenv", "cmake")
     session.run("virtualenv", os.fsdecode(VENV_DIR), silent=True)
     python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
+    session.run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "pip",
+        "setuptools",
+        "wheel",
+        external=True,
+    )
     if sys.platform == "linux":
-        session.run(python,
-                    "-m",
-                    "pip",
-                    "install",
-                    ".[all,dev,jax,odes]",
-                    external=True,
+        session.run(
+            python,
+            "-m",
+            "pip",
+            "install",
+            ".[all,dev,jax,odes]",
+            external=True,
         )
     else:
         session.run(python, "-m", "pip", "install", "-e", ".[all,dev]", external=True)
@@ -153,26 +165,26 @@ def build_docs(session):
     # Local development
     if session.interactive:
         session.run(
-        "sphinx-autobuild",
-        "-j",
-        "auto",
-        "--open-browser",
-        "-qT",
-        ".",
-        f"{envbindir}/../tmp/html",
+            "sphinx-autobuild",
+            "-j",
+            "auto",
+            "--open-browser",
+            "-qT",
+            ".",
+            f"{envbindir}/../tmp/html",
         )
     # Runs in CI only, treating warnings as errors
     else:
         session.run(
-        "sphinx-build",
-        "-j",
-        "auto",
-        "-b",
-        "html",
-        "-W",
-        "--keep-going",
-        ".",
-        f"{envbindir}/../tmp/html",
+            "sphinx-build",
+            "-j",
+            "auto",
+            "-b",
+            "html",
+            "-W",
+            "--keep-going",
+            ".",
+            f"{envbindir}/../tmp/html",
         )
 
 


### PR DESCRIPTION
# Description

The `nox -s dev` session should also install upgraded versions of `pip`, `setuptools`, and `wheel` before attempting to install PyBaMM. This fixes a few installation errors with `casadi` headers not being found by CMake when using `nox` to install PyBaMM. Related to #3529.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
