### PR TITLE
Fix indexing bug with infeasible experiments for `IDAKLUSolver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Removed the `start_step_offset` setting and disabled minimum `dt` warnings for drive cycles with the (`IDAKLUSolver`). ([#4416](https://github.com/pybamm-team/PyBaMM/pull/4416))
 
 ## Bug Fixes
-
+- Fixed bug in post-processing solutions with infeasible experiments using the (`IDAKLUSolver`). ([#4541](https://github.com/pybamm-team/PyBaMM/pull/4541))
 - Disabled IREE on MacOS due to compatibility issues and added the CasADI
   path to the environment to resolve issues on MacOS and Linux. Windows
   users may still experience issues with interpolation. ([#4528](https://github.com/pybamm-team/PyBaMM/pull/4528))

--- a/src/pybamm/solvers/c_solvers/idaklu/observe.cpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/observe.cpp
@@ -100,6 +100,11 @@ public:
         ) {
         for (size_t i = 0; i < ts_data_np.size(); i++) {
             const auto& t_data = ts_data_np[i].unchecked<1>();
+            // Continue if there is no data
+            if (t_data.size() == 0) {
+                continue;
+            }
+
             const realtype t_data_final = t_data(t_data.size() - 1);
             realtype t_interp_next = t_interp(i_interp);
             // Continue if the next interpolation point is beyond the final data point
@@ -227,6 +232,10 @@ public:
         int i_entries = 0;
         for (size_t i = 0; i < ts.size(); i++) {
             const auto& t = ts[i].unchecked<1>();
+            // Continue if there is no data
+            if (t.size() == 0) {
+                continue;
+            }
             const auto& y = ys[i].unchecked<2>();
             const auto input = inputs[i].data();
             const auto func = *funcs[i];

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -133,19 +133,24 @@ class ProcessedVariable:
         ys = self.all_ys
         yps = self.all_yps
         inputs = self.all_inputs_casadi
+
+        # Remove all empty ts
+        idxs_nonempty = np.where([ti.size > 0 for ti in ts])[0]
+
         # Find the indices of the time points to observe
         if full_range:
-            idxs = range(len(ts))
+            idxs = idxs_nonempty
         else:
-            idxs = _find_ts_indices(ts, t)
+            ts_nonempty = [ts[idx] for idx in idxs_nonempty]
+            idxs_subset = _find_ts_indices(ts_nonempty, t)
+            idxs = idxs_nonempty[idxs_subset]
 
-        if isinstance(idxs, list):
-            # Extract the time points and inputs
-            ts = [ts[idx] for idx in idxs]
-            ys = [ys[idx] for idx in idxs]
-            if self.hermite_interpolation:
-                yps = [yps[idx] for idx in idxs]
-            inputs = [self.all_inputs_casadi[idx] for idx in idxs]
+        # Extract the time points and inputs
+        ts = [ts[idx] for idx in idxs]
+        ys = [ys[idx] for idx in idxs]
+        if self.hermite_interpolation:
+            yps = [yps[idx] for idx in idxs]
+        inputs = [self.all_inputs_casadi[idx] for idx in idxs]
 
         is_f_contiguous = _is_f_contiguous(ys)
 
@@ -976,9 +981,5 @@ def _find_ts_indices(ts, t):
     # extrapolating
     if (t[-1] > ts[-1][-1]) and (len(indices) == 0 or indices[-1] != len(ts) - 1):
         indices.append(len(ts) - 1)
-
-    if len(indices) == len(ts):
-        # All indices are included
-        return range(len(ts))
 
     return indices

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -580,11 +580,15 @@ class Solution:
         # Iterate through all models, some may be in the list several times and
         # therefore only get set up once
         vars_casadi = []
-        for i, (model, ys, inputs, var_pybamm) in enumerate(
-            zip(self.all_models, self.all_ys, self.all_inputs, vars_pybamm)
+        for i, (model, ts, ys, inputs, var_pybamm) in enumerate(
+            zip(self.all_models, self.all_ts, self.all_ys, self.all_inputs, vars_pybamm)
         ):
-            if ys.size == 0 and var_pybamm.has_symbol_of_classes(
-                pybamm.expression_tree.state_vector.StateVector
+            if (
+                ys.size == 0
+                and var_pybamm.has_symbol_of_classes(
+                    pybamm.expression_tree.state_vector.StateVector
+                )
+                and not ts.size == 0
             ):
                 raise KeyError(
                     f"Cannot process variable '{variable}' as it was not part of the "


### PR DESCRIPTION
# Description

@pipliggins figured out why infeasible experiments were failing with the `IDAKLUSolver`:
> I checked this with #4534 to confirm it's not an `output_variables` specific problem - it's not, but related. 
> 
> Having the voltage limit violation at the start of a cycle step results in the final solution containing an empty array in the middle of `all_ys`. The assumption leading to the output_variables error was that the only time an empty numpy array would be present in `all_ys` is if the solver isn’t returning the full state vector, as with IDAKLU(output_variables=true), so an false error is being flagged. I fixed that by checking for an empty `t` array too in `_update_variables()`, i.e.:
> ```
>       for i, (model, ts, ys, inputs, var_pybamm) in enumerate(
>           zip(self.all_models, self.all_ts, self.all_ys, self.all_inputs, vars_pybamm)
>       ):
>           if (
>               ys.size == 0
>               and var_pybamm.has_symbol_of_classes(
>                   pybamm.expression_tree.state_vector.StateVector
>               )
>               and not ts.size == 0
>           ):
> ```
> But using this I get a different error related to the hermite interpolation. Turning off hermite interpolation in the solver (and with the output_variables fix) the example runs as expected. I suspect the interpolation issue is also being caused by an unexpected empty array in the state vector, but haven’t dug that far. 

 _Originally posted by @pipliggins in [#4496](https://github.com/pybamm-team/PyBaMM/issues/4496#issuecomment-2432607221)_

I added additional checking in the `ProcessedVariable` class to ignore empty sub-solutions.

Fixes #4496

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
