### PR TITLE
i3991 use Python-3.12 compatible `pybind11` to fix benchmarks

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -25,10 +25,12 @@
   // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
   "build_command": [
     "/bin/rm -rf pybind11",
-    "/usr/bin/git clone --depth 1 --branch v2.6.2 https://github.com/pybind/pybind11.git",
-    "python setup.py build",
-    "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    "/usr/bin/git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git",
+    "python -m pip install build",
+    "python -m build --wheel -o {build_cache_dir} {build_dir}"
   ],
+  "build_cache_dir": ".asv/cache",
+  "build_dir": ".asv/build",
 
   // List of branches to benchmark. If not provided, defaults to "master"
   // (for git) or "default" (for mercurial).


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #3991 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
