### PR TITLE
Fixed JAX solver compatibility test

### DIFF
--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,6 +88,10 @@ class TestUtil:
             path = os.path.join(package_dir, tempfile_obj.name)
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
+@pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
+def test_is_jax_compatible():
+    compatible = pybamm.is_jax_compatible()
+    assert compatible
     def test_git_commit_info(self):
         git_commit_info = pybamm.get_git_commit_info()
         assert isinstance(git_commit_info, str)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,12 +88,6 @@ class TestUtil:
             path = os.path.join(package_dir, tempfile_obj.name)
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
-    @pytest.mark.skipif(
-        pybamm.is_jax_compatible(), reason="The JAX solver is compatible"
-    )
-    def test_is_jax_compatible(self):
-        assert True
-
     def test_git_commit_info(self):
         git_commit_info = pybamm.get_git_commit_info()
         assert isinstance(git_commit_info, str)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,10 +88,12 @@ class TestUtil:
             path = os.path.join(package_dir, tempfile_obj.name)
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
+
 @pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
 def test_is_jax_compatible():
     compatible = pybamm.is_jax_compatible()
     assert compatible
+
     def test_git_commit_info(self):
         git_commit_info = pybamm.get_git_commit_info()
         assert isinstance(git_commit_info, str)

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,7 +88,6 @@ class TestUtil:
             path = os.path.join(package_dir, tempfile_obj.name)
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
-
     @pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
     def test_is_jax_compatible():
         assert pybamm.is_jax_compatible()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -89,7 +89,7 @@ class TestUtil:
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
     @pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
-    def test_is_jax_compatible():
+    def test_is_jax_compatible(self):
         assert pybamm.is_jax_compatible()
 
     def test_git_commit_info(self):

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -89,10 +89,9 @@ class TestUtil:
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
 
-@pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
-def test_is_jax_compatible():
-    compatible = pybamm.is_jax_compatible()
-    assert compatible
+    @pytest.mark.skipif(not pybamm.have_jax(), reason="JAX is not installed")
+    def test_is_jax_compatible():
+        assert pybamm.is_jax_compatible()
 
     def test_git_commit_info(self):
         git_commit_info = pybamm.get_git_commit_info()

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -88,7 +88,9 @@ class TestUtil:
             path = os.path.join(package_dir, tempfile_obj.name)
             assert pybamm.get_parameters_filepath(tempfile_obj.name) == path
 
-    @pytest.mark.skipif(pybamm.have_jax(), reason="The JAX solver is not installed")
+    @pytest.mark.skipif(
+        pybamm.is_jax_compatible(), reason="The JAX solver is compatible"
+    )
     def test_is_jax_compatible(self):
         assert True
 


### PR DESCRIPTION
# Description

I caught this while running `nox -s unit` and also in CI [here](https://github.com/pybamm-team/PyBaMM/actions/runs/10285560857/job/28464203323).
Instead of checking the compatibility of the JAX solver the test was checking if JAX solver was present and logging `JAX is not installed`, when it should log something like `JAX is compatible` when the check passes inside the `skipif` marker of pytest.

```bash
SKIPPED [1] tests/unit/test_solvers/test_idaklu_jax.py:91: Both IDAKLU and JAX are available
SKIPPED [1] tests/unit/test_util.py:91: The JAX solver is not installed
```

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
