### PR TITLE
Updated scipy and jax versions to fix `linalg.tri` deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.23.5",
-    "scipy>=1.9.3,<1.13.0",
+    "scipy>=1.11.0",
     "casadi>=3.6.5",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
@@ -113,8 +113,8 @@ dev = [
 ]
 # For the Jax solver. Note: these must be kept in sync with the versions defined in pybamm/util.py.
 jax = [
-    "jax==0.4.20; python_version >= '3.9'",
-    "jaxlib==0.4.20; python_version >= '3.9'",
+    "jax==0.4.28; python_version >= '3.9'",
+    "jaxlib==0.4.28; python_version >= '3.9'",
 ]
 # Contains all optional dependencies, except for jax and dev dependencies
 all = [


### PR DESCRIPTION
# Description

Updated jax & jaxlib to most recent version and scipy to >= 1.11.0 (the one that introduced the deprecation warning).

Fixes #3959

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
