### PR TITLE
Use distinct names for macOS and Linux wheel artifacts

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -109,10 +109,19 @@ jobs:
             delocate-wheel -v -w {dest_dir} {wheel}
           CIBW_SKIP: "pp* *musllinux*"
 
-      - name: Upload wheels
+      - name: Upload wheels for Linux
         uses: actions/upload-artifact@v4
+        if: matrix.os == 'ubuntu-latest'
         with:
-          name: wheels
+          name: linux_wheels
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+
+      - name: Upload wheels for macOS
+        uses: actions/upload-artifact@v4
+        if: matrix.os == 'macos-latest'
+        with:
+          name: macos_wheels
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -151,7 +160,7 @@ jobs:
       - name: Move all package files to files/
         run: |
           mkdir files
-          mv windows_wheels/* wheels/* sdist/* files/
+          mv windows_wheels/* linux_wheels/* macos_wheels/* sdist/* files/
 
       - name: Publish on PyPI
         if: github.event.inputs.target == 'pypi' || github.event_name == 'release'


### PR DESCRIPTION
# Description

A small fix because the `actions/upload-artifact@v4` GitHub Action now requires unique artifact names.

Fixes #3676

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
