### PR TITLE
Standardise BaseSolver.solve() multiprocessing context to `fork`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Updates multiprocess `Pool` in `BaseSolver.solve()` to be constructed with context `fork`. Adds small example for multiprocess inputs. ([#3974](https://github.com/pybamm-team/PyBaMM/pull/3974))
 - Added custom experiment steps ([#3835](https://github.com/pybamm-team/PyBaMM/pull/3835))
 - Added support for macOS arm64 (M-series) platforms. ([#3789](https://github.com/pybamm-team/PyBaMM/pull/3789))
 - Added the ability to specify a custom solver tolerance in `get_initial_stoichiometries` and related functions ([#3714](https://github.com/pybamm-team/PyBaMM/pull/3714))

--- a/examples/scripts/multiprocess_inputs.py
+++ b/examples/scripts/multiprocess_inputs.py
@@ -1,0 +1,18 @@
+import pybamm
+import numpy as np
+
+# create the model
+model = pybamm.lithium_ion.DFN()
+
+# set the default model parameters
+param = model.default_parameter_values
+
+# change the current function to be an input parameter
+param["Current function [A]"] = "[input]"
+
+simulation = pybamm.Simulation(model, parameter_values=param)
+
+# solve the model at the given time points, passing multiple current values as inputs
+t_eval = np.linspace(0, 600, 300)
+inputs = [{"Current function [A]": x} for x in range(1, 3)]
+sol = simulation.solve(t_eval, inputs=inputs)

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -912,7 +912,7 @@ class BaseSolver:
                         model_inputs_list,
                     )
                 else:
-                    with mp.Pool(processes=nproc) as p:
+                    with mp.get_context("fork").Pool(processes=nproc) as p:
                         new_solutions = p.starmap(
                             self._integrate,
                             zip(

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -5,12 +5,17 @@ import multiprocessing as mp
 import numbers
 import sys
 import warnings
+import platform
 
 import casadi
 import numpy as np
 
 import pybamm
 from pybamm.expression_tree.binary_operators import _Heaviside
+
+# Set context for parallel processing depending on the platform
+if platform.system() == "Darwin" or platform.system() == "Linux":
+    mp.set_start_method("fork")
 
 
 class BaseSolver:
@@ -912,7 +917,7 @@ class BaseSolver:
                         model_inputs_list,
                     )
                 else:
-                    with mp.get_context("fork").Pool(processes=nproc) as p:
+                    with mp.Pool(processes=nproc) as p:
                         new_solutions = p.starmap(
                             self._integrate,
                             zip(

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_outputs_two_phase.py
@@ -145,8 +145,8 @@ class TestCompareOutputsTwoPhase(TestCase):
 
         sim = pybamm.Simulation(model, parameter_values=param)
         t_eval = np.linspace(0, 9000, 1000)
-        sol1 = sim.solve(t_eval, inputs={"x": 0.01})
-        sol2 = sim.solve(t_eval, inputs={"x": 0.1})
+        inputs = [{"x": 0.01}, {"x": 0.1}]
+        sol = sim.solve(t_eval, inputs=inputs)
 
         # Starting values should be close
         for var in [
@@ -155,11 +155,11 @@ class TestCompareOutputsTwoPhase(TestCase):
             "Average negative secondary particle concentration",
         ]:
             np.testing.assert_allclose(
-                sol1[var].data[:20], sol2[var].data[:20], rtol=1e-2
+                sol[0][var].data[:20], sol[1][var].data[:20], rtol=1e-2
             )
 
         # More silicon means longer sim
-        self.assertLess(sol1["Time [s]"].data[-1], sol2["Time [s]"].data[-1])
+        self.assertLess(sol[0]["Time [s]"].data[-1], sol[1]["Time [s]"].data[-1])
 
     def test_compare_SPM_silicon_graphite(self):
         model_class = pybamm.lithium_ion.SPM


### PR DESCRIPTION
# Description

This PR updated the multiprocess pool to be constructed with context `fork` for `darwin` and `linux` platforms. It also adds an example and updates integration tests to use the list of dictionaries input functionality which should ensure this get tested in script formation.

Fixes #3974 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [X] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [X] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [X] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [X] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [X] Tests added that prove fix is effective or that feature works
