### PR TITLE
CasADi 3.6.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=64",
     "wheel",
     # On Windows, use the CasADi vcpkg registry and CMake bundled from MSVC
-    "casadi>=3.6.3; platform_system!='Windows'",
+    "casadi>=3.6.5; platform_system!='Windows'",
     # Note: the version of CasADi as a build-time dependency should be matched
     # cross platforms, so updates to its minimum version here should be accompanied
     # by a version bump in https://github.com/pybamm-team/casadi-vcpkg-registry.
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.23.5",
     "scipy>=1.9.3,<1.13.0",
-    "casadi>=3.6.3",
+    "casadi>=3.6.5",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
     "sympy>=1.12",

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -13,7 +13,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/pybamm-team/casadi-vcpkg-registry.git",
-      "baseline": "baa26c2e629ea18fbb1aefa7d27c6612c4068fa7",
+      "baseline": "ceee3ed50246744cdef43517d7d7617b8ac291e7",
       "packages": ["casadi"]
     }
   ]


### PR DESCRIPTION
# Description

Fixes #4044

Wheels are building: https://github.com/pybamm-team/casadi-vcpkg-registry/pull/1
Workflow run logs: https://github.com/agriyakhetarpal/PyBaMM/actions/runs/8950718520/job/24586326296

https://github.com/pybamm-team/casadi-vcpkg-registry has been updated and the baseline has been updated accordingly.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
