### PR TITLE
Fix a type issue for windows

### DIFF
--- a/src/pybamm/solvers/c_solvers/idaklu/observe.hpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/observe.hpp
@@ -9,6 +9,11 @@
 #include <vector>
 using std::vector;
 
+#if defined(_MSC_VER)
+    #include <BaseTsd.h>
+    typedef SSIZE_T ssize_t;
+#endif
+
 /**
  * @brief Observe and Hermite interpolate ND variables
  */


### PR DESCRIPTION
# Description

This was an issue caught here: https://github.com/pybamm-team/pybammsolvers

In the standalone repo, wheels are built as part of the tests and were failing on windows. This fixed the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
