### PR TITLE
More accurate `QuickPlot`s with Hermite interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Improved `QuickPlot` accuracy for simulations with Hermite interpolation. ([#4483](https://github.com/pybamm-team/PyBaMM/pull/4483))
 - Added Hermite interpolation to the (`IDAKLUSolver`) that improves the accuracy and performance of post-processing variables. ([#4464](https://github.com/pybamm-team/PyBaMM/pull/4464))
 - Added sensitivity calculation support for `pybamm.Simulation` and `pybamm.Experiment` ([#4415](https://github.com/pybamm-team/PyBaMM/pull/4415))
 - Added OpenMP parallelization to IDAKLU solver for lists of input parameters ([#4449](https://github.com/pybamm-team/PyBaMM/pull/4449))

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -5,9 +5,14 @@ import pytest
 import numpy as np
 from tempfile import TemporaryDirectory
 
+_solver_args = [pybamm.CasadiSolver()]
+if pybamm.has_idaklu():
+    _solver_args.append(pybamm.IDAKLUSolver())
+
 
 class TestQuickPlot:
-    def test_simple_ode_model(self):
+    @pytest.mark.parametrize("solver", _solver_args)
+    def test_simple_ode_model(self, solver):
         model = pybamm.lithium_ion.BaseModel(name="Simple ODE Model")
 
         whole_cell = ["negative electrode", "separator", "positive electrode"]
@@ -48,9 +53,6 @@ class TestQuickPlot:
             "NaN variable": pybamm.Scalar(np.nan),
         }
 
-        # ODEs only (don't use Jacobian)
-        model.use_jacobian = False
-
         # Process and solve
         geometry = model.default_geometry
         param = model.default_parameter_values
@@ -59,7 +61,6 @@ class TestQuickPlot:
         mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
         disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
         disc.process_model(model)
-        solver = model.default_solver
         t_eval = np.linspace(0, 2, 100)
         solution = solver.solve(model, t_eval)
         quick_plot = pybamm.QuickPlot(
@@ -142,6 +143,13 @@ class TestQuickPlot:
         assert quick_plot.n_rows == 2
         assert quick_plot.n_cols == 1
 
+        if solution.hermite_interpolation:
+            t_plot = np.union1d(
+                solution.t, np.linspace(solution.t[0], solution.t[-1], 100 + 2)[1:-1]
+            )
+        else:
+            t_plot = t_eval
+
         # Test different time units
         quick_plot = pybamm.QuickPlot(solution, ["a"])
         assert quick_plot.time_scaling_factor == 1
@@ -149,28 +157,28 @@ class TestQuickPlot:
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 1
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_eval
+            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot
         )
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_eval
+            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
         )
         quick_plot = pybamm.QuickPlot(solution, ["a"], time_unit="minutes")
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 60
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_eval / 60
+            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot / 60
         )
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_eval
+            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
         )
         quick_plot = pybamm.QuickPlot(solution, ["a"], time_unit="hours")
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 3600
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_eval / 3600
+            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot / 3600
         )
         np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_eval
+            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
         )
         with pytest.raises(ValueError, match="time unit"):
             pybamm.QuickPlot(solution, ["a"], time_unit="bad unit")


### PR DESCRIPTION
# Description

The `QuickPlot` class plots the results using the raw data points. With the new Hermite interpolation changes in the `IDAKLUSolver`, we can improve the visual appearance of plots by interpolating the data. This PR adds 100 evenly spaced interpolation time points for all sub-solutions.

For example,
```python
import pybamm

model = pybamm.lithium_ion.SPM()
solver = pybamm.IDAKLUSolver()
sim = pybamm.Simulation(model, solver=solver)
sol = sim.solve([0, 3600])

sol.plot(output_variables=["Voltage [V]"])
```

### Hermite interpolation (new)
<img width="389" alt="image" src="https://github.com/user-attachments/assets/812dd21c-8a78-4119-a283-8c587b846cf4">

### Raw data (old)
<img width="389" alt="image" src="https://github.com/user-attachments/assets/5feadba3-484a-4901-aa4e-39d7d6b69a75">


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
