### PR TITLE
Add generalised copy for expression tree nodes

### DIFF
--- a/pybamm/expression_tree/array.py
+++ b/pybamm/expression_tree/array.py
@@ -128,7 +128,7 @@ class Array(pybamm.Symbol):
         jac = csr_matrix((self.size, variable.evaluation_array.count(True)))
         return pybamm.Matrix(jac)
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return self.__class__(
             self.entries,

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -133,9 +133,7 @@ class BinaryOperator(pybamm.Symbol):
 
         # make new symbol, ensure domain(s) remain the same
         out = self._binary_new_copy(new_left, new_right)
-        out.copy_domains(
-            self
-        )  # FIXUP: This needs checking if random new children are supplied
+        out.copy_domains(self)
 
         return out
 

--- a/pybamm/expression_tree/binary_operators.py
+++ b/pybamm/expression_tree/binary_operators.py
@@ -115,16 +115,27 @@ class BinaryOperator(pybamm.Symbol):
             right_str = f"{self.right!s}"
         return f"{left_str} {self.name} {right_str}"
 
-    def create_copy(self):
+    def create_copy(
+        self, new_children: list[pybamm.Symbol, pybamm.Symbol] | None = None
+    ):
         """See :meth:`pybamm.Symbol.new_copy()`."""
 
         # process children
-        new_left = self.left.new_copy()
-        new_right = self.right.new_copy()
+        if new_children is None:
+            new_left = self.left.new_copy()
+            new_right = self.right.new_copy()
+        else:
+            if len(new_children) != 2:
+                raise ValueError(
+                    f"Symbol of type {type(self)} must have exactly two children."
+                )
+            new_left, new_right = new_children
 
         # make new symbol, ensure domain(s) remain the same
         out = self._binary_new_copy(new_left, new_right)
-        out.copy_domains(self)
+        out.copy_domains(
+            self
+        )  # FIXUP: This needs checking if random new children are supplied
 
         return out
 

--- a/pybamm/expression_tree/concatenations.py
+++ b/pybamm/expression_tree/concatenations.py
@@ -129,9 +129,10 @@ class Concatenation(pybamm.Symbol):
         children_eval = [child.evaluate(t, y, y_dot, inputs) for child in self.children]
         return self._concatenation_evaluate(children_eval)
 
-    def create_copy(self):
+    def create_copy(self, new_children: list[pybamm.Symbol] | None = None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
-        new_children = [child.new_copy() for child in self.children]
+        if new_children is None:
+            new_children = [child.new_copy() for child in self.children]
         return self._concatenation_new_copy(new_children)
 
     def _concatenation_new_copy(self, children):

--- a/pybamm/expression_tree/functions.py
+++ b/pybamm/expression_tree/functions.py
@@ -176,10 +176,11 @@ class Function(pybamm.Symbol):
     def _function_evaluate(self, evaluated_children):
         return self.function(*evaluated_children)
 
-    def create_copy(self):
+    def create_copy(self, new_children: list[pybamm.Symbol] | None = None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
-        children_copy = [child.new_copy() for child in self.children]
-        return self._function_new_copy(children_copy)
+        if new_children is None:
+            new_children = [child.new_copy() for child in self.children]
+        return self._function_new_copy(new_children)
 
     def _function_new_copy(self, children: list) -> Function:
         """

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -75,7 +75,7 @@ class Time(IndependentVariable):
     def _from_json(cls, snippet: dict):
         return cls()
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return Time()
 
@@ -158,7 +158,7 @@ class SpatialVariable(IndependentVariable):
         ):
             raise pybamm.DomainError(f"domain cannot be particle if name is '{name}'")
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return self.__class__(self.name, domains=self.domains, coord_sys=self.coord_sys)
 

--- a/pybamm/expression_tree/independent_variable.py
+++ b/pybamm/expression_tree/independent_variable.py
@@ -62,6 +62,10 @@ class IndependentVariable(pybamm.Symbol):
         else:
             return sympy.Symbol(self.name)
 
+    def create_copy(self, new_children=None):
+        """See :meth:`pybamm.Symbol.new_copy()`."""
+        return self.__class__(self.name, domains=self.domains)
+
 
 class Time(IndependentVariable):
     """

--- a/pybamm/expression_tree/input_parameter.py
+++ b/pybamm/expression_tree/input_parameter.py
@@ -51,7 +51,7 @@ class InputParameter(pybamm.Symbol):
             expected_size=snippet["expected_size"],
         )
 
-    def create_copy(self) -> pybamm.InputParameter:
+    def create_copy(self, new_children=None) -> pybamm.InputParameter:
         """See :meth:`pybamm.Symbol.new_copy()`."""
         new_input_parameter = InputParameter(
             self.name, self.domain, expected_size=self._expected_size

--- a/pybamm/expression_tree/parameter.py
+++ b/pybamm/expression_tree/parameter.py
@@ -28,7 +28,7 @@ class Parameter(pybamm.Symbol):
     def __init__(self, name: str) -> None:
         super().__init__(name)
 
-    def create_copy(self) -> pybamm.Parameter:
+    def create_copy(self, new_children=None) -> pybamm.Parameter:
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return Parameter(self.name)
 
@@ -193,7 +193,7 @@ class FunctionParameter(pybamm.Symbol):
             print_name=self.print_name + "'",
         )
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         out = self._function_parameter_new_copy(
             self._input_names, self.orphans, print_name=self.print_name

--- a/pybamm/expression_tree/scalar.py
+++ b/pybamm/expression_tree/scalar.py
@@ -77,7 +77,7 @@ class Scalar(pybamm.Symbol):
         """See :meth:`pybamm.Symbol._jac()`."""
         return pybamm.Scalar(0)
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return Scalar(self.value, self.name)
 

--- a/pybamm/expression_tree/state_vector.py
+++ b/pybamm/expression_tree/state_vector.py
@@ -190,7 +190,7 @@ class StateVectorBase(pybamm.Symbol):
                 )
         return pybamm.Matrix(jac)
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return StateVector(
             *self.y_slices,

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -960,10 +960,9 @@ class Symbol:
         Make a new copy of a symbol, to avoid Tree corruption errors while bypassing
         copy.deepcopy(), which is slow.
         """
-        raise NotImplementedError(
-            f"""method self.new_copy() not implemented
-            for symbol {self!s} of type {type(self)}"""
-        )
+        if new_children is None:
+            new_children = [child.create_copy() for child in self.children]
+        return self.__class__(self.name, new_children, domains=self.domains)
 
     def new_copy(self, new_children: list[Symbol] | None = None):
         """

--- a/pybamm/expression_tree/symbol.py
+++ b/pybamm/expression_tree/symbol.py
@@ -955,7 +955,7 @@ class Symbol:
         """
         return pybamm.CasadiConverter(casadi_symbols).convert(self, t, y, y_dot, inputs)
 
-    def create_copy(self):
+    def create_copy(self, new_children: list[pybamm.Symbol] | None = None):
         """
         Make a new copy of a symbol, to avoid Tree corruption errors while bypassing
         copy.deepcopy(), which is slow.
@@ -965,11 +965,13 @@ class Symbol:
             for symbol {self!s} of type {type(self)}"""
         )
 
-    def new_copy(self):
+    def new_copy(self, new_children: list[Symbol] | None = None):
         """
         Returns `create_copy` with added attributes
+
+        Optionally gives the copied symbol new children.
         """
-        obj = self.create_copy()
+        obj = self.create_copy(new_children)
         obj._print_name = self.print_name
         return obj
 

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -64,7 +64,9 @@ class UnaryOperator(pybamm.Symbol):
             new_child = self.child.new_copy()
         else:
             if len(new_children) > 1:
-                raise ValueError("Can only have one child for a unary operator")
+                raise ValueError(
+                    f"Unary operator of type {type(self)} must have exactly one child."
+                )
             new_child = new_children[0]
         new_symbol = self._unary_new_copy(new_child)
         new_symbol.copy_domains(self)

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -60,12 +60,15 @@ class UnaryOperator(pybamm.Symbol):
 
     def create_copy(self, new_children: list[pybamm.Symbol] | None = None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
-        # FIXUP: I guess there should be a check that the domains match?
         if new_children is None:
             new_child = self.child.new_copy()
         else:
+            if len(new_children) > 1:
+                raise ValueError("Can only have one child for a unary operator")
             new_child = new_children[0]
-        return self._unary_new_copy(new_child)
+        new_symbol = self._unary_new_copy(new_child)
+        new_symbol.copy_domains(self)
+        return new_symbol
 
     def _unary_new_copy(self, child):
         """Make a new copy of the unary operator, with child `child`"""

--- a/pybamm/expression_tree/unary_operators.py
+++ b/pybamm/expression_tree/unary_operators.py
@@ -58,9 +58,13 @@ class UnaryOperator(pybamm.Symbol):
         """See :meth:`pybamm.Symbol.__str__()`."""
         return f"{self.name}({self.child!s})"
 
-    def create_copy(self):
+    def create_copy(self, new_children: list[pybamm.Symbol] | None = None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
-        new_child = self.child.new_copy()
+        # FIXUP: I guess there should be a check that the domains match?
+        if new_children is None:
+            new_child = self.child.new_copy()
+        else:
+            new_child = new_children[0]
         return self._unary_new_copy(new_child)
 
     def _unary_new_copy(self, child):

--- a/pybamm/expression_tree/variable.py
+++ b/pybamm/expression_tree/variable.py
@@ -118,7 +118,7 @@ class VariableBase(pybamm.Symbol):
             )
         )
 
-    def create_copy(self):
+    def create_copy(self, new_children=None):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return self.__class__(
             self.name,

--- a/pybamm/parameters/parameter_values.py
+++ b/pybamm/parameters/parameter_values.py
@@ -704,21 +704,10 @@ class ParameterValues:
             # Process again just to be sure
             return self.process_symbol(function_out)
 
-        elif isinstance(symbol, pybamm.BinaryOperator):
-            # process children
-            new_left = self.process_symbol(symbol.left)
-            new_right = self.process_symbol(symbol.right)
-            # make new symbol, ensure domain remains the same
-            new_symbol = symbol._binary_new_copy(new_left, new_right)
-            new_symbol.copy_domains(symbol)
-            return new_symbol
-
         # Unary operators
         elif isinstance(symbol, pybamm.UnaryOperator):
             new_child = self.process_symbol(symbol.child)
-            new_symbol = symbol._unary_new_copy(new_child)
-            # ensure domain remains the same
-            new_symbol.copy_domains(symbol)
+            new_symbol = symbol.create_copy(new_children=[new_child])
             # x_average can sometimes create a new symbol with electrode thickness
             # parameters, so we process again to make sure these parameters are set
             if isinstance(symbol, pybamm.XAverage) and not isinstance(
@@ -739,15 +728,14 @@ class ParameterValues:
                     new_symbol.position = new_symbol_position
             return new_symbol
 
-        # Functions
-        elif isinstance(symbol, pybamm.Function):
+        # Functions, Concatenations & BinaryOperators
+        elif (
+            isinstance(symbol, pybamm.Function)
+            or isinstance(symbol, pybamm.Concatenation)
+            or isinstance(symbol, pybamm.BinaryOperator)
+        ):
             new_children = [self.process_symbol(child) for child in symbol.children]
-            return symbol._function_new_copy(new_children)
-
-        # Concatenations
-        elif isinstance(symbol, pybamm.Concatenation):
-            new_children = [self.process_symbol(child) for child in symbol.children]
-            return symbol._concatenation_new_copy(new_children)
+            return symbol.create_copy(new_children)
 
         # Variables: update scale
         elif isinstance(symbol, pybamm.Variable):

--- a/tests/unit/test_expression_tree/test_operations/test_copy.py
+++ b/tests/unit/test_expression_tree/test_operations/test_copy.py
@@ -12,6 +12,7 @@ class TestCopy(TestCase):
     def test_symbol_new_copy(self):
         a = pybamm.Parameter("a")
         b = pybamm.Parameter("b")
+        c = pybamm.IndependentVariable("Variable_c")
         v_n = pybamm.Variable("v", "negative electrode")
         v_n_2D = pybamm.Variable(
             "v",
@@ -32,6 +33,7 @@ class TestCopy(TestCase):
             a**b,
             -a,
             abs(a),
+            c,
             pybamm.Function(np.sin, a),
             pybamm.FunctionParameter("function", {"a": a}),
             pybamm.grad(v_n),
@@ -196,6 +198,22 @@ class TestCopy(TestCase):
             pybamm.SparseStack(mat, mat).new_copy(new_children=[mat_b, mat_b]),
             pybamm.SparseStack(mat_b, mat_b),
         )
+
+    def test_binary_new_copy_new_children_error(self):
+        a = pybamm.Parameter("a")
+        b = pybamm.Parameter("b")
+
+        with self.assertRaisesRegex(ValueError, "must have exactly two children"):
+            (a + b).new_copy(new_children=[a])
+
+    def test_unary_new_copy_new_children_error(self):
+        vec = pybamm.Vector([1, 2, 3, 4, 5])
+        vec_b = pybamm.Vector([6, 7, 8, 9, 10])
+
+        I = pybamm.Index(vec, 1)
+
+        with self.assertRaisesRegex(ValueError, "must have exactly one child"):
+            I.new_copy(new_children=[vec, vec_b])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_expression_tree/test_operations/test_copy.py
+++ b/tests/unit/test_expression_tree/test_operations/test_copy.py
@@ -64,6 +64,139 @@ class TestCopy(TestCase):
         ]:
             self.assertEqual(symbol, symbol.new_copy())
 
+    def test_symbol_new_copy_new_children(self):
+        a = pybamm.Parameter("a")
+        b = pybamm.Parameter("b")
+
+        # binary operations
+        for symbol_ab, symbol_ba in zip(
+            [
+                a + b,
+                a - b,
+                a * b,
+                a / b,
+                a**b,
+                pybamm.minimum(a, b),
+                pybamm.maximum(a, b),
+                pybamm.Equality(a, b),
+            ],
+            [
+                b + a,
+                b - a,
+                b * a,
+                b / a,
+                b**a,
+                pybamm.minimum(b, a),
+                pybamm.maximum(b, a),
+                pybamm.Equality(b, a),
+            ],
+        ):
+            self.assertEqual(symbol_ab.new_copy(new_children=[b, a]), symbol_ba)
+
+        # unary operations
+        for symbol_a, symbol_b in zip(
+            [
+                -a,
+                abs(a),
+                pybamm.Function(np.sin, a),
+                pybamm.PrimaryBroadcast(a, "domain"),
+                pybamm.FullBroadcast(a, "domain", {"secondary": "other domain"}),
+                pybamm.NotConstant(a),
+                pybamm.EvaluateAt(a, 0),
+            ],
+            [
+                -b,
+                abs(b),
+                pybamm.Function(np.sin, b),
+                pybamm.PrimaryBroadcast(b, "domain"),
+                pybamm.FullBroadcast(b, "domain", {"secondary": "other domain"}),
+                pybamm.NotConstant(b),
+                pybamm.EvaluateAt(b, 0),
+            ],
+        ):
+            self.assertEqual(symbol_a.new_copy(new_children=[b]), symbol_b)
+
+        v_n = pybamm.Variable("v", "negative electrode")
+        w_n = pybamm.Variable("w", "negative electrode")
+        x_n = pybamm.standard_spatial_vars.x_n
+
+        for symbol_v, symbol_w in zip(
+            [
+                pybamm.grad(v_n),
+                pybamm.upwind(v_n),
+                pybamm.IndefiniteIntegral(v_n, x_n),
+                pybamm.BackwardIndefiniteIntegral(v_n, x_n),
+                pybamm.BoundaryValue(v_n, "right"),
+                pybamm.BoundaryGradient(v_n, "right"),
+                pybamm.SecondaryBroadcast(v_n, "current collector"),
+            ],
+            [
+                pybamm.grad(w_n),
+                pybamm.upwind(w_n),
+                pybamm.IndefiniteIntegral(w_n, x_n),
+                pybamm.BackwardIndefiniteIntegral(w_n, x_n),
+                pybamm.BoundaryValue(w_n, "right"),
+                pybamm.BoundaryGradient(w_n, "right"),
+                pybamm.SecondaryBroadcast(w_n, "current collector"),
+            ],
+        ):
+            self.assertEqual(symbol_v.new_copy(new_children=[w_n]), symbol_w)
+
+        self.assertEqual(
+            pybamm.div(pybamm.grad(v_n)).new_copy(new_children=[pybamm.grad(w_n)]),
+            pybamm.div(pybamm.grad(w_n)),
+        )
+
+        v_s = pybamm.Variable("v", "separator")
+        mesh = get_mesh_for_testing()
+
+        for symbol_n, symbol_s in zip(
+            [
+                pybamm.concatenation(v_n, v_s),
+                pybamm.DomainConcatenation([v_n, v_s], mesh),
+            ],
+            [
+                pybamm.concatenation(v_s, v_n),
+                pybamm.DomainConcatenation([v_s, v_n], mesh),
+            ],
+        ):
+            self.assertEqual(symbol_n.new_copy(new_children=[v_s, v_n]), symbol_s)
+
+        self.assertEqual(
+            pybamm.NumpyConcatenation(a, b, v_s).new_copy(new_children=[b, a, v_n]),
+            pybamm.NumpyConcatenation(b, a, v_n),
+        )
+
+        v_n_2D = pybamm.Variable(
+            "v",
+            domain="negative particle",
+            auxiliary_domains={"secondary": "negative electrode"},
+        )
+        w_n_2D = pybamm.Variable(
+            "w",
+            domain="negative particle",
+            auxiliary_domains={"secondary": "negative electrode"},
+        )
+        vec = pybamm.Vector([1, 2, 3, 4, 5])
+        vec_b = pybamm.Vector([6, 7, 8, 9, 10])
+        mat = pybamm.Matrix([[1, 2], [3, 4]])
+        mat_b = pybamm.Matrix([[5, 6], [7, 8]])
+
+        self.assertEqual(
+            pybamm.TertiaryBroadcast(v_n_2D, "current collector").new_copy(
+                new_children=[w_n_2D]
+            ),
+            pybamm.TertiaryBroadcast(w_n_2D, "current collector"),
+        )
+        self.assertEqual(
+            pybamm.Index(vec, 1).new_copy(new_children=[vec_b]),
+            pybamm.Index(vec_b, 1),
+        )
+        self.assertEqual(
+            pybamm.SparseStack(mat, mat).new_copy(new_children=[mat_b, mat_b]),
+            pybamm.SparseStack(mat_b, mat_b),
+        )
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -169,8 +169,12 @@ class TestSymbol(TestCase):
 
     def test_symbol_create_copy(self):
         a = pybamm.Symbol("a")
-        with self.assertRaisesRegex(NotImplementedError, "method self.new_copy()"):
-            a.create_copy()
+        new_a = a.create_copy()
+        self.assertEqual(new_a, a)
+
+        b = pybamm.Symbol("b")
+        new_b = b.create_copy(new_children=[a])
+        self.assertEqual(new_b, pybamm.Symbol("b", children=[a]))
 
     def test_sigmoid(self):
         # Test that smooth heaviside is used when the setting is changed


### PR DESCRIPTION
# Description

Generalises create_copy to be usable by all expression tree symbols.

Fixes #3798 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
