### PR TITLE
3937 events with idaklu output variables

### DIFF
--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -1468,21 +1468,12 @@ class BaseSolver:
                 for k, v in model.variables.items():
                     if v in event_children:
                         required_vars.append(k)
-                if required_vars:
-                    joined_vars = "\n".join(required_vars)
-                    raise ValueError(
-                        f"{self.name}: Event '{event.name}' cannot be calculated "
-                        "using the current output variables.\n"
-                        f"Add one of the following to `output_variables`:\n{joined_vars}"
-                    )
-                else:
-                    # no variables identified which match the event children
-                    raise ValueError(
-                        f"{self.name}: Event '{event.name}' cannot be calculated "
-                        "using the current output variables.\n"
-                        f"Add one of {event_children} as a variable in the model, "
-                        "then add the variable to `output_varaibles`."
-                    )
+                joined_vars = "\n".join(required_vars)
+                raise ValueError(
+                    f"{self.name}: Event '{event.name}' cannot be calculated "
+                    "using the current output variables.\n"
+                    f"Add one of the following to `output_variables`:\n{joined_vars}"
+                )
 
 
 def process(

--- a/pybamm/solvers/base_solver.py
+++ b/pybamm/solvers/base_solver.py
@@ -958,7 +958,7 @@ class BaseSolver:
             # Identify the event that caused termination and update the solution to
             # include the event time and state
             solutions[i], termination = self.get_termination_reason(
-                solution, model.events
+                solution, model.events, model.variables_and_events
             )
             # Assign times
             solutions[i].set_up_time = set_up_time
@@ -1252,7 +1252,9 @@ class BaseSolver:
 
         # Identify the event that caused termination and update the solution to
         # include the event time and state
-        solution, termination = self.get_termination_reason(solution, model.events)
+        solution, termination = self.get_termination_reason(
+            solution, model.events, model.variables_and_events
+        )
 
         # Assign setup time
         solution.set_up_time = set_up_time
@@ -1271,7 +1273,7 @@ class BaseSolver:
             return old_solution + solution
 
     @staticmethod
-    def get_termination_reason(solution, events):
+    def get_termination_reason(solution, events, variables=None):
         """
         Identify the cause for termination. In particular, if the solver terminated
         due to an event, (try to) pinpoint which event was responsible. If an event

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -753,10 +753,18 @@ class IDAKLUSolver(pybamm.BaseSolver):
                     k: v for k, v in output_vars.items() if v in event_children
                 }
                 if len(matching_var) != 1:
-                    raise pybamm.SolverError(
-                        "Could not determine which variable should be used to calculate"
-                        " the termination event"
-                    )
+                    try:
+                        final_event_values[event.name] = event.expression.evaluate(
+                            solution.t_event,
+                            solution.y_event,
+                            inputs=solution.all_inputs[-1],
+                        )
+                        continue
+                    except ValueError as e:  # pragma: no cover
+                        raise pybamm.SolverError(
+                            "Could not determine which variable should be used to calculate"
+                            f" the termination event {event.name}"
+                        ) from e
                 ((k, v),) = matching_var.items()
                 # replace the function that matches the output variable with the final
                 # value

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -792,22 +792,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 )
             # Add the event to the solution object
             solution.termination = f"event: {termination_event}"
-            # Update t, y and inputs to include event time and state
-            # Note: if the final entry of t is equal to the event time we skip
-            # this (having duplicate entries causes an error later in ProcessedVariable)
-            if solution.t_event != solution.all_ts[-1][-1]:
-                event_sol = pybamm.Solution(
-                    solution.t_event,
-                    solution.y_event,
-                    solution.all_models[-1],
-                    solution.all_inputs[-1],
-                    solution.t_event,
-                    solution.y_event,
-                    solution.termination,
-                )
-                event_sol.solve_time = 0
-                event_sol.integration_time = 0
-                solution = solution + event_sol
 
             pybamm.logger.debug("Finish post-processing events")
             return solution, solution.termination

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -608,12 +608,8 @@ class IDAKLUSolver(pybamm.BaseSolver):
         if self.output_variables:
             # Substitute empty vectors for state vector 'y'
             y_out = np.zeros((number_of_timesteps * number_of_states, 0))
-            number_of_samples = sol.y.shape[0] // number_of_timesteps
-            sol.y = sol.y.reshape((number_of_timesteps, number_of_samples))
-            y_out_events = sol.y
         else:
             y_out = sol.y.reshape((number_of_timesteps, number_of_states))
-            y_out_events = y_out
 
         # return sensitivity solution, we need to flatten yS to
         # (#timesteps * #states (where t is changing the quickest),)
@@ -643,13 +639,15 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 model,
                 inputs_dict,
                 np.array([t[-1]]),
-                np.transpose(y_out_events[-1])[:, np.newaxis],
+                np.transpose(y_out[-1])[:, np.newaxis],
                 termination,
                 sensitivities=yS_out,
             )
             newsol.integration_time = integration_time
             if self.output_variables:
                 # Populate variables and sensititivies dictionaries directly
+                number_of_samples = sol.y.shape[0] // number_of_timesteps
+                sol.y = sol.y.reshape((number_of_timesteps, number_of_samples))
                 startk = 0
                 for _, var in enumerate(self.output_variables):
                     # ExplicitTimeIntegral's are not computed as part of the solver and

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -100,10 +100,6 @@ class Solution:
 
         self.sensitivities = sensitivities
 
-        self._t_event = t_event
-        self._y_event = y_event
-        self._termination = termination
-
         # Check no ys are too large
         if check_solution:
             self.check_ys_are_not_too_large()

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -730,7 +730,7 @@ class TestIDAKLUSolver(TestCase):
             solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
         )
         sol = sim.solve(np.linspace(0, 3600, 1000))
-        assert sol.termination == "event: Minimum voltage [V]"
+        self.assertEqual(sol.termination, "event: Minimum voltage [V]")
 
         sim2 = pybamm.Simulation(
             model,
@@ -758,7 +758,7 @@ class TestIDAKLUSolver(TestCase):
             solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
         )
         sol3 = sim3.solve(np.linspace(0, 3600, 1000))
-        assert sol3.termination == "event: Minimum voltage [V]"
+        self.assertEqual(sol3.termination, "event: Minimum voltage [V]")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -724,20 +724,41 @@ class TestIDAKLUSolver(TestCase):
         model = pybamm.lithium_ion.DFN()
         parameter_values = pybamm.ParameterValues("Chen2020")
 
-        sim1 = pybamm.Simulation(
-            model,
-            parameter_values=parameter_values,
-            solver=pybamm.IDAKLUSolver(),
-        )
-        sim2 = pybamm.Simulation(
+        sim = pybamm.Simulation(
             model,
             parameter_values=parameter_values,
             solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
         )
-        sol1 = sim1.solve(np.linspace(0, 3600, 1000))
-        sol2 = sim2.solve(np.linspace(0, 3600, 1000))
+        sol = sim.solve(np.linspace(0, 3600, 1000))
+        assert sol.termination == "event: Minimum voltage [V]"
 
-        assert sol1.termination == sol2.termination
+        sim2 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Cell temperature [K]"]),
+        )
+        with self.assertRaisesRegex(
+            ValueError, "cannot be calculated using the current output variables"
+        ):
+            sim2.solve(np.linspace(0, 3600, 1000))
+
+        # create an event that doesn't require the state vector
+        eps_p = model.variables["Positive electrode porosity"]
+        model.events.append(
+            pybamm.Event(
+                "Zero positive electrode porosity cut-off",
+                pybamm.min(eps_p),
+                pybamm.EventType.TERMINATION,
+            )
+        )
+
+        sim3 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
+        )
+        sol3 = sim3.solve(np.linspace(0, 3600, 1000))
+        assert sol3.termination == "event: Minimum voltage [V]"
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -547,7 +547,7 @@ class TestIDAKLUSolver(TestCase):
                             soln = solver.solve(model, t_eval)
 
     def test_with_output_variables(self):
-        # Construct a model and solve for all vairables, then test
+        # Construct a model and solve for all variables, then test
         # the 'output_variables' option for each variable in turn, confirming
         # equivalence
         input_parameters = {}  # Sensitivities dictionary
@@ -719,6 +719,25 @@ class TestIDAKLUSolver(TestCase):
         # Mock a 1D current collector and initialise (none in the model)
         sol["x_s [m]"].domain = ["current collector"]
         sol["x_s [m]"].initialise_1D()
+
+    def test_with_output_variables_and_event_termination(self):
+        model = pybamm.lithium_ion.DFN()
+        parameter_values = pybamm.ParameterValues("Chen2020")
+
+        sim1 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(),
+        )
+        sim2 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
+        )
+        sol1 = sim1.solve(np.linspace(0, 3600, 1000))
+        sol2 = sim2.solve(np.linspace(0, 3600, 1000))
+
+        assert sol1.termination == sol2.termination
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Simulations using the IDAKLU solver with output variables specified which terminated with an event rather than the final time step would crash trying to find the termination event.

Termination events are found in the Solution class by using the state vector of the final time-step to evaluate each potential termination event and find the minimum (the event which caused the termination). When output variables are specified in the IDAKLU solver only those variables are output, not the entire state vector, so the events could not be evaluated outside the solver.

This PR adds a check to see if the events specified in a model can be calculated using the values of the output variables rather than the state vector. If they can, the events are calculated using these values after the solve. If not, an error is raised warning that events will not be able to be calculated with the current output variables, and provides a list of variables to choose from to add to the output_variables list, e.g.:
```
model = pybamm.lithium_ion.DFN()
parameter_values = pybamm.ParameterValues("Chen2020")

sim2 = pybamm.Simulation(
  model,
  parameter_values=parameter_values,
  solver=pybamm.IDAKLUSolver(output_variables=["Cell temperature [K]"]),
)
sim2.solve(np.linspace(0, 3600, 1000))
```
raises
```
ValueError: IDA KLU solver: Event 'Minimum voltage [V]' cannot be calculated using the current output variables.
Add one of the following to `output_variables`:
Positive current collector potential [V]
Local voltage [V]
Terminal voltage [V]
Voltage [V]
Battery voltage [V]
```

Fixes #3937 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
