### PR TITLE
Removed pybtex warnings on downstream projects

### DIFF
--- a/src/pybamm/citations.py
+++ b/src/pybamm/citations.py
@@ -68,15 +68,12 @@ class Citations:
         """
         try:
             parse_file = import_optional_dependency("pybtex.database", "parse_file")
-            citations_file = os.path.join(pybamm.__path__[0], "CITATIONS.bib")
+            citations_file = os.path.join(pybamm.root_dir(), "pybamm", "CITATIONS.bib")
             bib_data = parse_file(citations_file, bib_format="bibtex")
             for key, entry in bib_data.entries.items():
                 self._add_citation(key, entry)
         except ModuleNotFoundError:  # pragma: no cover
-            pybamm.logger.warning(
-                "Citations could not be read because the 'pybtex' library is not installed. "
-                "Install 'pybamm[cite]' to enable citation reading."
-            )
+            pass
 
     def _add_citation(self, key, entry):
         """Adds `entry` to `self._all_citations` under `key`, warning the user if a
@@ -272,15 +269,20 @@ class Citations:
 
 def print_citations(filename=None, output_format="text", verbose=False):
     """See :meth:`Citations.print`"""
+    try:
+        import_optional_dependency("pybtex")
+    except ImportError:
+        raise ImportError(
+            "Citations could not be read because the 'pybtex' library is not installed. " 
+            "Install 'pybamm[cite]' to enable citation reading."
+        )
+    
     if verbose:  # pragma: no cover
         if filename is not None:  # pragma: no cover
             raise Exception(
                 "Verbose output is available only for the terminal and not for printing to files",
             )
         else:
-            citations.print(filename, output_format, verbose=True)
+            pybamm.citations.print(filename, output_format, verbose=True)
     else:
         pybamm.citations.print(filename, output_format)
-
-
-citations = Citations()

--- a/src/pybamm/citations.py
+++ b/src/pybamm/citations.py
@@ -275,13 +275,13 @@ def print_citations(filename=None, output_format="text", verbose=False):
         raise ImportError(
             "Citations could not be read because the 'pybtex' library is not installed. "
             "Install 'pybamm[cite]' to enable citation reading."
-        )
+        ) from None
 
     if verbose:  # pragma: no cover
         if filename is not None:  # pragma: no cover
             raise Exception(
-                "Verbose output is available only for the terminal and not for printing to files",
-            )
+                "Verbose output is available only for the terminal and not for printing to files"
+            ) from None
         else:
             pybamm.citations.print(filename, output_format, verbose=True)
     else:

--- a/src/pybamm/citations.py
+++ b/src/pybamm/citations.py
@@ -273,10 +273,10 @@ def print_citations(filename=None, output_format="text", verbose=False):
         import_optional_dependency("pybtex")
     except ImportError:
         raise ImportError(
-            "Citations could not be read because the 'pybtex' library is not installed. " 
+            "Citations could not be read because the 'pybtex' library is not installed. "
             "Install 'pybamm[cite]' to enable citation reading."
         )
-    
+
     if verbose:  # pragma: no cover
         if filename is not None:  # pragma: no cover
             raise Exception(

--- a/src/pybamm/citations.py
+++ b/src/pybamm/citations.py
@@ -173,7 +173,7 @@ class Citations:
                 f"Could not parse citation for '{key}' because the 'pybtex' library is not installed. "
                 "Install 'pybamm[cite]' to enable citation parsing.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
 
     def _tag_citations(self):
@@ -264,7 +264,7 @@ class Citations:
                 "Could not print citations because the 'pybtex' library is not installed. "
                 "Please, install 'pybamm[cite]' to print citations.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
 
 
@@ -279,5 +279,6 @@ def print_citations(filename=None, output_format="text", verbose=False):
             citations.print(filename, output_format, verbose=True)
     else:
         pybamm.citations.print(filename, output_format)
+
 
 citations = Citations()


### PR DESCRIPTION
# Description

This PR aims to remove the unnecessary citation warning by replacing the warning with a pass statement.

Fixes #4304

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
