### PR TITLE
separate boundary grad and val, make grad default quadratic

### DIFF
--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -824,7 +824,8 @@ class FiniteVolume(pybamm.SpatialMethod):
         if bcs is None:
             bcs = {}
 
-        extrap_order = self.options["extrapolation"]["order"]
+        extrap_order_gradient = self.options["extrapolation"]["order"]["gradient"]
+        extrap_order_value = self.options["extrapolation"]["order"]["value"]
         use_bcs = self.options["extrapolation"]["use bcs"]
 
         nodes = submesh.nodes
@@ -850,7 +851,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                 additive = bcs[child][symbol.side][0]
 
             elif symbol.side == "left":
-                if extrap_order == "linear":
+                if extrap_order_value == "linear":
                     # to find value at x* use formula:
                     # f(x*) = f_1 - (dx0 / dx1) (f_2 - f_1)
 
@@ -868,7 +869,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                         )
                         additive = pybamm.Scalar(0)
 
-                elif extrap_order == "quadratic":
+                elif extrap_order_value == "quadratic":
                     if use_bcs and pybamm.has_bc_of_form(
                         child, symbol.side, bcs, "Neumann"
                     ):
@@ -895,7 +896,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                     raise NotImplementedError
 
             elif symbol.side == "right":
-                if extrap_order == "linear":
+                if extrap_order_value == "linear":
                     if use_bcs and pybamm.has_bc_of_form(
                         child, symbol.side, bcs, "Neumann"
                     ):
@@ -917,7 +918,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                             shape=(1, prim_pts),
                         )
                         additive = pybamm.Scalar(0)
-                elif extrap_order == "quadratic":
+                elif extrap_order_value == "quadratic":
                     if use_bcs and pybamm.has_bc_of_form(
                         child, symbol.side, bcs, "Neumann"
                     ):
@@ -958,14 +959,14 @@ class FiniteVolume(pybamm.SpatialMethod):
                 additive = bcs[child][symbol.side][0]
 
             elif symbol.side == "left":
-                if extrap_order == "linear":
+                if extrap_order_gradient == "linear":
                     # f'(x*) = (f_2 - f_1) / dx1
                     sub_matrix = (1 / dx1) * csr_matrix(
                         ([-1, 1], ([0, 0], [0, 1])), shape=(1, prim_pts)
                     )
                     additive = pybamm.Scalar(0)
 
-                elif extrap_order == "quadratic":
+                elif extrap_order_gradient == "quadratic":
                     a = -(2 * dx0 + 2 * dx1 + dx2) / (dx1**2 + dx1 * dx2)
                     b = (2 * dx0 + dx1 + dx2) / (dx1 * dx2)
                     c = -(2 * dx0 + dx1) / (dx1 * dx2 + dx2**2)
@@ -978,7 +979,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                     raise NotImplementedError
 
             elif symbol.side == "right":
-                if extrap_order == "linear":
+                if extrap_order_gradient == "linear":
                     # use formula:
                     # f'(x*) = (f_N - f_Nm1) / dxNm1
                     sub_matrix = (1 / dxNm1) * csr_matrix(
@@ -987,7 +988,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                     )
                     additive = pybamm.Scalar(0)
 
-                elif extrap_order == "quadratic":
+                elif extrap_order_gradient == "quadratic":
                     a = (2 * dxN + 2 * dxNm1 + dxNm2) / (dxNm1**2 + dxNm1 * dxNm2)
                     b = -(2 * dxN + dxNm1 + dxNm2) / (dxNm1 * dxNm2)
                     c = (2 * dxN + dxNm1) / (dxNm1 * dxNm2 + dxNm2**2)

