### PR TITLE
Remove unnecessary `dt` checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Optimizations
+- Removed the `start_step_offset` setting and disabled minimum `dt` warnings for drive cycles with the (`IDAKLUSolver`). ([#4416](https://github.com/pybamm-team/PyBaMM/pull/4416))
+
 # [v24.9.0](https://github.com/pybamm-team/PyBaMM/tree/v24.9.0) - 2024-09-03
 
 ## Features

--- a/src/pybamm/settings.py
+++ b/src/pybamm/settings.py
@@ -12,7 +12,6 @@ class Settings:
     _abs_smoothing = "exact"
     max_words_in_line = 4
     max_y_value = 1e5
-    step_start_offset = 1e-9
     tolerances = {
         "D_e__c_e": 10,  # dimensional
         "kappa_e__c_e": 10,  # dimensional

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1173,7 +1173,7 @@ class BaseSolver:
         if t_start == 0:
             t_start_shifted = t_start
         else:
-            # offset t_start by t_start_offset (default 1 ns)
+            # find the next largest floating point value for t_start
             # to avoid repeated times in the solution
             # from having the same time at the end of the previous step and
             # the start of the next step

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1142,12 +1142,9 @@ class BaseSolver:
         # Make sure model isn't empty
         self._check_empty_model(model)
 
-        # Make sure dt is greater than the offset
-        step_start_offset = pybamm.settings.step_start_offset
-        if dt <= step_start_offset:
-            raise pybamm.SolverError(
-                f"Step time must be at least {pybamm.TimerTime(step_start_offset)}"
-            )
+        # Make sure dt is greater than zero
+        if dt <= 0:
+            raise pybamm.SolverError("Step time must be >0")
 
         # Raise deprecation warning for npts and convert it to t_eval
         if npts is not None:
@@ -1180,7 +1177,7 @@ class BaseSolver:
             # to avoid repeated times in the solution
             # from having the same time at the end of the previous step and
             # the start of the next step
-            t_start_shifted = t_start + step_start_offset
+            t_start_shifted = np.nextafter(t_start, np.inf)
             t_eval[0] = t_start_shifted
             if t_interp.size > 0 and t_interp[0] == t_start:
                 t_interp[0] = t_start_shifted

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -70,10 +70,8 @@ class TestBaseSolver(unittest.TestCase):
             solver.solve(model, np.array([1, 2, 3, 2]))
 
         # Check stepping with step size too small
-        dt = 1e-9
-        with self.assertRaisesRegex(
-            pybamm.SolverError, "Step time must be at least 1.000 ns"
-        ):
+        dt = -1e-9
+        with self.assertRaisesRegex(pybamm.SolverError, "Step time must be >0"):
             solver.step(None, model, dt)
 
         # Checking if array t_eval lies within range

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -289,7 +289,7 @@ class TestCasadiSolver(unittest.TestCase):
         # Step again (return 5 points)
         step_sol_2 = solver.step(step_sol, model, dt, npts=5)
         np.testing.assert_array_equal(
-            step_sol_2.t, np.array([0, 1, 1 + 1e-9, 1.25, 1.5, 1.75, 2])
+            step_sol_2.t, np.array([0, 1, np.nextafter(1, np.inf), 1.25, 1.5, 1.75, 2])
         )
         np.testing.assert_array_almost_equal(
             step_sol_2.y.full()[0], np.exp(0.1 * step_sol_2.t)

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -1079,7 +1079,7 @@ class TestIDAKLUSolver(unittest.TestCase):
         sim = pybamm.Simulation(model, experiment=experiment, solver=solver)
         sol = sim.solve()
         np.testing.assert_equal(
-            sol.sub_solutions[0].t[-1] + pybamm.settings.step_start_offset,
+            np.nextafter(sol.sub_solutions[0].t[-1], np.inf),
             sol.sub_solutions[1].t[0],
         )
 

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -181,7 +181,7 @@ class TestScipySolver(unittest.TestCase):
         # Step again (return 5 points)
         step_sol_2 = solver.step(step_sol, model, dt, npts=5)
         np.testing.assert_array_equal(
-            step_sol_2.t, np.array([0, 1, 1 + 1e-9, 1.25, 1.5, 1.75, 2])
+            step_sol_2.t, np.array([0, 1, np.nextafter(1, np.inf), 1.25, 1.5, 1.75, 2])
         )
         np.testing.assert_array_almost_equal(
             step_sol_2.y[0], np.exp(0.1 * step_sol_2.t)


### PR DESCRIPTION
# Description

I removed a few unnecessary checks for minimum `dt` values to proceed with the simulation.

I also removed the `start_step_offset = 1e-9` heuristic setting. For large `t_start` values, you can get floating point arithmetic errors like `t == t + 1e-9` that cause duplicate `t` values in the solution. I replaced `start_step_offset` with `np.nextafter(t, np.inf)`, which prevents these errors by giving the next largest floating point number. cc @valentinsulzer 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Optimization (back-end change that speeds up the code)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
