### PR TITLE
Fix IDAKLU solver crash when running in multiple threads + when telemetry is prompted for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Adds an option "voltage as a state" that can be "false" (default) or "true". If "true" adds an explicit algebraic equation for the voltage. ([#4507](https://github.com/pybamm-team/PyBaMM/pull/4507))
 - Improved `QuickPlot` accuracy for simulations with Hermite interpolation. ([#4483](https://github.com/pybamm-team/PyBaMM/pull/4483))
 - Added Hermite interpolation to the (`IDAKLUSolver`) that improves the accuracy and performance of post-processing variables. ([#4464](https://github.com/pybamm-team/PyBaMM/pull/4464))
-- Added basic telemetry to record which functions are being run. See [Telemetry section in the User Guide](https://docs.pybamm.org/en/latest/source/user_guide/index.html#telemetry) for more information. ([#4441](https://github.com/pybamm-team/PyBaMM/pull/4441))
+- Added basic telemetry to record which functions are being run. See [Telemetry section in the User Guide](https://docs.pybamm.org/en/latest/source/user_guide/index.html#telemetry) for more information. ([#4441](https://github.com/pybamm-team/PyBaMM/pull/4441), [#4583](https://github.com/pybamm-team/PyBaMM/pull/4583))
 - Added `BasicDFN` model for sodium-ion batteries ([#4451](https://github.com/pybamm-team/PyBaMM/pull/4451))
 - Added sensitivity calculation support for `pybamm.Simulation` and `pybamm.Experiment` ([#4415](https://github.com/pybamm-team/PyBaMM/pull/4415))
 - Added OpenMP parallelization to IDAKLU solver for lists of input parameters ([#4449](https://github.com/pybamm-team/PyBaMM/pull/4449))

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -72,6 +72,7 @@ Package                                                             Minimum supp
 `pandas <https://pypi.org/project/pandas/>`__                       1.5.0
 `pooch <https://www.fatiando.org/pooch/>`__                         1.8.1
 `posthog <https://posthog.com/>`__                                  3.6.5
+`platformdirs <https://pypi.org/project/platformdirs/>`__           4.0.0
 =================================================================== ==========================
 
 .. _install.optional_dependencies:

--- a/noxfile.py
+++ b/noxfile.py
@@ -254,9 +254,10 @@ def run_tests(session):
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     specific_test_files = session.posargs if session.posargs else []
-    session.run(
-        "python", "-m", "pytest", *specific_test_files, "-m", "unit or integration"
-    )
+    if specific_test_files:
+        session.run("python", "-m", "pytest", *specific_test_files)
+    else:
+        session.run("python", "-m", "pytest", "-m", "unit or integration")
 
 
 @nox.session(name="docs")

--- a/noxfile.py
+++ b/noxfile.py
@@ -253,11 +253,12 @@ def run_tests(session):
     set_environment_variables(PYBAMM_ENV, session=session)
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
-    specific_test_files = session.posargs if session.posargs else []
-    if specific_test_files:
-        session.run("python", "-m", "pytest", *specific_test_files)
-    else:
-        session.run("python", "-m", "pytest", "-m", "unit or integration")
+    session.run(
+        "python",
+        "-m",
+        "pytest",
+        *(session.posargs if session.posargs else ["-m", "unit or integration"]),
+    )
 
 
 @nox.session(name="docs")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pandas>=1.5.0",
     "pooch>=1.8.1",
     "posthog",
+    "platformdirs",
 ]
 
 [project.urls]

--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -4,10 +4,10 @@ from pybamm.version import __version__
 demote_expressions_to_32bit = False
 
 # Utility classes and methods
-from .util import root_dir
 from .util import Timer, TimerTime, FuzzyDict
 from .util import (
     root_dir,
+    is_notebook,
     load,
     is_constant_and_can_evaluate,
 )
@@ -190,7 +190,7 @@ from .plotting.plot_summary_variables import plot_summary_variables
 from .plotting.dynamic_plot import dynamic_plot
 
 # Simulation
-from .simulation import Simulation, load_sim, is_notebook
+from .simulation import Simulation, load_sim
 
 # Batch Study
 from .batch_study import BatchStudy

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -71,7 +71,7 @@ def get_input_or_timeout(timeout):  # pragma: no cover
         return None, True
 
     # 1. special handling for Jupyter notebooks
-    if is_notebook():
+    if is_notebook():  # pragma: no cover
         try:
             from ipywidgets import widgets
             from IPython.display import display, clear_output
@@ -114,12 +114,14 @@ def get_input_or_timeout(timeout):  # pragma: no cover
             if not result["set"]:
                 with output:
                     clear_output()
-                    print("Timeout reached or negative input. Defaulting to not enabling telemetry.")
+                    print(
+                        "Timeout reached or negative input. Defaulting to not enabling telemetry."
+                    )
                 return None, True
 
             return result["value"], False
 
-        except Exception:
+        except Exception:  # pragma: no cover
             # Fallback to regular input for Jupyter environments where widgets
             # aren't available. This should be quite rare at this point but is
             # included for completeness.
@@ -153,8 +155,8 @@ def get_input_or_timeout(timeout):  # pragma: no cover
             return None, True
         except Exception:
             return None, True
-    # POSIX-like systems will need to use termios
-    else:
+    # 3. POSIX-like systems will need to use termios
+    else:  # pragma: no cover
         try:
             import termios
             import tty
@@ -190,7 +192,7 @@ def get_input_or_timeout(timeout):  # pragma: no cover
                 sys.stdout.write("\n")
                 sys.stdout.flush()
 
-        except Exception:
+        except Exception:  # pragma: no cover
             return None, True
 
     return None, True
@@ -206,7 +208,7 @@ def ask_user_opt_in(timeout=10):  # pragma: no cover
 
     # Skip telemetry prompt in non-interactive environments
     if not (sys.stdin.isatty() or is_notebook()):
-        False
+        return False
 
     print(
         "PyBaMM can collect usage data and send it to the PyBaMM team to "

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -145,7 +145,7 @@ def get_input_or_timeout(timeout):  # pragma: no cover
 
             finally:
                 # Restore saved terminal settings
-                termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+                termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, old_settings)
                 sys.stdout.write("\n")
                 sys.stdout.flush()
 

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -80,11 +80,6 @@ def get_input_or_timeout(timeout):  # pragma: no cover
             user_input = input("Do you want to enable telemetry? (Y/n): ")
             clear_output()
 
-            if user_input.lower() in ["y", "yes", ""]:
-                print("Telemetry enabled.")
-            elif user_input.lower() in ["n", "no"]:
-                print("Telemetry disabled.")
-
             return user_input, False
 
         except Exception:  # pragma: no cover

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -1,11 +1,14 @@
-import uuid
 import os
-import platformdirs
-from pathlib import Path
-import pybamm
 import sys
-import threading
 import time
+import uuid
+
+from pathlib import Path
+
+import pybamm
+import platformdirs
+
+from pybamm.util import is_notebook
 
 
 def is_running_tests():  # pragma: no cover

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -184,10 +184,7 @@ def ask_user_opt_in(timeout=10):  # pragma: no cover
         return False
 
     while True:
-        if user_input == "":  # Empty input should mean a no
-            print("Telemetry enabled.\n")
-            return False
-        elif user_input.lower() in ["y", "yes"]:
+        if user_input.lower() in ["y", "yes", ""]:
             print("Telemetry enabled.\n")
             return True
         elif user_input.lower() in ["n", "no"]:
@@ -210,7 +207,7 @@ def generate():
         return
 
     # Ask the user if they want to opt in to telemetry
-    opt_in = ask_user_opt_in(timeout=10)
+    opt_in = ask_user_opt_in()
     config_file = Path(platformdirs.user_config_dir("pybamm")) / "config.yml"
     write_uuid_to_file(config_file, opt_in)
 

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -159,13 +159,6 @@ def ask_user_opt_in(timeout=10):  # pragma: no cover
     """
     Ask the user if they want to opt in to telemetry.
     """
-    # Check for telemetry disable flag first
-    if os.getenv("PYBAMM_DISABLE_TELEMETRY", "false").lower() != "false":
-        return False
-
-    # Skip telemetry prompt in non-interactive environments
-    if not (sys.stdin.isatty() or is_notebook()):
-        return False
 
     print(
         "PyBaMM can collect usage data and send it to the PyBaMM team to "

--- a/src/pybamm/config.py
+++ b/src/pybamm/config.py
@@ -183,18 +183,22 @@ def ask_user_opt_in(timeout=10):  # pragma: no cover
         print("\nTimeout reached. Defaulting to not enabling telemetry.")
         return False
 
-    if not user_input:  # Empty input should mean a yes
-        print("\nTelemetry enabled.\n")
-        return True
-    elif user_input.lower() in ["y", "yes"]:
-        print("\nTelemetry enabled.\n")
-        return True
-    elif user_input.lower() in ["n", "no"]:
-        print("\nTelemetry disabled.\n")
-        return False
-    else:
-        print("\nInvalid input. Defaulting to not enabling telemetry.")
-        return False
+    while True:
+        if user_input == "":  # Empty input should mean a no
+            print("Telemetry enabled.\n")
+            return False
+        elif user_input.lower() in ["y", "yes"]:
+            print("Telemetry enabled.\n")
+            return True
+        elif user_input.lower() in ["n", "no"]:
+            print("Telemetry disabled.")
+            return False
+        else:
+            print("Invalid input. Please enter 'Y/y' for yes or 'n/N' for no:")
+            user_input = get_input_or_timeout(timeout)
+            if user_input is None:
+                print("\nTimeout reached. Defaulting to not enabling telemetry.")
+                return False
 
 
 def generate():

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -16,24 +16,6 @@ from pybamm.util import import_optional_dependency
 from pybamm.expression_tree.operations.serialise import Serialise
 
 
-def is_notebook():
-    try:
-        shell = get_ipython().__class__.__name__
-        if shell == "ZMQInteractiveShell":  # pragma: no cover
-            # Jupyter notebook or qtconsole
-            cfg = get_ipython().config
-            nb = len(cfg["InteractiveShell"].keys()) == 0
-            return nb
-        elif shell == "TerminalInteractiveShell":  # pragma: no cover
-            return False  # Terminal running IPython
-        elif shell == "Shell":  # pragma: no cover
-            return True  # Google Colab notebook
-        else:  # pragma: no cover
-            return False  # Other type (?)
-    except NameError:
-        return False  # Probably standard Python interpreter
-
-
 class Simulation:
     """A Simulation class for easy building and running of PyBaMM simulations.
 
@@ -141,7 +123,7 @@ class Simulation:
         self._set_random_seed()
 
         # ignore runtime warnings in notebooks
-        if is_notebook():  # pragma: no cover
+        if pybamm.is_notebook():  # pragma: no cover
             import warnings
 
             warnings.filterwarnings("ignore")

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -22,6 +22,24 @@ def root_dir():
     return str(pathlib.Path(pybamm.__path__[0]).parent.parent)
 
 
+def is_notebook():
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":  # pragma: no cover
+            # Jupyter notebook or qtconsole
+            cfg = get_ipython().config
+            nb = len(cfg["InteractiveShell"].keys()) == 0
+            return nb
+        elif shell == "TerminalInteractiveShell":  # pragma: no cover
+            return False  # Terminal running IPython
+        elif shell == "Shell":  # pragma: no cover
+            return True  # Google Colab notebook
+        else:  # pragma: no cover
+            return False  # Other type (?)
+    except NameError:
+        return False  # Probably standard Python interpreter
+
+
 def get_git_commit_info():
     """
     Get the git commit info for the current PyBaMM version, e.g. v22.8-39-gb25ce8c41

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,7 +57,7 @@ class TestConfig:
         # Mock get_input_or_timeout based on scenario
         def mock_get_input(timeout):
             print("Do you want to enable telemetry? (Y/n): ", end="")
-            return user_input, user_input is None
+            return user_input
 
         monkeypatch.setattr(pybamm.config, "get_input_or_timeout", mock_get_input)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,7 +40,7 @@ class TestConfig:
         [
             (["y"], True, ["Telemetry enabled"]),
             (["n"], False, ["Telemetry disabled"]),
-            ([""], False, ["Telemetry enabled"]),
+            ([""], True, ["Telemetry enabled"]),
             (["x", "y"], True, ["Invalid input", "Telemetry enabled"]),
             (["x", "n"], False, ["Invalid input", "Telemetry disabled"]),
             (["x", None], False, ["Invalid input", "Timeout reached"]),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -35,7 +35,6 @@ class TestConfig:
         else:
             assert config_dict["enable_telemetry"] is False
 
-
     @pytest.mark.parametrize(
         "user_input,expected_output,expected_message",
         [
@@ -69,7 +68,6 @@ class TestConfig:
         assert "PyBaMM can collect usage data" in captured.out
         assert expected_message in captured.out
         assert opt_in is expected_output
-
 
     @pytest.mark.parametrize(
         "test_scenario",


### PR DESCRIPTION
# Description

This came up as an unrelated issue in #4582 when testing the wheels and apparently stems from #4441 where a thread was being used to check for the input. This caused the Linux wheel tests to fail: https://github.com/agriyakhetarpal/PyBaMM/actions/runs/11805727556/job/32890103930. This PR redoes that with a multi-platform approach and avoids the use of threads altogether by checking for different environments: Windows via `msvcrt` and Linux/macOS via `termios`. 

~A _possible_ corner case for Jupyter Notebooks (running in VS Code versus Jupyter Notebook/JupyterLab) has also been fixed.~ I've resorted to a more rudimentary fix using the previous method for now, since this fix was erroneous and did not work intermittently.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