--- a/src/pybamm/spatial_methods/spatial_method.py
+++ b/src/pybamm/spatial_methods/spatial_method.py
@@ -13,7 +13,12 @@ class SpatialMethod:
     """
 
     def __init__(self, options=None):
-        self.options = {"extrapolation": {"order": "linear", "use bcs": False}}
+        self.options = {
+            "extrapolation": {
+                "order": {"gradient": "quadratic", "value": "linear"},
+                "use bcs": False,
+            }
+        }
 
         # update double-layered dict
         if options:

--- a/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_asymptotics_convergence.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lead_acid/test_asymptotics_convergence.py
@@ -28,7 +28,12 @@ class TestAsymptoticConvergence:
         var_pts = {"x_n": 3, "x_s": 3, "x_p": 3}
         mesh = pybamm.Mesh(geometry, full_model.default_submesh_types, var_pts)
 
-        method_options = {"extrapolation": {"order": "linear", "use bcs": False}}
+        method_options = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": False,
+            }
+        }
         spatial_methods = {
             "macroscale": pybamm.FiniteVolume(method_options),
             "current collector": pybamm.ZeroDimensionalSpatialMethod(method_options),

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -59,8 +59,10 @@ def get_errors(function, method_options, pts, bcs=None):
 class TestExtrapolation:
     def test_convergence_without_bcs(self):
         # all tests are performed on x in [0, 1]
-        linear = {"extrapolation": {"order": "linear"}}
-        quad = {"extrapolation": {"order": "quadratic"}}
+        linear = {"extrapolation": {"order": {"gradient": "linear", "value": "linear"}}}
+        quad = {
+            "extrapolation": {"order": {"gradient": "quadratic", "value": "quadratic"}}
+        }
 
         def x_squared(x):
             y = x**2
@@ -147,8 +149,18 @@ class TestExtrapolation:
 
         bcs = {"left": (left_val, "Dirichlet"), "right": (right_flux, "Neumann")}
 
-        linear = {"extrapolation": {"order": "linear", "use bcs": True}}
-        quad = {"extrapolation": {"order": "quadratic", "use bcs": True}}
+        linear = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": True,
+            }
+        }
+        quad = {
+            "extrapolation": {
+                "order": {"gradient": "quadratic", "value": "quadratic"},
+                "use bcs": True,
+            }
+        }
         l_errors_lin_no_bc, r_errors_lin_no_bc = get_errors(x_cubed, linear, pts)
         l_errors_quad_no_bc, r_errors_quad_no_bc = get_errors(x_cubed, quad, pts)
 
@@ -202,8 +214,18 @@ class TestExtrapolation:
 
         bcs = {"left": (left_flux, "Neumann"), "right": (right_val, "Dirichlet")}
 
-        linear = {"extrapolation": {"order": "linear", "use bcs": True}}
-        quad = {"extrapolation": {"order": "quadratic", "use bcs": True}}
+        linear = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": True,
+            }
+        }
+        quad = {
+            "extrapolation": {
+                "order": {"gradient": "quadratic", "value": "quadratic"},
+                "use bcs": True,
+            }
+        }
         l_errors_lin_no_bc, r_errors_lin_no_bc = get_errors(x_cubed, linear, pts)
         l_errors_quad_no_bc, r_errors_quad_no_bc = get_errors(x_cubed, quad, pts)
 
@@ -237,7 +259,12 @@ class TestExtrapolation:
     def test_linear_extrapolate_left_right(self):
         # create discretisation
         mesh = get_mesh_for_testing()
-        method_options = {"extrapolation": {"order": "linear", "use bcs": True}}
+        method_options = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": True,
+            }
+        }
         spatial_methods = {
             "macroscale": pybamm.FiniteVolume(method_options),
             "negative particle": pybamm.FiniteVolume(method_options),
@@ -308,7 +335,12 @@ class TestExtrapolation:
     def test_quadratic_extrapolate_left_right(self):
         # create discretisation
         mesh = get_mesh_for_testing()
-        method_options = {"extrapolation": {"order": "quadratic", "use bcs": False}}
+        method_options = {
+            "extrapolation": {
+                "order": {"gradient": "quadratic", "value": "quadratic"},
+                "use bcs": False,
+            }
+        }
         spatial_methods = {
             "macroscale": pybamm.FiniteVolume(method_options),
             "negative particle": pybamm.FiniteVolume(method_options),
@@ -402,7 +434,12 @@ class TestExtrapolation:
         rpts = 10
         var_pts = {"r_n": rpts, "r_p": rpts}
         mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
-        method_options = {"extrapolation": {"order": "linear", "use bcs": False}}
+        method_options = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": False,
+            }
+        }
         spatial_methods = {"negative particle": pybamm.FiniteVolume(method_options)}
         disc = pybamm.Discretisation(mesh, spatial_methods)
 
@@ -429,7 +466,12 @@ class TestExtrapolation:
     def test_extrapolate_2d_models(self):
         # create discretisation
         mesh = get_p2d_mesh_for_testing()
-        method_options = {"extrapolation": {"order": "linear", "use bcs": False}}
+        method_options = {
+            "extrapolation": {
+                "order": {"gradient": "linear", "value": "linear"},
+                "use bcs": False,
+            }
+        }
         spatial_methods = {
             "macroscale": pybamm.FiniteVolume(method_options),
             "negative particle": pybamm.FiniteVolume(method_options),


### PR DESCRIPTION
# Description

Issue #4433 pointed out that the boundary gradient is only first-order accurate. This is by default true, though the option to make it quadratic exists. I ran into this doing something else. 

I tried setting it to be default quadratic, but this caused many test failures, often related to the diffusivity becoming negative when extrapolated. I'm guessing users have tuned parameter sets to just barely work with linear extrapolation:
![test](https://github.com/user-attachments/assets/297ddaa5-48e9-4620-a200-4fd0d411f3bb) 

In any case, linear extrapolation for boundary values is less of a priority than for boundary gradients. 

So, this pull request separates extrapolation methods for boundary gradient and boundary value, and sets the default to be quadratic for the gradient. This solves the issue discussed in #4433 while not breaking other parameter sets. 

Here is the modified graph from #4433 
![test_boundary_grad](https://github.com/user-attachments/assets/6a83ef18-d71d-4e1a-ba59-8517b5811c2f)




Fixes #4433 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
