### PR TITLE
Add `PYBAMM_OPENMP` flag to enable/disable OpenMP at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,20 @@ endif()
 
 project(idaklu)
 
+# add an OpenMP option: we'll keep this ON by default, except for Emscripten builds
+if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+  set(PYBAMM_OPENMP_DEFAULT OFF)
+else()
+  set(PYBAMM_OPENMP_DEFAULT ON)
+endif()
+
+option(PYBAMM_OPENMP "Enable OpenMP support" ${PYBAMM_OPENMP_DEFAULT})
+message(STATUS "PYBAMM_OPENMP set to: ${PYBAMM_OPENMP}")
+
+if(PYBAMM_OPENMP)
+  add_compile_definitions(PYBAMM_OPENMP)
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -145,20 +159,22 @@ set_target_properties(
 )
 
 # openmp
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  execute_process(
-      COMMAND "brew" "--prefix"
-      OUTPUT_VARIABLE HOMEBREW_PREFIX
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if (OpenMP_ROOT)
-    set(OpenMP_ROOT "${OpenMP_ROOT}:${HOMEBREW_PREFIX}/opt/libomp")
-  else()
-    set(OpenMP_ROOT "${HOMEBREW_PREFIX}/opt/libomp")
+if(PYBAMM_OPENMP)
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    execute_process(
+        COMMAND "brew" "--prefix"
+        OUTPUT_VARIABLE HOMEBREW_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (OpenMP_ROOT)
+      set(OpenMP_ROOT "${OpenMP_ROOT}:${HOMEBREW_PREFIX}/opt/libomp")
+    else()
+      set(OpenMP_ROOT "${HOMEBREW_PREFIX}/opt/libomp")
+    endif()
   endif()
-endif()
-find_package(OpenMP)
-if(OpenMP_CXX_FOUND)
-    target_link_libraries(idaklu PRIVATE OpenMP::OpenMP_CXX)
+  find_package(OpenMP)
+  if(OpenMP_CXX_FOUND)
+      target_link_libraries(idaklu PRIVATE OpenMP::OpenMP_CXX)
+  endif()
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})

--- a/setup.py
+++ b/setup.py
@@ -94,10 +94,15 @@ class CMakeBuild(build_ext):
         build_type = os.getenv("PYBAMM_CPP_BUILD_TYPE", "RELEASE")
         idaklu_expr_casadi = os.getenv("PYBAMM_IDAKLU_EXPR_CASADI", "ON")
         idaklu_expr_iree = os.getenv("PYBAMM_IDAKLU_EXPR_IREE", "OFF")
+        # OpenMP is enabled by default, we'll disable it for WASM builds
+        pybamm_openmp = (
+            "OFF" if os.getenv("PYODIDE") else os.getenv("PYBAMM_OPENMP", "ON")
+        )
         cmake_args = [
             f"-DCMAKE_BUILD_TYPE={build_type}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             "-DUSE_PYTHON_CASADI={}".format("TRUE" if use_python_casadi else "FALSE"),
+            f"-DPYBAMM_OPENMP={pybamm_openmp}",
             f"-DPYBAMM_IDAKLU_EXPR_CASADI={idaklu_expr_casadi}",
             f"-DPYBAMM_IDAKLU_EXPR_IREE={idaklu_expr_iree}",
         ]

--- a/src/pybamm/solvers/c_solvers/idaklu/common.hpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/common.hpp
@@ -7,7 +7,9 @@
 #include <idas/idas_bbdpre.h>         /* access to IDABBDPRE preconditioner          */
 
 #include <nvector/nvector_serial.h>  /* access to serial N_Vector            */
+#ifdef PYBAMM_OPENMP
 #include <nvector/nvector_openmp.h>  /* access to openmp N_Vector            */
+#endif
 #include <sundials/sundials_math.h>  /* defs. of SUNRabs, SUNRexp, etc.      */
 #include <sundials/sundials_config.h>  /* defs. of SUNRabs, SUNRexp, etc.      */
 #include <sundials/sundials_types.h> /* defs. of realtype, sunindextype      */


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python run-tests.py --all` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python run-tests.py --doctest` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ python run-tests.py --quick` (or `$ nox -s quick`).

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
