### PR TITLE
3937 events with idaklu output variables - solver edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added additional user-configurable options to the (`IDAKLUSolver`) and adjusted the default values to improve performance. ([#4282](https://github.com/pybamm-team/PyBaMM/pull/4282))
 
+## Bug Fixes
+
+- Fixed bug where IDAKLU solver failed when `output variables` were specified and an event triggered. ([#4300](https://github.com/pybamm-team/PyBaMM/pull/4300))
+
 # [v24.5](https://github.com/pybamm-team/PyBaMM/tree/v24.5) - 2024-07-26
 
 ## Features

--- a/pybamm/solvers/c_solvers/idaklu.cpp
+++ b/pybamm/solvers/c_solvers/idaklu.cpp
@@ -187,5 +187,6 @@ PYBIND11_MODULE(idaklu, m)
     .def_readwrite("t", &Solution::t)
     .def_readwrite("y", &Solution::y)
     .def_readwrite("yS", &Solution::yS)
+    .def_readwrite("y_term", &Solution::y_term)
     .def_readwrite("flag", &Solution::flag);
 }

--- a/pybamm/solvers/c_solvers/idaklu/Solution.hpp
+++ b/pybamm/solvers/c_solvers/idaklu/Solution.hpp
@@ -12,8 +12,8 @@ public:
   /**
    * @brief Constructor
    */
-  Solution(int retval, np_array t_np, np_array y_np, np_array yS_np)
-      : flag(retval), t(t_np), y(y_np), yS(yS_np)
+  Solution(int retval, np_array t_np, np_array y_np, np_array yS_np, np_array y_term_np)
+      : flag(retval), t(t_np), y(y_np), yS(yS_np), y_term(y_term_np)
   {
   }
 
@@ -21,6 +21,7 @@ public:
   np_array t;
   np_array y;
   np_array yS;
+  np_array y_term;
 };
 
 #endif // PYBAMM_IDAKLU_COMMON_HPP

--- a/pybamm/solvers/c_solvers/idaklu/python.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/python.cpp
@@ -396,7 +396,6 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
     std::vector<double> t_return(number_of_timesteps);
     std::vector<double> y_return(number_of_timesteps * number_of_states);
     std::vector<double> yS_return(number_of_parameters * number_of_timesteps * number_of_states);
-    std::vector<double> yterm_return(number_of_states);
 
     t_return[0] = t(0);
     for (int j = 0; j < number_of_states; j++)
@@ -450,11 +449,6 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
             }
             t_i += 1;
             if (retval == IDA_SUCCESS || retval == IDA_ROOT_RETURN) {
-                // Store the final state vector
-                for (int j = 0; j < number_of_states; j++)
-                {
-                    yterm_return[j] = yval[j];
-                }
                 break;
             }
 
@@ -484,7 +478,7 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
                           std::vector<ptrdiff_t> {number_of_parameters, number_of_timesteps, number_of_states},
                           &yS_return[0]
                       );
-    np_array yterm_ret = np_array(number_of_states, &yterm_return[0]);
+    np_array yterm_ret = np_array(0);
 
     Solution sol(retval, t_ret, y_ret, yS_ret, yterm_ret);
 

--- a/pybamm/solvers/c_solvers/idaklu/python.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/python.cpp
@@ -478,8 +478,9 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
                           std::vector<ptrdiff_t> {number_of_parameters, number_of_timesteps, number_of_states},
                           &yS_return[0]
                       );
+    np_array yterm_ret = np_array(0); // TODO: this will need filling in
 
-    Solution sol(retval, t_ret, y_ret, yS_ret);
+    Solution sol(retval, t_ret, y_ret, yS_ret, yterm_ret);
 
     return sol;
 }

--- a/pybamm/solvers/c_solvers/idaklu/python.cpp
+++ b/pybamm/solvers/c_solvers/idaklu/python.cpp
@@ -396,6 +396,7 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
     std::vector<double> t_return(number_of_timesteps);
     std::vector<double> y_return(number_of_timesteps * number_of_states);
     std::vector<double> yS_return(number_of_parameters * number_of_timesteps * number_of_states);
+    std::vector<double> yterm_return(number_of_states);
 
     t_return[0] = t(0);
     for (int j = 0; j < number_of_states; j++)
@@ -449,6 +450,11 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
             }
             t_i += 1;
             if (retval == IDA_SUCCESS || retval == IDA_ROOT_RETURN) {
+                // Store the final state vector
+                for (int j = 0; j < number_of_states; j++)
+                {
+                    yterm_return[j] = yval[j];
+                }
                 break;
             }
 
@@ -478,7 +484,7 @@ Solution solve_python(np_array t_np, np_array y0_np, np_array yp0_np,
                           std::vector<ptrdiff_t> {number_of_parameters, number_of_timesteps, number_of_states},
                           &yS_return[0]
                       );
