### PR TITLE
Display a warning for individual notebook pages on latest versions of the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -371,6 +371,28 @@ env.doc2path(env.docname, base=None) %}
 
 """
 
+if os.environ.get("READTHEDOCS_VERSION") == "latest":
+    # append another admonition to warn about unreleased features
+    # note: this needs to be appended with a newline and correct dedentation
+    nbsphinx_prolog += r"""
+
+    <div class="admonition attention">
+        <p class="admonition-title">
+            Attention
+        </p>
+        <p>
+            You are viewing this notebook on the latest version of the documentation,
+            where these notebooks may not be compatible with the stable release of
+            PyBaMM since they can contain features that are not yet released.
+            It is recommended to switch to a stable version of the documentation
+            to access these notebooks, or you may consider
+            <a href="https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html\#full-installation-guide
+            ">building PyBaMM from sources</a>.
+        </p>
+    </div>
+
+"""
+
 # -- sphinxext/inheritance_diagram.py options --------------------------------
 
 graphviz_output_format = "svg"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,7 +384,7 @@ if os.environ.get("READTHEDOCS_VERSION") == "latest":
             You are viewing this notebook on the latest version of the documentation,
             where these notebooks may not be compatible with the stable release of
             PyBaMM since they can contain features that are not yet released.
-            We recommend viewing these notebooks from the stable version of the documentation. To install the latest version of PyBaMM that is compatible with the latest notebooks, 
+            We recommend viewing these notebooks from the stable version of the documentation. To install the latest version of PyBaMM that is compatible with the latest notebooks,
             <a href="https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html\#full-installation-guide
             ">build PyBaMM from source</a>.
         </p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,10 +384,9 @@ if os.environ.get("READTHEDOCS_VERSION") == "latest":
             You are viewing this notebook on the latest version of the documentation,
             where these notebooks may not be compatible with the stable release of
             PyBaMM since they can contain features that are not yet released.
-            It is recommended to switch to a stable version of the documentation
-            to access these notebooks, or you may consider
+            We recommend viewing these notebooks from the stable version of the documentation. To install the latest version of PyBaMM that is compatible with the latest notebooks, 
             <a href="https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html\#full-installation-guide
-            ">building PyBaMM from sources</a>.
+            ">build PyBaMM from source</a>.
         </p>
     </div>
 


### PR DESCRIPTION
# Description

This is a fix to some issues that were highlighted in recent bug reports (#4034, #4035) where I feel that the versioning warning admonition displayed by Read the Docs is not prominent enough or does not display properly on other devices. Since the example notebooks are very frequently used based on insights from the analytics that can be derived from our analytics hosting service, this is an improvement over #3333 and will display a `sphinx`/`docutils` admonition before the notebook headings and subsequent sections.

## Screenshots

This is how it looks like:

![Version warning through nbsphinx displayed via a Sphinx admonition using raw HTML and in orange/ochre colour, warning users about unreleased features](https://github.com/pybamm-team/PyBaMM/assets/74401230/0fde8dd6-1c7a-4b02-96c8-2994a751e3df)

Locally, this can be verified with the command with the relevant in-line environment variable:

```bash
READTHEDOCS_VERSION="latest" nox -s docs
```

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
