### PR TITLE
Make mechanical properties a function of stoichiometry and sometimes temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Serialisation added so models can be written to/read from JSON ([#3397](https://github.com/pybamm-team/PyBaMM/pull/3397))
+- Mechanical parameters are now a function of stoichiometry ([#3576](https://github.com/pybamm-team/PyBaMM/pull/3576))
 
 ## Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Serialisation added so models can be written to/read from JSON ([#3397](https://github.com/pybamm-team/PyBaMM/pull/3397))
-- Mechanical parameters are now a function of stoichiometry ([#3576](https://github.com/pybamm-team/PyBaMM/pull/3576))
+- Mechanical parameters are now a function of stoichiometry and temperature ([#3576](https://github.com/pybamm-team/PyBaMM/pull/3576))
 
 ## Bug fixes
 

--- a/pybamm/models/submodels/particle/base_particle.py
+++ b/pybamm/models/submodels/particle/base_particle.py
@@ -58,7 +58,7 @@ class BaseParticle(pybamm.BaseSubModel):
             # Ai2019 eq [12]
             sto = c / phase_param.c_max
             Omega = pybamm.r_average(domain_param.Omega(sto))
-            E = domain_param.E
+            E = pybamm.r_average(domain_param.E(sto, T))
             nu = domain_param.nu
             theta_M = Omega / (param.R * T) * (2 * Omega * E) / (9 * (1 - nu))
             stress_factor = 1 + theta_M * (c - domain_param.c_0)

--- a/pybamm/models/submodels/particle/base_particle.py
+++ b/pybamm/models/submodels/particle/base_particle.py
@@ -57,7 +57,7 @@ class BaseParticle(pybamm.BaseSubModel):
         if stress_option == "true":
             # Ai2019 eq [12]
             sto = c / phase_param.c_max
-            Omega = pybamm.r_average(domain_param.Omega(sto))
+            Omega = pybamm.r_average(domain_param.Omega(sto, T))
             E = pybamm.r_average(domain_param.E(sto, T))
             nu = domain_param.nu
             theta_M = Omega / (param.R * T) * (2 * Omega * E) / (9 * (1 - nu))

--- a/pybamm/models/submodels/particle/base_particle.py
+++ b/pybamm/models/submodels/particle/base_particle.py
@@ -56,7 +56,8 @@ class BaseParticle(pybamm.BaseSubModel):
 
         if stress_option == "true":
             # Ai2019 eq [12]
-            Omega = domain_param.Omega
+            sto = c / phase_param.c_max
+            Omega = pybamm.r_average(domain_param.Omega(sto))
             E = domain_param.E
             nu = domain_param.nu
             theta_M = Omega / (param.R * T) * (2 * Omega * E) / (9 * (1 - nu))

--- a/pybamm/models/submodels/particle_mechanics/base_mechanics.py
+++ b/pybamm/models/submodels/particle_mechanics/base_mechanics.py
@@ -43,6 +43,11 @@ class BaseMechanics(pybamm.BaseSubModel):
         sto_rav = variables[f"R-averaged {domain} particle concentration"]
         c_s_surf = variables[f"{Domain} particle surface concentration [mol.m-3]"]
         T_xav = variables["X-averaged cell temperature [K]"]
+        phase_name = self.phase_name
+        T = pybamm.PrimaryBroadcast(
+            variables[f"{Domain} electrode temperature [K]"],
+            [f"{domain} {phase_name}particle"],
+        )
         eps_s = variables[f"{Domain} electrode active material volume fraction"]
 
         #use a tangential approximation for omega
@@ -50,7 +55,7 @@ class BaseMechanics(pybamm.BaseSubModel):
         Omega = pybamm.r_average(domain_param.Omega(sto))
         R0 = domain_param.prim.R
         c_0 = domain_param.c_0
-        E0 = domain_param.E
+        E0 = pybamm.r_average(domain_param.E(sto, T))
         nu = domain_param.nu
         L0 = domain_param.L
         sto_init = pybamm.r_average(domain_param.prim.c_init / domain_param.prim.c_max)

--- a/pybamm/models/submodels/particle_mechanics/base_mechanics.py
+++ b/pybamm/models/submodels/particle_mechanics/base_mechanics.py
@@ -45,7 +45,9 @@ class BaseMechanics(pybamm.BaseSubModel):
         T_xav = variables["X-averaged cell temperature [K]"]
         eps_s = variables[f"{Domain} electrode active material volume fraction"]
 
-        Omega = domain_param.Omega
+        #use a tangential approximation for omega
+        sto = variables[f"{Domain} particle concentration"]
+        Omega = pybamm.r_average(domain_param.Omega(sto))
         R0 = domain_param.prim.R
         c_0 = domain_param.c_0
         E0 = domain_param.E

--- a/pybamm/models/submodels/particle_mechanics/base_mechanics.py
+++ b/pybamm/models/submodels/particle_mechanics/base_mechanics.py
@@ -52,7 +52,7 @@ class BaseMechanics(pybamm.BaseSubModel):
 
         #use a tangential approximation for omega
         sto = variables[f"{Domain} particle concentration"]
-        Omega = pybamm.r_average(domain_param.Omega(sto))
+        Omega = pybamm.r_average(domain_param.Omega(sto, T))
         R0 = domain_param.prim.R
         c_0 = domain_param.c_0
         E0 = pybamm.r_average(domain_param.E(sto, T))

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -308,9 +308,7 @@ class DomainLithiumIonParameters(BaseParameters):
             f"{Domain} electrode reference concentration for free of deformation "
             "[mol.m-3]"
         )
-        self.Omega = pybamm.Parameter(
-            f"{Domain} electrode partial molar volume [m3.mol-1]"
-        )
+
         self.l_cr_0 = pybamm.Parameter(f"{Domain} electrode initial crack length [m]")
         self.w_cr = pybamm.Parameter(f"{Domain} electrode initial crack width [m]")
         self.rho_cr = pybamm.Parameter(
@@ -347,6 +345,14 @@ class DomainLithiumIonParameters(BaseParameters):
         Domain = self.domain.capitalize()
         return pybamm.FunctionParameter(
             f"{Domain} electrode double-layer capacity [F.m-2]", inputs
+        )
+
+    def Omega(self, sto):
+        """Dimensional partial molar volume of Li in solid solution [m3.mol-1]"""
+        Domain = self.domain.capitalize()
+        inputs = {f"{Domain} particle stoichiometry": sto}
+        return pybamm.FunctionParameter(
+            f"{Domain} electrode partial molar volume [m3.mol-1]"
         )
 
     def sigma(self, T):

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -303,7 +303,6 @@ class DomainLithiumIonParameters(BaseParameters):
 
         # Mechanical parameters
         self.nu = pybamm.Parameter(f"{Domain} electrode Poisson's ratio")
-        self.E = pybamm.Parameter(f"{Domain} electrode Young's modulus [Pa]")
         self.c_0 = pybamm.Parameter(
             f"{Domain} electrode reference concentration for free of deformation "
             "[mol.m-3]"
@@ -353,6 +352,14 @@ class DomainLithiumIonParameters(BaseParameters):
         inputs = {f"{Domain} particle stoichiometry": sto}
         return pybamm.FunctionParameter(
             f"{Domain} electrode partial molar volume [m3.mol-1]", inputs
+        )
+
+    def E(self, sto, T):
+        """Dimensional Young's modulus"""
+        Domain = self.domain.capitalize()
+        inputs = {f"{Domain} particle stoichiometry": sto, "Temperature [K]": T}
+        return pybamm.FunctionParameter(
+            f"{Domain} electrode Young's modulus [Pa]", inputs
         )
 
     def sigma(self, T):

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -346,10 +346,10 @@ class DomainLithiumIonParameters(BaseParameters):
             f"{Domain} electrode double-layer capacity [F.m-2]", inputs
         )
 
-    def Omega(self, sto):
+    def Omega(self, sto, T):
         """Dimensional partial molar volume of Li in solid solution [m3.mol-1]"""
         Domain = self.domain.capitalize()
-        inputs = {f"{Domain} particle stoichiometry": sto}
+        inputs = {f"{Domain} particle stoichiometry": sto, "Temperature [K]": T}
         return pybamm.FunctionParameter(
             f"{Domain} electrode partial molar volume [m3.mol-1]", inputs
         )

--- a/pybamm/parameters/lithium_ion_parameters.py
+++ b/pybamm/parameters/lithium_ion_parameters.py
@@ -352,7 +352,7 @@ class DomainLithiumIonParameters(BaseParameters):
         Domain = self.domain.capitalize()
         inputs = {f"{Domain} particle stoichiometry": sto}
         return pybamm.FunctionParameter(
-            f"{Domain} electrode partial molar volume [m3.mol-1]"
+            f"{Domain} electrode partial molar volume [m3.mol-1]", inputs
         )
 
     def sigma(self, T):


### PR DESCRIPTION
# Description

For many chemistries, notably high-nickel NMCs and graphite, the volume change associated with intercalation is a strong function of stoichiometry. Here, I have taken the r-averaged value for Ω and used it to calculate total stress. This accounts for the change without violating the initial model assumptions.

This is the same as #2943 but it was easier to start over than just update that one

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Optimization (back-end change that speeds up the code)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
