### PR TITLE
changed default value to float

### DIFF
--- a/src/pybamm/parameters/parameter_values.py
+++ b/src/pybamm/parameters/parameter_values.py
@@ -79,7 +79,7 @@ class ParameterValues:
                 pybamm.citations.register(citation)
 
     @staticmethod
-    def create_from_bpx(filename, target_soc=1.0):
+    def create_from_bpx(filename, target_soc: float = 1):
         """
         Parameters
         ----------

--- a/src/pybamm/parameters/parameter_values.py
+++ b/src/pybamm/parameters/parameter_values.py
@@ -79,7 +79,7 @@ class ParameterValues:
                 pybamm.citations.register(citation)
 
     @staticmethod
-    def create_from_bpx(filename, target_soc=1):
+    def create_from_bpx(filename, target_soc=1.0):
         """
         Parameters
         ----------


### PR DESCRIPTION
# Description

Default value for  `target_soc` argument in `create_from_bpx` static method is set to `1`.  As the function does not have type hints, `target_soc` data type is inferred as `int` while it is `float`. This causes our linters to fail.

This PR just changes the default value to `1.0` to mitigate linting issues.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
