### PR TITLE
Resolve broken `scikits.odes` installation on self-hosted M-series runner

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -147,6 +147,7 @@ jobs:
           # Don't use Homebrew to install SUNDIALS because scikits.odes looks for
           # in Homebrew folders instead, which we don't want
           brew uninstall sundials --force
+          pip cache remove scikits.odes
           python -m nox -s pybamm-requires -- --force
           python -m nox -s unit
 

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -134,11 +134,19 @@ jobs:
 
       - name: Install build-time dependencies & run unit tests for M-series macOS runner
         shell: bash
+        env:
+          # Point scikits.odes to the correct SUNDIALS installation
+          SUNDIALS_INST: $HOME/.local/lib
+          # Homebrew environment variables
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          NONINTERACTIVE: 1
         run: |
           eval "$(pyenv init -)"
           pyenv activate pybamm-${{ matrix.python-version }}
           python -m pip install --upgrade pip nox
-          brew uninstall sundials
+          # Don't use Homebrew to install SUNDIALS because scikits.odes looks for
+          # in Homebrew folders instead, which we don't want
+          brew uninstall sundials --force
           python -m nox -s pybamm-requires -- --force
           python -m nox -s unit
 

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: python -m nox -s scripts
 
-  #M-series Mac Mini
+  # M-series Mac Mini
   build-apple-mseries:
     if: github.repository_owner == 'pybamm-team'
     needs: style
@@ -124,28 +124,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install python & create virtualenv
+      - name: Install Python & create virtualenv
         shell: bash
         run: |
           eval "$(pyenv init -)"
           pyenv install ${{ matrix.python-version }} -s
           pyenv virtualenv ${{ matrix.python-version }} pybamm-${{ matrix.python-version }}
 
-      - name: Install dependencies & run unit tests for Windows and MacOS
+      - name: Install build-time dependencies & run unit tests for M-series macOS runner
         shell: bash
         run: |
           eval "$(pyenv init -)"
           pyenv activate pybamm-${{ matrix.python-version }}
-          python -m pip install --upgrade pip wheel setuptools nox
+          python -m pip install --upgrade pip nox
+          python -m nox -s pybamm-requires
           python -m nox -s unit
 
-      - name: Run integration tests for Windows and MacOS
+      - name: Run integration tests for M-series macOS runner
         run: |
           eval "$(pyenv init -)"
           pyenv activate pybamm-${{ matrix.python-version }}
           python -m nox -s integration
 
-      - name: Uninstall pyenv-virtualenv & python
+      - name: Uninstall pyenv-virtualenv & Python
         if: always()
         shell: bash
         run: |

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -117,6 +117,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     env:
       GITHUB_PATH: ${PYENV_ROOT/bin:$PATH}
+      LD_LIBRARY_PATH: $HOME/.local/lib
     strategy:
       fail-fast: false
       matrix:
@@ -137,7 +138,8 @@ jobs:
           eval "$(pyenv init -)"
           pyenv activate pybamm-${{ matrix.python-version }}
           python -m pip install --upgrade pip nox
-          python -m nox -s pybamm-requires
+          brew uninstall sundials
+          python -m nox -s pybamm-requires -- --force
           python -m nox -s unit
 
       - name: Run integration tests for M-series macOS runner


### PR DESCRIPTION
# Description

The M-series self-hosted runner was using a cached, un-repaired `scikits.odes` wheel which had been linked to the Homebrew rendition of SUNDIALS (which isn't a problem though) instead of the one we regularly use in CI. Apple has a history of [sanitising runtime search paths](https://hynek.me/articles/macos-dyld-env/), which caused the SUNDIALS dynamic libraries to not be found at runtime by the Python extension modules for `scikits.odes`. 

This PR ensures that the build-time dependencies for PyBaMM are always re-compiled on each run, the `SUNDIALS_INST` variable is set, and that `scikits.odes` is built from source every time.

The M-series build passed here: https://github.com/pybamm-team/PyBaMM/actions/runs/7713296977/job/21022885593

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
