### PR TITLE
Fix batch study test

### DIFF
--- a/tests/unit/test_batch_study.py
+++ b/tests/unit/test_batch_study.py
@@ -8,34 +8,38 @@ import pybamm
 import unittest
 from tempfile import TemporaryDirectory
 
-spm = pybamm.lithium_ion.SPM()
-spm_uniform = pybamm.lithium_ion.SPM({"particle": "uniform profile"})
-casadi_safe = pybamm.CasadiSolver(mode="safe")
-casadi_fast = pybamm.CasadiSolver(mode="fast")
-exp1 = pybamm.Experiment([("Discharge at C/5 for 10 minutes", "Rest for 1 hour")])
-exp2 = pybamm.Experiment([("Discharge at C/20 for 10 minutes", "Rest for 1 hour")])
-
-bs_false_only_models = pybamm.BatchStudy(
-    models={"SPM": spm, "SPM uniform": spm_uniform}
-)
-bs_true_only_models = pybamm.BatchStudy(
-    models={"SPM": spm, "SPM uniform": spm_uniform}, permutations=True
-)
-bs_false = pybamm.BatchStudy(
-    models={"SPM": spm, "SPM uniform": spm_uniform},
-    solvers={"casadi safe": casadi_safe, "casadi fast": casadi_fast},
-    experiments={"exp1": exp1, "exp2": exp2},
-)
-bs_true = pybamm.BatchStudy(
-    models={"SPM": spm, "SPM uniform": spm_uniform},
-    solvers={"casadi safe": casadi_safe, "casadi fast": casadi_fast},
-    experiments={"exp2": exp2},
-    permutations=True,
-)
-
 
 class TestBatchStudy(TestCase):
     def test_solve(self):
+        spm = pybamm.lithium_ion.SPM()
+        spm_uniform = pybamm.lithium_ion.SPM({"particle": "uniform profile"})
+        casadi_safe = pybamm.CasadiSolver(mode="safe")
+        casadi_fast = pybamm.CasadiSolver(mode="fast")
+        exp1 = pybamm.Experiment(
+            [("Discharge at C/5 for 10 minutes", "Rest for 1 hour")]
+        )
+        exp2 = pybamm.Experiment(
+            [("Discharge at C/20 for 10 minutes", "Rest for 1 hour")]
+        )
+
+        bs_false_only_models = pybamm.BatchStudy(
+            models={"SPM": spm, "SPM uniform": spm_uniform}
+        )
+        bs_true_only_models = pybamm.BatchStudy(
+            models={"SPM": spm, "SPM uniform": spm_uniform}, permutations=True
+        )
+        bs_false = pybamm.BatchStudy(
+            models={"SPM": spm, "SPM uniform": spm_uniform},
+            solvers={"casadi safe": casadi_safe, "casadi fast": casadi_fast},
+            experiments={"exp1": exp1, "exp2": exp2},
+        )
+        bs_true = pybamm.BatchStudy(
+            models={"SPM": spm, "SPM uniform": spm_uniform},
+            solvers={"casadi safe": casadi_safe, "casadi fast": casadi_fast},
+            experiments={"exp2": exp2},
+            permutations=True,
+        )
+
         # Tests for exceptions
         for name in pybamm.BatchStudy.INPUT_LIST:
             with self.assertRaises(ValueError):
@@ -96,7 +100,12 @@ class TestBatchStudy(TestCase):
                 ValueError, "The simulations have not been solved yet."
             ):
                 pybamm.BatchStudy(
-                    models={"SPM": spm, "SPM uniform": spm_uniform}
+                    models={
+                        "SPM": pybamm.lithium_ion.SPM(),
+                        "SPM uniform": pybamm.lithium_ion.SPM(
+                            {"particle": "uniform profile"}
+                        ),
+                    }
                 ).create_gif()
             bs.solve([0, 10])
 


### PR DESCRIPTION
# Description

When debugging some tests, it went into some classes that are defined at the top level of `test_ batch_study.py`, which made it harder (and a bit slower) to debug. Moving the setup into the test to avoid this - likely a temporary solution anyway before we migrate to pytest

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
