### PR TITLE
allow tol in initial voltage for setting stoichiometries

### DIFF
--- a/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -673,7 +673,7 @@ class ElectrodeSOHSolver:
             V_min = parameter_values.evaluate(self.param.ocp_soc_0)
             V_max = parameter_values.evaluate(self.param.ocp_soc_100)
 
-            if not V_min <= V_init <= V_max:
+            if not V_min - tol <= V_init <= V_max + tol:
                 raise ValueError(
                     f"Initial voltage {V_init}V is outside the voltage limits "
                     f"({V_min}, {V_max})"
@@ -881,7 +881,6 @@ def get_initial_stoichiometries(
         :class:`pybamm.BatteryModelOptions`.
     tol : float, optional
         The tolerance for the solver used to compute the initial stoichiometries.
-        A lower value results in higher precision but may increase computation time.
         Default is 1e-6.
     inputs : dict, optional
         A dictionary of input parameters passed to the model.


### PR DESCRIPTION
# Description
When setting initial stoichiometries using a voltage, allow the initial voltage to be outside the voltage limits by `tol`. This is useful for example when setting the initial voltage to match some data where, say, the voltage is 4.2000001V and the upper voltage limit is 4.2V. Right now, this throws an error but clearly, that is an acceptable initial voltage to within a sensible user-specified tolerance. 

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
