### PR TITLE
Fixed Python3.12 failing CI tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,7 @@ def run_pybamm_requires(session):
 def run_coverage(session):
     """Run the coverage tests and generate an XML report."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    session.install("setuptools", silent=False)
     session.install("coverage", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     session.run("pytest", "--cov=pybamm", "--cov-report=xml", "tests/unit")
@@ -70,6 +71,7 @@ def run_coverage(session):
 def run_integration(session):
     """Run the integration tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     session.run("python", "run-tests.py", "--integration")
 
@@ -88,6 +90,7 @@ def run_doctests(session):
 def run_unit(session):
     """Run the unit tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     session.run("python", "run-tests.py", "--unit")
 
@@ -96,6 +99,7 @@ def run_unit(session):
 def run_examples(session):
     """Run the examples tests for Jupyter notebooks."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev]", silent=False)
     notebooks_to_test = session.posargs if session.posargs else []
     session.run("pytest", "--nbmake", *notebooks_to_test, external=True)
@@ -139,6 +143,7 @@ def set_dev(session):
 def run_tests(session):
     """Run the unit tests and integration tests sequentially."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     session.run("python", "run-tests.py", "--all")
 


### PR DESCRIPTION
# Description

CI tests are failing in python3.12 on [this](https://github.com/pybamm-team/PyBaMM/actions/runs/9290109029/job/25567375568?pr=4098) workflow action under `unit/coverage` tests. Looking at the `noxfile` there was a temporary fix included for python3.12 in this [commit](https://github.com/pybamm-team/PyBaMM/commit/5f35628f21d44a4152419b7d8215a40f201709bc#diff-f7a16a65f061822bcc73b8296f4dc837353d379d8d9cc5307982cb6941442835) which I included in other `nox.sessions` as well. Though it is a temporary fix, I tested it on my [branch](https://github.com/santacodes/PyBaMM/actions/runs/9292250506/job/25572739026) and it seems to be working.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
