### PR TITLE
change remove independent variables setting to False by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added `plot_thermal_components` to plot the contributions to the total heat generation in a battery ([#4021](https://github.com/pybamm-team/PyBaMM/pull/4021))
 - Added functions for normal probability density function (`pybamm.normal_pdf`) and cumulative distribution function (`pybamm.normal_cdf`) ([#3999](https://github.com/pybamm-team/PyBaMM/pull/3999))
 - Updates multiprocess `Pool` in `BaseSolver.solve()` to be constructed with context `fork`. Adds small example for multiprocess inputs. ([#3974](https://github.com/pybamm-team/PyBaMM/pull/3974))
 - Added custom experiment steps ([#3835](https://github.com/pybamm-team/PyBaMM/pull/3835))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Bug Fixes
 
+- Set the `remove_independent_variables_from_rhs` to `False` by default, and moved the option from `Discretisation.process_model` to `Discretisation.__init__`. This fixes a bug related to the discharge capacity, but may make the simulation slower in some cases. To set the option to `True`, use `Simulation(..., discretisation_kwargs={"remove_independent_variables_from_rhs": True})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))
 - Fix bug with upwind and downwind schemes producing the wrong discretised system ([#3979](https://github.com/pybamm-team/PyBaMM/pull/3979))
 - Allow evaluation of an `Interpolant` object with a number ([#3932](https://github.com/pybamm-team/PyBaMM/pull/3932))
 - `plot_voltage_components` now works even if the time does not start at 0 ([#3915](https://github.com/pybamm-team/PyBaMM/pull/3915))
@@ -32,6 +33,7 @@
 
 ## Breaking changes
 
+- Removed `check_model` argument from `Simulation.solve`. To change the `check_model` option, use `Simulation(..., discretisation_kwargs={"check_model": False})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))
 - Removed multiple Docker images. Here on, a single Docker image tagged `pybamm/pybamm:latest` will be provided with both solvers (`IDAKLU` and `JAX`) pre-installed. ([#3992](https://github.com/pybamm-team/PyBaMM/pull/3992))
 - Removed support for Python 3.8 ([#3961](https://github.com/pybamm-team/PyBaMM/pull/3961))
 - Renamed "ocp_soc_0_dimensional" to "ocp_soc_0" and "ocp_soc_100_dimensional" to "ocp_soc_100" ([#3942](https://github.com/pybamm-team/PyBaMM/pull/3942))

--- a/pybamm/batch_study.py
+++ b/pybamm/batch_study.py
@@ -102,7 +102,6 @@ class BatchStudy:
         self,
         t_eval=None,
         solver=None,
-        check_model=True,
         save_at_cycles=None,
         calc_esoh=True,
         starting_solution=None,
@@ -158,7 +157,6 @@ class BatchStudy:
                 sol = sim.solve(
                     t_eval,
                     solver,
-                    check_model,
                     save_at_cycles,
                     calc_esoh,
                     starting_solution,

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -1127,6 +1127,7 @@ class Discretisation:
                     # in variables twice under different names
                     for key in model.variables:
                         if model.variables[key] == var:
+                            print("here")
                             model.variables[key] = model.variables[var.name]
                     del model.rhs[var]
                     del model.initial_conditions[var]

--- a/pybamm/discretisations/discretisation.py
+++ b/pybamm/discretisations/discretisation.py
@@ -26,14 +26,32 @@ class Discretisation:
     Parameters
     ----------
     mesh : pybamm.Mesh
-            contains all submeshes to be used on each domain
+        contains all submeshes to be used on each domain
     spatial_methods : dict
-            a dictionary of the spatial methods to be used on each
-            domain. The keys correspond to the model domains and the
-            values to the spatial method.
+        a dictionary of the spatial methods to be used on each
+        domain. The keys correspond to the model domains and the
+        values to the spatial method.
+    check_model : bool, optional
+            If True, model checks are performed after discretisation. For large
+            systems these checks can be slow, so can be skipped by setting this
+            option to False. When developing, testing or debugging it is recommended
+            to leave this option as True as it may help to identify any errors.
+            Default is True.
+    remove_independent_variables_from_rhs : bool, optional
+        If True, model checks to see whether any variables from the RHS are used
+        in any other equation. If a variable meets all of the following criteria
+        (not used anywhere in the model, len(rhs)>1), then the variable
+        is moved to be explicitly integrated when called by the solution object.
+        Default is False.
     """
 
-    def __init__(self, mesh=None, spatial_methods=None):
+    def __init__(
+        self,
+        mesh=None,
+        spatial_methods=None,
+        check_model=True,
+        remove_independent_variables_from_rhs=False,
+    ):
         self._mesh = mesh
         if mesh is None:
             self._spatial_methods = {}
@@ -60,6 +78,10 @@ class Discretisation:
         self._bcs = {}
         self.y_slices = {}
         self._discretised_symbols = {}
+        self._check_model_flag = check_model
+        self._remove_independent_variables_from_rhs_flag = (
+            remove_independent_variables_from_rhs
+        )
 
     @property
     def mesh(self):
@@ -90,13 +112,7 @@ class Discretisation:
         # reset discretised_symbols
         self._discretised_symbols = {}
 
-    def process_model(
-        self,
-        model,
-        inplace=True,
-        check_model=True,
-        remove_independent_variables_from_rhs=True,
-    ):
+    def process_model(self, model, inplace=True):
         """
         Discretise a model. Currently inplace, could be changed to return a new model.
 
@@ -108,18 +124,6 @@ class Discretisation:
         inplace : bool, optional
             If True, discretise the model in place. Otherwise, return a new
             discretised model. Default is True.
-        check_model : bool, optional
-            If True, model checks are performed after discretisation. For large
-            systems these checks can be slow, so can be skipped by setting this
-            option to False. When developing, testing or debugging it is recommended
-            to leave this option as True as it may help to identify any errors.
-            Default is True.
-        remove_independent_variables_from_rhs : bool, optional
-            If True, model checks to see whether any variables from the RHS are used
-            in any other equation. If a variable meets all of the following criteria
-            (not used anywhere in the model, len(rhs)>1), then the variable
-            is moved to be explicitly integrated when called by the solution object.
-            Default is True.
 
         Returns
         -------
@@ -158,7 +162,7 @@ class Discretisation:
         # set variables (we require the full variable not just id)
 
         # Search Equations for Independence
-        if remove_independent_variables_from_rhs:
+        if self._remove_independent_variables_from_rhs_flag:
             model = self.remove_independent_variables_from_rhs(model)
         variables = list(model.rhs.keys()) + list(model.algebraic.keys())
         # Find those RHS's that are constant
@@ -240,7 +244,7 @@ class Discretisation:
         model_disc._geometry = getattr(self.mesh, "_geometry", None)
 
         # Check that resulting model makes sense
-        if check_model:
+        if self._check_model_flag:
             pybamm.logger.verbose(f"Performing model checks for {model.name}")
             self.check_model(model_disc)
 

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -1236,7 +1236,7 @@ class TestDiscretise(TestCase):
             c: pybamm.Scalar(1),
         }
         model.events = [pybamm.Event("a=1", a - 1)]
-        disc = pybamm.Discretisation()
+        disc = pybamm.Discretisation(remove_independent_variables_from_rhs=True)
         disc.process_model(model)
         self.assertEqual(len(model.rhs), 3)
 

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -1212,17 +1212,34 @@ class TestDiscretise(TestCase):
     def test_independent_rhs(self):
         a = pybamm.Variable("a")
         b = pybamm.Variable("b")
-        c = pybamm.Variable("c")
+        # Include a concatenation for the test
+        c_n = pybamm.Variable("c_n", ["negative electrode"])
+        c_s = pybamm.Variable("c_s", ["separator"])
+        c = pybamm.concatenation(c_n, c_s)
+
         model = pybamm.BaseModel()
-        model.rhs = {a: b, b: c, c: -c}
-        model.initial_conditions = {
-            a: pybamm.Scalar(0),
-            b: pybamm.Scalar(1),
-            c: pybamm.Scalar(1),
-        }
-        disc = pybamm.Discretisation(remove_independent_variables_from_rhs=True)
+        model.rhs = {a: b, b: 0, c: -c}
+        model.initial_conditions = {a: 0, b: 1, c: 1}
+        # test edge case where variable appears twice with different names
+        model.variables = {"a": a, "a again": a}
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": SpatialMethodForTesting()}
+        disc = pybamm.Discretisation(
+            mesh, spatial_methods, remove_independent_variables_from_rhs=True
+        )
         disc.process_model(model)
         self.assertEqual(len(model.rhs), 2)
+        self.assertEqual(model.variables["a"], model.variables["a again"])
+
+    def test_independent_rhs_one_equation(self):
+        # Test that if there is only one equation, it is not removed
+        a = pybamm.Variable("a")
+        model = pybamm.BaseModel()
+        model.rhs = {a: 0}
+        model.initial_conditions = {a: 0}
+        disc = pybamm.Discretisation(remove_independent_variables_from_rhs=True)
+        disc.process_model(model)
+        self.assertEqual(len(model.rhs), 1)
 
     def test_independent_rhs_with_event(self):
         a = pybamm.Variable("a")

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -1074,23 +1074,6 @@ class TestDiscretise(TestCase):
         with self.assertRaisesRegex(pybamm.ModelError, "Boundary conditions"):
             disc.check_tab_conditions(b, bcs)
 
-    def test_process_with_no_check(self):
-        # create model
-        whole_cell = ["negative electrode", "separator", "positive electrode"]
-        c = pybamm.Variable("c", domain=whole_cell)
-        N = pybamm.grad(c)
-        model = pybamm.BaseModel()
-        model.rhs = {c: pybamm.div(N)}
-        model.initial_conditions = {c: pybamm.Scalar(3)}
-        model.boundary_conditions = {
-            c: {"left": (0, "Neumann"), "right": (0, "Neumann")}
-        }
-        model.variables = {"c": c, "N": N}
-
-        # create discretisation
-        disc = get_discretisation_for_testing()
-        disc.process_model(model, check_model=False)
-
     def test_mass_matrix_inverse(self):
         # get mesh
         mesh = get_2p1d_mesh_for_testing(ypts=5, zpts=5)
@@ -1237,7 +1220,7 @@ class TestDiscretise(TestCase):
             b: pybamm.Scalar(1),
             c: pybamm.Scalar(1),
         }
-        disc = pybamm.Discretisation()
+        disc = pybamm.Discretisation(remove_independent_variables_from_rhs=True)
         disc.process_model(model)
         self.assertEqual(len(model.rhs), 2)
 

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -69,8 +69,10 @@ class TestSimulation(TestCase):
                 self.assertTrue(val.has_symbol_of_classes(pybamm.Matrix))
 
         # test solve without check
-        sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
-        sol = sim.solve(t_eval=[0, 600], check_model=False)
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(), discretisation_kwargs={"check_model": False}
+        )
+        sol = sim.solve(t_eval=[0, 600])
         for val in list(sim.built_model.rhs.values()):
             self.assertFalse(val.has_symbol_of_classes(pybamm.Parameter))
             # skip test for scalar variables (e.g. discharge capacity)

--- a/tests/unit/test_solvers/test_idaklu_jax.py
+++ b/tests/unit/test_solvers/test_idaklu_jax.py
@@ -30,7 +30,7 @@ if pybamm.have_idaklu() and pybamm.have_jax():
     model.initial_conditions = {u1: 0, u2: 0, v: 1}
     model.variables = {"v": v, "u1": u1, "u2": u2}
     disc = pybamm.Discretisation()
-    disc.process_model(model, remove_independent_variables_from_rhs=False)
+    disc.process_model(model)
     t_eval = np.linspace(0, 1, 100)
     idaklu_solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6)
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -563,7 +563,11 @@ class TestIDAKLUSolver(TestCase):
             param.process_geometry(geometry)
             var_pts = {"x_n": 50, "x_s": 50, "x_p": 50, "r_n": 5, "r_p": 5}
             mesh = pybamm.Mesh(geometry, model.default_submesh_types, var_pts)
-            disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+            disc = pybamm.Discretisation(
+                mesh,
+                model.default_spatial_methods,
+                remove_independent_variables_from_rhs=True,
+            )
             disc.process_model(model)
             return model
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -160,7 +160,7 @@ class TestIDAKLUSolver(TestCase):
             model.initial_conditions = {u1: 0, u2: 0, u3: 0, v: 1}
 
             disc = pybamm.Discretisation()
-            disc.process_model(model, remove_independent_variables_from_rhs=False)
+            disc.process_model(model)
 
             solver = pybamm.IDAKLUSolver(root_method=root_method)
 


### PR DESCRIPTION
# Description

Been meaning to do this for a while due to hard-to-fix bugs such as #2528 . #4019 was good motivation.

To set the setting to True (which can speed up the simulation, especially during the rest period), do
```python
pybamm.Simulation(..., discretisation_kwargs={"remove_independent_variables_from_rhs": True)
```

Fixes #2528 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
