### PR TITLE
Cleanup formatting in error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ PyBaMM provides a utility function `import_optional_dependency`, to check for th
 Optional dependencies should never be imported at the module level, but always inside methods. For example:
 
 ```python
-def use_pybtex(x,y,z):
+def use_pybtex(x, y, z):
     pybtex = import_optional_dependency("pybtex")
     ...
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You now have everything you need to start making changes!
 
 ### B. Writing your code
 
-6. PyBaMM is developed in [Python](https://www.python.org)), and makes heavy use of [NumPy](https://numpy.org/) (see also [NumPy for MatLab users](https://numpy.org/doc/stable/user/numpy-for-matlab-users.html) and [Python for R users](https://www.rebeccabarter.com/blog/2023-09-11-from_r_to_python)).
+6. PyBaMM is developed in [Python](https://www.python.org), and makes heavy use of [NumPy](https://numpy.org/).
 7. Make sure to follow our [coding style guidelines](#coding-style-guidelines).
 8. Commit your changes to your branch with [useful, descriptive commit messages](https://chris.beams.io/posts/git-commit/): Remember these are
    publicly visible and should still make sense a few months ahead in time.
@@ -116,7 +116,7 @@ PyBaMM provides a utility function `import_optional_dependency`, to check for th
 
 Optional dependencies should never be imported at the module level, but always inside methods. For example:
 
-```
+```python
 def use_pybtex(x,y,z):
     pybtex = import_optional_dependency("pybtex")
     ...

--- a/src/pybamm/discretisations/discretisation.py
+++ b/src/pybamm/discretisations/discretisation.py
@@ -500,7 +500,7 @@ class Discretisation:
 
         if domain != "current collector":
             raise pybamm.ModelError(
-                "Boundary conditions can only be applied on the tabs in the domain"
+                "Boundary conditions can only be applied on the tabs in the domain "
                 f"'current collector', but {symbol} has domain {domain}"
             )
         # Replace keys with "left" and "right" as appropriate for 1D meshes

--- a/src/pybamm/discretisations/discretisation.py
+++ b/src/pybamm/discretisations/discretisation.py
@@ -500,8 +500,8 @@ class Discretisation:
 
         if domain != "current collector":
             raise pybamm.ModelError(
-                f"""Boundary conditions can only be applied on the tabs in the domain
-            'current collector', but {symbol} has domain {domain}"""
+                "Boundary conditions can only be applied on the tabs in the domain"
+                f"'current collector', but {symbol} has domain {domain}"
             )
         # Replace keys with "left" and "right" as appropriate for 1D meshes
         if isinstance(mesh, pybamm.SubMesh1D):
@@ -893,11 +893,9 @@ class Discretisation:
                 y_slices = self.y_slices[symbol]
             except KeyError as error:
                 raise pybamm.ModelError(
-                    f"""
-                    No key set for variable '{symbol.name}'. Make sure it is included in either
-                    model.rhs or model.algebraic in an unmodified form
-                    (e.g. not Broadcasted)
-                    """
+                    f"No key set for variable '{symbol.name}'. Make sure it is included in either "
+                    "model.rhs or model.algebraic in an unmodified form "
+                    "(e.g. not Broadcasted)"
                 ) from error
             # Add symbol's reference and multiply by the symbol's scale
             # so that the state vector is of order 1

--- a/src/pybamm/expression_tree/averages.py
+++ b/src/pybamm/expression_tree/averages.py
@@ -251,8 +251,8 @@ def z_average(symbol: pybamm.Symbol) -> pybamm.Symbol:
     # Symbol must have domain [] or ["current collector"]
     if symbol.domain not in [[], ["current collector"]]:
         raise pybamm.DomainError(
-            f"""z-average only implemented in the 'current collector' domain,
-            but symbol has domains {symbol.domain}"""
+            "z-average only implemented in the 'current collector' domain, "
+            f"but symbol has domains {symbol.domain}"
         )
     # If symbol doesn't have a domain, its average value is itself
     if symbol.domain == []:
@@ -285,8 +285,8 @@ def yz_average(symbol: pybamm.Symbol) -> pybamm.Symbol:
     # Symbol must have domain [] or ["current collector"]
     if symbol.domain not in [[], ["current collector"]]:
         raise pybamm.DomainError(
-            f"""y-z-average only implemented in the 'current collector' domain,
-            but symbol has domains {symbol.domain}"""
+            "y-z-average only implemented in the 'current collector' domain, "
+            f"but symbol has domains {symbol.domain}"
         )
     # If symbol doesn't have a domain, its average value is itself
     if symbol.domain == []:

--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -36,7 +36,7 @@ def _preprocess_binary(
     # Check both left and right are pybamm Symbols
     if not (isinstance(left, pybamm.Symbol) and isinstance(right, pybamm.Symbol)):
         raise NotImplementedError(
-            f"""BinaryOperator not implemented for symbols of type {type(left)} and {type(right)}"""
+            f"BinaryOperator not implemented for symbols of type {type(left)} and {type(right)}"
         )
 
     # Do some broadcasting in special cases, to avoid having to do this manually
@@ -389,9 +389,9 @@ class MatrixMultiplication(BinaryOperator):
             return left @ right_jac
         else:
             raise NotImplementedError(
-                f"""jac of 'MatrixMultiplication' is only
-             implemented for left of type 'pybamm.Array',
-             not {left.__class__}"""
+                f"jac of 'MatrixMultiplication' is only "
+                "implemented for left of type 'pybamm.Array', "
+                f"not {left.__class__}"
             )
 
     def _binary_evaluate(self, left, right):
@@ -1541,8 +1541,8 @@ def source(
 
     if left.domain != ["current collector"] or right.domain != ["current collector"]:
         raise pybamm.DomainError(
-            f"""'source' only implemented in the 'current collector' domain,
-            but symbols have domains {left.domain} and {right.domain}"""
+            "'source' only implemented in the 'current collector' domain, "
+            f"but symbols have domains {left.domain} and {right.domain}"
         )
     if boundary:
         return pybamm.BoundaryMass(right) @ left

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -231,8 +231,6 @@ class CasadiConverter:
 
         else:
             raise TypeError(
-                f"""
-                Cannot convert symbol of type '{type(symbol)}' to CasADi. Symbols must all be
-                'linear algebra' at this stage.
-                """
+                f"Cannot convert symbol of type '{type(symbol)}' to CasADi. Symbols must all be"
+                "'linear algebra' at this stage."
             )

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -231,6 +231,6 @@ class CasadiConverter:
 
         else:
             raise TypeError(
-                f"Cannot convert symbol of type '{type(symbol)}' to CasADi. Symbols must all be"
+                f"Cannot convert symbol of type '{type(symbol)}' to CasADi. Symbols must all be "
                 "'linear algebra' at this stage."
             )

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -992,8 +992,8 @@ class BoundaryOperator(SpatialOperator):
         if side in ["negative tab", "positive tab"]:
             if child.domain[0] != "current collector":
                 raise pybamm.ModelError(
-                    f"""Can only take boundary value on the tabs in the domain
-                'current collector', but {child} has domain {child.domain[0]}"""
+                    "Can only take boundary value on the tabs in the domain "
+                    f"'current collector', but {child} has domain {child.domain[0]}"
                 )
         self.side = side
         # boundary value of a child takes the primary domain from secondary domain

--- a/src/pybamm/expression_tree/vector.py
+++ b/src/pybamm/expression_tree/vector.py
@@ -29,9 +29,7 @@ class Vector(pybamm.Array):
             entries = entries[:, np.newaxis]
         if entries.shape[1] != 1:
             raise ValueError(
-                f"""
-                Entries must have 1 dimension or be column vector, not have shape {entries.shape}
-                """
+                f"Entries must have 1 dimension or be column vector, not have shape {entries.shape}"
             )
         if name is None:
             name = f"Column vector of length {entries.shape[0]!s}"

--- a/src/pybamm/meshes/one_dimensional_submeshes.py
+++ b/src/pybamm/meshes/one_dimensional_submeshes.py
@@ -297,8 +297,8 @@ class UserSupplied1DSubMesh(SubMesh1D):
 
         if (npts + 1) != len(edges):
             raise pybamm.GeometryError(
-                f"""User-suppled edges has should have length (npts + 1) but has length
-                {len(edges)}.Number of points (npts) for domain {spatial_var.domain} is {npts}.""".replace(
+                "User-suppled edges has should have length (npts + 1) but has length "
+                f"{len(edges)}.Number of points (npts) for domain {spatial_var.domain} is {npts}.".replace(
                     "\n                ", " "
                 )
             )

--- a/src/pybamm/meshes/scikit_fem_submeshes.py
+++ b/src/pybamm/meshes/scikit_fem_submeshes.py
@@ -92,8 +92,8 @@ class ScikitSubMesh2D(SubMesh):
         # check coordinate system agrees
         if spatial_vars[0].coord_sys != spatial_vars[1].coord_sys:
             raise pybamm.DomainError(
-                f"""spatial variables should have the same coordinate system,
-                but have coordinate systems {spatial_vars[0].coord_sys} and {spatial_vars[1].coord_sys}"""
+                "spatial variables should have the same coordinate system, "
+                f"but have coordinate systems {spatial_vars[0].coord_sys} and {spatial_vars[1].coord_sys}"
             )
         return spatial_vars, tabs
 
@@ -360,9 +360,9 @@ class UserSupplied2DSubMesh(ScikitSubMesh2D):
             # check that npts equals number of user-supplied edges
             if npts[var.name] != len(edges[var.name]):
                 raise pybamm.GeometryError(
-                    f"""User-suppled edges has should have length npts but has length {len(edges[var.name])}.
-                     Number of points (npts) for variable {var.name} in
-                     domain {var.domain} is {npts[var.name]}."""
+                    f"User-supplied edges has should have length npts but has length {len(edges[var.name])}. "
+                    f"Number of points (npts) for variable {var.name} in "
+                    f"domain {var.domain} is {npts[var.name]}."
                 )
 
             # check end points of edges agree with spatial_lims

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -1110,7 +1110,7 @@ class BaseModel:
         for var in self.rhs.keys():
             if var not in self.initial_conditions.keys():
                 raise pybamm.ModelError(
-                    f"""no initial condition given for variable '{var}'"""
+                    f"no initial condition given for variable '{var}'"
                 )
 
     def check_variables(self):
@@ -1132,11 +1132,9 @@ class BaseModel:
         for var in all_vars:
             if var not in vars_in_keys:
                 raise pybamm.ModelError(
-                    f"""
-                    No key set for variable '{var}'. Make sure it is included in either
-                    model.rhs or model.algebraic, in an unmodified form
-                    (e.g. not Broadcasted)
-                    """
+                    f"No key set for variable '{var}'. Make sure it is included in either "
+                    "model.rhs or model.algebraic, in an unmodified form "
+                    "(e.g. not Broadcasted)"
                 )
 
     def check_no_repeated_keys(self):
@@ -1550,9 +1548,7 @@ class BoundaryConditionsDict(dict):
                 # Check types
                 if bc[1] not in ["Dirichlet", "Neumann"]:
                     raise pybamm.ModelError(
-                        f"""
-                        boundary condition types must be Dirichlet or Neumann, not '{bc[1]}'
-                        """
+                        f"boundary condition types must be Dirichlet or Neumann, not '{bc[1]}'"
                     )
 
         return boundary_conditions

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -519,14 +519,12 @@ class Simulation:
                     dt_eval_max = np.max(np.diff(t_eval))
                     if dt_eval_max > np.nextafter(dt_data_min, np.inf):
                         warnings.warn(
-                            f"""
-                            The largest timestep in t_eval ({dt_eval_max}) is larger than
-                            the smallest timestep in the data ({dt_data_min}). The returned
-                            solution may not have the correct resolution to accurately
-                            capture the input. Try refining t_eval. Alternatively,
-                            passing t_eval = None automatically sets t_eval to be the
-                            points in the data.
-                            """,
+                            f"The largest timestep in t_eval ({dt_eval_max}) is larger than "
+                            f"the smallest timestep in the data ({dt_data_min}). The returned "
+                            "solution may not have the correct resolution to accurately "
+                            "capture the input. Try refining t_eval. Alternatively, "
+                            "passing t_eval = None automatically sets t_eval to be the "
+                            "points in the data.",
                             pybamm.SolverWarning,
                             stacklevel=2,
                         )

--- a/src/pybamm/solvers/casadi_algebraic_solver.py
+++ b/src/pybamm/solvers/casadi_algebraic_solver.py
@@ -146,11 +146,9 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
                 )
             else:
                 raise pybamm.SolverError(
-                    f"""
-                    Could not find acceptable solution: solver terminated
-                    successfully, but maximum solution error ({casadi.mmax(casadi.fabs(fun))})
-                    above tolerance ({self.tol})
-                    """
+                    "Could not find acceptable solution: solver terminated "
+                    f"successfully, but maximum solution error ({casadi.mmax(casadi.fabs(fun))}) "
+                    f"above tolerance ({self.tol})"
                 )
 
         # Concatenate differential part


### PR DESCRIPTION
# Description

I noticed some of the longer f-strings printed out with large indents. This PR is to clean that up a bit. There are still some triple quoted strings that could be cleaned up, but these are the easy ones to catch.

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
