### PR TITLE
#3828 fix pouch cell voltage control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Bug Fixes
 
+- Fixed a bug where 1+1D and 2+1D models would not work with voltage or power controlled experiments([#3829](https://github.com/pybamm-team/PyBaMM/pull/3829))
 - Updated `_steps_util.py` to throw a specific exception when drive cycle starts at t>0 ([#3756](https://github.com/pybamm-team/PyBaMM/pull/3756))
 - Updated `plot_voltage_components.py` to support both `Simulation` and `Solution` objects. Added new methods in both `Simulation` and `Solution` classes for allow the syntax `simulation.plot_voltage_components` and `solution.plot_voltage_components`. Updated `test_plot_voltage_components.py` to reflect these changes ([#3723](https://github.com/pybamm-team/PyBaMM/pull/3723)).
 - The SEI thickness decreased at some intervals when the 'electron-migration limited' model was used. It has been corrected ([#3622](https://github.com/pybamm-team/PyBaMM/pull/3622))

--- a/pybamm/models/submodels/current_collector/potential_pair.py
+++ b/pybamm/models/submodels/current_collector/potential_pair.py
@@ -58,13 +58,12 @@ class BasePotentialPair(BaseModel):
         }
 
     def set_initial_conditions(self, variables):
-        applied_current = self.param.current_with_time
         phi_s_cn = variables["Negative current collector potential [V]"]
         i_boundary_cc = variables["Current collector current density [A.m-2]"]
 
         self.initial_conditions = {
             phi_s_cn: pybamm.Scalar(0),
-            i_boundary_cc: applied_current,
+            i_boundary_cc: pybamm.Scalar(0),
         }
 
 

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -350,6 +350,44 @@ class BaseUnitTestLithiumIon:
         options = {"operating mode": external_circuit_function}
         self.check_well_posedness(options)
 
+    def test_well_posed_external_circuit_function_1plus1D(self):
+        def external_circuit_function(variables):
+            I = variables["Current [A]"]
+            V = variables["Voltage [V]"]
+            return (
+                V
+                + I
+                - pybamm.FunctionParameter(
+                    "Function", {"Time [s]": pybamm.t}, print_name="test_fun"
+                )
+            )
+
+        options = {
+            "current collector": "potential pair",
+            "dimensionality": 1,
+            "operating mode": external_circuit_function,
+        }
+        self.check_well_posedness(options)
+
+    def test_well_posed_external_circuit_function_2plus1D(self):
+        def external_circuit_function(variables):
+            I = variables["Current [A]"]
+            V = variables["Voltage [V]"]
+            return (
+                V
+                + I
+                - pybamm.FunctionParameter(
+                    "Function", {"Time [s]": pybamm.t}, print_name="test_fun"
+                )
+            )
+
+        options = {
+            "current collector": "potential pair",
+            "dimensionality": 2,
+            "operating mode": external_circuit_function,
+        }
+        self.check_well_posedness(options)
+
     def test_well_posed_particle_phases(self):
         options = {"particle phases": "2"}
         self.check_well_posedness(options)


### PR DESCRIPTION
# Description
Fix a bug where you couldn't use voltage or power control with pouch cell models

Fixes #3828 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