-    np_array yterm_ret = np_array(0); // TODO: this will need filling in
+    np_array yterm_ret = np_array(number_of_states, &yterm_return[0]);
 
     Solution sol(retval, t_ret, y_ret, yS_ret, yterm_ret);
 

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -970,8 +970,10 @@ class IDAKLUSolver(pybamm.BaseSolver):
         if self.output_variables:
             # Substitute empty vectors for state vector 'y'
             y_out = np.zeros((number_of_timesteps * number_of_states, 0))
+            y_event = sol.y_term
         else:
             y_out = sol.y.reshape((number_of_timesteps, number_of_states))
+            y_event = y_out[-1]
 
         # return sensitivity solution, we need to flatten yS to
         # (#timesteps * #states (where t is changing the quickest),)
@@ -1001,7 +1003,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             model,
             inputs_dict,
             np.array([t[-1]]),
-            np.transpose(sol.y_term)[:, np.newaxis],
+            np.transpose(y_event)[:, np.newaxis],
             termination,
             sensitivities=yS_out,
         )

--- a/pybamm/solvers/idaklu_solver.py
+++ b/pybamm/solvers/idaklu_solver.py
@@ -816,6 +816,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
                 def fcn(*args):
                     return fcn_inner(*args)[coo.row, coo.col]
+
             elif coo.nnz != iree_fcn.numel:
                 iree_fcn.nnz = iree_fcn.numel
                 iree_fcn.col = list(range(iree_fcn.numel))
@@ -1000,7 +1001,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             model,
             inputs_dict,
             np.array([t[-1]]),
-            np.transpose(y_out[-1])[:, np.newaxis],
+            np.transpose(sol.y_term)[:, np.newaxis],
             termination,
             sensitivities=yS_out,
         )

--- a/pybamm/solvers/solution.py
+++ b/pybamm/solvers/solution.py
@@ -100,10 +100,6 @@ class Solution:
 
         self.sensitivities = sensitivities
 
-        self._t_event = t_event
-        self._y_event = y_event
-        self._termination = termination
-
         # Check no ys are too large
         if check_solution:
             self.check_ys_are_not_too_large()

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -905,16 +905,6 @@ class TestIDAKLUSolver(TestCase):
         sol = sim.solve(np.linspace(0, 3600, 1000))
         self.assertEqual(sol.termination, "event: Minimum voltage [V]")
 
-        sim2 = pybamm.Simulation(
-            model,
-            parameter_values=parameter_values,
-            solver=pybamm.IDAKLUSolver(output_variables=["Cell temperature [K]"]),
-        )
-        with self.assertRaisesRegex(
-            ValueError, "cannot be calculated using the current output variables"
-        ):
-            sim2.solve(np.linspace(0, 3600, 1000))
-
         # create an event that doesn't require the state vector
         eps_p = model.variables["Positive electrode porosity"]
         model.events.append(

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -893,6 +893,46 @@ class TestIDAKLUSolver(TestCase):
                 output_variables=["Terminal voltage [V]"],
             )
 
+    def test_with_output_variables_and_event_termination(self):
+        model = pybamm.lithium_ion.DFN()
+        parameter_values = pybamm.ParameterValues("Chen2020")
+
+        sim = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
+        )
+        sol = sim.solve(np.linspace(0, 3600, 1000))
+        self.assertEqual(sol.termination, "event: Minimum voltage [V]")
+
+        sim2 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Cell temperature [K]"]),
+        )
+        with self.assertRaisesRegex(
+            ValueError, "cannot be calculated using the current output variables"
+        ):
+            sim2.solve(np.linspace(0, 3600, 1000))
+
+        # create an event that doesn't require the state vector
+        eps_p = model.variables["Positive electrode porosity"]
+        model.events.append(
+            pybamm.Event(
+                "Zero positive electrode porosity cut-off",
+                pybamm.min(eps_p),
+                pybamm.EventType.TERMINATION,
+            )
+        )
+
+        sim3 = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            solver=pybamm.IDAKLUSolver(output_variables=["Terminal voltage [V]"]),
+        )
+        sol3 = sim3.solve(np.linspace(0, 3600, 1000))
+        self.assertEqual(sol3.termination, "event: Minimum voltage [V]")
+
 
 if __name__ == "__main__":
     print("Add -v for more debug output")


### PR DESCRIPTION
# Description

This is an alternative to #4150 (old pull request will be closed)

Simulations using the IDAKLU solver with output variables specified which terminated with an event rather than the final time step would crash trying to find the termination event.

Termination events are found in the Solution class by using the state vector of the final time-step to evaluate each potential termination event and find the minimum (the event which caused the termination). When output variables are specified in the IDAKLU solver only those variables are output in `y_out`, not the entire state vector, so the events could not be evaluated outside the solver.

This PR edits the IDAKLU solver to add an additional return value containing the state vector for the final timestep only ('y_term') when output variables are specified. This value is used to fill the `Solution.y_event` attribute and allows termination events to be calculated as normal, while not impacting the performance advantages of selecting only a few output variables. When output variables are not specified, this returns an empty array as it copies part of the provided state vector.

Fixes #3937 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
