### PR TITLE
Fix docs about Jax solver compatibility with Python versions

### DIFF
--- a/docs/source/user_guide/installation/gnu-linux-mac.rst
+++ b/docs/source/user_guide/installation/gnu-linux-mac.rst
@@ -161,7 +161,7 @@ Users can install ``jax`` and ``jaxlib`` to use the Jax solver.
 
 .. note::
 
-   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, 3.11, and 3.12.
+   The Jax solver is only supported for Python versions 3.9 through 3.12.
 
 .. code:: bash
 

--- a/docs/source/user_guide/installation/gnu-linux-mac.rst
+++ b/docs/source/user_guide/installation/gnu-linux-mac.rst
@@ -161,7 +161,7 @@ Users can install ``jax`` and ``jaxlib`` to use the Jax solver.
 
 .. note::
 
-   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, and 3.11.
+   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, 3.11, and 3.12.
 
 .. code:: bash
 

--- a/docs/source/user_guide/installation/windows.rst
+++ b/docs/source/user_guide/installation/windows.rst
@@ -73,7 +73,7 @@ Users can install ``jax`` and ``jaxlib`` to use the Jax solver.
 
 .. note::
 
-   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, and 3.11.
+   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, 3.11, and 3.12.
 
 .. code:: bash
 

--- a/docs/source/user_guide/installation/windows.rst
+++ b/docs/source/user_guide/installation/windows.rst
@@ -73,7 +73,7 @@ Users can install ``jax`` and ``jaxlib`` to use the Jax solver.
 
 .. note::
 
-   The Jax solver is not supported on Python 3.8. It is supported on Python 3.9, 3.10, 3.11, and 3.12.
+   The Jax solver is only supported for Python versions 3.9 through 3.12.
 
 .. code:: bash
 


### PR DESCRIPTION
# Description

I missed this while working on the changes in #3550 and #3531 – sorry!

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
