### PR TITLE
Removing the macos-12 runner

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -242,7 +242,7 @@ jobs:
             python scripts/install_KLU_Sundials.py
             python -m cibuildwheel --output-dir wheelhouse
         env:
-          # 10.13 for Intel (macos-12/macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
+          # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
           CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools wheel delocate

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get install gfortran gcc graphviz pandoc libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -65,7 +65,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-12' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/noxfile.py
+++ b/noxfile.py
@@ -40,7 +40,7 @@ def set_iree_state():
             # iree-compiler is currently only available as a wheel on macOS 13 (or
             # higher) and Python version 3.11
             mac_ver = int(platform.mac_ver()[0].split(".")[0])
-            if (not sys.version_info[:2] == (3, 11)) or mac_ver < 13:
+            if (not sys.version_info[:2] == (3, 11)) or mac_ver < 14:
                 warnings.warn(
                     (
                         "IREE is only supported on MacOS 13 (or higher) and Python"
@@ -113,7 +113,7 @@ def run_pybamm_requires(session):
                 "--depth=1",
                 "--recurse-submodules",
                 "--shallow-submodules",
-                "--branch=candidate-20240621.931",
+                "--branch=candidate-20240507.886",
                 "https://github.com/openxla/iree",
                 "iree/",
                 external=True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def run_pybamm_requires(session):
                 "--depth=1",
                 "--recurse-submodules",
                 "--shallow-submodules",
-                "--branch=candidate-20240507.886",
+                "--branch=candidate-20240621.931",
                 "https://github.com/openxla/iree",
                 "iree/",
                 external=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,8 @@ dev = [
 # Note: These must be kept in sync with the versions defined in pybamm/util.py, and
 #       must remain compatible with IREE (see noxfile.py for IREE compatibility).
 jax = [
-    "jax==0.4.29",
-    "jaxlib==0.4.29",
+    "jax==0.4.31",
+    "jaxlib==0.4.31",
 ]
 # For MLIR expression evaluation (IDAKLU Solver)
 iree = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ jax = [
 # For MLIR expression evaluation (IDAKLU Solver)
 iree = [
     # must be pip installed with --find-links=https://iree.dev/pip-release-links.html
-    "iree-compiler==20240828.999",  # see IREE compatibility notes in noxfile.py
+    "iree-compiler==20240621.931",  # see IREE compatibility notes in noxfile.py
 ]
 # Contains all optional dependencies, except for jax, iree, and dev dependencies
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,13 +120,13 @@ dev = [
 # Note: These must be kept in sync with the versions defined in pybamm/util.py, and
 #       must remain compatible with IREE (see noxfile.py for IREE compatibility).
 jax = [
-    "jax==0.4.31",
-    "jaxlib==0.4.31",
+    "jax==0.4.27",
+    "jaxlib==0.4.27",
 ]
 # For MLIR expression evaluation (IDAKLU Solver)
 iree = [
     # must be pip installed with --find-links=https://iree.dev/pip-release-links.html
-    "iree-compiler==20240621.931",  # see IREE compatibility notes in noxfile.py
+    "iree-compiler==20240507.886",  # see IREE compatibility notes in noxfile.py
 ]
 # Contains all optional dependencies, except for jax, iree, and dev dependencies
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,8 @@ dev = [
 # Note: These must be kept in sync with the versions defined in pybamm/util.py, and
 #       must remain compatible with IREE (see noxfile.py for IREE compatibility).
 jax = [
-    "jax==0.4.27",
-    "jaxlib==0.4.27",
+    "jax==0.4.29",
+    "jaxlib==0.4.29",
 ]
 # For MLIR expression evaluation (IDAKLU Solver)
 iree = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ jax = [
 # For MLIR expression evaluation (IDAKLU Solver)
 iree = [
     # must be pip installed with --find-links=https://iree.dev/pip-release-links.html
-    "iree-compiler==20240507.886",  # see IREE compatibility notes in noxfile.py
+    "iree-compiler==20240828.999",  # see IREE compatibility notes in noxfile.py
 ]
 # Contains all optional dependencies, except for jax, iree, and dev dependencies
 all = [

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -19,8 +19,8 @@ import pybamm
 
 # Versions of jax and jaxlib compatible with PyBaMM. Note: these are also defined in
 # the extras dependencies in pyproject.toml, and therefore must be kept in sync.
-JAX_VERSION = "0.4.27"
-JAXLIB_VERSION = "0.4.27"
+JAX_VERSION = "0.4.29"
+JAXLIB_VERSION = "0.4.29"
 
 
 def root_dir():

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -1,9 +1,3 @@
-#
-# Utility classes for PyBaMM
-#
-# The code in this file is adapted from Pints
-# (see https://github.com/pints-team/pints)
-#
 import importlib.util
 import importlib.metadata
 import numbers
@@ -19,8 +13,8 @@ import pybamm
 
 # Versions of jax and jaxlib compatible with PyBaMM. Note: these are also defined in
 # the extras dependencies in pyproject.toml, and therefore must be kept in sync.
-JAX_VERSION = "0.4.29"
-JAXLIB_VERSION = "0.4.29"
+JAX_VERSION = "0.4.31"
+JAXLIB_VERSION = "0.4.31"
 
 
 def root_dir():

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -13,8 +13,8 @@ import pybamm
 
 # Versions of jax and jaxlib compatible with PyBaMM. Note: these are also defined in
 # the extras dependencies in pyproject.toml, and therefore must be kept in sync.
-JAX_VERSION = "0.4.31"
-JAXLIB_VERSION = "0.4.31"
+JAX_VERSION = "0.4.27"
+JAXLIB_VERSION = "0.4.27"
 
 
 def root_dir():


### PR DESCRIPTION
# Description

The macos-12 runner is being deprecated in December. This switches to the macos-13 runner

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
