### PR TITLE
Issue 4082 Documentation CI Fix

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -24,20 +24,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  style:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: Check style
-        run: |
-          python -m pip install pre-commit
-          pre-commit run -a
-
   run_unit_tests:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -271,7 +257,6 @@ jobs:
   # M-series Mac Mini
   build-apple-mseries:
     if: github.repository_owner == 'pybamm-team'
-    needs: style
     runs-on: [self-hosted, macOS, ARM64]
     env:
       GITHUB_PATH: ${PYENV_ROOT/bin:$PATH}

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -238,7 +238,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-      
+
       - name: Install setuptools
         run: python -m pip install setuptools
 

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -331,7 +331,7 @@ jobs:
 
   # M-series Mac Mini
   build-apple-mseries:
-    # if: github.repository_owner == 'pybamm-team'
+    if: github.repository_owner == 'pybamm-team'
     needs: style
     runs-on: [self-hosted, macOS, ARM64]
     env:

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -120,7 +120,6 @@ jobs:
 
       # dot -c is for registering graphviz fonts and plugins
       - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo dot -c
@@ -229,7 +228,6 @@ jobs:
 
       # dot -c is for registering graphviz fonts and plugins
       - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo dot -c
@@ -262,14 +260,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Linux system dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz pandoc
 
       # dot -c is for registering graphviz fonts and plugins
       - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo dot -c
@@ -303,14 +299,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Linux system dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz
 
       # dot -c is for registering graphviz fonts and plugins
       - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo dot -c

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -318,7 +318,7 @@ jobs:
     steps:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
-      
+
       - name: Install Python & create virtualenv
         shell: bash
         run: |

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -334,7 +334,7 @@ jobs:
 
   # M-series Mac Mini
   build-apple-mseries:
-    if: github.repository_owner == 'pybamm-team'
+    # if: github.repository_owner == 'pybamm-team'
     needs: style
     runs-on: [self-hosted, macOS, ARM64]
     env:

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -238,6 +238,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+      
+      - name: Install setuptools
+        run: python -m pip install setuptools
 
       - name: Install nox
         run: python -m pip install nox

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        # Exclude Python 3.12 from unit tests since we run it in the coverage jobs 
+        # Exclude Python 3.12 from unit tests since we run it in the coverage jobs
         exclude:
           - os: ubuntu-latest
             python-version: "3.12"
@@ -103,8 +103,8 @@ jobs:
 
       - name: Install Linux system dependencies
         run: |
-          sudo apt-get update  
-          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng  
+          sudo apt-get update
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng
 
       - name: Set up Python 3.12
         id: setup-python
@@ -141,8 +141,8 @@ jobs:
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update  
-          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng  
+          sudo apt-get update
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
         if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
@@ -178,7 +178,7 @@ jobs:
 
       - name: Run integration tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
         run: python -m nox -s integration
-    
+
   # Skips IDAKLU module compilation for speedups, which is already tested in other jobs.
   run_doctests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -25,6 +25,7 @@ concurrency:
 
 jobs:
   run_unit_tests:
+    name: Unit tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -93,7 +94,6 @@ jobs:
           sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
@@ -110,10 +110,12 @@ jobs:
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.3.1
+        if: github.repository == 'pybamm-team/PyBaMM'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   run_integration_tests:
+    name: Integration tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -149,7 +151,6 @@ jobs:
         run: choco install graphviz --version=8.0.5
 
       - name: Set up Python ${{ matrix.python-version }}
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -182,7 +183,6 @@ jobs:
           sudo apt-get install graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.11
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
@@ -210,7 +210,6 @@ jobs:
           sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
@@ -239,7 +238,6 @@ jobs:
           sudo apt install gfortran gcc graphviz libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: 3.12

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -53,12 +53,17 @@ jobs:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz pandoc
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
@@ -108,11 +113,16 @@ jobs:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz pandoc
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
@@ -149,12 +159,17 @@ jobs:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz pandoc
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
@@ -207,13 +222,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
           sudo apt install graphviz pandoc
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
-          sudo apt-get install texlive-latex-extra dvipng
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
         id: setup-python
@@ -241,12 +261,17 @@ jobs:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz pandoc
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
@@ -277,12 +302,17 @@ jobs:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
 
-      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install gfortran gcc graphviz
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install OpenBLAS and TeXLive for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
           sudo dot -c
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -39,13 +39,13 @@ jobs:
           pre-commit run -a
 
   run_unit_tests:
-    needs: style
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        # Exclude Python 3.12 from unit tests since we run it in the coverage jobs 
         exclude:
           - os: ubuntu-latest
             python-version: "3.12"
@@ -57,15 +57,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt install gfortran gcc graphviz pandoc
-
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng
 
       - name: Install macOS system dependencies
         if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
