### PR TITLE
Fix multiple configurations and adhere to scientific python guidelines

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # group updates in a single PR
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=64",
-    "wheel",
     # On Windows, use the CasADi vcpkg registry and CMake bundled from MSVC
     "casadi>=3.6.3; platform_system!='Windows'",
     "cmake; platform_system!='Windows'",
@@ -226,6 +225,7 @@ ignore = [
 
 # NOTE: currently used only for notebook tests with the nbmake plugin.
 [tool.pytest.ini_options]
+minversion = "6"
 # Use pytest-xdist to run tests in parallel by default, exit with
 # error if not installed
 required_plugins = [
@@ -234,11 +234,16 @@ required_plugins = [
 addopts = [
   "-nauto",
   "-v",
+  "-ra",
+  "--strict-config",
+  "--strict-markers",
 ]
 testpaths = [
   "docs/source/examples/",
 ]
 console_output_style = "progress"
+xfail_strict = true
+filterwarnings = ["error"]
 
 # Logging configuration
 log_cli = "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
 requires = [
     "setuptools>=64",
+    "wheel",
     # On Windows, use the CasADi vcpkg registry and CMake bundled from MSVC
     "casadi>=3.6.3; platform_system!='Windows'",
     "cmake; platform_system!='Windows'",
-    ]
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -181,40 +182,40 @@ extend-exclude = ["__init__.py"]
 
 [tool.ruff.lint]
 extend-select = [
-  # "B",           # flake8-bugbear
-  # "I",           # isort
-  # "ARG",         # flake8-unused-arguments
-  # "C4",          # flake8-comprehensions
-  # "ICN",         # flake8-import-conventions
-  # "ISC",         # flake8-implicit-str-concat
-  # "PGH",         # pygrep-hooks
-  # "PIE",         # flake8-pie
-  # "PL",          # pylint
-  # "PT",          # flake8-pytest-style
-  # "PTH",         # flake8-use-pathlib
-  # "RET",         # flake8-return
-  "RUF",         # Ruff-specific
-  # "SIM",         # flake8-simplify
-  # "T20",         # flake8-print
-  "UP",          # pyupgrade
-  "YTT",         # flake8-2020
+    # "B",           # flake8-bugbear
+    # "I",           # isort
+    # "ARG",         # flake8-unused-arguments
+    # "C4",          # flake8-comprehensions
+    # "ICN",         # flake8-import-conventions
+    # "ISC",         # flake8-implicit-str-concat
+    # "PGH",         # pygrep-hooks
+    # "PIE",         # flake8-pie
+    # "PL",          # pylint
+    # "PT",          # flake8-pytest-style
+    # "PTH",         # flake8-use-pathlib
+    # "RET",         # flake8-return
+    "RUF",         # Ruff-specific
+    # "SIM",         # flake8-simplify
+    # "T20",         # flake8-print
+    "UP",          # pyupgrade
+    "YTT",         # flake8-2020
 ]
 ignore = [
-  "E741",        # Ambiguous variable name
-  "RUF012",      # Mutable class attributes should be annotated with `typing.ClassVar`
-  "SIM108",      # Use ternary operator
-  "ARG001",      # Unused function argument:
-  "ARG002",      # Unused method arguments
-  "PLR2004",     # Magic value used in comparison
-  "PLR0915",     # Too many statements
-  "PLR0913",     # Too many arguments
-  "PLR0912",     # Too many branches
-  "RET504",      # Unnecessary assignment
-  "RET505",      # Unnecessary `else`
-  "RET506",      # Unnecessary `elif`
-  "B018",        # Found useless expression
-  "RUF002",      # Docstring contains ambiguous
-  "UP007",       # For pyupgrade
+    "E741",        # Ambiguous variable name
+    "RUF012",      # Mutable class attributes should be annotated with `typing.ClassVar`
+    "SIM108",      # Use ternary operator
+    "ARG001",      # Unused function argument:
+    "ARG002",      # Unused method arguments
+    "PLR2004",     # Magic value used in comparison
+    "PLR0915",     # Too many statements
+    "PLR0913",     # Too many arguments
+    "PLR0912",     # Too many branches
+    "RET504",      # Unnecessary assignment
+    "RET505",      # Unnecessary `else`
+    "RET506",      # Unnecessary `elif`
+    "B018",        # Found useless expression
+    "RUF002",      # Docstring contains ambiguous
+    "UP007",       # For pyupgrade
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -229,17 +230,17 @@ minversion = "6"
 # Use pytest-xdist to run tests in parallel by default, exit with
 # error if not installed
 required_plugins = [
-  "pytest-xdist",
+    "pytest-xdist",
 ]
 addopts = [
-  "-nauto",
-  "-v",
-  "-ra",
-  "--strict-config",
-  "--strict-markers",
+    "-nauto",
+    "-v",
+    "-ra",
+    "--strict-config",
+    "--strict-markers",
 ]
 testpaths = [
-  "docs/source/examples/",
+    "docs/source/examples/",
 ]
 console_output_style = "progress"
 xfail_strict = true
@@ -254,3 +255,8 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 [tool.coverage.run]
 source = ["pybamm"]
 concurrency = ["multiprocessing"]
+
+[tool.repo-review]
+ignore = [
+    "PP003"  # list wheel as a build-dep
+]


### PR DESCRIPTION
# Description

Looks much better now:
```
saransh@saranshs-air PyBaMM % python3 -m pipx run "sp-repo-review[cli]" .
General:

 • Detected build backend: setuptools.build_meta                                                                                                    
 • Detected license(s): BSD License                                                                                                                 

├── PY001 Has a pyproject.toml ✅
├── PY002 Has a README.(md|rst) file ✅
├── PY003 Has a LICENSE* file ✅
├── PY004 Has docs folder ✅
├── PY005 Has tests folder ✅
├── PY006 Has pre-commit config ✅
└── PY007 Supports an easy task runner (nox or tox) ✅

PyProject:
├── PP002 Has a proper build-system table ✅
├── PP003 Does not list wheel as a build-dep ✅
├── PP301 Has pytest in pyproject ✅
├── PP302 Sets a minimum pytest to at least 6 ✅
├── PP303 Sets the test paths ✅
├── PP304 Sets the log level in pytest ✅
├── PP305 Specifies xfail_strict ✅
├── PP306 Specifies strict config ✅
├── PP307 Specifies strict markers ✅
├── PP308 Specifies useful pytest summary ✅
└── PP309 Filter warnings specified ✅

GitHub Actions:
├── GH100 Has GitHub Actions config ✅
├── GH101 Has nice names ✅
├── GH102 Auto-cancel on repeated PRs ✅
├── GH103 At least one workflow with manual dispatch trigger ✅
├── GH104 Use unique names for upload-artifact ✅
├── GH200 Maintained by Dependabot ✅
├── GH210 Maintains the GitHub action versions with Dependabot ✅
├── GH211 Do not pin core actions as major versions ✅
└── GH212 Require GHA update grouping ✅

Pre-commit:
├── PC100 Has pre-commit-hooks ✅
├── PC110 Uses black or ruff-format ❌
│   Must have https://github.com/psf/black-pre-commit-mirror or https://github.com/astral-sh/ruff-pre-commit + id: ruff-format in                   
│   .pre-commit-config.yaml                                                                                                                         
├── PC111 Uses blacken-docs [skipped]
├── PC140 Uses mypy ❌
│   Must have https://github.com/pre-commit/mirrors-mypy repo in .pre-commit-config.yaml                                                            
├── PC160 Uses codespell ❌
│   Must have https://github.com/codespell-project/codespell repo in .pre-commit-config.yaml                                                        
├── PC170 Uses PyGrep hooks (only needed if RST present) ✅
├── PC180 Uses prettier ❌
│   Must have https://github.com/pre-commit/mirrors-prettier repo in .pre-commit-config.yaml                                                        
├── PC190 Uses Ruff ✅
├── PC191 Ruff show fixes if fixes enabled ✅
└── PC901 Custom pre-commit CI message ✅

MyPy:
├── MY100 Uses MyPy (pyproject config) ❌
│   Must have tool.mypy section in pyproject.toml. Other forms of configuration are not supported by this check.                                    
├── MY101 MyPy strict mode [skipped]
├── MY102 MyPy show_error_codes deprecated [skipped]
├── MY103 MyPy warn unreachable [skipped]
├── MY104 MyPy enables ignore-without-code [skipped]
├── MY105 MyPy enables redundant-expr [skipped]
└── MY106 MyPy enables truthy-bool [skipped]

Ruff:
├── RF001 Has Ruff config ✅
├── RF002 Target version must be set ✅
├── RF003 src directory specified if used [skipped]
├── RF101 Bugbear must be selected ❌
│   Must select the flake8-bugbear B checks. Recommended:                                                                                           
│   
│                                                                                                                                                   
│    [tool.ruff.lint]                                                                                                                               
│    extend-select = [                                                                                                                              
│      "B",  # flake8-bugbear                                                                                                                       
│    ]                                                                                                                                              
│                                                                                                                                                   
├── RF102 isort must be selected ❌
│   Must select the isort I checks. Recommended:                                                                                                    
│   
│                                                                                                                                                   
│    [tool.ruff.lint]                                                                                                                               
│    extend-select = [                                                                                                                              
│      "I",  # isort                                                                                                                                
│    ]                                                                                                                                              
│                                                                                                                                                   
├── RF103 pyupgrade must be selected ✅
├── RF201 Avoid using deprecated config settings ✅
└── RF202 Use (new) lint config section ✅

Documentation:
├── RTD100 Uses ReadTheDocs (pyproject config) ✅
├── RTD101 You have to set the RTD version number to 2 ✅
├── RTD102 You have to set the RTD build image ✅
└── RTD103 You have to set the RTD python version ✅
```

XRef #3489

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
