### PR TITLE
Fix Li foil thickness and conductivity in basic DFN half-cell model

### DIFF
--- a/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -221,8 +221,8 @@ class BasicDFNHalfCell(BaseModel):
         self.algebraic[phi_e] = param.L_x**2 * (pybamm.div(i_e) - a_j)
 
         # reference potential
-        L_Li = param.p.L
-        sigma_Li = param.p.sigma
+        L_Li = param.n.L
+        sigma_Li = param.n.sigma
         j_Li = param.j0_Li_metal(pybamm.boundary_value(c_e, "left"), c_w_max, T)
         eta_Li = 2 * RT_F * pybamm.arcsinh(i_cell / (2 * j_Li))
 


### PR DESCRIPTION
# Description
Fixes a bug in the `BasicDFNHalfCell` model where the counter electrode thickness and conductivity are incorrectly taken from the working electrode.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
