### PR TITLE
Faster (re)initialization of ODEs in `IDA`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Optimizations
 
+- Improved performance of initialization and reinitialization of ODEs in the (`IDAKLUSolver`). ([#4453](https://github.com/pybamm-team/PyBaMM/pull/4453))
 - Removed the `start_step_offset` setting and disabled minimum `dt` warnings for drive cycles with the (`IDAKLUSolver`). ([#4416](https://github.com/pybamm-team/PyBaMM/pull/4416))
 
 ## Features

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
@@ -54,7 +54,7 @@ public:
   int const number_of_events;  // cppcheck-suppress unusedStructMember
   int number_of_timesteps;
   int precon_type;  // cppcheck-suppress unusedStructMember
-  N_Vector yy, yp, avtol;  // y, y', and absolute tolerance
+  N_Vector yy, yp, y_cache, avtol;  // y, y', y cache vector, and absolute tolerance
   N_Vector *yyS;  // cppcheck-suppress unusedStructMember
   N_Vector *ypS;  // cppcheck-suppress unusedStructMember
   N_Vector id;              // rhs_alg_id
@@ -70,6 +70,7 @@ public:
   vector<realtype> res_dvar_dp;
   bool const sensitivity;  // cppcheck-suppress unusedStructMember
   bool const save_outputs_only; // cppcheck-suppress unusedStructMember
+  bool is_ODE;  // cppcheck-suppress unusedStructMember
   int length_of_return_vector;  // cppcheck-suppress unusedStructMember
   vector<realtype> t;  // cppcheck-suppress unusedStructMember
   vector<vector<realtype>> y;  // cppcheck-suppress unusedStructMember
@@ -157,6 +158,27 @@ public:
    * @brief Print the solver statistics
    */
   void PrintStats();
+
+  /**
+   * @brief Set a consistent initialization for the system of equations
+   */
+  void ConsistentInitialization(
+    const realtype& t_val,
+    const realtype& t_next,
+    const int& icopt);
+
+  /**
+   * @brief Set a consistent initialization for DAEs
+   */
+  void ConsistentInitializationDAE(
+    const realtype& t_val,
+    const realtype& t_next,
+    const int& icopt);
+
+  /**
+   * @brief Set a consistent initialization for ODEs
+   */
+  void ConsistentInitializationODE(const realtype& t_val);
 
   /**
    * @brief Extend the adaptive arrays by 1

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.hpp
@@ -160,6 +160,11 @@ public:
   void PrintStats();
 
   /**
+   * @brief Set a consistent initialization for ODEs
+   */
+  void ReinitializeIntegrator(const realtype& t_val);
+
+  /**
    * @brief Set a consistent initialization for the system of equations
    */
   void ConsistentInitialization(

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
@@ -298,9 +298,10 @@ void IDAKLUSolverOpenMP<ExprSet>::Initialize() {
   // Determine if the system is an ODE
   is_ODE = number_of_states > 0;
   for (int ii = 0; ii < number_of_states; ii++) {
-    const bool id_i = id_np_val[ii];
-    id_val[ii] = id_i;
-    is_ODE &= id_i;
+    id_val[ii] = id_np_val[ii];
+    // check if id_val[ii] approximately equals 1 (>0.999) handles
+    // cases where id_val[ii] is not exactly 1 due to numerical errors
+    is_ODE &= id_val[ii] > 0.999;
   }
 
   // Variable types: differential (1) and algebraic (0)

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
@@ -83,6 +83,10 @@ IDAKLUSolverOpenMP<ExprSet>::IDAKLUSolverOpenMP(
   if (this->setup_opts.preconditioner != "none") {
     precon_type = SUN_PREC_LEFT;
   }
+
+  // The default is to solve a DAE for generality. This may be changed
+  // to an ODE during the Initialize() call
+  is_ODE = false;
 }
 
 template <class ExprSet>
@@ -92,12 +96,14 @@ void IDAKLUSolverOpenMP<ExprSet>::AllocateVectors() {
   if (setup_opts.num_threads == 1) {
     yy = N_VNew_Serial(number_of_states, sunctx);
     yp = N_VNew_Serial(number_of_states, sunctx);
+    y_cache = N_VNew_Serial(number_of_states, sunctx);
     avtol = N_VNew_Serial(number_of_states, sunctx);
     id = N_VNew_Serial(number_of_states, sunctx);
   } else {
     DEBUG("IDAKLUSolverOpenMP::AllocateVectors OpenMP");
     yy = N_VNew_OpenMP(number_of_states, setup_opts.num_threads, sunctx);
     yp = N_VNew_OpenMP(number_of_states, setup_opts.num_threads, sunctx);
+    y_cache = N_VNew_OpenMP(number_of_states, setup_opts.num_threads, sunctx);
     avtol = N_VNew_OpenMP(number_of_states, setup_opts.num_threads, sunctx);
     id = N_VNew_OpenMP(number_of_states, setup_opts.num_threads, sunctx);
   }
@@ -289,9 +295,13 @@ void IDAKLUSolverOpenMP<ExprSet>::Initialize() {
   realtype *id_val;
   id_val = N_VGetArrayPointer(id);
 
+  // Determine if the system is an ODE
+  is_ODE = number_of_states > 0;
   int ii;
   for (ii = 0; ii < number_of_states; ii++) {
-    id_val[ii] = id_np_val[ii];
+    const bool id_i = id_np_val[ii];
+    id_val[ii] = id_i;
+    is_ODE &= id_i == 1;
   }
 
   // Variable types: differential (1) and algebraic (0)
@@ -312,6 +322,7 @@ IDAKLUSolverOpenMP<ExprSet>::~IDAKLUSolverOpenMP() {
   N_VDestroy(avtol);
   N_VDestroy(yy);
   N_VDestroy(yp);
+  N_VDestroy(y_cache);
   N_VDestroy(id);
 
   if (sensitivity) {
@@ -398,9 +409,7 @@ SolutionData IDAKLUSolverOpenMP<ExprSet>::solve(
   // Consistent initialization
   int const init_type = solver_opts.init_all_y_ic ? IDA_Y_INIT : IDA_YA_YDP_INIT;
   if (solver_opts.calc_ic) {
-    DEBUG("IDACalcIC");
-    // IDACalcIC will throw a warning if it fails to find initial conditions
-    IDACalcIC(ida_mem, init_type, t_eval_next);
+    ConsistentInitialization(t0, t_eval_next, init_type);
   }
 
   if (sensitivity) {
@@ -480,12 +489,7 @@ SolutionData IDAKLUSolverOpenMP<ExprSet>::solve(
       CheckErrors(IDASetStopTime(ida_mem, t_eval_next));
 
       // Reinitialize the solver to deal with the discontinuity at t = t_val.
-      // We must reinitialize the algebraic terms, so do not use init_type.
-      IDACalcIC(ida_mem, IDA_YA_YDP_INIT, t_eval_next);
-      CheckErrors(IDAReInit(ida_mem, t_val, yy, yp));
-      if (sensitivity) {
-        CheckErrors(IDASensReInit(ida_mem, IDA_SIMULTANEOUS, yyS, ypS));
-      }
+      ConsistentInitialization(t_val, t_eval_next, IDA_YA_YDP_INIT);
     }
 
     t_prev = t_val;
@@ -561,6 +565,49 @@ void IDAKLUSolverOpenMP<ExprSet>::ExtendAdaptiveArrays() {
   if (sensitivity) {
     yS.emplace_back(number_of_parameters, vector<realtype>(length_of_return_vector, 0.0));
   }
+}
+
+template <class ExprSet>
+void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitialization(
+  const realtype& t_val,
+  const realtype& t_next,
+  const int& icopt) {
+  DEBUG("IDAKLUSolver::ConsistentInitialization");
+
+  CheckErrors(IDAReInit(ida_mem, t_val, yy, yp));
+  if (sensitivity) {
+    CheckErrors(IDASensReInit(ida_mem, IDA_SIMULTANEOUS, yyS, ypS));
+  }
+
+  if (is_ODE && icopt == IDA_YA_YDP_INIT) {
+    ConsistentInitializationODE(t_val);
+  } else {
+    ConsistentInitializationDAE(t_val, t_next, icopt);
+  }
+}
+
+template <class ExprSet>
+void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitializationDAE(
+  const realtype& t_val,
+  const realtype& t_next,
+  const int& icopt) {
+  DEBUG("IDAKLUSolver::ConsistentInitializationDAE");
+  IDACalcIC(ida_mem, icopt, t_next);
+}
+
+template <class ExprSet>
+void IDAKLUSolverOpenMP<ExprSet>::ConsistentInitializationODE(
+  const realtype& t_val) {
+  DEBUG("IDAKLUSolver::ConsistentInitializationODE");
+
+  // For ODEs where the mass matrix M = I, we can simplify the problem
+  // by analytically computing the yp values. If we take our implicit
+  // DAE system res(t,y,yp) = f(t,y) - I*yp, then yp = res(t,y,0). This
+  // avoids an expensive call to IDACalcIC.
+  realtype *y_cache_val = N_VGetArrayPointer(y_cache);
+  std::memset(y_cache_val, 0, number_of_states * sizeof(realtype));
+  // Overwrite yp
+  residual_eval<ExprSet>(t_val, yy, y_cache, yp, functions.get());
 }
 
 template <class ExprSet>

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
@@ -297,11 +297,10 @@ void IDAKLUSolverOpenMP<ExprSet>::Initialize() {
 
   // Determine if the system is an ODE
   is_ODE = number_of_states > 0;
-  int ii;
-  for (ii = 0; ii < number_of_states; ii++) {
+  for (int ii = 0; ii < number_of_states; ii++) {
     const bool id_i = id_np_val[ii];
     id_val[ii] = id_i;
-    is_ODE &= id_i == 1;
+    is_ODE &= id_i;
   }
 
   // Variable types: differential (1) and algebraic (0)

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -988,7 +988,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
 
         rhs0 = rhs_alg0[: model.len_rhs]
 
-        # for the differential terms, ydot = -M^-1 * (rhs)
+        # for the differential terms, ydot = M^-1 * (rhs)
         ydot0[: model.len_rhs] = model.mass_matrix_inv.entries @ rhs0
 
         return ydot0


### PR DESCRIPTION
# Description

In `IDA`, we can compute an analytical solution for consistent initialization/reinitialization of ODEs, which avoids an expensive call to `IDACalcIC`. This change gives a modest speed improvement to all the ODE models solved by the `IDAKLUSolver` and will give a bigger speedup to those with a dense `t_eval` vector. For example,

```python
import pybamm
import numpy as np

model = pybamm.lithium_ion.SPM()
solver = pybamm.IDAKLUSolver()
sim = pybamm.Simulation(model, solver=solver)

t_eval = np.linspace(0, 3600, 10000)
sol = sim.solve(t_eval)

print(sol.integration_time)
```
- New `integration_time`: **367 ms**
- Old `integration_time`: **514 ms**
- Speedup: **1.4x**

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Optimization (back-end change that speeds up the code)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
