### PR TITLE
Remove "check_already_exists" from BPX

### DIFF
--- a/src/pybamm/parameters/bpx.py
+++ b/src/pybamm/parameters/bpx.py
@@ -214,9 +214,7 @@ def _bpx_to_param_dict(bpx: BPX) -> dict:
         pybamm_dict[domain.pre_name + "conductivity [S.m-1]"] = 4e7
 
     # add a default heat transfer coefficient
-    pybamm_dict.update(
-        {"Total heat transfer coefficient [W.m-2.K-1]": 0}, check_already_exists=False
-    )
+    pybamm_dict.update({"Total heat transfer coefficient [W.m-2.K-1]": 0})
 
     # transport efficiency
     for domain in [negative_electrode, separator, positive_electrode]:

--- a/tests/unit/test_parameters/test_bpx.py
+++ b/tests/unit/test_parameters/test_bpx.py
@@ -238,7 +238,7 @@ class TestBPX(unittest.TestCase):
         with tempfile.NamedTemporaryFile(
             suffix=filename, delete=False, mode="w"
         ) as tmp:
-            # write to a temporay file so we can
+            # write to a temporary file so we can
             # get the source later on using inspect.getsource
             # (as long as the file still exists)
             json.dump(bpx_obj, tmp)

--- a/tests/unit/test_parameters/test_bpx.py
+++ b/tests/unit/test_parameters/test_bpx.py
@@ -1,8 +1,3 @@
-#
-# Tests for the create_from_bpx function
-#
-
-
 import tempfile
 import unittest
 import json
@@ -154,6 +149,13 @@ class TestBPX(unittest.TestCase):
             np.testing.assert_allclose(
                 sols[0]["Voltage [V]"].data, sols[1]["Voltage [V]"].data, atol=1e-7
             )
+
+    def test_no_already_exists_in_BPX(self):
+        with tempfile.NamedTemporaryFile(suffix="test.json", mode="w") as test_file:
+            json.dump(copy.copy(self.base), test_file)
+            test_file.flush()
+            params = pybamm.ParameterValues.create_from_bpx(test_file.name)
+            assert "check_already_exists" not in params.keys()
 
     def test_constant_functions(self):
         bpx_obj = copy.copy(self.base)

--- a/tests/unit/test_parameters/test_bpx.py
+++ b/tests/unit/test_parameters/test_bpx.py
@@ -151,7 +151,9 @@ class TestBPX(unittest.TestCase):
             )
 
     def test_no_already_exists_in_BPX(self):
-        with tempfile.NamedTemporaryFile(suffix="test.json", mode="w") as test_file:
+        with tempfile.NamedTemporaryFile(
+            suffix="test.json", delete=False, mode="w"
+        ) as test_file:
             json.dump(copy.copy(self.base), test_file)
             test_file.flush()
             params = pybamm.ParameterValues.create_from_bpx(test_file.name)
@@ -236,7 +238,7 @@ class TestBPX(unittest.TestCase):
         with tempfile.NamedTemporaryFile(
             suffix=filename, delete=False, mode="w"
         ) as tmp:
-            # write to a tempory file so we can
+            # write to a temporay file so we can
             # get the source later on using inspect.getsource
             # (as long as the file still exists)
             json.dump(bpx_obj, tmp)


### PR DESCRIPTION
# Description

Removed check_already_exists from parameter sets created from BPX parameter sets.

Fixes #4339

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
