### PR TITLE
Use unique artifact names

### DIFF
--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -55,6 +55,7 @@ jobs:
           if-no-files-found: error
 
   publish-results:
+    if: github.repository == 'pybamm-team/PyBaMM'
     name: Push and publish results
     needs: benchmarks
     runs-on: ubuntu-latest

--- a/.github/workflows/periodic_benchmarks.yml
+++ b/.github/workflows/periodic_benchmarks.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: asv_periodic_results
           path: results
+          if-no-files-found: error
 
   publish-results:
     name: Push and publish results
@@ -72,18 +73,17 @@ jobs:
           repository: pybamm-team/pybamm-bench
           token: ${{ secrets.BENCH_PAT }}
 
-      - name: Download results artifact
+      - name: Download results artifact(s)
         uses: actions/download-artifact@v4
         with:
-          name: asv_periodic_results
-          path: new_results
+          path: results
+          merge-multiple: true
 
       - name: Copy new results and push to pybamm-bench repo
         env:
           PUSH_BENCH_EMAIL: ${{ secrets.PUSH_BENCH_EMAIL }}
           PUSH_BENCH_NAME: ${{ secrets.PUSH_BENCH_NAME }}
         run: |
-          cp -vr new_results/* results
           git config --global user.email "$PUSH_BENCH_EMAIL"
           git config --global user.name "$PUSH_BENCH_NAME"
           git add results

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Upload Windows wheels
         uses: actions/upload-artifact@v4
         with:
-          name: windows_wheels
+          name: wheels_windows
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -142,19 +142,10 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: python -c "import pybamm; pybamm.IDAKLUSolver()"
 
-      - name: Upload wheels for Linux
+      - name: Upload wheels for ${{ matrix.os }}
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-latest'
         with:
-          name: linux_wheels
-          path: ./wheelhouse/*.whl
-          if-no-files-found: error
-
-      - name: Upload wheels for macOS amd64
-        uses: actions/upload-artifact@v4
-        if: matrix.os == 'macos-12'
-        with:
-          name: macos_amd64_wheels
+          name: wheels_${{ matrix.os }}
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -188,7 +179,7 @@ jobs:
       - name: Upload wheels for macOS arm64
         uses: actions/upload-artifact@v4
         with:
-          name: macos_arm64_wheels
+          name: wheels_macos_arm64
           path: ./wheelhouse/*.whl
           if-no-files-found: error
 
@@ -227,19 +218,20 @@ jobs:
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
 
-      - name: Move all package files to files/
-        run: |
-          mkdir files
-          mv windows_wheels/* linux_wheels/* macos_amd64_wheels/* macos_arm64_wheels/* sdist/* files/
+      - name: Sanity check downloaded artifacts
+        run: ls -lTA artifacts/
 
-      - name: Publish on PyPI
+      - name: Publish to PyPI
         if: github.event.inputs.target == 'pypi' || github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: files/
+          packages-dir: artifacts/
 
-      - name: Publish on TestPyPI
+      - name: Publish to TestPyPI
         if: github.event.inputs.target == 'testpypi'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -249,7 +241,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   open_failure_issue:
-    needs: [build_windows_wheels, build_macos_and_linux_wheels, build_sdist]
+    needs: [build_windows_wheels, build_macos_and_linux_wheels, build_macos_arm64_wheels, build_sdist]
     name: Open an issue if build fails
     if: ${{ always() && contains(needs.*.result, 'failure') && github.repository_owner == 'pybamm-team'}}
     runs-on: ubuntu-latest

--- a/.github/workflows/run_benchmarks_over_history.yml
+++ b/.github/workflows/run_benchmarks_over_history.yml
@@ -27,8 +27,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+
       - name: Install nox and asv
         run: pip install -U pip nox asv
+
       - name: Fetch develop branch
         # Not required when worklow trigerred
         # on develop, but useful when
@@ -36,16 +38,19 @@ jobs:
         if: github.ref != 'refs/heads/develop'
         run: |
           git fetch origin develop:develop
+
       - name: Run benchmarks
         run: |
           asv machine --machine "GitHubRunner"
           asv run -m "GitHubRunner" -s ${{ github.event.inputs.ncommits }} \
           ${{ github.event.inputs.commit_start }}..${{ github.event.inputs.commit_end }}
+
       - name: Upload results as artifact
         uses: actions/upload-artifact@v4
         with:
           name: asv_over_history_results
           path: results
+          if-no-files-found: error
 
   publish-results:
     if: github.repository_owner == 'pybamm-team'
@@ -57,29 +62,33 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+
       - name: Install asv
         run: pip install asv
+
       - name: Checkout pybamm-bench repo
         uses: actions/checkout@v4
         with:
           repository: pybamm-team/pybamm-bench
           token: ${{ secrets.BENCH_PAT }}
-      - name: Download results artifact
+
+      - name: Download results artifact(s)
         uses: actions/download-artifact@v4
         with:
-          name: asv_over_history_results
-          path: new_results
+          path: results
+          merge-multiple: true
+
       - name: Copy new results and push to pybamm-bench repo
         env:
           PUSH_BENCH_EMAIL: ${{ secrets.PUSH_BENCH_EMAIL }}
           PUSH_BENCH_NAME: ${{ secrets.PUSH_BENCH_NAME }}
         run: |
-          cp -vr new_results/* results
           git config --global user.email "$PUSH_BENCH_EMAIL"
           git config --global user.name "$PUSH_BENCH_NAME"
           git add results
           git commit -am "Add new results"
           git push
+
       - name: Publish results
         run: |
           asv publish


### PR DESCRIPTION
# Description

Addresses one out of two parts of issue #3489 – resolves artifacts names and how they are downloaded to fix the rule `GH104 Use unique names for upload-artifact`. They are now all downloaded in one folder for the benchmarks and the wheel builder workflows.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).
