### PR TITLE
fix deprecation warning and check for electrode/particle diffusivity

### DIFF
--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -58,12 +58,12 @@ class FuzzyDict(dict):
         try:
             return super().__getitem__(key)
         except KeyError:
-            if "electrode diffusivity" in key:
+            if "particle diffusivity" in key:
                 warn(
-                    f"The parameter '{key}' has been renamed to '{key.replace('electrode', 'particle')}'",
+                    f"The parameter '{key.replace('particle', 'electrode')}' has been renamed to '{key}'",
                     DeprecationWarning,
                 )
-                return super().__getitem__(key.replace("electrode", "particle"))
+                return super().__getitem__(key.replace("particle", "electrode"))
             if key in ["Negative electrode SOC", "Positive electrode SOC"]:
                 domain = key.split(" ")[0]
                 raise KeyError(

--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -60,7 +60,8 @@ class FuzzyDict(dict):
         except KeyError:
             if "particle diffusivity" in key:
                 warn(
-                    f"The parameter '{key.replace('particle', 'electrode')}' has been renamed to '{key}'",
+                    f"The parameter '{key.replace('particle', 'electrode')}' "
+                    f"has been renamed to '{key}'",
                     DeprecationWarning,
                 )
                 return super().__getitem__(key.replace("particle", "electrode"))

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -48,7 +48,7 @@ class TestUtil(TestCase):
                 "SEI current": 3,
                 "Lithium plating current": 4,
                 "A dimensional variable [m]": 5,
-                "Positive particle diffusivity [m2.s-1]": 6,
+                "Positive electrode diffusivity [m2.s-1]": 6,
             }
         )
         self.assertEqual(d["test"], 1)


### PR DESCRIPTION
# Description

The logic for this was the wrong way round. We need to check if "particle diffusivity" fails and change it to "electrode diffusivity"

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
