### PR TITLE
refactor: use pytest fixtures to reduce repetition in tests

### DIFF
--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -12,12 +12,15 @@ import pytest
 def path():
     return os.path.abspath(os.path.dirname(__file__))
 
-@pytest.fixture(params=[
-    ("lico2_ocv_example", pybamm.parameters.process_1D_data),
-    ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
-    ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
-    ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
-])
+
+@pytest.fixture(
+    params=[
+        ("lico2_ocv_example", pybamm.parameters.process_1D_data),
+        ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
+        ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
+        ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
+    ]
+)
 def parameter_data(request, path):
     name, processing_function = request.param
     processed = processing_function(name, path)
@@ -32,10 +35,10 @@ class TestProcessParameterData:
     def test_processed_structure(self, parameter_data):
         """
         Test that the processed data has the correct structure.
-        
+
         Args:
             parameter_data: A tuple containing the name and processed data.
-        
+
         Asserts:
             - The second element of the processed data is a tuple.
             - The first element of the second item in the processed data is a numpy array.
@@ -48,8 +51,8 @@ class TestProcessParameterData:
 
         if len(processed[1][0]) > 1:
             assert isinstance(processed[1][0][1], np.ndarray)
-        
-        elif len(processed[1]) == 3:  
+
+        elif len(processed[1]) == 3:
             assert isinstance(processed[1][0][1], np.ndarray)
             assert isinstance(processed[1][0][2], np.ndarray)
 

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -7,21 +7,25 @@ import pybamm
 import pytest
 from pathlib import Path
 
+
 @pytest.fixture
 def parameters_path():
     return Path(__file__).parent.resolve()
 
-@pytest.fixture(params=[
-    ("lico2_ocv_example", pybamm.parameters.process_1D_data),
-    ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
-    ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
-    ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
-])
 
+@pytest.fixture(
+    params=[
+        ("lico2_ocv_example", pybamm.parameters.process_1D_data),
+        ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
+        ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
+        ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
+    ]
+)
 def parameter_data(request, parameters_path):
     name, processing_function = request.param
     processed = processing_function(name, parameters_path)
     return name, processed
+
 
 class TestProcessParameterData:
     def test_processed_name(self, parameter_data):
@@ -36,8 +40,8 @@ class TestProcessParameterData:
 
         if len(processed[1][0]) > 1:
             assert isinstance(processed[1][0][1], np.ndarray)
-        
-        elif len(processed[1]) == 3:  
+
+        elif len(processed[1]) == 3:
             assert isinstance(processed[1][0][1], np.ndarray)
             assert isinstance(processed[1][0][2], np.ndarray)
 

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -17,11 +17,11 @@ def parameters_path():
     ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
     ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
 ])
+
 def parameter_data(request, parameters_path):
     name, processing_function = request.param
     processed = processing_function(name, parameters_path)
     return name, processed
-
 
 class TestProcessParameterData:
     def test_processed_name(self, parameter_data):

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -17,7 +17,7 @@ def parameters_path():
     ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
     ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
 ])
-def parameter_data(request, path):
+def parameter_data(request, parameters_path):
     name, processing_function = request.param
     processed = processing_function(name, parameters_path)
     return name, processed
@@ -36,8 +36,8 @@ class TestProcessParameterData:
 
         if len(processed[1][0]) > 1:
             assert isinstance(processed[1][0][1], np.ndarray)
-
-        elif len(processed[1]) == 3:
+        
+        elif len(processed[1]) == 3:  
             assert isinstance(processed[1][0][1], np.ndarray)
             assert isinstance(processed[1][0][2], np.ndarray)
 

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -2,56 +2,56 @@
 # Tests for the parameter processing functions
 #
 
-
 import os
 import numpy as np
 import pybamm
-
 import pytest
 
 
+@pytest.fixture
+def path():
+    return os.path.abspath(os.path.dirname(__file__))
+
+@pytest.fixture(params=[
+    ("lico2_ocv_example", pybamm.parameters.process_1D_data),
+    ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
+    ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
+    ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
+])
+def parameter_data(request, path):
+    name, processing_function = request.param
+    processed = processing_function(name, path)
+    return name, processed
+
+
 class TestProcessParameterData:
-    def test_process_1D_data(self):
-        name = "lico2_ocv_example"
-        path = os.path.abspath(os.path.dirname(__file__))
-        processed = pybamm.parameters.process_1D_data(name, path)
+    def test_processed_name(self, parameter_data):
+        name, processed = parameter_data
         assert processed[0] == name
+
+    def test_processed_structure(self, parameter_data):
+        """
+        Test that the processed data has the correct structure.
+        
+        Args:
+            parameter_data: A tuple containing the name and processed data.
+        
+        Asserts:
+            - The second element of the processed data is a tuple.
+            - The first element of the second item in the processed data is a numpy array.
+            - Additional checks based on the shape of the processed data.
+        """
+        name, processed = parameter_data
         assert isinstance(processed[1], tuple)
         assert isinstance(processed[1][0][0], np.ndarray)
         assert isinstance(processed[1][1], np.ndarray)
 
-    def test_process_2D_data(self):
-        name = "lico2_diffusivity_Dualfoil1998_2D"
-        path = os.path.abspath(os.path.dirname(__file__))
-        processed = pybamm.parameters.process_2D_data(name, path)
-        assert processed[0] == name
-        assert isinstance(processed[1], tuple)
-        assert isinstance(processed[1][0][0], np.ndarray)
-        assert isinstance(processed[1][0][1], np.ndarray)
-        assert isinstance(processed[1][1], np.ndarray)
-
-    def test_process_2D_data_csv(self):
-        name = "data_for_testing_2D"
-        path = os.path.abspath(os.path.dirname(__file__))
-        processed = pybamm.parameters.process_2D_data_csv(name, path)
-
-        assert processed[0] == name
-        assert isinstance(processed[1], tuple)
-        assert isinstance(processed[1][0][0], np.ndarray)
-        assert isinstance(processed[1][0][1], np.ndarray)
-        assert isinstance(processed[1][1], np.ndarray)
-
-    def test_process_3D_data_csv(self):
-        name = "data_for_testing_3D"
-        path = os.path.abspath(os.path.dirname(__file__))
-        processed = pybamm.parameters.process_3D_data_csv(name, path)
-
-        assert processed[0] == name
-        assert isinstance(processed[1], tuple)
-        assert isinstance(processed[1][0][0], np.ndarray)
-        assert isinstance(processed[1][0][1], np.ndarray)
-        assert isinstance(processed[1][0][2], np.ndarray)
-        assert isinstance(processed[1][1], np.ndarray)
+        if len(processed[1][0]) > 1:
+            assert isinstance(processed[1][0][1], np.ndarray)
+        
+        elif len(processed[1]) == 3:  
+            assert isinstance(processed[1][0][1], np.ndarray)
+            assert isinstance(processed[1][0][2], np.ndarray)
 
     def test_error(self):
         with pytest.raises(FileNotFoundError, match="Could not find file"):

--- a/tests/unit/test_parameters/test_process_parameter_data.py
+++ b/tests/unit/test_parameters/test_process_parameter_data.py
@@ -2,28 +2,24 @@
 # Tests for the parameter processing functions
 #
 
-import os
 import numpy as np
 import pybamm
 import pytest
-
+from pathlib import Path
 
 @pytest.fixture
-def path():
-    return os.path.abspath(os.path.dirname(__file__))
+def parameters_path():
+    return Path(__file__).parent.resolve()
 
-
-@pytest.fixture(
-    params=[
-        ("lico2_ocv_example", pybamm.parameters.process_1D_data),
-        ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
-        ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
-        ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
-    ]
-)
+@pytest.fixture(params=[
+    ("lico2_ocv_example", pybamm.parameters.process_1D_data),
+    ("lico2_diffusivity_Dualfoil1998_2D", pybamm.parameters.process_2D_data),
+    ("data_for_testing_2D", pybamm.parameters.process_2D_data_csv),
+    ("data_for_testing_3D", pybamm.parameters.process_3D_data_csv),
+])
 def parameter_data(request, path):
     name, processing_function = request.param
-    processed = processing_function(name, path)
+    processed = processing_function(name, parameters_path)
     return name, processed
 
 
@@ -33,17 +29,6 @@ class TestProcessParameterData:
         assert processed[0] == name
 
     def test_processed_structure(self, parameter_data):
-        """
-        Test that the processed data has the correct structure.
-
-        Args:
-            parameter_data: A tuple containing the name and processed data.
-
-        Asserts:
-            - The second element of the processed data is a tuple.
-            - The first element of the second item in the processed data is a numpy array.
-            - Additional checks based on the shape of the processed data.
-        """
         name, processed = parameter_data
         assert isinstance(processed[1], tuple)
         assert isinstance(processed[1][0][0], np.ndarray)


### PR DESCRIPTION
# Description

Refactored the parameter processing test cases to use `pytest` fixtures and `pytest.mark.parametrize` to reduce code duplication and improve test maintainability.

Related to #4502 

## Type of change

- [x] Code refactor (test improvements to reduce repetition)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
