### PR TITLE
Improved error handling and added type hinting in Experiment

### DIFF
--- a/pybamm/experiment/experiment.py
+++ b/pybamm/experiment/experiment.py
@@ -52,7 +52,7 @@ class Experiment:
         if not (isinstance(operating_conditions, list)):
             raise TypeError("operating_conditions must be list of strings. For example:"
                             f"\n\n [{operating_conditions}]")
-        
+
         if cccv_handling is not None:
             raise ValueError(
                 "cccv_handling has been deprecated, use "

--- a/pybamm/experiment/experiment.py
+++ b/pybamm/experiment/experiment.py
@@ -2,6 +2,7 @@
 # Experiment class
 #
 
+from __future__ import annotations
 import pybamm
 from pybamm.step._steps_util import (
     _convert_time_to_seconds,
@@ -42,16 +43,13 @@ class Experiment:
 
     def __init__(
         self,
-        operating_conditions: list,
+        operating_conditions: list[str],
         period: str = "1 minute",
-        temperature: float = None,
-        termination: list = None,
+        temperature: float | None = None,
+        termination: list[str] | None = None,
         drive_cycles=None,
         cccv_handling=None,
     ):
-        if not (isinstance(operating_conditions, list)):
-            raise TypeError("operating_conditions must be list of strings. For example:"
-                            f"\n\n [{operating_conditions}]")
 
         if cccv_handling is not None:
             raise ValueError(

--- a/pybamm/experiment/experiment.py
+++ b/pybamm/experiment/experiment.py
@@ -42,13 +42,17 @@ class Experiment:
 
     def __init__(
         self,
-        operating_conditions,
-        period="1 minute",
-        temperature=None,
-        termination=None,
+        operating_conditions: list,
+        period: str = "1 minute",
+        temperature: float = None,
+        termination: list = None,
         drive_cycles=None,
         cccv_handling=None,
     ):
+        if not (isinstance(operating_conditions, list)):
+            raise TypeError("operating_conditions must be list of strings. For example:"
+                            f"\n\n [{operating_conditions}]")
+        
         if cccv_handling is not None:
             raise ValueError(
                 "cccv_handling has been deprecated, use "

--- a/pybamm/experiment/experiment.py
+++ b/pybamm/experiment/experiment.py
@@ -22,8 +22,8 @@ class Experiment:
 
     Parameters
     ----------
-    operating_conditions : list
-        List of operating conditions
+    operating_conditions : list[str]
+        List of strings representing the operating conditions.
     period : string, optional
         Period (1/frequency) at which to record outputs. Default is 1 minute. Can be
         overwritten by individual operating conditions.
@@ -31,8 +31,8 @@ class Experiment:
         The ambient air temperature in degrees Celsius at which to run the experiment.
         Default is None whereby the ambient temperature is taken from the parameter set.
         This value is overwritten if the temperature is specified in a step.
-    termination : list, optional
-        List of conditions under which to terminate the experiment. Default is None.
+    termination : list[str], optional
+        List of strings representing the conditions to terminate the experiment. Default is None.
         This is different from the termination for individual steps. Termination for
         individual steps is specified in the step itself, and the simulation moves to
         the next step when the termination condition is met


### PR DESCRIPTION
# Description

1. Improved error handling by raising TypeError when a str is passed to Experiment instead of list of strings
2. Added type hinting for better readability.

Fixes #3623

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
