### PR TITLE
included `CMakeLists.txt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ## Bug Fixes
 
+- Added `CMakeLists.txt` to `Manifest.in` ([#4101](https://github.com/pybamm-team/PyBaMM/pull/4101))
 - Set the `remove_independent_variables_from_rhs` to `False` by default, and moved the option from `Discretisation.process_model` to `Discretisation.__init__`. This fixes a bug related to the discharge capacity, but may make the simulation slower in some cases. To set the option to `True`, use `Simulation(..., discretisation_kwargs={"remove_independent_variables_from_rhs": True})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))
 - Fixed a bug where independent variables were removed from models even if they appeared in events ([#4019](https://github.com/pybamm-team/PyBaMM/pull/4019))
 - Fix bug with upwind and downwind schemes producing the wrong discretised system ([#3979](https://github.com/pybamm-team/PyBaMM/pull/3979))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 
 ## Bug Fixes
 
-- Added `CMakeLists.txt` to `Manifest.in` ([#4101](https://github.com/pybamm-team/PyBaMM/pull/4101))
 - Set the `remove_independent_variables_from_rhs` to `False` by default, and moved the option from `Discretisation.process_model` to `Discretisation.__init__`. This fixes a bug related to the discharge capacity, but may make the simulation slower in some cases. To set the option to `True`, use `Simulation(..., discretisation_kwargs={"remove_independent_variables_from_rhs": True})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))
 - Fixed a bug where independent variables were removed from models even if they appeared in events ([#4019](https://github.com/pybamm-team/PyBaMM/pull/4019))
 - Fix bug with upwind and downwind schemes producing the wrong discretised system ([#3979](https://github.com/pybamm-team/PyBaMM/pull/3979))

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ graft pybamm
 include CITATION.cff
 prune tests
 
-exclude CHANGELOG.md CODE-OF-CONDUCT.md CONTRIBUTING.md CMakeLists.txt all_contributors.md
+exclude CHANGELOG.md CODE-OF-CONDUCT.md CONTRIBUTING.md all_contributors.md
 include CMakeLists.txt
 
 global-exclude __pycache__ *.py[cod] .venv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include CITATION.cff
 prune tests
 
 exclude CHANGELOG.md CODE-OF-CONDUCT.md CONTRIBUTING.md CMakeLists.txt all_contributors.md
+include CMakeLists.txt
 
 global-exclude __pycache__ *.py[cod] .venv


### PR DESCRIPTION
# Description

Current source distributions do not have the CMakelists.txt shipped in them, so the users cannot build it. 
Fixed by adding CMakeLists.txt in Manifest.in

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
