### PR TITLE
`pybind11` v2.12.0

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -48,7 +48,7 @@ jobs:
               output_stream.write(f"count={num_cpus}\n")
 
       - name: Clone pybind11 repo (no history)
-        run: git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git
+        run: git clone --depth 1 --branch v2.12.0 https://github.com/pybind/pybind11.git -c advice.detachedHead=false
 
       - name: Install vcpkg on Windows
         run: |
@@ -107,7 +107,7 @@ jobs:
           python-version: 3.11
 
       - name: Clone pybind11 repo (no history)
-        run: git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git
+        run: git clone --depth 1 --branch v2.12.0 https://github.com/pybind/pybind11.git -c advice.detachedHead=false
 
       - name: Build wheels on Linux
         run: pipx run cibuildwheel --output-dir wheelhouse
@@ -143,7 +143,7 @@ jobs:
           python-version: '3.11'
 
       - name: Clone pybind11 repo (no history)
-        run: git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git
+        run: git clone --depth 1 --branch v2.12.0 https://github.com/pybind/pybind11.git -c advice.detachedHead=false
 
       - name: Set macOS-specific environment variables
         run: echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> $GITHUB_ENV

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -25,7 +25,7 @@
   // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
   "build_command": [
     "/bin/rm -rf pybind11",
-    "/usr/bin/git clone --depth 1 --branch v2.11.1 https://github.com/pybind/pybind11.git",
+    "/usr/bin/git clone --depth 1 --branch v2.12.0 https://github.com/pybind/pybind11.git pybind11 -c advice.detachedHead=false",
     "python -m pip install build",
     "python -m build --wheel -o {build_cache_dir} {build_dir}"
   ],

--- a/noxfile.py
+++ b/noxfile.py
@@ -49,8 +49,14 @@ def run_pybamm_requires(session):
             session.run(
                 "git",
                 "clone",
+                "--depth",
+                "1",
+                "--branch",
+                "v2.12.0",
                 "https://github.com/pybind/pybind11.git",
                 "pybind11/",
+                "-c",
+                "advice.detachedHead=false",
                 external=True,
             )
     else:


### PR DESCRIPTION
# Description

Bump to pybind11 v2.12.0 to introduce upcoming NumPy v2 compatibility – it shouldn't be needed for our case because we don't build against the NumPy-C API but just to be sure, I tested the solvers against NumPy v2.0.0rc2 because the IDAKLU-Jax solver uses quite a few NumPy array in its implementation.

`pybind11` is scheduled to be a build-time dependency through #3564, earlier through #3560.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