@@ -86,7 +78,6 @@ jobs:
         run: choco install graphviz --version=8.0.5
 
       - name: Set up Python ${{ matrix.python-version }}
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -103,10 +94,7 @@ jobs:
         run: python -m nox -s unit
 
   check_coverage:
-    needs: style
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     name: Coverage tests (ubuntu-latest / Python 3.12)
 
     steps:
@@ -115,15 +103,8 @@ jobs:
 
       - name: Install Linux system dependencies
         run: |
-          sudo apt-get update
-          sudo apt install gfortran gcc graphviz pandoc
-
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+          sudo apt-get update  
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng  
 
       - name: Set up Python 3.12
         id: setup-python
@@ -138,7 +119,7 @@ jobs:
         timeout-minutes: 10
         run: python -m nox -s pybamm-requires
 
-      - name: Run unit tests for Ubuntu with Python 3.11 and generate coverage report
+      - name: Run unit tests for Ubuntu with Python 3.12 and generate coverage report
         run: python -m nox -s coverage
 
       - name: Upload coverage report
@@ -147,7 +128,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   run_integration_tests:
-    needs: style
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -161,16 +141,8 @@ jobs:
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
-          sudo apt install gfortran gcc graphviz pandoc
-
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+          sudo apt-get update  
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng  
 
       - name: Install macOS system dependencies
         if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
@@ -206,13 +178,10 @@ jobs:
 
       - name: Run integration tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
         run: python -m nox -s integration
-    # Skips IDAKLU module compilation for speedups, which is already tested in other jobs.
-
+    
+  # Skips IDAKLU module compilation for speedups, which is already tested in other jobs.
   run_doctests:
-    needs: style
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     name: Doctests (ubuntu-latest / Python 3.11)
 
     steps:
@@ -224,23 +193,13 @@ jobs:
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt install graphviz pandoc
+          sudo apt-get install graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
-
-      - name: Set up Python 3.12
+      - name: Set up Python 3.11
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-
-      - name: Install setuptools
-        run: python -m pip install setuptools
+          python-version: 3.11
 
       - name: Install nox
         run: python -m pip install nox
@@ -252,10 +211,7 @@ jobs:
         run: python -m nox -s docs
 
   run_example_tests:
-    needs: style
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     name: Example notebooks (ubuntu-latest / Python 3.12)
 
     steps:
@@ -265,14 +221,7 @@ jobs:
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt install gfortran gcc graphviz pandoc
-
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
         id: setup-python
@@ -291,10 +240,7 @@ jobs:
         run: python -m nox -s examples
 
   run_scripts_tests:
-    needs: style
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     name: Example scripts (ubuntu-latest / Python 3.12)
 
     steps:
@@ -304,14 +250,7 @@ jobs:
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt install gfortran gcc graphviz
-
-      # dot -c is for registering graphviz fonts and plugins
-      - name: Install OpenBLAS and TeXLive for Linux
-        run: |
-          sudo apt-get update
-          sudo dot -c
-          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+          sudo apt install gfortran gcc graphviz libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
         id: setup-python

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-    - main
+      - main
 
   # Run every day at 3 am UTC
   schedule:
@@ -38,7 +38,106 @@ jobs:
           python -m pip install pre-commit
           pre-commit run -a
 
-  build:
+  run_unit_tests:
+    needs: style
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.12"
+    steps:
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran gcc graphviz pandoc
+          sudo dot -c
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+
+      - name: Install macOS system dependencies
+        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_COLOR: 1
+          # Speed up CI
+          NONINTERACTIVE: 1
+        # sometimes gfortran cannot be found, so reinstall gcc just to be sure
+        run: |
+          brew analytics off
+          brew install graphviz
+          brew reinstall gcc
+
+      - name: Install Windows system dependencies
+        if: matrix.os == 'windows-latest'
+        run: choco install graphviz --version=8.0.5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux and macOS
+        timeout-minutes: 10
+        if: matrix.os != 'windows-latest'
+        run: python -m nox -s pybamm-requires
+
+      - name: Run unit tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
+        run: python -m nox -s unit
+
+  check_coverage:
+    needs: style
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Coverage tests (ubuntu-latest / Python 3.12)
+
+    steps:
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran gcc graphviz pandoc
+          sudo dot -c
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+
+      - name: Set up Python 3.12
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux
+        timeout-minutes: 10
+        run: python -m nox -s pybamm-requires
+
+      - name: Run unit tests for Ubuntu with Python 3.11 and generate coverage report
+        run: python -m nox -s coverage
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4.3.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  run_integration_tests:
     needs: style
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,23 +148,25 @@ jobs:
     steps:
       - name: Check out PyBaMM repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
+      # dot -c is for registering graphviz fonts and plugins
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt install gfortran gcc libopenblas-dev graphviz pandoc
-          sudo apt install texlive-full
+          sudo apt install gfortran gcc graphviz pandoc
+          sudo dot -c
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
         if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_COLOR: 1
