### PR TITLE
remove QLi user warning

### DIFF
--- a/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -4,7 +4,6 @@
 import pybamm
 import numpy as np
 from functools import lru_cache
-import warnings
 
 
 class _BaseElectrodeSOH(pybamm.BaseModel):
@@ -527,8 +526,6 @@ class ElectrodeSOHSolver:
                     f"Q_Li={Q_Li:.4f} Ah is outside the range of possible values "
                     f"[{Q_Li_min:.4f}, {Q_Li_max:.4f}]."
                 )
-            if Q_Li > Q_p:
-                warnings.warn(f"Q_Li={Q_Li:.4f} Ah is greater than Q_p={Q_p:.4f} Ah.")
 
             # Update (tighten) stoich limits based on total lithium content and
             # electrode capacities


### PR DESCRIPTION
# Description

It's just confusing people and Q_Li could be greater than Q_p if there is prelithiation

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
