### PR TITLE
Reduced the number of docker images by one `pybamm:latest`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,10 +7,10 @@ on:
     - develop
 
 jobs:
-  build_docker_images:
+  build_docker_image:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
-    name: Image
+    name: Build image
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,16 +29,12 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create latest tag for Docker image
-        id: tags
-        run: echo "tag=latest" >> "$GITHUB_OUTPUT"
-
       - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@v5
         with:
           context: .
           file: scripts/Dockerfile
-          tags: pybamm/pybamm:${{ steps.tags.outputs.tag }}
+          tags: pybamm/pybamm:latest
           push: true
           platforms: linux/amd64, linux/arm64
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,12 +10,8 @@ jobs:
   build_docker_images:
     # This workflow is only of value to PyBaMM and would always be skipped in forks
     if: github.repository_owner == 'pybamm-team'
-    name: Image (${{ matrix.build-args }})
+    name: Image
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        build-args: ["No solvers", "JAX", "IDAKLU", "ALL"]
-      fail-fast: true
 
     steps:
       - name: Checkout
@@ -33,22 +29,11 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create tags for Docker images based on build-time arguments
+      - name: Create latest tag for Docker image
         id: tags
-        run: |
-          if [ "${{ matrix.build-args }}" = "No solvers" ]; then
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "JAX" ]; then
-            echo "tag=jax" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "ODES" ]; then
-            echo "tag=odes" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "IDAKLU" ]; then
-            echo "tag=idaklu" >> "$GITHUB_OUTPUT"
-          elif [ "${{ matrix.build-args }}" = "ALL" ]; then
-            echo "tag=all" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "tag=latest" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Docker image to Docker Hub (${{ matrix.build-args }})
+      - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 ## Breaking changes
 
