### PR TITLE
switch thermal component plot to cumulative heating

### DIFF
--- a/tests/unit/test_plotting/test_plot_thermal_components.py
+++ b/tests/unit/test_plotting/test_plot_thermal_components.py
@@ -11,15 +11,22 @@ use("Agg")
 class TestPlotThermalComponents(TestCase):
     def test_plot_with_solution(self):
         model = pybamm.lithium_ion.SPM({"thermal": "lumped"})
-        sim = pybamm.Simulation(model)
+        sim = pybamm.Simulation(
+            model, parameter_values=pybamm.ParameterValues("ORegan2022")
+        )
         sol = sim.solve([0, 3600])
         for input_data in [sim, sol]:
             _, ax = pybamm.plot_thermal_components(input_data, show_plot=False)
-            t, T = ax[0].get_lines()[-1].get_data()
+            t, cumul_heat = ax[1].get_lines()[-1].get_data()
             np.testing.assert_array_almost_equal(t, sol["Time [h]"].data)
-            np.testing.assert_array_almost_equal(
-                T, sol["X-averaged cell temperature [K]"].data
-            )
+            t, cumul_heat = ax[1].get_lines()[-1].get_data()
+            T_sol = sol["X-averaged cell temperature [K]"].data
+            np.testing.assert_array_almost_equal(t, sol["Time [h]"].data)
+            rho_c_p_eff = sol[
+                "Volume-averaged effective heat capacity [J.K-1.m-3]"
+            ].data
+            T_plot = T_sol[0] + cumul_heat / rho_c_p_eff
+            np.testing.assert_allclose(T_sol, T_plot, rtol=1e-2)
 
             _, ax = plt.subplots(1, 2)
             _, ax_out = pybamm.plot_thermal_components(sol, ax=ax, show_legend=True)


### PR DESCRIPTION
# Description

Temperature components were confusing.
New plot:

<img width="1192" alt="Screenshot 2024-04-30 at 1 19 54 PM" src="https://github.com/pybamm-team/PyBaMM/assets/20817509/f2a3f0df-65ca-40a3-9b55-b5719a292189">


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
