### PR TITLE
Added pybamm user id to 1000 and set its group to root

### DIFF
--- a/docs/source/user_guide/installation/install-from-docker.rst
+++ b/docs/source/user_guide/installation/install-from-docker.rst
@@ -85,6 +85,9 @@ Once you have pulled the Docker image, you can run a Docker container with the P
 
 3. You can execute PyBaMM-related commands, run tests develop & contribute from the container.
 
+.. note::
+    The default user for the container is ``pybamm`` with ``pybamm`` as password. The user belongs to ``sudoers`` and ``root`` group so the sudo command can be issued to install additional packages to the container.  After a clean install, ``sudo apt-get update`` should be executed to update the source list. Additional packages can be installed using ``sudo apt-get install [package_name]``.
+
 Exiting the Docker container
 ----------------------------
 

--- a/docs/source/user_guide/installation/install-from-docker.rst
+++ b/docs/source/user_guide/installation/install-from-docker.rst
@@ -86,7 +86,11 @@ Once you have pulled the Docker image, you can run a Docker container with the P
 3. You can execute PyBaMM-related commands, run tests develop & contribute from the container.
 
 .. note::
-    The default user for the container is ``pybamm`` with ``pybamm`` as password. The user belongs to ``sudoers`` and ``root`` group so the sudo command can be issued to install additional packages to the container.  After a clean install, ``sudo apt-get update`` should be executed to update the source list. Additional packages can be installed using ``sudo apt-get install [package_name]``.
+
+    The default user for the container is ``pybamm`` with ``pybamm`` as password. The user belongs to
+    ``sudoers`` and ``root`` group, so the sudo command can be issued to install additional packages to
+    the container.  After a clean install, ``sudo apt-get update`` should be executed to update the source
+    list. Additional packages can be installed using ``sudo apt-get install [package_name]``.
 
 Exiting the Docker container
 ----------------------------

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get install -y libopenblas-dev gcc gfortran graphviz git make g++ build-
 RUN rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash pybamm
+RUN usermod -ou 1000 -g 0 pybamm
 USER pybamm
 
 WORKDIR /home/pybamm/

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,10 +3,10 @@ FROM continuumio/miniconda3:latest
 WORKDIR /
 
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y libopenblas-dev gcc gfortran graphviz git make g++ build-essential cmake pandoc texlive-latex-extra dvipng
+RUN apt-get install -y libopenblas-dev gcc gfortran graphviz git make g++ build-essential cmake pandoc texlive-latex-extra dvipng sudo
 RUN rm -rf /var/lib/apt/lists/*
 
-RUN useradd -m -s /bin/bash pybamm
+RUN useradd -m -s /bin/bash pybamm && echo "pybamm:pybamm" | chpasswd && adduser pybamm sudo
 RUN usermod -ou 1000 -g 0 pybamm
 USER pybamm
 


### PR DESCRIPTION
# Description

Changed the pybamm userID to 1000 and groupID to 0 (root).

Related to #3312 
![docker](https://github.com/pybamm-team/PyBaMM/assets/52504160/8e6e98cd-39b8-4b2f-a696-870032358d95)


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
