### PR TITLE
Update cron schedule for PyPI publishing workflow and add cache for vcpkg dependencies

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -3,8 +3,8 @@ on:
   release:
     types: [published]
   schedule:
-    # Run at 10 am UTC on day-of-month 1 and 15.
-    - cron: "0 10 1,15 * *"
+    # Run every Sunday at 00:00.
+    - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -110,6 +110,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: python -m nox -s scripts
 
+      - name: Cache vcpkg dependencies
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/vcpkg
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('**/vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-
+
+
   #M-series Mac Mini
   build-apple-mseries:
     if: github.repository_owner == 'pybamm-team'


### PR DESCRIPTION
Update cron schedule for PyPI publishing workflow and add cache for vcpkg dependencies

# Description

Added a process to cache vcpkg dependencies in `run_periodic_tests.yaml` and made the tests run every week by editing `publish_pypi.yaml`

Fixes #3664 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
