### PR TITLE
Fix CasADI path and disable IREE for MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
 
 ## Bug Fixes
 
-- Disabled IREE on MacOS due to compatibility issues and added the CasADI 
-  path to the environment to resolve issues on MacOS and Linux. Windows 
+- Disabled IREE on MacOS due to compatibility issues and added the CasADI
+  path to the environment to resolve issues on MacOS and Linux. Windows
   users may still experience issues with interpolation. ([#4528](https://github.com/pybamm-team/PyBaMM/pull/4528))
 - Added `_from_json()` functionality to `Sign` which was erroneously omitted previously. ([#4517](https://github.com/pybamm-team/PyBaMM/pull/4517))
 - Fixed bug where IDAKLU solver failed when `output variables` were specified and an extrapolation event is present. ([#4440](https://github.com/pybamm-team/PyBaMM/pull/4440))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 
 ## Bug Fixes
 
+- Disabled IREE on MacOS due to compatibility issues and added the CasADI 
+  path to the environment to resolve issues on MacOS and Linux. Windows 
+  users may still experience issues with interpolation. ([#4528](https://github.com/pybamm-team/PyBaMM/pull/4528))
 - Added `_from_json()` functionality to `Sign` which was erroneously omitted previously. ([#4517](https://github.com/pybamm-team/PyBaMM/pull/4517))
 - Fixed bug where IDAKLU solver failed when `output variables` were specified and an extrapolation event is present. ([#4440](https://github.com/pybamm-team/PyBaMM/pull/4440))
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -469,7 +469,7 @@ Editable notebooks are made available using [Google Colab](https://colab.researc
 GitHub does some magic with particular filenames. In particular:
 
 - The first page people see when they go to [our GitHub page](https://github.com/pybamm-team/PyBaMM) displays the contents of [README.md](https://github.com/pybamm-team/PyBaMM/blob/develop/README.md), which is written in the [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format. Some guidelines can be found [here](https://help.github.com/articles/about-readmes/).
-- The license for using PyBaMM is stored in [LICENSE](https://github.com/pybamm-team/PyBaMM/blob/develop/LICENSE.txt), and [automatically](https://help.github.com/articles/adding-a-license-to-a-repository/) linked to by GitHub.
+- The license for using PyBaMM is stored in [LICENSE](https://github.com/pybamm-team/PyBaMM/blob/develop/LICENSE.txt), and [automatically](https://docs.github.com/articles/adding-a-license-to-a-repository/) linked to by GitHub.
 - This file, [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md) is recognised as the contribution guidelines and a link is [automatically](https://github.com/blog/1184-contributing-guidelines) displayed when new issues or pull requests are created.
 
 ## Acknowledgements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -468,7 +468,11 @@ Editable notebooks are made available using [Google Colab](https://colab.researc
 
 GitHub does some magic with particular filenames. In particular:
 
-- The first page people see when they go to [our GitHub page](https://github.com/pybamm-team/PyBaMM) displays the contents of [README.md](https://github.com/pybamm-team/PyBaMM/blob/develop/README.md), which is written in the [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format. Some guidelines can be found [here](https://help.github.com/articles/about-readmes/).
+- The first page people see when they go to [our GitHub page](https://github.
+  com/pybamm-team/PyBaMM) displays the contents of [README.md]
+  (https://github.com/pybamm-team/PyBaMM/blob/develop/README.md), which is 
+  written in the [Markdown](https://github.
+  com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format. Some guidelines can be found [here](https://docs.github.com/articles/about-readmes/).
 - The license for using PyBaMM is stored in [LICENSE](https://github.com/pybamm-team/PyBaMM/blob/develop/LICENSE.txt), and [automatically](https://docs.github.com/articles/adding-a-license-to-a-repository/) linked to by GitHub.
 - This file, [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md) is recognised as the contribution guidelines and a link is [automatically](https://github.com/blog/1184-contributing-guidelines) displayed when new issues or pull requests are created.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -468,11 +468,7 @@ Editable notebooks are made available using [Google Colab](https://colab.researc
 
 GitHub does some magic with particular filenames. In particular:
 
-- The first page people see when they go to [our GitHub page](https://github.
-  com/pybamm-team/PyBaMM) displays the contents of [README.md]
-  (https://github.com/pybamm-team/PyBaMM/blob/develop/README.md), which is 
-  written in the [Markdown](https://github.
-  com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format. Some guidelines can be found [here](https://docs.github.com/articles/about-readmes/).
+- The first page people see when they go to [our GitHub page](https://github.com/pybamm-team/PyBaMM) displays the contents of [README.md](https://github.com/pybamm-team/PyBaMM/blob/develop/README.md), which is written in the [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) format. Some guidelines can be found [here](https://docs.github.com/articles/about-readmes/).
 - The license for using PyBaMM is stored in [LICENSE](https://github.com/pybamm-team/PyBaMM/blob/develop/LICENSE.txt), and [automatically](https://docs.github.com/articles/adding-a-license-to-a-repository/) linked to by GitHub.
 - This file, [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md) is recognised as the contribution guidelines and a link is [automatically](https://github.com/blog/1184-contributing-guidelines) displayed when new issues or pull requests are created.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,6 @@ import nox
 import os
 import sys
 import warnings
-import platform
 from pathlib import Path
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,28 +27,15 @@ def set_iree_state():
     """
     state = "ON" if os.getenv("PYBAMM_IDAKLU_EXPR_IREE", "OFF") == "ON" else "OFF"
     if state == "ON":
-        if sys.platform == "win32":
+        if sys.platform == "win32" or sys.platform == "darwin":
             warnings.warn(
                 (
-                    "IREE is not enabled on Windows yet. "
+                    "IREE is not enabled on Windows and MacOS. "
                     "Setting PYBAMM_IDAKLU_EXPR_IREE=OFF."
                 ),
                 stacklevel=2,
             )
             return "OFF"
-        if sys.platform == "darwin":
-            # iree-compiler is currently only available as a wheel on macOS 13 (or
-            # higher) and Python version 3.11
-            mac_ver = int(platform.mac_ver()[0].split(".")[0])
-            if (not sys.version_info[:2] == (3, 11)) or mac_ver < 14:
-                warnings.warn(
-                    (
-                        "IREE is only supported on MacOS 13 (or higher) and Python"
-                        "version 3.11. Setting PYBAMM_IDAKLU_EXPR_IREE=OFF."
-                    ),
-                    stacklevel=2,
-                )
-                return "OFF"
     return state
 
 

--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -201,8 +201,11 @@ from . import callbacks
 # Pybamm Data manager using pooch
 from .pybamm_data import DataLoader
 
-# Remove any imported modules, so we don't expose them as part of pybamm
-del sys
+# Fix Casadi import
+import os
+import pathlib
+import sysconfig
+os.environ["CASADIPATH"] = str(pathlib.Path(sysconfig.get_path('purelib')) / 'casadi')
 
 __all__ = [
     "batch_study",

--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 from pybamm.version import __version__
 
 # Demote expressions to 32-bit floats/ints - option used for IDAKLU-MLIR compilation


### PR DESCRIPTION
# Description

Quick fixes for the issues with CasADI and IREE.

Related #4524
Related #4521 

## Type of change

The CasADI fix should work for MacOS and Linux builds, but does not fix Windows issues.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
