### PR TITLE
Style checker on PRs does not actually check anything #3571

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Check style
         run: |
           python -m pip install pre-commit
-          pre-commit run --files $(git diff --name-only HEAD^)
+          git add .
+          pre-commit run ruff
 
   build:
     needs: style

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Check style
         run: |
           python -m pip install pre-commit
-          pre-commit run --files $(git diff --name-only HEAD^)
+          git add .
+          pre-commit run ruff
 
   run_unit_tests:
     needs: style

--- a/pybamm/spatial_methods/scikit_finite_element.py
+++ b/pybamm/spatial_methods/scikit_finite_element.py
@@ -353,13 +353,10 @@ class ScikitFiniteElement(pybamm.SpatialMethod):
     def boundary_integral(self, child, discretised_child, region):
         """Implementation of the boundary integral operator.
         See :meth:`pybamm.SpatialMethod.boundary_integral`
-
-        hviyougougou
         """
         # Calculate integration vector
         integration_vector = self.boundary_integral_vector(child.domain, region=region)
-        jlbkhvb
-         jo[and]
+
         out = integration_vector @ discretised_child
         out.clear_domains()
         return out


### PR DESCRIPTION
# Description

Style checker on PRs does not actually check anything #3571

Fixes # 3571

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [❌] New feature (non-breaking change which adds functionality)
- [❌] Optimization (back-end change that speeds up the code)
- [✅] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [✅] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [✅] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [✅] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [✅] Code is commented, particularly in hard-to-understand areas
- [✅] Tests added that prove fix is effective or that feature works
