### PR TITLE
fix bug in composite surface form model

### DIFF
--- a/pybamm/models/submodels/electrolyte_conductivity/surface_potential_form/composite_surface_form_conductivity.py
+++ b/pybamm/models/submodels/electrolyte_conductivity/surface_potential_form/composite_surface_form_conductivity.py
@@ -99,6 +99,10 @@ class CompositeDifferential(BaseModel):
     def set_rhs(self, variables):
         domain = self.domain
 
+        a = variables[
+            f"X-averaged {domain} electrode surface area to volume ratio [m-1]"
+        ]
+
         sum_a_j = variables[
             f"Sum of x-averaged {domain} electrode volumetric "
             "interfacial current densities [A.m-3]"
@@ -116,7 +120,7 @@ class CompositeDifferential(BaseModel):
 
         C_dl = self.domain_param.C_dl(T)
 
-        self.rhs[delta_phi] = 1 / C_dl * (sum_a_j_av - sum_a_j)
+        self.rhs[delta_phi] = 1 / (a * C_dl) * (sum_a_j_av - sum_a_j)
 
 
 class CompositeAlgebraic(BaseModel):


### PR DESCRIPTION
# Description
Fixes a bug where a factor of electrode surface area to volume ratio is missing in the rhs of the `CompositeDifferential` conductivity model.

In particular, this fixes the missing semi-circle when simulating EIS with SPMe. This got missed in https://github.com/pybamm-team/PyBaMM/pull/4139

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
