### PR TITLE
Fix broken `Open in Colab` badges linked to example notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,7 @@ if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (
 
 if os.environ.get("READTHEDOCS_VERSION") == "stable":
     notebooks_version = version
-    append_to_url = f"tree/blob/v{notebooks_version}"
+    append_to_url = f"blob/v{notebooks_version}"
 
 if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
     notebooks_version = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,7 @@ if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (
 
 if os.environ.get("READTHEDOCS_VERSION") == "stable":
     notebooks_version = version
-    append_to_url = f"tree/v{notebooks_version}"
+    append_to_url = f"tree/blob/v{notebooks_version}"
 
 if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
     notebooks_version = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")


### PR DESCRIPTION
# Description

This issue aims to fix broken `Open in Colab` badges on docs.pybamm.org

Fixes #3817 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
