### PR TITLE
Fixed a bug where the SEI thickness decreased at some intervals when using the 'electron-migration limited' model.

### DIFF
--- a/pybamm/models/submodels/interface/sei/sei_growth.py
+++ b/pybamm/models/submodels/interface/sei/sei_growth.py
@@ -134,7 +134,7 @@ class SEIGrowth(BaseModel):
         elif SEI_option == "electron-migration limited":
             # Scott Marquis thesis (eq. 5.94)
             eta_inner = delta_phi - phase_param.U_inner
-            j_sei = phase_param.kappa_inner * eta_inner / L_sei_inner * pybamm.EqualHeaviside(eta_inner, 0)
+            j_sei = (eta_inner < 0) * phase_param.kappa_inner * eta_inner / L_sei_inner
         elif SEI_option == "interstitial-diffusion limited":
             # Scott Marquis thesis (eq. 5.96)
             j_sei = -(

--- a/pybamm/models/submodels/interface/sei/sei_growth.py
+++ b/pybamm/models/submodels/interface/sei/sei_growth.py
@@ -134,8 +134,7 @@ class SEIGrowth(BaseModel):
         elif SEI_option == "electron-migration limited":
             # Scott Marquis thesis (eq. 5.94)
             eta_inner = delta_phi - phase_param.U_inner
-            j_sei = phase_param.kappa_inner * eta_inner / L_sei_inner
-
+            j_sei = phase_param.kappa_inner * eta_inner / L_sei_inner * pybamm.EqualHeaviside(eta_inner, 0)
         elif SEI_option == "interstitial-diffusion limited":
             # Scott Marquis thesis (eq. 5.96)
             j_sei = -(


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The SEI thickness decreased at some intervals when the 'electron-migration limited' model was used. It has been corrected by considering only negative contributions to eta_sei in the j_sei, using the Heaviside function.


Fixes #3613 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.



- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works


