### PR TITLE
Added conditions to workflows to be skipped

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -140,7 +140,7 @@ jobs:
           if-no-files-found: error
 
   publish_pypi:
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && github.repository_owner == 'pybamm-team'
     name: Upload package to PyPI
     needs: [build_wheels, build_windows_wheels, build_sdist]
     runs-on: ubuntu-latest

--- a/.github/workflows/release_reminder.yml
+++ b/.github/workflows/release_reminder.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   remind:
+    if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_benchmarks_over_history.yml
+++ b/.github/workflows/run_benchmarks_over_history.yml
@@ -48,6 +48,7 @@ jobs:
           path: results
 
   publish-results:
+    if: github.repository_owner == 'pybamm-team'
     name: Push and publish results
     needs: benchmarks
     runs-on: ubuntu-latest

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -113,6 +113,7 @@ jobs:
 
   #M-series Mac Mini
   build-apple-mseries:
+    if: github.repository_owner == 'pybamm-team'
     needs: style
     runs-on: [self-hosted, macOS, ARM64]
     env:

--- a/.github/workflows/validation_benchmarks.yml
+++ b/.github/workflows/validation_benchmarks.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository_owner == 'pybamm-team'
     name: Dispatch to `pybamm-validation`
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/work_precision_sets.yml
+++ b/.github/workflows/work_precision_sets.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   benchmarks_on_release:
+    if: github.repository_owner == 'pybamm-team'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Added conditions to PyBaMM-specific workflows so that they always be skipped in forks. Used the same condition found on `update_license.yml`.
Changed the branch of the PR.

- [x] `release_reminder.yml`: does not run much since it's on schedule, but uses write permissions, should be skipped for security reasons
- [x] `publish_pypi.yml`: the publishing job should be skipped on forks
- [x] `run_benchmarks_over_history.yml`: the publish-results job will fail on forks due to the absence of a repo-scoped PAT
- [x] `validation_benchmarks.yml`: runs on releases, requires secrets to be configured, the entire workflow should be skipped
- [x] `work_precision_sets.yml`: runs on releases, the entire workflow should be skipped
- [x] In `run_periodic_tests.yml`, i.e., the scheduled tests: we should skip the job written for the M-series runner

Fixes #3592

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
