### PR TITLE
Update notebook timeout

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -95,7 +95,9 @@ def run_examples(session):
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("-e", ".[all,dev]", silent=False)
     notebooks_to_test = session.posargs if session.posargs else []
-    session.run("pytest", "--nbmake", *notebooks_to_test, external=True)
+    session.run(
+        "pytest", "--nbmake", "--nbmake-timeout=600", *notebooks_to_test, external=True
+    )
 
 
 @nox.session(name="scripts")


### PR DESCRIPTION
# Description

Temporary fix for the notebook timeouts. This doubles the default time to see if it is stable.

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
