### PR TITLE
Fix Jax tests

### DIFF
--- a/pybamm/util.py
+++ b/pybamm/util.py
@@ -22,7 +22,7 @@ import numpy as np
 import pybamm
 
 # Versions of jax and jaxlib compatible with PyBaMM. Note: these are also defined in
-# in the extras dependencies in pyproject.toml, and therefore must be kept in sync.
+# the extras dependencies in pyproject.toml, and therefore must be kept in sync.
 JAX_VERSION = "0.4"
 JAXLIB_VERSION = "0.4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23.5",
-    "scipy>=1.9.3",
+    "scipy>=1.9.3,<1.13.0",
     "casadi>=3.6.3",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
@@ -118,8 +118,8 @@ dev = [
 ]
 # For the Jax solver. Note: these must be kept in sync with the versions defined in pybamm/util.py.
 jax = [
-    "jax==0.4.25; python_version >= '3.9'",
-    "jaxlib==0.4.25; python_version >= '3.9'",
+    "jax==0.4.20; python_version >= '3.9'",
+    "jaxlib==0.4.20; python_version >= '3.9'",
 ]
 # Contains all optional dependencies, except for jax and dev dependencies
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,8 @@ dev = [
 ]
 # For the Jax solver. Note: these must be kept in sync with the versions defined in pybamm/util.py.
 jax = [
-    "jax==0.4.20; python_version >= '3.9'",
-    "jaxlib==0.4.20; python_version >= '3.9'",
+    "jax==0.4.25; python_version >= '3.9'",
+    "jaxlib==0.4.25; python_version >= '3.9'",
 ]
 # Contains all optional dependencies, except for jax and dev dependencies
 all = [


### PR DESCRIPTION
# Description

Gets the Jax tests up and running again so we can working fixing the problem

Related #3959 

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
