### PR TITLE
Update IDAKLU time stepping in tests and benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@
 
 ## Optimizations
 
+- Update `IDAKLU` tests and benchmarks to use adaptive time stepping. ([#4390](https://github.com/pybamm-team/PyBaMM/pull/4390))
 - Improved adaptive time-stepping performance of the (`IDAKLUSolver`). ([#4351](https://github.com/pybamm-team/PyBaMM/pull/4351))
 - Improved performance and reliability of DAE consistent initialization. ([#4301](https://github.com/pybamm-team/PyBaMM/pull/4301))
 - Replaced rounded Faraday constant with its exact value in `bpx.py` for better comparison between different tools. ([#4290](https://github.com/pybamm-team/PyBaMM/pull/4290))
 
 ## Bug Fixes
 
-- Fixed memory issue that caused failure when `output variables` were specified with (`IDAKLUSolver`). ([#4379](https://github.com/pybamm-team/PyBaMM/issues/4379))
+- Fixed memory issue that caused failure when `output variables` were specified with (`IDAKLUSolver`). ([#4379](https://github.com/pybamm-team/PyBaMM/pull/4379))
 - Fixed bug where IDAKLU solver failed when `output variables` were specified and an event triggered. ([#4300](https://github.com/pybamm-team/PyBaMM/pull/4300))
 
 ## Breaking changes

--- a/benchmarks/different_model_options.py
+++ b/benchmarks/different_model_options.py
@@ -34,6 +34,7 @@ class SolveModel:
     solver: pybamm.BaseSolver
     model: pybamm.BaseModel
     t_eval: np.ndarray
+    t_interp: np.ndarray | None
 
     def solve_setup(self, parameter, model_, option, value, solver_class):
         import importlib
@@ -51,8 +52,13 @@ class SolveModel:
         self.model = model_({option: value})
         c_rate = 1
         tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
+        if self.solver.supports_interp:
+            self.t_eval = np.array([0, tmax])
+            self.t_interp = None
+        else:
+            nb_points = 500
+            self.t_eval = np.linspace(0, tmax, nb_points)
+            self.t_interp = None
         geometry = self.model.default_geometry
 
         # load parameter values and process model and geometry
@@ -77,7 +83,7 @@ class SolveModel:
         disc.process_model(self.model)
 
     def solve_model(self, _model, _params):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelLossActiveMaterial:
@@ -109,7 +115,7 @@ class TimeSolveLossActiveMaterial(SolveModel):
         )
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelLithiumPlating:
@@ -141,7 +147,7 @@ class TimeSolveLithiumPlating(SolveModel):
         )
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelSEI:
@@ -187,7 +193,7 @@ class TimeSolveSEI(SolveModel):
         SolveModel.solve_setup(self, "Marquis2019", model, "SEI", params, solver_class)
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelParticle:
@@ -229,7 +235,7 @@ class TimeSolveParticle(SolveModel):
         )
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelThermal:
@@ -261,7 +267,7 @@ class TimeSolveThermal(SolveModel):
         )
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeBuildModelSurfaceForm:
@@ -299,4 +305,4 @@ class TimeSolveSurfaceForm(SolveModel):
         )
 
     def time_solve_model(self, _model, _params, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -6,8 +6,8 @@ from benchmarks.benchmark_utils import set_random_seed
 import numpy as np
 
 
-def solve_model_once(model, solver, t_eval):
-    solver.solve(model, t_eval=t_eval)
+def solve_model_once(model, solver, t_eval, t_interp):
+    solver.solve(model, t_eval=t_eval, t_interp=t_interp)
 
 
 class TimeSolveSPM:
@@ -31,6 +31,7 @@ class TimeSolveSPM:
     model: pybamm.BaseModel
     solver: pybamm.BaseSolver
     t_eval: np.ndarray
+    t_interp: np.ndarray | None
 
     def setup(self, solve_first, parameters, solver_class):
         set_random_seed()
@@ -38,8 +39,14 @@ class TimeSolveSPM:
         self.model = pybamm.lithium_ion.SPM()
         c_rate = 1
         tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
+        if self.solver.supports_interp:
+            self.t_eval = np.array([0, tmax])
+            self.t_interp = None
+        else:
+            nb_points = 500
+            self.t_eval = np.linspace(0, tmax, nb_points)
+            self.t_interp = None
+
         geometry = self.model.default_geometry
 
         # load parameter values and process model and geometry
@@ -63,10 +70,10 @@ class TimeSolveSPM:
         disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
         disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, self.solver, self.t_eval)
+            solve_model_once(self.model, self.solver, self.t_eval, self.t_interp)
 
     def time_solve_model(self, _solve_first, _parameters, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeSolveSPMe:
@@ -97,8 +104,13 @@ class TimeSolveSPMe:
         self.model = pybamm.lithium_ion.SPMe()
         c_rate = 1
         tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
+        if self.solver.supports_interp:
+            self.t_eval = np.array([0, tmax])
+            self.t_interp = None
+        else:
+            nb_points = 500
+            self.t_eval = np.linspace(0, tmax, nb_points)
+            self.t_interp = None
         geometry = self.model.default_geometry
 
         # load parameter values and process model and geometry
@@ -122,10 +134,10 @@ class TimeSolveSPMe:
         disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
         disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, self.solver, self.t_eval)
+            solve_model_once(self.model, self.solver, self.t_eval, self.t_interp)
 
     def time_solve_model(self, _solve_first, _parameters, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)
 
 
 class TimeSolveDFN:
@@ -161,8 +173,13 @@ class TimeSolveDFN:
         self.model = pybamm.lithium_ion.DFN()
         c_rate = 1
         tmax = 4000 / c_rate
-        nb_points = 500
-        self.t_eval = np.linspace(0, tmax, nb_points)
+        if self.solver.supports_interp:
+            self.t_eval = np.array([0, tmax])
+            self.t_interp = None
+        else:
+            nb_points = 500
+            self.t_eval = np.linspace(0, tmax, nb_points)
+            self.t_interp = None
         geometry = self.model.default_geometry
 
         # load parameter values and process model and geometry
@@ -186,7 +203,7 @@ class TimeSolveDFN:
         disc = pybamm.Discretisation(mesh, self.model.default_spatial_methods)
         disc.process_model(self.model)
         if solve_first:
-            solve_model_once(self.model, self.solver, self.t_eval)
+            solve_model_once(self.model, self.solver, self.t_eval, self.t_interp)
 
     def time_solve_model(self, _solve_first, _parameters, _solver_class):
-        self.solver.solve(self.model, t_eval=self.t_eval)
+        self.solver.solve(self.model, t_eval=self.t_eval, t_interp=self.t_interp)

--- a/benchmarks/work_precision_sets/time_vs_abstols.py
+++ b/benchmarks/work_precision_sets/time_vs_abstols.py
@@ -42,8 +42,13 @@ for ax, i, j in zip(
         model = i[1].new_copy()
         c_rate = 1
         tmax = 3500 / c_rate
-        nb_points = 500
-        t_eval = np.linspace(0, tmax, nb_points)
+        if solver.supports_interp:
+            t_eval = np.array([0, tmax])
+            t_interp = None
+        else:
+            nb_points = 500
+            t_eval = np.linspace(0, tmax, nb_points)
+            t_interp = None
         geometry = model.default_geometry
 
         # load parameter values and process model and geometry
@@ -69,11 +74,11 @@ for ax, i, j in zip(
 
         for tol in abstols:
             solver.atol = tol
-            solver.solve(model, t_eval=t_eval)
+            solver.solve(model, t_eval=t_eval, t_interp=t_interp)
             time = 0
             runs = 20
             for _ in range(0, runs):
-                solution = solver.solve(model, t_eval=t_eval)
+                solution = solver.solve(model, t_eval=t_eval, t_interp=t_interp)
                 time += solution.solve_time.value
             time = time / runs
 

--- a/benchmarks/work_precision_sets/time_vs_mesh_size.py
+++ b/benchmarks/work_precision_sets/time_vs_mesh_size.py
@@ -17,6 +17,7 @@ models = {"SPM": pybamm.lithium_ion.SPM(), "DFN": pybamm.lithium_ion.DFN()}
 npts = [4, 8, 16, 32, 64]
 
 solvers = {
+    "IDAKLUSolver": pybamm.IDAKLUSolver(),
     "Casadi - safe": pybamm.CasadiSolver(),
     "Casadi - fast": pybamm.CasadiSolver(mode="fast"),
 }

--- a/benchmarks/work_precision_sets/time_vs_no_of_states.py
+++ b/benchmarks/work_precision_sets/time_vs_no_of_states.py
@@ -16,6 +16,7 @@ models = {"SPM": pybamm.lithium_ion.SPM(), "DFN": pybamm.lithium_ion.DFN()}
 npts = [4, 8, 16, 32, 64]
 
 solvers = {
+    "IDAKLUSolver": pybamm.IDAKLUSolver(),
     "Casadi - safe": pybamm.CasadiSolver(),
     "Casadi - fast": pybamm.CasadiSolver(mode="fast"),
 }

--- a/benchmarks/work_precision_sets/time_vs_reltols.py
+++ b/benchmarks/work_precision_sets/time_vs_reltols.py
@@ -48,8 +48,13 @@ for ax, i, j in zip(
         model = i[1].new_copy()
         c_rate = 1
         tmax = 3500 / c_rate
-        nb_points = 500
-        t_eval = np.linspace(0, tmax, nb_points)
+        if solver.supports_interp:
+            t_eval = np.array([0, tmax])
+            t_interp = None
+        else:
+            nb_points = 500
+            t_eval = np.linspace(0, tmax, nb_points)
+            t_interp = None
         geometry = model.default_geometry
 
         # load parameter values and process model and geometry
@@ -75,11 +80,11 @@ for ax, i, j in zip(
 
         for tol in reltols:
             solver.rtol = tol
-            solver.solve(model, t_eval=t_eval)
+            solver.solve(model, t_eval=t_eval, t_interp=t_interp)
             time = 0
             runs = 20
             for _ in range(0, runs):
-                solution = solver.solve(model, t_eval=t_eval)
+                solution = solver.solve(model, t_eval=t_eval, t_interp=t_interp)
                 time += solution.solve_time.value
             time = time / runs
 

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -32,7 +32,7 @@ class TestIDAKLUSolver:
         disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
         disc.process_model(model)
         t_interp = np.linspace(0, 3500, 100)
-        t_eval = np.array([t_interp[0], t_interp[-1]])
+        t_eval = [t_interp[0], t_interp[-1]]
         solver = pybamm.IDAKLUSolver(rtol=1e-10, atol=1e-10)
         solution = solver.solve(
             model,

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -20,9 +20,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         # example provided in sundials
         # see sundials ida examples pdf
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -66,9 +64,7 @@ class TestIDAKLUSolver(unittest.TestCase):
 
     def test_model_events(self):
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -92,15 +88,8 @@ class TestIDAKLUSolver(unittest.TestCase):
                 options={"jax_evaluator": "iree"} if form == "iree" else {},
             )
 
-            if model.convert_to_format == "casadi" or (
-                model.convert_to_format == "jax"
-                and solver._options["jax_evaluator"] == "iree"
-            ):
-                t_interp = np.linspace(0, 1, 100)
-                t_eval = np.array([t_interp[0], t_interp[-1]])
-            else:
-                t_eval = np.linspace(0, 1, 100)
-                t_interp = t_eval
+            t_interp = np.linspace(0, 1, 100)
+            t_eval = [t_interp[0], t_interp[-1]]
 
             solution = solver.solve(model_disc, t_eval, t_interp=t_interp)
             np.testing.assert_array_equal(
@@ -196,9 +185,7 @@ class TestIDAKLUSolver(unittest.TestCase):
     def test_input_params(self):
         # test a mix of scalar and vector input params
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -224,7 +211,8 @@ class TestIDAKLUSolver(unittest.TestCase):
                 options={"jax_evaluator": "iree"} if form == "iree" else {},
             )
 
-            t_eval = np.linspace(0, 3, 100)
+            t_interp = np.linspace(0, 3, 100)
+            t_eval = [t_interp[0], t_interp[-1]]
             a_value = 0.1
             b_value = np.array([[0.2], [0.3]])
 
@@ -232,6 +220,7 @@ class TestIDAKLUSolver(unittest.TestCase):
                 model,
                 t_eval,
                 inputs={"a": a_value, "b": b_value},
+                t_interp=t_interp,
             )
 
             # test that y[3] remains constant
@@ -254,9 +243,9 @@ class TestIDAKLUSolver(unittest.TestCase):
     def test_sensitivities_initial_condition(self):
         for form in ["casadi", "iree"]:
             for output_variables in [[], ["2v"]]:
-                if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                    continue
-                if (form == "iree") and not pybamm.have_iree():
+                if (form == "iree") and (
+                    not pybamm.have_jax() or not pybamm.have_iree()
+                ):
                     continue
                 if form == "casadi":
                     root_method = "casadi"
@@ -283,7 +272,7 @@ class TestIDAKLUSolver(unittest.TestCase):
                 )
 
                 t_interp = np.linspace(0, 3, 100)
-                t_eval = np.array([t_interp[0], t_interp[-1]])
+                t_eval = [t_interp[0], t_interp[-1]]
 
                 a_value = 0.1
 
@@ -307,9 +296,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         # example provided in sundials
         # see sundials ida examples pdf
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -334,7 +321,7 @@ class TestIDAKLUSolver(unittest.TestCase):
             )
 
             t_interp = np.linspace(0, 3, 100)
-            t_eval = np.array([t_interp[0], t_interp[-1]])
+            t_eval = [t_interp[0], t_interp[-1]]
             a_value = 0.1
 
             # solve first without sensitivities
@@ -415,9 +402,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         # example provided in sundials
         # see sundials ida examples pdf
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -459,9 +444,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         # example provided in sundials
         # see sundials ida examples pdf
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -487,7 +470,7 @@ class TestIDAKLUSolver(unittest.TestCase):
             )
 
             t_interp = np.linspace(0, 3, 100)
-            t_eval = np.array([t_interp[0], t_interp[-1]])
+            t_eval = [t_interp[0], t_interp[-1]]
 
             a_value = 0.1
             b_value = 0.0
@@ -620,9 +603,7 @@ class TestIDAKLUSolver(unittest.TestCase):
 
     def test_dae_solver_algebraic_model(self):
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"
@@ -685,7 +666,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         disc.process_model(model)
 
         t_interp = np.linspace(0, 1)
-        t_eval = np.array([t_interp[0], t_interp[-1]])
+        t_eval = [t_interp[0], t_interp[-1]]
         solver = pybamm.IDAKLUSolver()
         soln_base = solver.solve(model, t_eval, t_interp=t_interp)
 
@@ -763,7 +744,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         disc.process_model(model)
 
         t_interp = np.linspace(0, 1)
-        t_eval = np.array([t_interp[0], t_interp[-1]])
+        t_eval = [t_interp[0], t_interp[-1]]
         solver = pybamm.IDAKLUSolver()
         soln_base = solver.solve(model, t_eval, t_interp=t_interp)
 
@@ -927,9 +908,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         # equivalence
 
         for form in ["casadi", "iree"]:
-            if (form == "jax" or form == "iree") and not pybamm.have_jax():
-                continue
-            if (form == "iree") and not pybamm.have_iree():
+            if (form == "iree") and (not pybamm.have_jax() or not pybamm.have_iree()):
                 continue
             if form == "casadi":
                 root_method = "casadi"


### PR DESCRIPTION
# Description

This PR updates the IDAKLU tests and benchmarks to use the updated `t_eval` and `t_interp` arguments. This will speed up the github actions a bit and better reflect the performance of the `IDAKLUSolver` in benchmarks.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Optimization (back-end change that speeds up the code)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
