### PR TITLE
delay xarray.DataArray initialization

### DIFF
--- a/examples/scripts/experimental_protocols/cccv.py
+++ b/examples/scripts/experimental_protocols/cccv.py
@@ -8,16 +8,16 @@ pybamm.set_logging_level("NOTICE")
 experiment = pybamm.Experiment(
     [
         (
-            "Discharge at 1C for 1 minute",
-            "Rest for 1 minute",
-            # "Charge at 5 A until 4.2 V",
-            # "Hold at 4.2 V until 10 mA",
-            # "Rest for 1 hour",
+            "Discharge at 1C until 2.5 V",
+            "Rest for 1 hour",
+            "Charge at 5 A until 4.2 V",
+            "Hold at 4.2 V until 10 mA",
+            "Rest for 1 hour",
         ),
     ]
-    * 10
+    * 3
 )
-model = pybamm.lithium_ion.SPM()
+model = pybamm.lithium_ion.DFN({"SEI": "ec reaction limited"})
 parameter_values = pybamm.ParameterValues("Chen2020")
 
 sim = pybamm.Simulation(

--- a/examples/scripts/experimental_protocols/cccv.py
+++ b/examples/scripts/experimental_protocols/cccv.py
@@ -8,16 +8,16 @@ pybamm.set_logging_level("NOTICE")
 experiment = pybamm.Experiment(
     [
         (
-            "Discharge at 1C until 2.5 V",
-            "Rest for 1 hour",
-            "Charge at 5 A until 4.2 V",
-            "Hold at 4.2 V until 10 mA",
-            "Rest for 1 hour",
+            "Discharge at 1C for 1 minute",
+            "Rest for 1 minute",
+            # "Charge at 5 A until 4.2 V",
+            # "Hold at 4.2 V until 10 mA",
+            # "Rest for 1 hour",
         ),
     ]
-    * 3
+    * 10
 )
-model = pybamm.lithium_ion.DFN({"SEI": "ec reaction limited"})
+model = pybamm.lithium_ion.SPM()
 parameter_values = pybamm.ParameterValues("Chen2020")
 
 sim = pybamm.Simulation(


### PR DESCRIPTION
# Description

This speeds up simulations by 5x because xarray.DataArray initialization is slow
Before (560ms, 2% time spent solving the model):
<img width="998" alt="Screenshot 2024-03-04 at 4 42 08 PM" src="https://github.com/pybamm-team/PyBaMM/assets/20817509/027210a9-afe5-477e-ae21-c611dc08b051">
After (130ms, 10% time spent solving the model):
<img width="1003" alt="Screenshot 2024-03-04 at 4 42 24 PM" src="https://github.com/pybamm-team/PyBaMM/assets/20817509/e86b75fe-88f0-44cf-ba78-68edae375193">

Test code (this example is a "worst-case scenario" for overheads where solving the simulation is very quick, it highlights the other parts of the code that are slow):
```python
import pybamm
import matplotlib.pyplot as plt

pybamm.set_logging_level("NOTICE")
experiment = pybamm.Experiment(
    [
        (
            "Discharge at 1C for 1 minute",
            "Rest for 1 minute",
            # "Charge at 5 A until 4.2 V",
            # "Hold at 4.2 V until 10 mA",
            # "Rest for 1 hour",
        ),
    ]
    * 10
)
model = pybamm.lithium_ion.SPM()
parameter_values = pybamm.ParameterValues("Chen2020")

sim = pybamm.Simulation(
    model,
    experiment=experiment,
    parameter_values=parameter_values,
    solver=pybamm.CasadiSolver("fast with events"),
)
sim.solve()
```

There are still some significant overheads, we should be as close to 100% time spent solving the model as possible, but this is a step in the right direction.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
