### PR TITLE
Build M-series (arm64) macOS wheels on GitHub Actions hosted runners

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Clone pybind11 repo (no history)
         run: git clone --depth 1 --branch v2.11.1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -133,7 +133,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
 
-      - name: Build wheels on macOS
+      - name: Build wheels on macOS amd64
         if: matrix.os == 'macos-latest'
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:
@@ -150,11 +150,45 @@ jobs:
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
-      - name: Upload wheels for macOS
+      - name: Upload wheels for macOS amd64
         uses: actions/upload-artifact@v4
         if: matrix.os == 'macos-latest'
         with:
-          name: macos_wheels
+          name: macos_amd64_wheels
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error
+
+  build_macos_arm64_wheels:
+    name: Wheels (macos-arm64)
+    # Current runner is macOS X 14+ on GitHub-hosted runners
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.8
+
+      - name: Clone pybind11 repo (no history)
+        run: git clone --depth 1 --branch v2.11.1
+
+      - name: Install SuiteSparse and SUNDIALS on macOS
+        run: |
+          brew install graphviz openblas libomp
+          brew reinstall gcc
+          python -m pip install cmake wget
+          python scripts/install_KLU_Sundials.py
+
+      - name: Build wheels on macOS arm64
+        run: pipx run cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools wheel
+          CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}
+          CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
+
+      - name: Upload wheels for macOS arm64
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos_arm64_wheels
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -182,7 +216,7 @@ jobs:
     # This job is only of value to PyBaMM and would always be skipped in forks
     if: github.event_name != 'schedule' && github.repository == 'pybamm-team/PyBaMM'
     name: Upload package to PyPI
-    needs: [build_macos_and_linux_wheels, build_windows_wheels, build_sdist]
+    needs: [build_macos_and_linux_wheels, build_macos_arm64_wheels, build_windows_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -191,7 +225,7 @@ jobs:
       - name: Move all package files to files/
         run: |
           mkdir files
-          mv windows_wheels/* linux_wheels/* macos_wheels/* sdist/* files/
+          mv windows_wheels/* linux_wheels/* macos_amd64_wheels/* macos_arm64_wheels/* sdist/* files/
 
       - name: Publish on PyPI
         if: github.event.inputs.target == 'pypi' || github.event_name == 'release'
@@ -213,7 +247,7 @@ jobs:
   open_failure_issue:
     needs: [build_windows_wheels, build_macos_and_linux_wheels, build_sdist]
     name: Open an issue if build fails
-    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository_owner == 'pybamm-team'}}
+    if: ${{ contains(needs.*.result, 'failure') && github.repository_owner == 'pybamm-team'}}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -247,7 +247,7 @@ jobs:
   open_failure_issue:
     needs: [build_windows_wheels, build_macos_and_linux_wheels, build_sdist]
     name: Open an issue if build fails
-    if: ${{ contains(needs.*.result, 'failure') && github.repository_owner == 'pybamm-team'}}
+    if: ${{ always() && contains(needs.*.result, 'failure') && github.repository_owner == 'pybamm-team'}}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -175,13 +175,13 @@ jobs:
         run: |
           brew install graphviz openblas libomp
           brew reinstall gcc
-          python -m pip install cmake wget
+          python -m pip install cmake pipx
           python scripts/install_KLU_Sundials.py
 
       - name: Build wheels on macOS arm64
-        run: pipx run cibuildwheel --output-dir wheelhouse
+        run: python -m pipx run cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools wheel
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools wheel delocate
           CIBW_REPAIR_WHEEL_COMMAND: delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
 

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -166,7 +166,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Clone pybind11 repo (no history)
         run: git clone --depth 1 --branch v2.11.1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -169,7 +169,7 @@ jobs:
           python-version: '3.10'
 
       - name: Clone pybind11 repo (no history)
-        run: git clone --depth 1 --branch v2.11.1
+        run: git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git
 
       - name: Install SuiteSparse and SUNDIALS on macOS
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added support for macOS arm64 (M-series) platforms. ([#3789](https://github.com/pybamm-team/PyBaMM/pull/3789))
 - Renamed "electrode diffusivity" to "particle diffusivity" as a non-breaking change with a deprecation warning ([#3624](https://github.com/pybamm-team/PyBaMM/pull/3624))
 - Add support for BPX version 0.4.0 which allows for blended electrodes and user-defined parameters in BPX([#3414](https://github.com/pybamm-team/PyBaMM/pull/3414))
 - Added the ability to specify a custom solver tolerance in `get_initial_stoichiometries` and related functions ([#3714](https://github.com/pybamm-team/PyBaMM/pull/3714))


### PR DESCRIPTION
# Description

GitHub Actions M1 runners are free for open-source repositories now – I have configured the PyPI workflow to add a job for these runners.

> [!IMPORTANT]
> The wheels can be tested on M-series hardware via the following link: https://github.com/pybamm-team/PyBaMM/actions/runs/7721068374/

Closes #3772, related to #3462

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
