### PR TITLE
Purge `scikits.odes` cached wheels when using `pybamm_install_odes`

### DIFF
--- a/pybamm/install_odes.py
+++ b/pybamm/install_odes.py
@@ -191,6 +191,11 @@ def main(arguments=None):
     os.environ["SUNDIALS_INST"] = SUNDIALS_LIB_DIR
     env = os.environ.copy()
     logger.info("Installing scikits.odes via pip")
+    logger.info("Purging scikits.odes whels from pip cache if present")
+    subprocess.run(
+        [f"{sys.executable}", "-m", "pip", "cache", "remove", "scikits.odes"],
+        check=True,
+    )
     subprocess.run(
         [f"{sys.executable}", "-m", "pip", "install", "scikits.odes", "--verbose"],
         env=env,


### PR DESCRIPTION


# Description

See discussion on #3785. This command exits with a warning if a cached wheel is not present, it does not raise an error and therefore should be safe to add within a subprocess.

We already purge any cached wheels in CI when running the scheduled tests for this entry point – this PR ensures it is done for users running it locally.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
