### PR TITLE
docstring fixes to pybamm.plotting.quick_plot

### DIFF
--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -464,6 +464,8 @@ class QuickPlot:
         ----------
         t : float
             Dimensional time (in 'time_units') at which to plot.
+        dynamic : bool
+
         """
 
         plt = import_optional_dependency("matplotlib.pyplot")
@@ -647,7 +649,7 @@ class QuickPlot:
 
         Parameters
         ----------
-        step : float
+        step : float, optional
             For notebook mode, size of steps to allow in the slider. Defaults to 1/100th
             of the total time.
         show_plot : bool, optional
@@ -764,11 +766,11 @@ class QuickPlot:
 
         Parameters
         ----------
-        number_of_images : int (optional)
+        number_of_images : int, optional
             Number of images/plots to be compiled for a GIF.
-        duration : float (optional)
+        duration : float, optional
             Duration of visibility of a single image/plot in the created GIF.
-        output_filename : str (optional)
+        output_filename : str, optional
             Name of the generated GIF file.
 
         """

--- a/pybamm/plotting/quick_plot.py
+++ b/pybamm/plotting/quick_plot.py
@@ -464,7 +464,8 @@ class QuickPlot:
         ----------
         t : float
             Dimensional time (in 'time_units') at which to plot.
-        dynamic : bool
+        dynamic : bool, optional
+            If True, creates a dynamic plot with a slider.
 
         """
 


### PR DESCRIPTION
# Description

Practise contributing to issue for Hackathon:

In the file pybamm.plotting.quick_plot.py, added "optional" keyword to "step" argument in dynamic_plot function. Removed round brackets around optional keywords in the arguments "number_of_images", "duration", "output_filename" in create_gif function.

Related #3392 - Improve documentation

## Type of change
Documentation Update
