### PR TITLE
#3630 fix interpolant shape error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+- Fixed a bug that lead to a `ShapeError` when specifying "Ambient temperature [K]" as an `Interpolant` with an isothermal model ([]())
 - Updated `plot_voltage_components.py` to support both `Simulation` and `Solution` objects. Added new methods in both `Simulation` and `Solution` classes for allow the syntax `simulation.plot_voltage_components` and `solution.plot_voltage_components`. Updated `test_plot_voltage_components.py` to reflect these changes ([#3723](https://github.com/pybamm-team/PyBaMM/pull/3723)).
 - The SEI thickness decreased at some intervals when the 'electron-migration limited' model was used. It has been corrected ([#3622](https://github.com/pybamm-team/PyBaMM/pull/3622))
 

--- a/pybamm/models/submodels/thermal/isothermal.py
+++ b/pybamm/models/submodels/thermal/isothermal.py
@@ -26,13 +26,17 @@ class Isothermal(BaseThermal):
         # specified as a function of space (y, z) only and time
         y = pybamm.standard_spatial_vars.y
         z = pybamm.standard_spatial_vars.z
-        T_x_av = self.param.T_amb(y, z, pybamm.t)
+        # Broadcast t to be the same size as y and z (to catch cases where the ambient
+        # temperature is a function of time only)
+        t_broadcast = pybamm.PrimaryBroadcast(pybamm.t, "current collector")
+        T_x_av = self.param.T_amb(y, z, t_broadcast)
+        T_vol_av = self._yz_average(T_x_av)
 
         T_dict = {
             "negative current collector": T_x_av,
             "positive current collector": T_x_av,
             "x-averaged cell": T_x_av,
-            "volume-averaged cell": T_x_av,
+            "volume-averaged cell": T_vol_av,
         }
         for domain in ["negative electrode", "separator", "positive electrode"]:
             T_dict[domain] = pybamm.PrimaryBroadcast(T_x_av, domain)
@@ -50,15 +54,25 @@ class Isothermal(BaseThermal):
                 "Ohmic heating [W.m-3]",
                 "X-averaged Ohmic heating [W.m-3]",
                 "Volume-averaged Ohmic heating [W.m-3]",
+                "Ohmic heating per unit electrode-pair area [W.m-2]",
+                "Ohmic heating [W]",
                 "Irreversible electrochemical heating [W.m-3]",
                 "X-averaged irreversible electrochemical heating [W.m-3]",
                 "Volume-averaged irreversible electrochemical heating [W.m-3]",
+                "Irreversible electrochemical heating per unit electrode-pair area [W.m-2]",
+                "Irreversible electrochemical heating [W]",
                 "Reversible heating [W.m-3]",
                 "X-averaged reversible heating [W.m-3]",
                 "Volume-averaged reversible heating [W.m-3]",
+                "Reversible heating per unit electrode-pair area [W.m-2]",
+                "Reversible heating [W]",
                 "Total heating [W.m-3]",
                 "X-averaged total heating [W.m-3]",
                 "Volume-averaged total heating [W.m-3]",
+                "Total heating per unit electrode-pair area [W.m-2]",
+                "Total heating [W]",
+                "Negative current collector Ohmic heating [W.m-3]",
+                "Positive current collector Ohmic heating [W.m-3]",
             ]:
                 # All variables are zero
                 variables.update({var: zero})

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -347,3 +347,25 @@ class BaseIntegrationTestLithiumIon:
         model = self.model(options)
         modeltest = tests.StandardModelTest(model, parameter_values=parameter_values)
         modeltest.test_all(skip_output_tests=True)
+
+    def test_basic_processing_temperature_interpolant(self):
+        times = np.arange(0, 4000, 10)
+        tmax = max(times)
+
+        def temp_drive_cycle(y, z, t):
+            return pybamm.Interpolant(
+                times,
+                298.15 + 20 * (times / tmax),
+                t,
+            )
+
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        parameter_values.update(
+            {
+                "Initial temperature [K]": 298.15,
+                "Ambient temperature [K]": temp_drive_cycle,
+            }
+        )
+        model = self.model()
+        modeltest = tests.StandardModelTest(model, parameter_values=parameter_values)
+        modeltest.test_all(skip_output_tests=True)


### PR DESCRIPTION
# Description

Fixed a bug that lead to a `ShapeError` when specifying "Ambient temperature [K]" as an `Interpolant` with an isothermal model.

Fixes #3630 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
