### PR TITLE
Fix Issue 3543 - Thermal model not working for a composite electrode particle model with two (or more) phases

### DIFF
--- a/pybamm/models/submodels/interface/open_circuit_potential/base_ocp.py
+++ b/pybamm/models/submodels/interface/open_circuit_potential/base_ocp.py
@@ -90,8 +90,8 @@ class BaseOpenCircuitPotential(BaseInterface):
         if self.reaction in ["lithium-ion main", "lead-acid main"]:
             variables.update(
                 {
-                    f"{Domain} electrode entropic change [V.K-1]": dUdT,
-                    f"X-averaged {domain} electrode entropic change [V.K-1]": dUdT_av,
+                    f"{Domain} electrode {reaction_name}entropic change [V.K-1]": dUdT,
+                    f"X-averaged {domain} electrode {reaction_name}entropic change [V.K-1]": dUdT_av,
                 }
             )
 

--- a/pybamm/models/submodels/thermal/base_thermal.py
+++ b/pybamm/models/submodels/thermal/base_thermal.py
@@ -121,7 +121,7 @@ class BaseThermal(pybamm.BaseSubModel):
         phase_names = [""]
         if num_phases > 1:
             phase_names = ["primary ", "secondary "]
-        
+
         Q_rxn_p, Q_rev_p = 0, 0
         T_p = variables["Positive electrode temperature [K]"]
         for phase in phase_names:
@@ -139,7 +139,7 @@ class BaseThermal(pybamm.BaseSubModel):
         num_phases = int(getattr(self.options, 'negative')["particle phases"])
         phase_names = [""]
         if num_phases > 1:
-            phase_names = ["primary", "secondary"]       
+            phase_names = ["primary", "secondary"]
 
         if self.options.electrode_types["negative"] == "planar":
             Q_rxn_n = pybamm.FullBroadcast(
@@ -159,11 +159,11 @@ class BaseThermal(pybamm.BaseSubModel):
                 eta_r_n = variables[f"Negative electrode {phase}reaction overpotential [V]"]
                 # Irreversible electrochemical heating
                 Q_rxn_n += a_j_n * eta_r_n
-                
+
                 # Reversible electrochemical heating
                 dUdT_n = variables[f"Negative electrode {phase}entropic change [V.K-1]"]
                 Q_rev_n += a_j_n * T_n * dUdT_n
-        
+
         # Irreversible electrochemical heating
         Q_rxn = pybamm.concatenation(
             Q_rxn_n, pybamm.FullBroadcast(0, "separator", "current collector"), Q_rxn_p

--- a/pybamm/models/submodels/thermal/base_thermal.py
+++ b/pybamm/models/submodels/thermal/base_thermal.py
@@ -117,38 +117,59 @@ class BaseThermal(pybamm.BaseSubModel):
         # Total Ohmic heating
         Q_ohm = Q_ohm_s + Q_ohm_e
 
-        # Irreversible electrochemical heating
-        a_j_p = variables[
-            "Positive electrode volumetric interfacial current density [A.m-3]"
-        ]
-        eta_r_p = variables["Positive electrode reaction overpotential [V]"]
+        num_phases = int(getattr(self.options, 'positive')["particle phases"])
+        phase_names = [""]
+        if num_phases > 1:
+            phase_names = ["primary ", "secondary "]
+        
+        Q_rxn_p, Q_rev_p = 0, 0
+        T_p = variables["Positive electrode temperature [K]"]
+        for phase in phase_names:
+            a_j_p = variables[
+                f"Positive electrode {phase}volumetric interfacial current density [A.m-3]"
+            ]
+            eta_r_p = variables[f"Positive electrode {phase}reaction overpotential [V]"]
+            # Irreversible electrochemical heating
+            Q_rxn_p += a_j_p * eta_r_p
+            # Reversible electrochemical heating
+            dUdT_p = variables[f"Positive electrode {phase}entropic change [V.K-1]"]
+            Q_rev_p += a_j_p * T_p * dUdT_p
+
+
+        num_phases = int(getattr(self.options, 'negative')["particle phases"])
+        phase_names = [""]
+        if num_phases > 1:
+            phase_names = ["primary", "secondary"]       
+
         if self.options.electrode_types["negative"] == "planar":
             Q_rxn_n = pybamm.FullBroadcast(
                 0, ["negative electrode"], "current collector"
             )
-        else:
-            a_j_n = variables[
-                "Negative electrode volumetric interfacial current density [A.m-3]"
-            ]
-            eta_r_n = variables["Negative electrode reaction overpotential [V]"]
-            Q_rxn_n = a_j_n * eta_r_n
-        Q_rxn_p = a_j_p * eta_r_p
-        Q_rxn = pybamm.concatenation(
-            Q_rxn_n, pybamm.FullBroadcast(0, "separator", "current collector"), Q_rxn_p
-        )
-
-        # Reversible electrochemical heating
-        T_p = variables["Positive electrode temperature [K]"]
-        dUdT_p = variables["Positive electrode entropic change [V.K-1]"]
-        if self.options.electrode_types["negative"] == "planar":
             Q_rev_n = pybamm.FullBroadcast(
                 0, ["negative electrode"], "current collector"
             )
         else:
             T_n = variables["Negative electrode temperature [K]"]
-            dUdT_n = variables["Negative electrode entropic change [V.K-1]"]
-            Q_rev_n = a_j_n * T_n * dUdT_n
-        Q_rev_p = a_j_p * T_p * dUdT_p
+            Q_rxn_n = 0
+            Q_rev_n = 0
+            for phase in phase_names:
+                a_j_n = variables[
+                    f"Negative electrode {phase}volumetric interfacial current density [A.m-3]"
+                ]
+                eta_r_n = variables[f"Negative electrode {phase}reaction overpotential [V]"]
+                # Irreversible electrochemical heating
+                Q_rxn_n += a_j_n * eta_r_n
+                
+                # Reversible electrochemical heating
+                dUdT_n = variables[f"Negative electrode {phase}entropic change [V.K-1]"]
+                Q_rev_n += a_j_n * T_n * dUdT_n
+        
+        # Irreversible electrochemical heating
+        Q_rxn = pybamm.concatenation(
+            Q_rxn_n, pybamm.FullBroadcast(0, "separator", "current collector"), Q_rxn_p
+        )
+
+        # Reversible electrochemical heating
         Q_rev = pybamm.concatenation(
             Q_rev_n, pybamm.FullBroadcast(0, "separator", "current collector"), Q_rev_p
         )


### PR DESCRIPTION
# Description

Summing the irreversible and reversible heating terms over the phases in the BaseThermal class as detailed in https://github.com/pybamm-team/PyBaMM/issues/3543#issuecomment-1836406296. To do so, the entropic change dUdT variables are stored for each phase in the BaseOpenCircuitPotential class.

Fixes #3543

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
