### PR TITLE
Make `typing-extensions` and `sympy` required dependencies to fix PyBaMM import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@
 
 ## Breaking changes
 
+- Integrated the `[latexify]` extra into the core PyBaMM package, deprecating the `pybamm[latexify]` set of optional dependencies. SymPy is now a required dependency and will be installed upon installing PyBaMM ([#3848](https://github.com/pybamm-team/PyBaMM/pull/3848))
 - Renamed "testing" argument for plots to "show_plot" and flipped its meaning (show_plot=True is now the default and shows the plot) ([#3842](https://github.com/pybamm-team/PyBaMM/pull/3842))
 - Dropped support for BPX version 0.3.0 and below ([#3414](https://github.com/pybamm-team/PyBaMM/pull/3414))
-- Integrated the `[latexify]` extra into the core PyBaMM package, deprecating the `pybamm[latexify]` set of optional dependencies. SymPy is now a required dependency and will be installed upon installing PyBaMM ([#3848](https://github.com/pybamm-team/PyBaMM/pull/3848))
 
 # [v24.1](https://github.com/pybamm-team/PyBaMM/tree/v24.1) - 2024-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Renamed "testing" argument for plots to "show_plot" and flipped its meaning (show_plot=True is now the default and shows the plot) ([#3842](https://github.com/pybamm-team/PyBaMM/pull/3842))
 - Dropped support for BPX version 0.3.0 and below ([#3414](https://github.com/pybamm-team/PyBaMM/pull/3414))
+- Integrated `[latexify]` module into the core PyBaMM package, deprecating the `pybamm[latexify]` version for installation.([#3848](https://github.com/pybamm-team/PyBaMM/pull/3848))
 
 # [v24.1](https://github.com/pybamm-team/PyBaMM/tree/v24.1) - 2024-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Renamed "testing" argument for plots to "show_plot" and flipped its meaning (show_plot=True is now the default and shows the plot) ([#3842](https://github.com/pybamm-team/PyBaMM/pull/3842))
 - Dropped support for BPX version 0.3.0 and below ([#3414](https://github.com/pybamm-team/PyBaMM/pull/3414))
-- Integrated `[latexify]` module into the core PyBaMM package, deprecating the `pybamm[latexify]` version for installation.([#3848](https://github.com/pybamm-team/PyBaMM/pull/3848))
+- Integrated the `[latexify]` extra into the core PyBaMM package, deprecating the `pybamm[latexify]` set of optional dependencies. SymPy is now a required dependency and will be installed upon installing PyBaMM ([#3848](https://github.com/pybamm-team/PyBaMM/pull/3848))
 
 # [v24.1](https://github.com/pybamm-team/PyBaMM/tree/v24.1) - 2024-01-31
 

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -67,6 +67,7 @@ Package                                                             Minimum supp
 `CasADi <https://web.casadi.org/docs/>`__                           3.6.3
 `Xarray <https://docs.xarray.dev/en/stable/>`__                     2022.6.0
 `Anytree <https://anytree.readthedocs.io/en/stable/>`__             2.8.0
+`SymPy <https://docs.sympy.org/latest/index.html>`__                1.9.3
 `typing-extensions <https://pypi.org/project/typing-extensions/>`__ 4.10.0
 =================================================================== ==========================
 
@@ -174,19 +175,6 @@ Dependency                                                  Minimum Version    p
 =========================================================== ================== ================== =========================================
 `pybtex <https://docs.pybtex.org/>`__                       0.24.0             cite               BibTeX-compatible bibliography processor.
 =========================================================== ================== ================== =========================================
-
-.. _install.latexify_dependencies:
-
-Latexify dependencies
-^^^^^^^^^^^^^^^^^^^^^
-
-Installable with ``pip install "pybamm[latexify]"``
-
-=========================================================== ================== ================== =========================
-Dependency                                                  Minimum Version    pip extra          Notes
-=========================================================== ================== ================== =========================
-`sympy <https://docs.sympy.org/latest/index.html>`__        1.9.3              latexify           For symbolic mathematics.
-=========================================================== ================== ================== =========================
 
 .. _install.bpx_dependencies:
 

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -59,15 +59,16 @@ Required dependencies
 
 PyBaMM requires the following dependencies.
 
-================================================================ ==========================
-Package                                                          Minimum supported version
-================================================================ ==========================
-`NumPy <https://numpy.org>`__                                    1.23.5
-`SciPy <https://docs.scipy.org/doc/scipy/>`__                    1.9.3
-`CasADi <https://web.casadi.org/docs/>`__                        3.6.3
-`Xarray <https://docs.xarray.dev/en/stable/>`__                  2022.6.0
-`Anytree <https://anytree.readthedocs.io/en/stable/>`__          2.8.0
-================================================================ ==========================
+=================================================================== ==========================
+Package                                                             Minimum supported version
+=================================================================== ==========================
+`NumPy <https://numpy.org>`__                                       1.23.5
+`SciPy <https://docs.scipy.org/doc/scipy/>`__                       1.9.3
+`CasADi <https://web.casadi.org/docs/>`__                           3.6.3
+`Xarray <https://docs.xarray.dev/en/stable/>`__                     2022.6.0
+`Anytree <https://anytree.readthedocs.io/en/stable/>`__             2.8.0
+`typing-extensions <https://pypi.org/project/typing-extensions/>`__ 4.10.0
+=================================================================== ==========================
 
 .. _install.optional_dependencies:
 

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -7,7 +7,6 @@ from scipy.sparse import csr_matrix, issparse
 from typing import TYPE_CHECKING
 
 import pybamm
-from pybamm.util import have_optional_dependency
 from pybamm.type_definitions import DomainType, AuxiliaryDomainType, DomainsType
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -157,7 +156,6 @@ class Array(pybamm.Symbol):
 
     def to_equation(self) -> sympy.Array:
         """Returns the value returned by the node when evaluated."""
-        sympy = have_optional_dependency("sympy")
         entries_list = self.entries.tolist()
         return sympy.Array(entries_list)
 

--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -4,13 +4,10 @@
 from __future__ import annotations
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
-from typing import TYPE_CHECKING
 
 import pybamm
 from pybamm.type_definitions import DomainType, AuxiliaryDomainType, DomainsType
-
-if TYPE_CHECKING:  # pragma: no cover
-    import sympy
+import sympy
 
 
 class Array(pybamm.Symbol):

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import numbers
 
 import numpy as np
+import sympy
 from scipy.sparse import csr_matrix, issparse
 import functools
 
 import pybamm
-from pybamm.util import have_optional_dependency
 
 from typing import Callable, cast
 
@@ -180,7 +180,6 @@ class BinaryOperator(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -388,7 +387,6 @@ class MatrixMultiplication(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         left = sympy.Matrix(left)
         right = sympy.Matrix(right)
         return left * right
@@ -737,7 +735,6 @@ class Minimum(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         return sympy.Min(left, right)
 
 
@@ -782,7 +779,6 @@ class Maximum(BinaryOperator):
 
     def _sympy_operator(self, left, right):
         """Override :meth:`pybamm.BinaryOperator._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         return sympy.Max(left, right)
 
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -6,11 +6,11 @@ import copy
 from collections import defaultdict
 
 import numpy as np
+import sympy
 from scipy.sparse import issparse, vstack
 from typing import Sequence
 
 import pybamm
-from pybamm.util import have_optional_dependency
 
 
 class Concatenation(pybamm.Symbol):
@@ -159,7 +159,6 @@ class Concatenation(pybamm.Symbol):
 
     def _sympy_operator(self, *children):
         """Apply appropriate SymPy operators."""
-        sympy = have_optional_dependency("sympy")
         self.concat_latex = tuple(map(sympy.latex, children))
 
         if self.print_name is not None:

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 from scipy import special
+import sympy
 from typing import Sequence, Callable
 from typing_extensions import TypeVar
 
@@ -210,7 +211,6 @@ class Function(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -275,7 +275,6 @@ class SpecificFunction(Function):
 
     def _sympy_operator(self, child):
         """Apply appropriate SymPy operators."""
-        sympy = have_optional_dependency("sympy")
         class_name = self.__class__.__name__.lower()
         sympy_function = getattr(sympy, class_name)
         return sympy_function(child)
@@ -332,7 +331,6 @@ class Arcsinh(SpecificFunction):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.Function._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         return sympy.asinh(child)
 
 
@@ -360,7 +358,6 @@ class Arctan(SpecificFunction):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.Function._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         return sympy.atan(child)
 
 

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -6,7 +6,6 @@ import sympy
 import numpy as np
 
 import pybamm
-from pybamm.util import have_optional_dependency
 from pybamm.type_definitions import DomainType, AuxiliaryDomainType, DomainsType
 
 KNOWN_COORD_SYS = ["cartesian", "cylindrical polar", "spherical polar"]
@@ -58,7 +57,6 @@ class IndependentVariable(pybamm.Symbol):
 
     def to_equation(self) -> sympy.Symbol:
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -102,7 +100,6 @@ class Time(IndependentVariable):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         return sympy.Symbol("t")
 
 

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -2,7 +2,6 @@
 # IndependentVariable class
 #
 from __future__ import annotations
-import sympy
 import numpy as np
 
 import pybamm
@@ -56,7 +55,7 @@ class IndependentVariable(pybamm.Symbol):
         """See :meth:`pybamm.Symbol._jac()`."""
         return pybamm.Scalar(0)
 
-    def to_equation(self) -> sympy.Symbol:
+    def to_equation(self) -> "sympy.Symbol":  # noqa: F821, UP037
         """Convert the node and its subtree into a SymPy equation."""
         sympy = have_optional_dependency("sympy")
         if self.print_name is not None:

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -2,6 +2,7 @@
 # IndependentVariable class
 #
 from __future__ import annotations
+import sympy
 import numpy as np
 
 import pybamm
@@ -55,7 +56,7 @@ class IndependentVariable(pybamm.Symbol):
         """See :meth:`pybamm.Symbol._jac()`."""
         return pybamm.Scalar(0)
 
-    def to_equation(self) -> "sympy.Symbol":  # noqa: F821, UP037
+    def to_equation(self) -> sympy.Symbol:
         """Convert the node and its subtree into a SymPy equation."""
         sympy = have_optional_dependency("sympy")
         if self.print_name is not None:

--- a/pybamm/expression_tree/operations/latexify.py
+++ b/pybamm/expression_tree/operations/latexify.py
@@ -9,7 +9,7 @@ import warnings
 
 import pybamm
 from pybamm.expression_tree.printing.sympy_overrides import custom_print_func
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 def get_rng_min_max_name(rng, min_or_max):
@@ -89,7 +89,6 @@ class Latexify:
         Returns a list of boundary condition equations with ranges in front of
         the equations.
         """
-        sympy = have_optional_dependency("sympy")
         bcs_eqn_list = []
         bcs = self.model.boundary_conditions.get(var, None)
 
@@ -120,7 +119,6 @@ class Latexify:
 
     def _get_param_var(self, node):
         """Returns a list of parameters and a list of variables."""
-        sympy = have_optional_dependency("sympy")
         param_list = []
         var_list = []
         dfs_nodes = [node]
@@ -163,7 +161,6 @@ class Latexify:
         return param_list, var_list
 
     def latexify(self, output_variables=None):
-        sympy = have_optional_dependency("sympy")
         # Voltage is the default output variable if it exists
         if output_variables is None:
             if "Voltage [V]" in self.model.variables:

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import sys
 
 import numpy as np
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
-if TYPE_CHECKING:  # pragma: no cover
-    import sympy
+import sympy
 
 import pybamm
 

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:  # pragma: no cover
     import sympy
 
 import pybamm
-from pybamm.util import have_optional_dependency
 
 
 class Parameter(pybamm.Symbol):
@@ -48,7 +47,6 @@ class Parameter(pybamm.Symbol):
 
     def to_equation(self) -> sympy.Symbol:
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -244,7 +242,6 @@ class FunctionParameter(pybamm.Symbol):
 
     def to_equation(self) -> sympy.Symbol:
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -3,10 +3,10 @@
 #
 from __future__ import annotations
 import numpy as np
+import sympy
 from typing import Literal
 
 import pybamm
-from pybamm.util import have_optional_dependency
 from pybamm.type_definitions import Numeric
 
 
@@ -87,7 +87,6 @@ class Scalar(pybamm.Symbol):
 
     def to_equation(self):
         """Returns the value returned by the node when evaluated."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numbers
 
 import numpy as np
+import sympy
 from scipy.sparse import csr_matrix, issparse
 from functools import lru_cache, cached_property
 from typing import TYPE_CHECKING, Sequence, cast
@@ -1056,7 +1057,6 @@ class Symbol:
         self._print_name = prettify_print_name(name)
 
     def to_equation(self):
-        sympy = have_optional_dependency("sympy")
         return sympy.Symbol(str(self.name))
 
     def to_json(self):

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
+import sympy
 import pybamm
 from pybamm.util import have_optional_dependency
 from pybamm.type_definitions import DomainsType
@@ -108,7 +109,6 @@ class UnaryOperator(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:
@@ -672,7 +672,6 @@ class Integral(SpatialOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         return sympy.Integral(child, sympy.Symbol("xn"))
 
 
@@ -996,7 +995,6 @@ class BoundaryValue(BoundaryOperator):
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
-        sympy = have_optional_dependency("sympy")
         if (
             self.child.domain[0] in ["negative particle", "positive particle"]
             and self.side == "right"

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import numpy as np
 import numbers
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 from pybamm.type_definitions import (
     DomainType,
     AuxiliaryDomainType,
@@ -135,7 +135,6 @@ class VariableBase(pybamm.Symbol):
 
     def to_equation(self):
         """Convert the node and its subtree into a SymPy equation."""
-        sympy = have_optional_dependency("sympy")
         if self.print_name is not None:
             return sympy.Symbol(self.print_name)
         else:

--- a/pybamm/models/base_model.py
+++ b/pybamm/models/base_model.py
@@ -13,7 +13,7 @@ import numpy as np
 
 import pybamm
 from pybamm.expression_tree.operations.serialise import Serialise
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class BaseModel:
@@ -1185,7 +1185,6 @@ class BaseModel:
         This will return first five model equations
         >>> model.latexify(newline=False)[1:5]
         """
-        sympy = have_optional_dependency("sympy")
         if sympy:
             from pybamm.expression_tree.operations.latexify import Latexify
 

--- a/pybamm/type_definitions.py
+++ b/pybamm/type_definitions.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 from typing import Union, List, Dict
-from typing_extensions import TypeAlias
 import numpy as np
 import pybamm
+from pybamm.util import have_optional_dependency
+
+TypeAlias = have_optional_dependency("typing_extensions", "TypeAlias")
 
 # numbers.Number should not be used for type hints
 Numeric: TypeAlias = Union[int, float, np.number]

--- a/pybamm/type_definitions.py
+++ b/pybamm/type_definitions.py
@@ -4,11 +4,9 @@
 from __future__ import annotations
 
 from typing import Union, List, Dict
+from typing_extensions import TypeAlias
 import numpy as np
 import pybamm
-from pybamm.util import have_optional_dependency
-
-TypeAlias = have_optional_dependency("typing_extensions", "TypeAlias")
 
 # numbers.Number should not be used for type hints
 Numeric: TypeAlias = Union[int, float, np.number]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "casadi>=3.6.3",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
+    "typing-extensions>=4.10.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "casadi>=3.6.3",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
+    "sympy>=1.12",
     "typing-extensions>=4.10.0",
 ]
 
@@ -86,10 +87,6 @@ plot = [
 # For the Citations class
 cite = [
     "pybtex>=0.24.0",
-]
-# To generate LaTeX strings
-latexify = [
-    "sympy>=1.12",
 ]
 # Battery Parameter eXchange format
 bpx = [

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy.sparse import coo_matrix
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 
 EMPTY_DOMAINS = {
     "primary": [],
@@ -790,7 +790,6 @@ class TestBinaryOperators(TestCase):
         self.assertEqual(pybamm.inner(a3, a3).evaluate(), 9)
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         # Test print_name
         pybamm.Addition.print_name = "test"
         self.assertEqual(pybamm.Addition(1, 2).to_equation(), sympy.Symbol("test"))

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -8,7 +8,7 @@ from tests import TestCase
 import numpy as np
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 from tests import get_discretisation_for_testing, get_mesh_for_testing
 
 
@@ -371,7 +371,6 @@ class TestConcatenations(TestCase):
         )
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         a = pybamm.Symbol("a", domain="test a")
         b = pybamm.Symbol("b", domain="test b")
         func_symbol = sympy.Symbol(r"\begin{cases}a\\b\end{cases}")

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import special
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 def test_function(arg):
@@ -121,7 +121,6 @@ class TestFunction(TestCase):
         self.assertEqual(fun.name, "function (cos)")
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         a = pybamm.Symbol("a", domain="test")
 
         # Test print_name

--- a/tests/unit/test_expression_tree/test_independent_variable.py
+++ b/tests/unit/test_expression_tree/test_independent_variable.py
@@ -6,7 +6,7 @@ import unittest
 
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class TestIndependentVariable(TestCase):
@@ -64,7 +64,6 @@ class TestIndependentVariable(TestCase):
         self.assertTrue(x.evaluates_on_edges("primary"))
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         # Test print_name
         func = pybamm.IndependentVariable("a")
         func.print_name = "test"

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -6,7 +6,7 @@ import numbers
 import unittest
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class TestParameter(TestCase):
@@ -20,7 +20,6 @@ class TestParameter(TestCase):
         self.assertIsInstance(a.evaluate_for_shape(), numbers.Number)
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         func = pybamm.Parameter("test_string")
         func1 = pybamm.Parameter("test_name")
 
@@ -107,7 +106,6 @@ class TestFunctionParameter(TestCase):
         self.assertEqual(_myfun(x).print_name, None)
 
     def test_function_parameter_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         func = pybamm.FunctionParameter("test", {"x": pybamm.Scalar(1)})
         func1 = pybamm.FunctionParameter("func", {"var": pybamm.Variable("var")})
 

--- a/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
+++ b/tests/unit/test_expression_tree/test_printing/test_sympy_overrides.py
@@ -6,12 +6,11 @@ import unittest
 
 import pybamm
 from pybamm.expression_tree.printing.sympy_overrides import custom_print_func
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class TestCustomPrint(TestCase):
     def test_print_Derivative(self):
-        sympy = have_optional_dependency("sympy")
         # Test force_partial
         der1 = sympy.Derivative("y", "x")
         der1.force_partial = True

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -12,7 +12,7 @@ from scipy.sparse import csr_matrix, coo_matrix
 
 import pybamm
 from pybamm.expression_tree.binary_operators import _Heaviside
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class TestSymbol(TestCase):
@@ -485,7 +485,6 @@ class TestSymbol(TestCase):
             (y1 + y2).test_shape()
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         self.assertEqual(pybamm.Symbol("test").to_equation(), sympy.Symbol("test"))
 
     def test_numpy_array_ufunc(self):

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -7,9 +7,11 @@ import unittest.mock as mock
 
 import numpy as np
 from scipy.sparse import diags
+import sympy
+from sympy.vector.operators import Divergence as sympy_Divergence
+from sympy.vector.operators import Gradient as sympy_Gradient
 
 import pybamm
-from pybamm.util import have_optional_dependency
 
 
 class TestUnaryOperators(TestCase):
@@ -678,12 +680,6 @@ class TestUnaryOperators(TestCase):
         self.assertFalse((2 * a).is_constant())
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
-        sympy_Divergence = have_optional_dependency(
-            "sympy.vector.operators", "Divergence"
-        )
-        sympy_Gradient = have_optional_dependency("sympy.vector.operators", "Gradient")
-
         a = pybamm.Symbol("a", domain="negative particle")
         b = pybamm.Symbol("b", domain="current collector")
         c = pybamm.Symbol("c", domain="test")

--- a/tests/unit/test_expression_tree/test_variable.py
+++ b/tests/unit/test_expression_tree/test_variable.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 
 import pybamm
-from pybamm.util import have_optional_dependency
+import sympy
 
 
 class TestVariable(TestCase):
@@ -55,7 +55,6 @@ class TestVariable(TestCase):
             pybamm.Variable("var", bounds=(1, 1))
 
     def test_to_equation(self):
-        sympy = have_optional_dependency("sympy")
         # Test print_name
         func = pybamm.Variable("test_string")
         func.print_name = "test"


### PR DESCRIPTION
# Description

Fix broken import of PyBaMM raised by type hinting.

Fixes #3836 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
