### PR TITLE
Update documentation on Integral operator (#4595)

### DIFF
--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -611,10 +611,13 @@ class Integral(SpatialOperator):
     A node in the expression tree representing an integral operator.
 
     .. math::
-        I = \\int_{a}^{b}\\!f(u)\\,du,
+        I = \\int_{u_{min}}^{u_{max}}\\!f(u)\\,dq,
 
-    where :math:`a` and :math:`b` are the left-hand and right-hand boundaries of
-    the domain respectively, and :math:`u\\in\\text{domain}`.
+    where :math:`u\\in\\text{domain}` is a spatial variable, :math:`u_{min}` and :math:`u_{max}` are the values of
+    :math:`u` at the left-hand and right-hand boundaries of the domain respectively, and :math:`dq` is given by, \n
+    :math:`dq=du` for cartesian coordinates, \n
+    :math:`dq=2\pi udu` for cylindrical coordinates, \n
+    :math:`dq=4\pi u^2 du` for spherical coordinates.
 
     Parameters
     ----------

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -616,8 +616,8 @@ class Integral(SpatialOperator):
     where :math:`u\\in\\text{domain}` is a spatial variable, :math:`u_{min}` and :math:`u_{max}` are the values of
     :math:`u` at the left-hand and right-hand boundaries of the domain respectively, and :math:`dq` is given by, \n
     :math:`dq=du` for cartesian coordinates, \n
-    :math:`dq=2\pi udu` for cylindrical coordinates, \n
-    :math:`dq=4\pi u^2 du` for spherical coordinates.
+    :math:`dq=2\\pi udu` for cylindrical coordinates, \n
+    :math:`dq=4\\pi u^2 du` for spherical coordinates.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR updates the documentation on the integral operator to describe how the coordinate system used affects the integral calculation (#4595).

# Description

The differential element used in the integral calculation changes depending on the coordinate system used, see Issue #4595 for a full description. 

As described in the issue, this is my first contribution to an open-source project. I tried running the tests, and they failed due to various problems with the Chayambuka2022 data set. I'm not really too sure what to do about that - as you can see it has nothing to do with my PR. 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
