### PR TITLE
Enable testing on Python 3.8, 3.9 for macOS arm64

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -44,17 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        # Include macOS M1 runners
-        include:
-          - os: macos-14
-            python-version: "3.10"
-          - os: macos-14
-            python-version: "3.11"
-          - os: macos-14
-            python-version: "3.12"
-
     steps:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,19 +36,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         # We check coverage on Ubuntu with Python 3.12, so we skip unit tests for it here
         exclude:
           - os: ubuntu-latest
-            python-version: "3.12"
-        # Include macOS M1 runners
-        include:
-          - os: macos-14
-            python-version: "3.10"
-          - os: macos-14
-            python-version: "3.11"
-          - os: macos-14
             python-version: "3.12"
     name: Unit tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -184,18 +176,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        # Include macOS M1 runners
-        include:
-          - os: macos-14
-            python-version: "3.10"
-          - os: macos-14
-            python-version: "3.11"
-          - os: macos-14
-            python-version: "3.12"
     name: Integration tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
-
     steps:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

See new releases at https://github.com/actions/python-versions/releases – Python 3.8 and Python 3.9 builds should be available for macOS arm64 (`macos-14` tag) now.

xref: https://github.com/actions/setup-python/issues/808

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
