### PR TITLE
Fixes for sympy update

### DIFF
--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -76,22 +76,24 @@ class TestFunction(TestCase):
         self.assertEqual(func.to_equation(), sympy.Symbol("test"))
 
         # Test Arcsinh
-        self.assertEqual(pybamm.Arcsinh(a).to_equation(), sympy.asinh(a))
+        self.assertEqual(pybamm.Arcsinh(a).to_equation(), sympy.asinh("a"))
 
         # Test Arctan
-        self.assertEqual(pybamm.Arctan(a).to_equation(), sympy.atan(a))
+        self.assertEqual(pybamm.Arctan(a).to_equation(), sympy.atan("a"))
 
         # Test Exp
-        self.assertEqual(pybamm.Exp(a).to_equation(), sympy.exp(a))
+        self.assertEqual(pybamm.Exp(a).to_equation(), sympy.exp("a"))
 
         # Test log
-        self.assertEqual(pybamm.Log(54.0).to_equation(), sympy.log(54.0))
+        value = 54.0
+        self.assertEqual(pybamm.Log(value).to_equation(), sympy.log(value))
 
         # Test sinh
-        self.assertEqual(pybamm.Sinh(a).to_equation(), sympy.sinh(a))
+        self.assertEqual(pybamm.Sinh(a).to_equation(), sympy.sinh("a"))
 
         # Test Function
-        self.assertEqual(pybamm.Function(np.log, 10).to_equation(), 10.0)
+        value = 10
+        self.assertEqual(pybamm.Function(np.log, value).to_equation(), value)
 
     def test_to_from_json_error(self):
         a = pybamm.Symbol("a")

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -699,10 +699,11 @@ class TestUnaryOperators(TestCase):
         self.assertEqual(pybamm.Floor(-2.5).to_equation(), sympy.Symbol("test"))
 
         # Test Negate
-        self.assertEqual(pybamm.Negate(4).to_equation(), -4.0)
+        value = 4
+        self.assertEqual(pybamm.Negate(value).to_equation(), -value)
 
         # Test AbsoluteValue
-        self.assertEqual(pybamm.AbsoluteValue(-4).to_equation(), 4.0)
+        self.assertEqual(pybamm.AbsoluteValue(-value).to_equation(), value)
 
         # Test Gradient
         self.assertEqual(pybamm.Gradient(a).to_equation(), sympy_Gradient("a"))
@@ -710,7 +711,7 @@ class TestUnaryOperators(TestCase):
         # Test Divergence
         self.assertEqual(
             pybamm.Divergence(pybamm.Gradient(a)).to_equation(),
-            sympy_Divergence(sympy_Gradient(a)),
+            sympy_Divergence(sympy_Gradient("a")),
         )
 
         # Test BoundaryValue


### PR DESCRIPTION
# Description

SymPy updated and seems to no longer recognize PyBaMM symbols as strings.

It gets to this block (N.B. warning text was edited for readability):
```
    if not isinstance(a, str):
        try:
            a = str(a)
        except Exception as exc:
            raise SympifyError(a, exc)
        sympy_deprecation_warning("The string fallback in sympify() is deprecated.")
```
Then fails due to an exception. Even if it did convert to a string, it would have caused a deprecation warning.

Failing tests looked like this:
```
a = pybamm.Symbol("a", domain="test")
self.assertEqual(pybamm.Arcsinh(a).to_equation(), sympy.asinh(a))
```

There seemed to be two options:
1.  Add a `pybamm.Symbol._sympy_()` method. This would be basically identical to `pybamm.Symbol.to_equation()`, and would not be a good test.
2. Explicitly put the expected string into the sympy function. This works as a test of `pybamm.Symbol.to_equation()` by confirming that `pybamm.Symbol.print_name()` returns the original name, but could be a bit redundant.

I went with option (2) since it keeps the tests working, but it could be good to determine if `pybamm.Symbol.print_name()` and `pybamm.Symbol.to_equation()` could be just replaced by a `pybamm.Symbol._sympy_()`method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
