### PR TITLE
Fix doc failures in notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -341,7 +341,7 @@ nbsphinx_prolog = r"""
 
 {% set github_docname =
 'github/pybamm-team/pybamm/blob/develop/docs/' +
-str(env.doc2path(env.docname, base=None)) %}
+env.doc2path(env.docname, base=None) | string() %}
 
 {% set notebooks_version = env.config.html_context.notebooks_version %}
 {% set github_download_url = env.config.html_context.github_download_url %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -341,13 +341,13 @@ nbsphinx_prolog = r"""
 
 {% set github_docname =
 'github/pybamm-team/pybamm/blob/develop/docs/' +
-env.doc2path(env.docname, base=None) %}
+str(env.doc2path(env.docname, base=None)) %}
 
 {% set notebooks_version = env.config.html_context.notebooks_version %}
 {% set github_download_url = env.config.html_context.github_download_url %}
 {% set google_colab_url = env.config.html_context.google_colab_url %}
 
-{% set doc_path = env.doc2path(env.docname, base=None) %}
+{% set doc_path = str(env.doc2path(env.docname, base=None)) %}
 
 .. raw:: html
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -347,7 +347,7 @@ str(env.doc2path(env.docname, base=None)) %}
 {% set github_download_url = env.config.html_context.github_download_url %}
 {% set google_colab_url = env.config.html_context.google_colab_url %}
 
-{% set doc_path = str(env.doc2path(env.docname, base=None)) %}
+{% set doc_path = env.doc2path(env.docname, base=None) %}
 
 .. raw:: html
 


### PR DESCRIPTION
# Description

I could not reproduce this in docker or locally (MacOS), but I saw this fix on another project.

Fixes #4495 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
