### PR TITLE
Add more `idaklu` solver options (number 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Features
+
+- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
+
+## Breaking changes
+
+- Changed the default `rtol` to `1e-4` in the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
+
 # [v24.5rc2](https://github.com/pybamm-team/PyBaMM/tree/v24.5rc2) - 2024-07-12
 
 ## Features
 
-- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 - Added functionality to pass in arbitrary functions of time as the argument for a (`pybamm.step`). ([#4222](https://github.com/pybamm-team/PyBaMM/pull/4222))
 - Added new parameters `"f{pref]Initial inner SEI on cracks thickness [m]"` and `"f{pref]Initial outer SEI on cracks thickness [m]"`, instead of hardcoding these to `L_inner_0 / 10000` and `L_outer_0 / 10000`. ([#4168](https://github.com/pybamm-team/PyBaMM/pull/4168))
 - Added `pybamm.DataLoader` class to fetch data files from [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0) and store it under local cache. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))
@@ -54,7 +61,6 @@
 
 ## Breaking changes
 
-- Changed the the default `rtol` to `1e-4` in the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 - Functions that are created using `pybamm.Function(function_object, children)` can no longer be differentiated symbolically (e.g. to compute the Jacobian). This should affect no users, since function derivatives for all "standard" functions are explicitly implemented ([#4196](https://github.com/pybamm-team/PyBaMM/pull/4196))
 - Removed data files under `pybamm/input` and released them in a separate repository upstream at [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0). Note that data files under `pybamm/input/parameters` have not been removed. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))
 - Removed `check_model` argument from `Simulation.solve`. To change the `check_model` option, use `Simulation(..., discretisation_kwargs={"check_model": False})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4249](https://github.com/pybamm-team/PyBaMM/pull/4249))
+- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 - Added functionality to pass in arbitrary functions of time as the argument for a (`pybamm.step`). ([#4222](https://github.com/pybamm-team/PyBaMM/pull/4222))
 - Added new parameters `"f{pref]Initial inner SEI on cracks thickness [m]"` and `"f{pref]Initial outer SEI on cracks thickness [m]"`, instead of hardcoding these to `L_inner_0 / 10000` and `L_outer_0 / 10000`. ([#4168](https://github.com/pybamm-team/PyBaMM/pull/4168))
 - Added `pybamm.DataLoader` class to fetch data files from [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0) and store it under local cache. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ## Features
 
-- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
-
-## Breaking changes
-
-- Changed the default `rtol` to `1e-4` in the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
+- Added additional user-configurable options to the (`IDAKLUSolver`) and adjusted the default values to improve performance. ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 
 # [v24.5rc2](https://github.com/pybamm-team/PyBaMM/tree/v24.5rc2) - 2024-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ## Breaking changes
 
+- Changed the the default `rtol` to `1e-4` in the (`IDAKLUSolver`). ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 - Functions that are created using `pybamm.Function(function_object, children)` can no longer be differentiated symbolically (e.g. to compute the Jacobian). This should affect no users, since function derivatives for all "standard" functions are explicitly implemented ([#4196](https://github.com/pybamm-team/PyBaMM/pull/4196))
 - Removed data files under `pybamm/input` and released them in a separate repository upstream at [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0). Note that data files under `pybamm/input/parameters` have not been removed. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))
 - Removed `check_model` argument from `Simulation.solve`. To change the `check_model` option, use `Simulation(..., discretisation_kwargs={"check_model": False})`. ([#4020](https://github.com/pybamm-team/PyBaMM/pull/4020))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Features
 
+- Added additional user-configurable options to the (`IDAKLUSolver`). ([#4249](https://github.com/pybamm-team/PyBaMM/pull/4249))
 - Added functionality to pass in arbitrary functions of time as the argument for a (`pybamm.step`). ([#4222](https://github.com/pybamm-team/PyBaMM/pull/4222))
 - Added new parameters `"f{pref]Initial inner SEI on cracks thickness [m]"` and `"f{pref]Initial outer SEI on cracks thickness [m]"`, instead of hardcoding these to `L_inner_0 / 10000` and `L_outer_0 / 10000`. ([#4168](https://github.com/pybamm-team/PyBaMM/pull/4168))
 - Added `pybamm.DataLoader` class to fetch data files from [pybamm-data](https://github.com/pybamm-team/pybamm-data/releases/tag/v1.0.0) and store it under local cache. ([#4098](https://github.com/pybamm-team/PyBaMM/pull/4098))

--- a/pybamm/solvers/c_solvers/idaklu/Expressions/Base/ExpressionSet.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/Expressions/Base/ExpressionSet.hpp
@@ -31,7 +31,7 @@ public:
     const int n_s,
     const int n_e,
     const int n_p,
-    const Options& options)
+    const SetupOptions& options)
       : number_of_states(n_s),
         number_of_events(n_e),
         number_of_parameters(n_p),
@@ -46,7 +46,7 @@ public:
         events(events),
         tmp_state_vector(number_of_states),
         tmp_sparse_jacobian_data(jac_times_cjmass_nnz),
-        options(options)
+        setup_opts(options)
       {};
 
   int number_of_states;
@@ -73,7 +73,7 @@ public:
   std::vector<int64_t> jac_times_cjmass_colptrs;  // cppcheck-suppress unusedStructMember
   std::vector<realtype> inputs;  // cppcheck-suppress unusedStructMember
 
-  Options options;
+  SetupOptions setup_opts;
 
   virtual realtype *get_tmp_state_vector() = 0;
   virtual realtype *get_tmp_sparse_jacobian_data() = 0;

--- a/pybamm/solvers/c_solvers/idaklu/Expressions/Casadi/CasadiFunctions.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/Expressions/Casadi/CasadiFunctions.hpp
@@ -76,7 +76,7 @@ public:
     const std::vector<BaseFunctionType*>& var_fcns,
     const std::vector<BaseFunctionType*>& dvar_dy_fcns,
     const std::vector<BaseFunctionType*>& dvar_dp_fcns,
-    const Options& options
+    const SetupOptions& setup_opts
   ) :
     rhs_alg_casadi(rhs_alg),
     jac_times_cjmass_casadi(jac_times_cjmass),
@@ -98,7 +98,7 @@ public:
       static_cast<Expression*>(&sens_casadi),
       static_cast<Expression*>(&events_casadi),
       n_s, n_e, n_p,
-      options)
+      setup_opts)
   {
     // convert BaseFunctionType list to CasadiFunction list
     // NOTE: You must allocate ALL std::vector elements before taking references

--- a/pybamm/solvers/c_solvers/idaklu/Expressions/IREE/IREEFunctions.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/Expressions/IREE/IREEFunctions.hpp
@@ -59,7 +59,7 @@ public:
     const std::vector<BaseFunctionType*>& var_fcns,
     const std::vector<BaseFunctionType*>& dvar_dy_fcns,
     const std::vector<BaseFunctionType*>& dvar_dp_fcns,
-    const Options& options
+    const SetupOptions& setup_opts
   ) :
     iree_init_status(iree_init()),
     rhs_alg_iree(rhs_alg),
@@ -82,7 +82,7 @@ public:
       static_cast<Expression*>(&sens_iree),
       static_cast<Expression*>(&events_iree),
       n_s, n_e, n_p,
-      options)
+      setup_opts)
   {
     // convert BaseFunctionType list to IREEFunction list
     // NOTE: You must allocate ALL std::vector elements before taking references

--- a/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
@@ -64,7 +64,8 @@ public:
   std::vector<realtype> res;
   std::vector<realtype> res_dvar_dy;
   std::vector<realtype> res_dvar_dp;
-  Options options;
+  SetupOptions setup_opts;
+  SolverOptions solver_opts;
 
 #if SUNDIALS_VERSION_MAJOR >= 6
   SUNContext sunctx;
@@ -84,7 +85,9 @@ public:
     int jac_bandwidth_lower,
     int jac_bandwidth_upper,
     std::unique_ptr<ExprSet> functions,
-    const Options& options);
+    const SetupOptions &setup_opts,
+    const SolverOptions &solver_opts
+  );
 
   /**
    * @brief Destructor
@@ -139,6 +142,16 @@ public:
    * @brief Allocate memory for matrices (noting appropriate matrix format/types)
    */
   void SetMatrix();
+
+  /**
+   * @brief Apply user-configurable IDA options
+   */
+  void SetSolverOptions();
+
+  /**
+   * @brief Check the return flag for errors
+   */
+  void CheckErrors(int const & flag);
 };
 
 #include "IDAKLUSolverOpenMP.inl"

--- a/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
+++ b/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
@@ -388,8 +388,7 @@ Solution IDAKLUSolverOpenMP<ExprSet>::solve(
   int const init_type = solver_opts.init_all_y_ic ? IDA_Y_INIT : IDA_YA_YDP_INIT;
   if (solver_opts.calc_ic) {
     DEBUG("IDACalcIC");
-    // Do not throw a warning if the initial conditions calculation fails
-    // as the solver will still run
+    // IDACalcIC will throw a warning if it fails to find initial conditions
     IDACalcIC(ida_mem, init_type, t(1));
   }
 

--- a/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP_solvers.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP_solvers.hpp
@@ -61,7 +61,7 @@ public:
     Base::LS = SUNLinSol_SPBCGS(
       Base::yy,
       Base::precon_type,
-      Base::options.linsol_max_iterations,
+      Base::setup_opts.linsol_max_iterations,
       Base::sunctx
     );
     Base::Initialize();
@@ -81,7 +81,7 @@ public:
     Base::LS = SUNLinSol_SPFGMR(
       Base::yy,
       Base::precon_type,
-      Base::options.linsol_max_iterations,
+      Base::setup_opts.linsol_max_iterations,
       Base::sunctx
     );
     Base::Initialize();
@@ -101,7 +101,7 @@ public:
     Base::LS = SUNLinSol_SPGMR(
       Base::yy,
       Base::precon_type,
-      Base::options.linsol_max_iterations,
+      Base::setup_opts.linsol_max_iterations,
       Base::sunctx
     );
     Base::Initialize();
@@ -121,7 +121,7 @@ public:
     Base::LS = SUNLinSol_SPTFQMR(
       Base::yy,
       Base::precon_type,
-      Base::options.linsol_max_iterations,
+      Base::setup_opts.linsol_max_iterations,
       Base::sunctx
     );
     Base::Initialize();

--- a/pybamm/solvers/c_solvers/idaklu/Options.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/Options.cpp
@@ -5,15 +5,14 @@
 
 using namespace std::string_literals;
 
-Options::Options(py::dict options)
-    : print_stats(options["print_stats"].cast<bool>()),
-      jacobian(options["jacobian"].cast<std::string>()),
-      preconditioner(options["preconditioner"].cast<std::string>()),
-      linsol_max_iterations(options["linsol_max_iterations"].cast<int>()),
-      linear_solver(options["linear_solver"].cast<std::string>()),
-      precon_half_bandwidth(options["precon_half_bandwidth"].cast<int>()),
-      precon_half_bandwidth_keep(options["precon_half_bandwidth_keep"].cast<int>()),
-      num_threads(options["num_threads"].cast<int>())
+SetupOptions::SetupOptions(py::dict &py_opts)
+    : jacobian(py_opts["jacobian"].cast<std::string>()),
+      preconditioner(py_opts["preconditioner"].cast<std::string>()),
+      precon_half_bandwidth(py_opts["precon_half_bandwidth"].cast<int>()),
+      precon_half_bandwidth_keep(py_opts["precon_half_bandwidth_keep"].cast<int>()),
+      num_threads(py_opts["num_threads"].cast<int>()),
+      linear_solver(py_opts["linear_solver"].cast<std::string>()),
+      linsol_max_iterations(py_opts["linsol_max_iterations"].cast<int>())
 {
 
     using_sparse_matrix = true;
@@ -118,4 +117,33 @@ Options::Options(py::dict options)
     {
         preconditioner = "none";
     }
+}
+
+SolverOptions::SolverOptions(py::dict &py_opts)
+    : print_stats(py_opts["print_stats"].cast<bool>()),
+      // IDA main solver
+      max_order_bdf(py_opts["max_order_bdf"].cast<int>()),
+      max_num_steps(py_opts["max_num_steps"].cast<int>()),
+      dt_init(RCONST(py_opts["dt_init"].cast<double>())),
+      dt_max(RCONST(py_opts["dt_max"].cast<double>())),
+      max_error_test_failures(py_opts["max_error_test_failures"].cast<int>()),
+      max_nonlinear_iterations(py_opts["max_nonlinear_iterations"].cast<int>()),
+      max_convergence_failures(py_opts["max_convergence_failures"].cast<int>()),
+      nonlinear_convergence_coefficient(RCONST(py_opts["nonlinear_convergence_coefficient"].cast<double>())),
+      nonlinear_convergence_coefficient_ic(RCONST(py_opts["nonlinear_convergence_coefficient_ic"].cast<double>())),
+      suppress_algebraic_error(py_opts["suppress_algebraic_error"].cast<sunbooleantype>()),
+      // IDA initial conditions calculation
+      calc_ic(py_opts["calc_ic"].cast<bool>()),
+      init_all_y_ic(py_opts["init_all_y_ic"].cast<bool>()),
+      max_num_steps_ic(py_opts["max_num_steps_ic"].cast<int>()),
+      max_num_jacobians_ic(py_opts["max_num_jacobians_ic"].cast<int>()),
+      max_num_iterations_ic(py_opts["max_num_iterations_ic"].cast<int>()),
+      max_linesearch_backtracks_ic(py_opts["max_linesearch_backtracks_ic"].cast<int>()),
+      linesearch_off_ic(py_opts["linesearch_off_ic"].cast<sunbooleantype>()),
+      // IDALS linear solver interface
+      linear_solution_scaling(py_opts["linear_solution_scaling"].cast<sunbooleantype>()),
+      epsilon_linear_tolerance(RCONST(py_opts["epsilon_linear_tolerance"].cast<double>())),
+      increment_factor(RCONST(py_opts["increment_factor"].cast<double>()))
+{
+
 }

--- a/pybamm/solvers/c_solvers/idaklu/Options.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/Options.cpp
@@ -144,6 +144,4 @@ SolverOptions::SolverOptions(py::dict &py_opts)
       linear_solution_scaling(py_opts["linear_solution_scaling"].cast<sunbooleantype>()),
       epsilon_linear_tolerance(RCONST(py_opts["epsilon_linear_tolerance"].cast<double>())),
       increment_factor(RCONST(py_opts["increment_factor"].cast<double>()))
-{
-
-}
+{}

--- a/pybamm/solvers/c_solvers/idaklu/Options.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/Options.hpp
@@ -4,22 +4,52 @@
 #include "common.hpp"
 
 /**
- * @brief Options passed to the idaklu solver by pybamm
+ * @brief SetupOptions passed to the idaklu setup by pybamm
  */
-struct Options {
-  bool print_stats;
+struct SetupOptions {
   bool using_sparse_matrix;
   bool using_banded_matrix;
   bool using_iterative_solver;
   std::string jacobian;
-  std::string linear_solver; // klu, lapack, spbcg
   std::string preconditioner; // spbcg
-  int linsol_max_iterations;
   int precon_half_bandwidth;
   int precon_half_bandwidth_keep;
   int num_threads;
-  explicit Options(py::dict options);
+  // IDALS linear solver interface
+  std::string linear_solver; // klu, lapack, spbcg
+  int linsol_max_iterations;
+  explicit SetupOptions(py::dict &py_opts);
+};
 
+/**
+ * @brief SolverOptions passed to the idaklu solver by pybamm
+ */
+struct SolverOptions {
+  bool print_stats;
+  // IDA main solver
+  int max_order_bdf;
+  int max_num_steps;
+  double dt_init;
+  double dt_max;
+  int max_error_test_failures;
+  int max_nonlinear_iterations;
+  int max_convergence_failures;
+  double nonlinear_convergence_coefficient;
+  double nonlinear_convergence_coefficient_ic;
+  sunbooleantype suppress_algebraic_error;
+  // IDA initial conditions calculation
+  bool calc_ic;
+  bool init_all_y_ic;
+  int max_num_steps_ic;
+  int max_num_jacobians_ic;
+  int max_num_iterations_ic;
+  int max_linesearch_backtracks_ic;
+  sunbooleantype linesearch_off_ic;
+  // IDALS linear solver interface
+  sunbooleantype linear_solution_scaling;
+  double epsilon_linear_tolerance;
+  double increment_factor;
+  explicit SolverOptions(py::dict &py_opts);
 };
 
 #endif // PYBAMM_OPTIONS_HPP

--- a/pybamm/solvers/c_solvers/idaklu/idaklu_solver.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/idaklu_solver.hpp
@@ -33,9 +33,10 @@ IDAKLUSolver *create_idaklu_solver(
   const std::vector<typename ExprSet::BaseFunctionType*>& var_fcns,
   const std::vector<typename ExprSet::BaseFunctionType*>& dvar_dy_fcns,
   const std::vector<typename ExprSet::BaseFunctionType*>& dvar_dp_fcns,
-  py::dict options
+  py::dict py_opts
 ) {
-  auto options_cpp = Options(options);
+  auto setup_opts = SetupOptions(py_opts);
+  auto solver_opts = SolverOptions(py_opts);
   auto functions = std::make_unique<ExprSet>(
     rhs_alg,
     jac_times_cjmass,
@@ -55,13 +56,13 @@ IDAKLUSolver *create_idaklu_solver(
     var_fcns,
     dvar_dy_fcns,
     dvar_dp_fcns,
-    options_cpp
+    setup_opts
   );
 
   IDAKLUSolver *idakluSolver = nullptr;
 
   // Instantiate solver class
-  if (options_cpp.linear_solver == "SUNLinSol_Dense")
+  if (setup_opts.linear_solver == "SUNLinSol_Dense")
   {
     DEBUG("\tsetting SUNLinSol_Dense linear solver");
     idakluSolver = new IDAKLUSolverOpenMP_Dense<ExprSet>(
@@ -74,10 +75,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_KLU")
+  else if (setup_opts.linear_solver == "SUNLinSol_KLU")
   {
     DEBUG("\tsetting SUNLinSol_KLU linear solver");
     idakluSolver = new IDAKLUSolverOpenMP_KLU<ExprSet>(
@@ -90,10 +92,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_Band")
+  else if (setup_opts.linear_solver == "SUNLinSol_Band")
   {
     DEBUG("\tsetting SUNLinSol_Band linear solver");
     idakluSolver = new IDAKLUSolverOpenMP_Band<ExprSet>(
@@ -106,10 +109,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_SPBCGS")
+  else if (setup_opts.linear_solver == "SUNLinSol_SPBCGS")
   {
     DEBUG("\tsetting SUNLinSol_SPBCGS_linear solver");
     idakluSolver = new IDAKLUSolverOpenMP_SPBCGS<ExprSet>(
@@ -122,10 +126,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_SPFGMR")
+  else if (setup_opts.linear_solver == "SUNLinSol_SPFGMR")
   {
     DEBUG("\tsetting SUNLinSol_SPFGMR_linear solver");
     idakluSolver = new IDAKLUSolverOpenMP_SPFGMR<ExprSet>(
@@ -138,10 +143,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_SPGMR")
+  else if (setup_opts.linear_solver == "SUNLinSol_SPGMR")
   {
     DEBUG("\tsetting SUNLinSol_SPGMR solver");
     idakluSolver = new IDAKLUSolverOpenMP_SPGMR<ExprSet>(
@@ -154,10 +160,11 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
-  else if (options_cpp.linear_solver == "SUNLinSol_SPTFQMR")
+  else if (setup_opts.linear_solver == "SUNLinSol_SPTFQMR")
   {
     DEBUG("\tsetting SUNLinSol_SPGMR solver");
     idakluSolver = new IDAKLUSolverOpenMP_SPTFQMR<ExprSet>(
@@ -170,7 +177,8 @@ IDAKLUSolver *create_idaklu_solver(
       jac_bandwidth_lower,
       jac_bandwidth_upper,
       std::move(functions),
-      options_cpp
+      setup_opts,
+      solver_opts
      );
   }
 

--- a/pybamm/solvers/c_solvers/idaklu/sundials_functions.inl
+++ b/pybamm/solvers/c_solvers/idaklu/sundials_functions.inl
@@ -161,11 +161,11 @@ int jacobian_eval(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
 
   // create pointer to jac data, column pointers, and row values
   realtype *jac_data;
-  if (p_python_functions->options.using_sparse_matrix)
+  if (p_python_functions->setup_opts.using_sparse_matrix)
   {
     jac_data = SUNSparseMatrix_Data(JJ);
   }
-  else if (p_python_functions->options.using_banded_matrix) {
+  else if (p_python_functions->setup_opts.using_banded_matrix) {
     jac_data = p_python_functions->get_tmp_sparse_jacobian_data();
   }
   else
@@ -191,7 +191,7 @@ int jacobian_eval(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
   DEBUG("cj = " << cj);
   DEBUG_v(jac_data, 100);
 
-  if (p_python_functions->options.using_banded_matrix)
+  if (p_python_functions->setup_opts.using_banded_matrix)
   {
     // copy data from temporary matrix to the banded matrix
     auto jac_colptrs = p_python_functions->jac_times_cjmass_colptrs.data();
@@ -207,7 +207,7 @@ int jacobian_eval(realtype tt, realtype cj, N_Vector yy, N_Vector yp,
       }
     }
   }
-  else if (p_python_functions->options.using_sparse_matrix)
+  else if (p_python_functions->setup_opts.using_sparse_matrix)
   {
     if (SUNSparseMatrix_SparseType(JJ) == CSC_MAT)
     {

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -120,13 +120,36 @@ class IDAKLUSolver(pybamm.BaseSolver):
         default_options = {
             "print_stats": False,
             "jacobian": "sparse",
-            "linear_solver": "SUNLinSol_KLU",
             "preconditioner": "BBDP",
-            "linsol_max_iterations": 5,
             "precon_half_bandwidth": 5,
             "precon_half_bandwidth_keep": 5,
             "num_threads": 1,
             "jax_evaluator": "jax",
+            # IDA main solver
+            "max_order_bdf": 5,
+            "max_num_steps": 500,
+            "dt_init": 0.0,  # The solver default is used if this is left at zero
+            "dt_max": 0.0,  # The solver default is used if this is left at zero
+            "max_error_test_failures": 10,
+            "max_nonlinear_iterations": 4,
+            "max_convergence_failures": 10,
+            "nonlinear_convergence_coefficient": 0.33,
+            "suppress_algebraic_error": False,
+            # IDA initial conditions calculation
+            "nonlinear_convergence_coefficient_ic": 0.0033,
+            "max_num_steps_ic": 5,
+            "max_num_jacobians_ic": 4,
+            "max_num_iterations_ic": 10,
+            "max_linesearch_backtracks_ic": 100,
+            "linesearch_off_ic": False,
+            "init_all_y_ic": False,
+            "calc_ic": True,
+            # IDALS linear solver interface
+            "linear_solver": "SUNLinSol_KLU",
+            "linsol_max_iterations": 5,
+            "epsilon_linear_tolerance": 0.05,
+            "increment_factor": 1.0,
+            "linear_solution_scaling": True,
         }
         if options is None:
             options = default_options
@@ -912,73 +935,71 @@ class IDAKLUSolver(pybamm.BaseSolver):
         else:
             yS_out = False
 
-        if sol.flag in [0, 2]:
-            # 0 = solved for all t_eval
-            if sol.flag == 0:
-                termination = "final time"
-            # 2 = found root(s)
-            elif sol.flag == 2:
-                termination = "event"
-
-            newsol = pybamm.Solution(
-                sol.t,
-                np.transpose(y_out),
-                model,
-                inputs_dict,
-                np.array([t[-1]]),
-                np.transpose(y_out[-1])[:, np.newaxis],
-                termination,
-                sensitivities=yS_out,
-            )
-            newsol.integration_time = integration_time
-            if self.output_variables:
-                # Populate variables and sensititivies dictionaries directly
-                number_of_samples = sol.y.shape[0] // number_of_timesteps
-                sol.y = sol.y.reshape((number_of_timesteps, number_of_samples))
-                startk = 0
-                for _, var in enumerate(self.output_variables):
-                    # ExplicitTimeIntegral's are not computed as part of the solver and
-                    # do not need to be converted
-                    if isinstance(
-                        model.variables_and_events[var], pybamm.ExplicitTimeIntegral
-                    ):
-                        continue
-                    if model.convert_to_format == "casadi":
-                        len_of_var = (
-                            self._setup["var_fcns"][var](0.0, 0.0, 0.0).sparsity().nnz()
-                        )
-                        base_variables = [self._setup["var_fcns"][var]]
-                    elif (
-                        model.convert_to_format == "jax"
-                        and self._options["jax_evaluator"] == "iree"
-                    ):
-                        idx = self.output_variables.index(var)
-                        len_of_var = self._setup["var_idaklu_fcns"][idx].nnz
-                        base_variables = [self._setup["var_idaklu_fcns"][idx]]
-                    else:  # pragma: no cover
-                        raise pybamm.SolverError(
-                            "Unsupported evaluation engine for convert_to_format="
-                            + f"{model.convert_to_format} "
-                            + f"(jax_evaluator={self._options['jax_evaluator']})"
-                        )
-                    newsol._variables[var] = pybamm.ProcessedVariableComputed(
-                        [model.variables_and_events[var]],
-                        base_variables,
-                        [sol.y[:, startk : (startk + len_of_var)]],
-                        newsol,
-                    )
-                    # Add sensitivities
-                    newsol[var]._sensitivities = {}
-                    if model.calculate_sensitivities:
-                        for paramk, param in enumerate(inputs_dict.keys()):
-                            newsol[var].add_sensitivity(
-                                param,
-                                [sol.yS[:, startk : (startk + len_of_var), paramk]],
-                            )
-                    startk += len_of_var
-            return newsol
+        # 0 = solved for all t_eval
+        if sol.flag == 0:
+            termination = "final time"
+        # 2 = found root(s)
+        elif sol.flag == 2:
+            termination = "event"
         else:
             raise pybamm.SolverError("idaklu solver failed")
+        newsol = pybamm.Solution(
+            sol.t,
+            np.transpose(y_out),
+            model,
+            inputs_dict,
+            np.array([t[-1]]),
+            np.transpose(y_out[-1])[:, np.newaxis],
+            termination,
+            sensitivities=yS_out,
+        )
+        newsol.integration_time = integration_time
+        if self.output_variables:
+            # Populate variables and sensititivies dictionaries directly
+            number_of_samples = sol.y.shape[0] // number_of_timesteps
+            sol.y = sol.y.reshape((number_of_timesteps, number_of_samples))
+            startk = 0
+            for var in self.output_variables:
+                # ExplicitTimeIntegral's are not computed as part of the solver and
+                # do not need to be converted
+                if isinstance(
+                    model.variables_and_events[var], pybamm.ExplicitTimeIntegral
+                ):
+                    continue
+                if model.convert_to_format == "casadi":
+                    len_of_var = (
+                        self._setup["var_fcns"][var](0.0, 0.0, 0.0).sparsity().nnz()
+                    )
+                    base_variables = [self._setup["var_fcns"][var]]
+                elif (
+                    model.convert_to_format == "jax"
+                    and self._options["jax_evaluator"] == "iree"
+                ):
+                    idx = self.output_variables.index(var)
+                    len_of_var = self._setup["var_idaklu_fcns"][idx].nnz
+                    base_variables = [self._setup["var_idaklu_fcns"][idx]]
+                else:  # pragma: no cover
+                    raise pybamm.SolverError(
+                        "Unsupported evaluation engine for convert_to_format="
+                        + f"{model.convert_to_format} "
+                        + f"(jax_evaluator={self._options['jax_evaluator']})"
+                    )
+                newsol._variables[var] = pybamm.ProcessedVariableComputed(
+                    [model.variables_and_events[var]],
+                    base_variables,
+                    [sol.y[:, startk : (startk + len_of_var)]],
+                    newsol,
+                )
+                # Add sensitivities
+                newsol[var]._sensitivities = {}
+                if model.calculate_sensitivities:
+                    for paramk, param in enumerate(inputs_dict.keys()):
+                        newsol[var].add_sensitivity(
+                            param,
+                            [sol.yS[:, startk : (startk + len_of_var), paramk]],
+                        )
+                startk += len_of_var
+        return newsol
 
     def jaxify(
         self,

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/base_lithium_ion_tests.py
@@ -20,10 +20,12 @@ class BaseIntegrationTestLithiumIon:
     def test_sensitivities(self):
         model = self.model()
         param = pybamm.ParameterValues("Ecker2015")
+        rtol = 1e-6
+        atol = 1e-6
         if pybamm.have_idaklu():
-            solver = pybamm.IDAKLUSolver()
+            solver = pybamm.IDAKLUSolver(rtol=rtol, atol=atol)
         else:
-            solver = pybamm.CasadiSolver()
+            solver = pybamm.CasadiSolver(rtol=rtol, atol=atol)
         modeltest = tests.StandardModelTest(
             model, parameter_values=param, solver=solver
         )

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -660,7 +660,7 @@ class TestIDAKLUSolver(TestCase):
         # test everything works
         for option in options_success:
             options = {option: options_success[option]}
-            solver = pybamm.IDAKLUSolver(options=options)
+            solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6, options=options)
             soln = solver.solve(model, t_eval)
 
             np.testing.assert_array_almost_equal(soln.y, soln_base.y, 5)

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -241,6 +241,8 @@ class TestIDAKLUSolver(TestCase):
                 disc = pybamm.Discretisation()
                 disc.process_model(model)
                 solver = pybamm.IDAKLUSolver(
+                    rtol=1e-6,
+                    atol=1e-6,
                     root_method=root_method,
                     output_variables=output_variables,
                     options={"jax_evaluator": "iree"} if form == "iree" else {},


### PR DESCRIPTION
# Description

Adds more user-configurable options to the IDA solver following the list in the IDA guide.

Some code cleanup to enforce early returns.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