-- Removed multiple docker images and reduced it to a single docker image tagged `pybamm/pybamm:latest` with all the solvers (`IDAKLU` and `JAX`) contained in it by default ([#3992](https://github.com/pybamm-team/PyBaMM/pull/3961))
+- Removed multiple Docker images. Here on, a single Docker image tagged `pybamm/pybamm:latest` will be provided with both solvers (`IDAKLU` and `JAX`) pre-installed. ([#3992](https://github.com/pybamm-team/PyBaMM/pull/3992))
 - Removed support for Python 3.8 ([#3961](https://github.com/pybamm-team/PyBaMM/pull/3961))
 - Renamed "ocp_soc_0_dimensional" to "ocp_soc_0" and "ocp_soc_100_dimensional" to "ocp_soc_100" ([#3942](https://github.com/pybamm-team/PyBaMM/pull/3942))
 - The ODES solver was removed due to compatibility issues. Users should use IDAKLU, Casadi, or JAX instead. ([#3932](https://github.com/pybamm-team/PyBaMM/pull/3932))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ## Breaking changes
 
+- Removed multiple docker images and reduced it to a single docker image tagged `pybamm/pybamm:latest` with all the solvers (`IDAKLU` and `JAX`) contained in it by default ([#3992](https://github.com/pybamm-team/PyBaMM/pull/3961))
 - Removed support for Python 3.8 ([#3961](https://github.com/pybamm-team/PyBaMM/pull/3961))
 - Renamed "ocp_soc_0_dimensional" to "ocp_soc_0" and "ocp_soc_100_dimensional" to "ocp_soc_100" ([#3942](https://github.com/pybamm-team/PyBaMM/pull/3942))
 - The ODES solver was removed due to compatibility issues. Users should use IDAKLU, Casadi, or JAX instead. ([#3932](https://github.com/pybamm-team/PyBaMM/pull/3932))

--- a/docs/source/user_guide/installation/install-from-docker.rst
+++ b/docs/source/user_guide/installation/install-from-docker.rst
@@ -98,7 +98,7 @@ If you want to build the PyBaMM Docker image locally from the PyBaMM source code
 
 .. note::
 
-  PyBaMM Docker image comes with all the solvers by default. These solvers include ``IDAKLU`` IDA solver provided by the SUNDIALS plus KLU and ``JAX`` solver.
+  PyBaMM's Docker image comes with all available solvers by default. These solvers include ``IDAKLU`` IDAS solver provided by the SUNDIALS linked with SuiteSparse's KLU and the ``JAX`` solver.
 
 
 Using Git inside a running Docker container

--- a/docs/source/user_guide/installation/install-from-docker.rst
+++ b/docs/source/user_guide/installation/install-from-docker.rst
@@ -23,7 +23,7 @@ Use the following command to pull the PyBaMM Docker image from Docker Hub:
 
 .. code:: bash
 
-    docker pull pybamm/pybamm:latest
+    docker pull pybamm/pybamm
 
 
 Running the Docker container
@@ -36,7 +36,7 @@ Once you have pulled the Docker image, you can run a Docker container with the P
 
 .. code:: bash
 
-    docker run -it pybamm/pybamm:latest
+    docker run -it pybamm/pybamm
 
 
 2. You will now be inside the Docker container's shell. You can use PyBaMM and its dependencies as if you were in a virtual environment.

--- a/docs/source/user_guide/installation/install-from-docker.rst
+++ b/docs/source/user_guide/installation/install-from-docker.rst
@@ -20,29 +20,11 @@ Pulling the Docker image
 
 Use the following command to pull the PyBaMM Docker image from Docker Hub:
 
-.. tab:: No optional solver
 
-      .. code:: bash
+.. code:: bash
 
-            docker pull pybamm/pybamm:latest
+    docker pull pybamm/pybamm:latest
 
-.. tab:: JAX solver
-
-      .. code:: bash
-
-            docker pull pybamm/pybamm:jax
-
-.. tab:: IDAKLU solver
-
-      .. code:: bash
-
-            docker pull pybamm/pybamm:idaklu
-
-.. tab:: All solvers
-
-      .. code:: bash
-
-            docker pull pybamm/pybamm:all
 
 Running the Docker container
 ----------------------------
@@ -51,35 +33,11 @@ Once you have pulled the Docker image, you can run a Docker container with the P
 
 1. In your terminal, use the following command to start a Docker container from the pulled image:
 
-.. tab:: Basic
 
-      .. code:: bash
+.. code:: bash
 
-            docker run -it pybamm/pybamm:latest
+    docker run -it pybamm/pybamm:latest
 
-.. tab:: ODES Solver
-
-      .. code:: bash
-
-            docker run -it pybamm/pybamm:odes
-
-.. tab:: JAX Solver
-
-      .. code:: bash
-
-            docker run -it pybamm/pybamm:jax
-
-.. tab:: IDAKLU Solver
-
-      .. code:: bash
-
-            docker run -it pybamm/pybamm:idaklu
-
-.. tab:: All Solver
-
-      .. code:: bash
-
-            docker run -it pybamm/pybamm:all
 
 2. You will now be inside the Docker container's shell. You can use PyBaMM and its dependencies as if you were in a virtual environment.
 
@@ -138,52 +96,9 @@ If you want to build the PyBaMM Docker image locally from the PyBaMM source code
 
       conda activate pybamm
 
-Building Docker images with optional arguments
-----------------------------------------------
+.. note::
 
-When building the PyBaMM Docker images locally, you have the option to include specific solvers by using optional arguments. These solvers include:
-
-- ``IDAKLU``: For IDA solver provided by the SUNDIALS plus KLU.
-- ``JAX``: For Jax solver.
-- ``ALL``: For all the above solvers.
-
-To build the Docker images with optional arguments, you can follow these steps for each solver:
-
-.. tab:: JAX solver
-
-      .. code-block:: bash
-
-            docker build -t pybamm:jax -f scripts/Dockerfile --build-arg JAX=true .
-
-.. tab:: IDAKLU solver
-
-      .. code-block:: bash
-
-            docker build -t pybamm:idaklu -f scripts/Dockerfile --build-arg IDAKLU=true .
-
-.. tab:: All solvers
-
-      .. code-block:: bash
-
-            docker build -t pybamm:all -f scripts/Dockerfile --build-arg ALL=true .
-
-After building the Docker images with the desired solvers, use the ``docker run`` command followed by the desired image name. For example, to run a container from the image built with all optional solvers:
-
-.. code-block:: bash
-
-      docker run -it pybamm:all
-
-Activate PyBaMM development environment inside docker container using:
-
-.. code-block:: bash
-
-      conda activate pybamm
-
-If you want to exit the Docker container's shell, you can simply type:
-
-.. code-block:: bash
-
-      exit
+  PyBaMM Docker image comes with all the solvers by default. These solvers include ``IDAKLU`` IDA solver provided by the SUNDIALS plus KLU and ``JAX`` solver.
 
 
 Using Git inside a running Docker container

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -26,35 +26,12 @@ RUN conda init --all
 SHELL ["conda", "run", "-n", "pybamm", "/bin/bash", "-c"]
 RUN conda install -y pip
 
-ARG IDAKLU
-ARG JAX
-ARG ALL
-
 RUN pip install --upgrade --user pip setuptools wheel wget
 RUN pip install cmake
 
-RUN if [ "$IDAKLU" = "true" ]; then \
-    python scripts/install_KLU_Sundials.py && \
+RUN python scripts/install_KLU_Sundials.py && \
     rm -rf pybind11 && \
     git clone https://github.com/pybind/pybind11.git && \
-    pip install --user -e ".[all,dev,docs]"; \
-    fi
-
-RUN if [ "$JAX" = "true" ]; then \
-    pip install --user -e ".[all,dev,docs,jax]"; \
-    fi
-
-RUN if [ "$ALL" = "true" ]; then \
-    python scripts/install_KLU_Sundials.py && \
-    rm -rf pybind11 && \
-    git clone https://github.com/pybind/pybind11.git && \
-    pip install --user -e ".[all,dev,docs,jax]"; \
-    fi
-
-RUN if [ -z "$IDAKLU" ] \
-    && [ -z "$JAX" ] \
-    && [ -z "$ALL" ]; then \
-    pip install --user -e ".[all,dev,docs]"; \
-    fi
+    pip install --user -e ".[all,dev,docs,jax]";
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
# Description

The `Dockerfile` is reduced to include all the solvers by default, the documentation for `install from source (docker)` and `docker.yml` workflow file have been updated to push only one single docker image tagged `pybamm:latest` to dockerhub with all the solvers contained in them by default, i.e `IDAKLU` and `JAX`.

Fixes #3666 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
