### PR TITLE
fix typo in f = F/RT

### DIFF
--- a/docs/source/examples/notebooks/models/MSMR.ipynb
+++ b/docs/source/examples/notebooks/models/MSMR.ipynb
@@ -48,7 +48,7 @@
     "$$ \\text{Li}^{+} + \\text{e}^{-} + \\text{H}_{j} \\rightleftharpoons  (\\text{Li--H})_{j}.$$\n",
     "For each species $j$, a vacant host site $\\text{H}_{j}$ can accommodate one lithium leading to a filled host site $(\\text{Li--H})_{j}$. The OCV for this reaction is written as\n",
     "$$ U_j = U_j^0 + \\frac{\\omega_j}{f}\\log\\left(\\frac{X_j - x_j}{x_j}\\right),$$\n",
-    "where $f = (RT)/F$, and $R$, $T$, and $F$ are the universal gas constant, temperature in Kelvin, and Faraday’s constant, respectively. Here $X_j$ represents the total fraction of available host sites which can be occupied by species $j$, $x_j$ is the fraction of filled sites occupied by species $j$, $U_j^0$ is a concentration independent standard electrode potential, and the $\\omega_j$ is an unitless parameter that describes the level of disorder of the reaction represented by gallery $j$. \n",
+    "where $f = F/(RT)$, and $R$, $T$, and $F$ are the universal gas constant, temperature in Kelvin, and Faraday’s constant, respectively. Here $X_j$ represents the total fraction of available host sites which can be occupied by species $j$, $x_j$ is the fraction of filled sites occupied by species $j$, $U_j^0$ is a concentration independent standard electrode potential, and the $\\omega_j$ is an unitless parameter that describes the level of disorder of the reaction represented by gallery $j$. \n",
     "\n",
     "The equation for each reaction can be inverted to give \n",
     "$$x_j = \\frac{X_j}{1+\\exp[f(U-U_j^0)/\\omega_j]}.$$\n",
@@ -539,7 +539,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -553,11 +553,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.6"
   },
   "vscode": {
    "interpreter": {
-    "hash": "bca2b99bfac80e18288b793d52fa0653ab9b5fe5d22e7b211c44eb982a41c00c"
+    "hash": "9ff3d0c7e37de5f5aa47f4f719e4c84fc6cba7b39c571a05173422444e82fa58"
    }
   }
  },


### PR DESCRIPTION
# Description
Fixes a typo in the MSMR notebook where it was written that `f=RT/F` instead of `f=F/RT`. This is correct in the code.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
