### PR TITLE
Replace casadi links

### DIFF
--- a/pybamm/solvers/casadi_algebraic_solver.py
+++ b/pybamm/solvers/casadi_algebraic_solver.py
@@ -1,6 +1,3 @@
-#
-# Casadi algebraic solver class
-#
 import casadi
 import pybamm
 import numpy as np
@@ -19,7 +16,7 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
         The tolerance for the solver (default is 1e-6).
     extra_options : dict, optional
         Any options to pass to the CasADi rootfinder.
-        Please consult `CasADi documentation <https://tinyurl.com/y7hrxm7d>`_ for
+        Please consult `CasADi documentation <https://web.casadi.org/python-api/#rootfinding>`_ for
         details.
 
     """

--- a/pybamm/solvers/casadi_solver.py
+++ b/pybamm/solvers/casadi_solver.py
@@ -1,6 +1,3 @@
-#
-# CasADi Solver class
-#
 import casadi
 import pybamm
 import numpy as np
@@ -51,7 +48,7 @@ class CasadiSolver(pybamm.BaseSolver):
         The tolerance to assert whether extrapolation occurs or not. Default is 0.
     extra_options_setup : dict, optional
         Any options to pass to the CasADi integrator when creating the integrator.
-        Please consult `CasADi documentation <https://tinyurl.com/y5rk76os>`_ for
+        Please consult `CasADi documentation <https://web.casadi.org/python-api/#integrator>`_ for
         details. Some useful options:
 
         - "max_num_steps": Maximum number of integrator steps
@@ -59,7 +56,7 @@ class CasadiSolver(pybamm.BaseSolver):
 
     extra_options_call : dict, optional
         Any options to pass to the CasADi integrator when calling the integrator.
-        Please consult `CasADi documentation <https://tinyurl.com/y5rk76os>`_ for
+        Please consult `CasADi documentation <https://web.casadi.org/python-api/#integrator>`_ for
         details.
     return_solution_if_failed_early : bool, optional
         Whether to return a Solution object if the solver fails to reach the end of


### PR DESCRIPTION
# Description

Fixes the lychee CI check. I replaced the tiny-urls with the integrator and root finder links in the current documentation.

## Type of change

Only documentation.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
