### PR TITLE
`macos-latest` ➡️ `macos-12`

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-12]
     steps:
       - uses: actions/checkout@v4
         name: Check out PyBaMM repository
@@ -114,7 +114,7 @@ jobs:
 
       # sometimes gfortran cannot be found, so reinstall gcc just to be sure
       - name: Install SuiteSparse and SUNDIALS on macOS
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-12'
         run: |
           brew install graphviz openblas libomp
           brew reinstall gcc
@@ -134,7 +134,7 @@ jobs:
           CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
 
       - name: Build wheels on macOS amd64
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-12'
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BEFORE_BUILD_MACOS: >
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload wheels for macOS amd64
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-12'
         with:
           name: macos_amd64_wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
         name: Check out PyBaMM repository
@@ -114,7 +114,7 @@ jobs:
 
       # sometimes gfortran cannot be found, so reinstall gcc just to be sure
       - name: Install SuiteSparse and SUNDIALS on macOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: |
           brew install graphviz openblas libomp
           brew reinstall gcc
@@ -134,7 +134,7 @@ jobs:
           CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
 
       - name: Build wheels on macOS amd64
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BEFORE_BUILD_MACOS: >
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload wheels for macOS amd64
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-13'
         with:
           name: macos_amd64_wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # Include macOS M1 runners
         include:
@@ -74,7 +74,7 @@ jobs:
           sudo apt install texlive-full
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
         run: |
           brew analytics off
           brew install graphviz openblas libomp
@@ -184,7 +184,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: [ubuntu-latest, macos-13]
+            os: [ubuntu-latest, macos-12]
             python-version: ["3.8", "3.9", "3.10", "3.11"]
           # Include macOS M1 runners
             include:
@@ -209,7 +209,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install gfortran gcc libopenblas-dev
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # Include macOS M1 runners
         include:
@@ -74,7 +74,7 @@ jobs:
           sudo apt install texlive-full
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         run: |
           brew analytics off
           brew install graphviz openblas libomp
@@ -184,7 +184,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: [ubuntu-latest, macos-latest]
+            os: [ubuntu-latest, macos-13]
             python-version: ["3.8", "3.9", "3.10", "3.11"]
           # Include macOS M1 runners
             include:
@@ -209,7 +209,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install gfortran gcc libopenblas-dev
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # We check coverage on Ubuntu with Python 3.11, so we skip unit tests for it here
         # TODO: check coverage with Python 3.12 when [odes] supports it
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # Include macOS M1 runners
         include:
@@ -223,7 +223,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # We check coverage on Ubuntu with Python 3.11, so we skip unit tests for it here
         # TODO: check coverage with Python 3.12 when [odes] supports it
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -190,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # Include macOS M1 runners
         include:
@@ -223,7 +223,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
         env:
           # Homebrew environment variables
           HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
# Description

This PR addresses a small future-proofing change – in June 2024, the `macos-latest` label on GitHub Actions runners will point to the ARM macOS images (`macos-14`) rather than the Intel ones. This won't affect building the wheels, as on both images `cibuildwheel` correctly sets `MACOSX_DEPLOYMENT_TARGET` to 10.9 on amd64 and 11.0 on arm64 for use by `setuptools.build_meta` when tagging the wheel.

There is an issue with Homebrew when using the `macos-13` images, but the `macos-12` ones work for now.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).