+          # Speed up CI
+          NONINTERACTIVE: 1
+        # sometimes gfortran cannot be found, so reinstall gcc just to be sure
         run: |
           brew analytics off
           brew install graphviz
@@ -73,7 +174,13 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: choco install graphviz --version=2.38.0.20190211
+        run: choco install graphviz --version=8.0.5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install nox
         run: python -m pip install nox
@@ -83,37 +190,116 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: python -m nox -s pybamm-requires
 
-      - name: Run unit tests for GNU/Linux, macOS, and Windows with all Python versions
-        if: (matrix.os == 'ubuntu-latest' && matrix.python-version != 3.11) || (matrix.os != 'ubuntu-latest')
-        run: python -m nox -s unit
-
-      - name: Run unit tests for GNU/Linux with Python 3.11 and generate coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-        run: python -m nox -s coverage
-
-      - name: Upload coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.11
-        uses: codecov/codecov-action@v4.3.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Run integration tests
+      - name: Run integration tests for ${{ matrix.os }} with Python ${{ matrix.python-version }}
         run: python -m nox -s integration
+    # Skips IDAKLU module compilation for speedups, which is already tested in other jobs.
 
-      - name: Install docs dependencies and run doctests
-        if: matrix.os == 'ubuntu-latest'
+  run_doctests:
+    needs: style
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Doctests (ubuntu-latest / Python 3.11)
+
+    steps:
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt install graphviz pandoc
+          sudo dot -c
+          sudo apt-get install texlive-latex-extra dvipng
+
+      - name: Set up Python 3.12
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Install docs dependencies and run doctests for GNU/Linux
         run: python -m nox -s doctests
 
-      - name: Check if the documentation can be built
-        if: matrix.os == 'ubuntu-latest'
+      - name: Check if the documentation can be built for GNU/Linux
         run: python -m nox -s docs
 
-      - name: Install dev dependencies and run example tests
+  run_example_tests:
+    needs: style
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Example notebooks (ubuntu-latest / Python 3.12)
+
+    steps:
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran gcc graphviz pandoc
+          sudo dot -c
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+
+      - name: Set up Python 3.12
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux
+        timeout-minutes: 10
+        run: python -m nox -s pybamm-requires
+
+      - name: Run example notebooks tests for GNU/Linux with Python 3.12
         run: python -m nox -s examples
 
-      - name: Run example scripts tests
+  run_scripts_tests:
+    needs: style
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    name: Example scripts (ubuntu-latest / Python 3.12)
+
+    steps:
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+
+      # dot -c is for registering graphviz fonts and plugins
+      - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt install gfortran gcc graphviz
+          sudo dot -c
+          sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
+
+      - name: Set up Python 3.12
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      - name: Install nox
+        run: python -m pip install nox
+
+      - name: Install SuiteSparse and SUNDIALS on GNU/Linux
+        timeout-minutes: 10
+        run: python -m nox -s pybamm-requires
+
+      - name: Run example scripts tests for GNU/Linux with Python 3.12
         run: python -m nox -s scripts
 
   # M-series Mac Mini
@@ -130,7 +316,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out PyBaMM repository
+        uses: actions/checkout@v4
+      
       - name: Install Python & create virtualenv
         shell: bash
         run: |

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -43,7 +43,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
         if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
@@ -90,7 +90,7 @@ jobs:
       - name: Install Linux system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra-dvipng
+          sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Set up Python 3.12
         id: setup-python

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,6 +78,7 @@ def run_integration(session):
 def run_doctests(session):
     """Run the doctests and generate the output(s) in the docs/build/ directory."""
     # TODO: Temporary fix for Python 3.12 CI.
+    # See: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,docs]", silent=False)
     session.run("python", "run-tests.py", "--doctest")
@@ -147,6 +148,7 @@ def build_docs(session):
     """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
     # TODO: Temporary fix for Python 3.12 CI.
+    # See: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,docs]", silent=False)
     session.chdir("docs")

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,6 +77,8 @@ def run_integration(session):
 @nox.session(name="doctests")
 def run_doctests(session):
     """Run the doctests and generate the output(s) in the docs/build/ directory."""
+    # TODO: Temporary fix for Python 3.12 CI.
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,docs]", silent=False)
     session.run("python", "run-tests.py", "--doctest")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -146,6 +146,8 @@ def run_tests(session):
 def build_docs(session):
     """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
+    # TODO: Temporary fix for Python 3.12 CI.
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,docs]", silent=False)
     session.chdir("docs")
     # Local development


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
The documentation built on CI fails with an error. It was found that we still need to install setuptools before docs/doctests sessions to avoid erroring out. 
Also, the scheduled jobs are parallelized for faster CI

Fixes #4082 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
