### PR TITLE
Disable benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmark_on_push.yml
+++ b/.github/workflows/benchmark_on_push.yml
@@ -2,7 +2,6 @@ name: Run benchmarks on push
 on:
   push:
     branches: [main, develop]
-  pull_request:
 
 concurrency:
   # Cancel intermediate builds always

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -8,7 +8,7 @@
 # - Publish website
 name: Benchmarks
 on:
-  # Everyday at 3 am UTC
+  # Every day at 3 am UTC
   schedule:
     - cron: "0 3 * * *"
   # Make it possible to trigger the

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -8,7 +8,7 @@ on:
     branches:
     - main
 
-  # Run everyday at 3 am UTC
+  # Run every day at 3 am UTC
   schedule:
     - cron: "0 3 * * *"
 


### PR DESCRIPTION
# Description

Stop the benchmarks from running on PRs. The reasons for this are the frequent failures and the long runtime. Benchmarks are still run daily and for main/develop

Related: #3662

## Type of change

- [x] Optimization (back-end change that speeds up the code)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
