### PR TITLE
fix plot_voltage_components to work when time doesn't start at 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug Fixes
 
+- `plot_voltage_components` now works even if the time does not start at 0 ([#3915](https://github.com/pybamm-team/PyBaMM/pull/3915))
 - Fixed bug where separator porosity was used in calculation instead of transport efficiency ([#3905](https://github.com/pybamm-team/PyBaMM/pull/3905))
 - Initial voltage can now match upper or lower cut-offs exactly ([#3842](https://github.com/pybamm-team/PyBaMM/pull/3842))
 - Fixed a bug where 1+1D and 2+1D models would not work with voltage or power controlled experiments([#3829](https://github.com/pybamm-team/PyBaMM/pull/3829))

--- a/pybamm/plotting/plot_voltage_components.py
+++ b/pybamm/plotting/plot_voltage_components.py
@@ -95,7 +95,7 @@ def plot_voltage_components(
     time = solution["Time [h]"].entries
     if split_by_electrode is False:
         ocv = solution["Battery open-circuit voltage [V]"]
-        initial_ocv = ocv(0)
+        initial_ocv = ocv(time[0])
         ocv = ocv.entries
         ax.fill_between(
             time, ocv, initial_ocv, **kwargs_fill, label="Open-circuit voltage"
@@ -103,8 +103,8 @@ def plot_voltage_components(
     else:
         ocp_n = solution["Battery negative electrode bulk open-circuit potential [V]"]
         ocp_p = solution["Battery positive electrode bulk open-circuit potential [V]"]
-        initial_ocp_n = ocp_n(0)
-        initial_ocp_p = ocp_p(0)
+        initial_ocp_n = ocp_n(time[0])
+        initial_ocp_p = ocp_p(time[0])
         initial_ocv = initial_ocp_p - initial_ocp_n
         delta_ocp_n = ocp_n.entries - initial_ocp_n
         delta_ocp_p = ocp_p.entries - initial_ocp_p


### PR DESCRIPTION
# Description

Before, it showed nothing because of propagation of nans

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
