### PR TITLE
Pin casadi to 3.6.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=64",
     "wheel",
     # On Windows, use the CasADi vcpkg registry and CMake bundled from MSVC
-    "casadi>=3.6.6; platform_system!='Windows'",
+    "casadi==3.6.6; platform_system!='Windows'",
     # Note: the version of CasADi as a build-time dependency should be matched
     # across platforms, so updates to its minimum version here should be accompanied
     # by a version bump in https://github.com/pybamm-team/casadi-vcpkg-registry.
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.23.5,<2.0.0",
     "scipy>=1.11.4",
-    "casadi>=3.6.6",
+    "casadi==3.6.6",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
     "sympy>=1.12",


### PR DESCRIPTION
# Description

I am seeing failures in some workflows due to casadi installs. Casadi just did a release this afternoon. I made this PR to pin casadi to a specific version while I investigate the issues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
