### PR TITLE
Add "voltage as a state" option

### DIFF
--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -210,6 +210,9 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 solve an algebraic equation for it. Default is "false", unless "SEI film
                 resistance" is distributed in which case it is automatically set to
                 "true".
+            * "voltage as a state" : str
+                Whether to make a state for the voltage and solve an algebraic equation
+                for it. Default is "false".
             * "working electrode" : str
                 Can be "both" (default) for a standard battery or "positive" for a
                 half-cell where the negative electrode is replaced with a lithium metal
@@ -321,6 +324,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 "heterogeneous catalyst",
                 "cation-exchange membrane",
             ],
+            "voltage as a state": ["false", "true"],
             "working electrode": ["both", "positive"],
             "x-average side reactions": ["false", "true"],
         }

--- a/src/pybamm/models/submodels/electrode/base_electrode.py
+++ b/src/pybamm/models/submodels/electrode/base_electrode.py
@@ -119,7 +119,7 @@ class BaseElectrode(pybamm.BaseSubModel):
         V_cc = phi_s_cp - phi_s_cn
 
         # Voltage
-        # Note phi_s_cn is always zero at the negative tab
+        # Note phi_s_cn is always zero at the negative tab by definition
         V = pybamm.boundary_value(phi_s_cp, "positive tab")
 
         # Voltage is local current collector potential difference at the tabs, in 1D
@@ -128,10 +128,12 @@ class BaseElectrode(pybamm.BaseSubModel):
             "Negative current collector potential [V]": phi_s_cn,
             "Positive current collector potential [V]": phi_s_cp,
             "Local voltage [V]": V_cc,
+            "Voltage expression [V]": V - delta_phi_contact,
             "Terminal voltage [V]": V - delta_phi_contact,
-            "Voltage [V]": V - delta_phi_contact,
             "Contact overpotential [V]": delta_phi_contact,
         }
+        if self.options["voltage as a state"] == "false":
+            variables.update({"Voltage [V]": V - delta_phi_contact})
 
         return variables
 

--- a/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
@@ -19,8 +19,22 @@ class ExplicitCurrentControl(BaseModel):
             "Current [A]": I,
             "C-rate": I / self.param.Q,
         }
+        if self.options.get("voltage as a state") == "true":
+            V = pybamm.Variable("Voltage [V]")
+            variables.update({"Voltage [V]": V})
 
         return variables
+
+    def set_initial_conditions(self, variables):
+        if self.options.get("voltage as a state") == "true":
+            V = variables["Voltage [V]"]
+            self.initial_conditions[V] = self.param.ocv_init
+
+    def set_algebraic(self, variables):
+        if self.options.get("voltage as a state") == "true":
+            V = variables["Voltage [V]"]
+            V_expression = variables["Voltage expression [V]"]
+            self.algebraic[V] = V - V_expression
 
 
 class ExplicitPowerControl(BaseModel):

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -51,6 +51,7 @@ PRINT_OPTIONS_OUTPUT = """\
 'thermal': 'x-full' (possible: ['isothermal', 'lumped', 'x-lumped', 'x-full'])
 'total interfacial current density as a state': 'false' (possible: ['false', 'true'])
 'transport efficiency': 'Bruggeman' (possible: ['Bruggeman', 'ordered packing', 'hyperbola of revolution', 'overlapping spheres', 'tortuosity factor', 'random overlapping cylinders', 'heterogeneous catalyst', 'cation-exchange membrane'])
+'voltage as a state': 'false' (possible: ['false', 'true'])
 'working electrode': 'both' (possible: ['both', 'positive'])
 'x-average side reactions': 'false' (possible: ['false', 'true'])
 """
@@ -471,6 +472,11 @@ class TestBaseBatteryModel:
             )
 
         os.remove("test_base_battery_model.json")
+
+    def test_voltage_as_state(self):
+        model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
+        assert model.options["voltage as a state"] == "true"
+        assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
 
 
 class TestOptions:


### PR DESCRIPTION
# Description
Adds an option "voltage as a state" that can be "false" (default) or "true". If "true" adds an explicit algebraic equation for the voltage. This can be used to reformulate the SPM(e) as a DAE rather than and ODE. This increases the solve time but evaluating the voltage as an explicit state rather than as a function of other state variables can be faster if the time eval is dense.

```python3
import pybamm
import numpy as np

t = np.linspace(0, 3600, 100000)
for value in ["true", "false"]:
    model = pybamm.lithium_ion.SPMe({"voltage as a state": value})
    sim = pybamm.Simulation(model, solver=pybamm.IDAKLUSolver())
    sim.solve([0, 3600])
    print("voltage as a state:", value)
    solve_time = sim.solution.solve_time
    print("solve time:", solve_time)
    timer = pybamm.Timer()
    sim.solution["Voltage [V]"](t)
    eval_time = timer.time()
    print("eval time:", eval_time)
    print("total time:", solve_time + eval_time, "\n")
```

returns 
```
voltage as a state: true
solve time: 3.293 ms
eval time: 8.836 ms
total time: 12.129 ms 

voltage as a state: false
solve time: 2.311 ms
eval time: 687.892 ms
total time: 690.204 ms 
```

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
