### PR TITLE
Add functions of time in experiment step 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added functionality to pass in arbitrary functions of time as the argument for a (`pybamm.step`). ([#4222](https://github.com/pybamm-team/PyBaMM/pull/4222))
 - Added new parameters `"f{pref]Initial inner SEI on cracks thickness [m]"` and `"f{pref]Initial outer SEI on cracks thickness [m]"`, instead of hardcoding these to `L_inner_0 / 10000` and `L_outer_0 / 10000`. ([#4168](https://github.com/pybamm-team/PyBaMM/pull/4168))
 - Added `pybamm.DataLoader` class to fetch data files from [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0) and store it under local cache. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))
 - Added `time` as an option for `Experiment.termination`. Now allows solving up to a user-specified time while also allowing different cycles and steps in an experiment to be handled normally. ([#4073](https://github.com/pybamm-team/PyBaMM/pull/4073))

--- a/pybamm/experiment/step/base_step.py
+++ b/pybamm/experiment/step/base_step.py
@@ -72,9 +72,9 @@ class BaseStep:
         direction=None,
     ):
         # Check if drive cycle
-        self.is_drive_cycle = isinstance(value, np.ndarray)
+        is_drive_cycle = isinstance(value, np.ndarray)
         is_python_function = callable(value)
-        if self.is_drive_cycle:
+        if is_drive_cycle:
             if value.ndim != 2 or value.shape[1] != 2:
                 raise ValueError(
                     "Drive cycle must be a 2-column array with time in the first column"
@@ -107,7 +107,7 @@ class BaseStep:
 
         # If drive cycle, repeat the drive cycle until the end of the experiment,
         # and create an interpolant
-        if self.is_drive_cycle:
+        if is_drive_cycle:
             t_max = self.duration
             if t_max > value[-1, 0]:
                 # duration longer than drive cycle values so loop

--- a/pybamm/experiment/step/base_step.py
+++ b/pybamm/experiment/step/base_step.py
@@ -145,26 +145,17 @@ class BaseStep:
             direction = self.value_based_charge_or_discharge()
         self.direction = direction
 
-        # Record all the args for repr and hash
-        self.repr_args = f"{value}, duration={duration}"
-        self.hash_args = f"{value}"
-        if termination:
-            self.repr_args += f", termination={termination}"
-            self.hash_args += f", termination={termination}"
-        if period:
-            self.repr_args += f", period={period}"
-        if temperature:
-            self.repr_args += f", temperature={temperature}"
-            self.hash_args += f", temperature={temperature}"
-        if tags:
-            self.repr_args += f", tags={tags}"
-        if start_time:
-            self.repr_args += f", start_time={start_time}"
-        if description:
-            self.repr_args += f", description={description}"
-        if direction:
-            self.repr_args += f", direction={direction}"
-            self.hash_args += f", direction={direction}"
+        self.repr_args, self.hash_args = self.record_tags(
+            value,
+            duration,
+            termination,
+            period,
+            temperature,
+            tags,
+            start_time,
+            description,
+            direction,
+        )
 
         self.description = description
 
@@ -319,6 +310,40 @@ class BaseStep:
             return "Discharge"
         else:
             return "Charge"
+
+    def record_tags(
+        self,
+        value,
+        duration,
+        termination,
+        period,
+        temperature,
+        tags,
+        start_time,
+        description,
+        direction,
+    ):
+        """Record all the args for repr and hash"""
+        repr_args = f"{value}, duration={duration}"
+        hash_args = f"{value}"
+        if termination:
+            repr_args += f", termination={termination}"
+            hash_args += f", termination={termination}"
+        if period:
+            repr_args += f", period={period}"
+        if temperature:
+            repr_args += f", temperature={temperature}"
+            hash_args += f", temperature={temperature}"
+        if tags:
+            repr_args += f", tags={tags}"
+        if start_time:
+            repr_args += f", start_time={start_time}"
+        if description:
+            repr_args += f", description={description}"
+        if direction:
+            repr_args += f", direction={direction}"
+            hash_args += f", direction={direction}"
+        return repr_args, hash_args
 
 
 class BaseStepExplicit(BaseStep):

--- a/pybamm/experiment/step/steps.py
+++ b/pybamm/experiment/step/steps.py
@@ -426,6 +426,9 @@ def value_based_charge_or_discharge(step_value):
     elif isinstance(step_value, pybamm.Symbol):
         inpt = {"start time": 0}
         init_curr = step_value.evaluate(t=0, inputs=inpt).flatten()[0]
+    elif callable(step_value):
+        inpt = {"start time": 0}
+        init_curr = step_value(pybamm.t).evaluate(t=0, inputs=inpt).flatten()[0]
     else:
         init_curr = step_value
     sign = np.sign(init_curr)

--- a/pybamm/experiment/step/steps.py
+++ b/pybamm/experiment/step/steps.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pybamm
 from .base_step import (
     BaseStepExplicit,
@@ -130,7 +129,7 @@ class Current(BaseStepExplicit):
     """
 
     def __init__(self, value, **kwargs):
-        kwargs["direction"] = value_based_charge_or_discharge(value)
+        self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
 
     def current_value(self, variables):
@@ -151,7 +150,7 @@ class CRate(BaseStepExplicit):
     """
 
     def __init__(self, value, **kwargs):
-        kwargs["direction"] = value_based_charge_or_discharge(value)
+        self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
 
     def current_value(self, variables):
@@ -201,7 +200,7 @@ class Power(BaseStepImplicit):
     """
 
     def __init__(self, value, **kwargs):
-        kwargs["direction"] = value_based_charge_or_discharge(value)
+        self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
 
     def get_parameter_values(self, variables):
@@ -232,7 +231,7 @@ class Resistance(BaseStepImplicit):
     """
 
     def __init__(self, value, **kwargs):
-        kwargs["direction"] = value_based_charge_or_discharge(value)
+        self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
 
     def get_parameter_values(self, variables):
@@ -414,27 +413,3 @@ class CustomStepImplicit(BaseStepImplicit):
         return CustomStepImplicit(
             self.current_rhs_function, self.control, **self.kwargs
         )
-
-
-def value_based_charge_or_discharge(step_value):
-    """
-    Determine whether the step is a charge or discharge step based on the value of the
-    step
-    """
-    if isinstance(step_value, np.ndarray):
-        init_curr = step_value[0, 1]
-    elif isinstance(step_value, pybamm.Symbol):
-        inpt = {"start time": 0}
-        init_curr = step_value.evaluate(t=0, inputs=inpt).flatten()[0]
-    elif callable(step_value):
-        inpt = {"start time": 0}
-        init_curr = step_value(pybamm.t).evaluate(t=0, inputs=inpt).flatten()[0]
-    else:
-        init_curr = step_value
-    sign = np.sign(init_curr)
-    if sign == 0:
-        return "Rest"
-    elif sign > 0:
-        return "Discharge"
-    else:
-        return "Charge"

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -392,6 +392,20 @@ class TestSimulation(TestCase):
                     sol[name].entries, np.array(oscillating(sol.t - t0))
                 )
 
+        for x in (np.nan, np.inf):
+
+            def f(t, x=x):
+                return x + t
+
+            with self.assertRaises(ValueError):
+                pybamm.step.current(f)
+
+        def g(t, y):
+            return t
+
+        with self.assertRaises(TypeError):
+            pybamm.step.current(g)
+
     def test_save_load(self):
         with TemporaryDirectory() as dir_name:
             test_name = os.path.join(dir_name, "tests.pickle")

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -380,7 +380,8 @@ class TestSimulation(TestCase):
             "Power [W]": pybamm.step.power,
         }
         for name in operating_modes:
-            step = operating_modes[name](oscillating, duration=tf / 2)
+            operating_mode = operating_modes[name]
+            step = operating_mode(oscillating, duration=tf / 2)
             experiment = pybamm.Experiment([step, step], period=f"{tf / 100} seconds")
 
             solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
@@ -392,19 +393,20 @@ class TestSimulation(TestCase):
                     sol[name].entries, np.array(oscillating(sol.t - t0))
                 )
 
-        for x in (np.nan, np.inf):
+            # check improper inputs
+            for x in (np.nan, np.inf):
 
-            def f(t, x=x):
-                return x + t
+                def f(t, x=x):
+                    return x + t
 
-            with self.assertRaises(ValueError):
-                pybamm.step.current(f)
+                with self.assertRaises(ValueError):
+                    operating_mode(f)
 
-        def g(t, y):
-            return t
+            def g(t, y):
+                return t
 
-        with self.assertRaises(TypeError):
-            pybamm.step.current(g)
+            with self.assertRaises(TypeError):
+                operating_mode(g)
 
     def test_save_load(self):
         with TemporaryDirectory() as dir_name:

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -365,6 +365,33 @@ class TestSimulation(TestCase):
             sim.solution.all_inputs[1]["Current function [A]"], 2
         )
 
+    def test_time_varying_input_function(self):
+        tf = 20.0
+
+        def oscillating(t):
+            return 3.6 + 0.1 * np.sin(2 * np.pi * t / tf)
+
+        model = pybamm.lithium_ion.SPM()
+
+        operating_modes = {
+            "Current [A]": pybamm.step.current,
+            "C-rate": pybamm.step.c_rate,
+            "Voltage [V]": pybamm.step.voltage,
+            "Power [W]": pybamm.step.power,
+        }
+        for name in operating_modes:
+            step = operating_modes[name](oscillating, duration=tf / 2)
+            experiment = pybamm.Experiment([step, step], period=f"{tf / 100} seconds")
+
+            solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
+            sim = pybamm.Simulation(model, experiment=experiment, solver=solver)
+            sim.solve()
+            for sol in sim.solution.sub_solutions:
+                t0 = sol.t[0]
+                np.testing.assert_array_almost_equal(
+                    sol[name].entries, np.array(oscillating(sol.t - t0))
+                )
+
     def test_save_load(self):
         with TemporaryDirectory() as dir_name:
             test_name = os.path.join(dir_name, "tests.pickle")


### PR DESCRIPTION
# Description

Adds functionality to pass in arbitrary functions of time as the argument for a `pybamm.step`

Fixes https://github.com/pybamm-team/PyBaMM/issues/4187

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`) (I haven't gotten `idaklu` installed so I'm not certain all tests pass)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
