### PR TITLE
Remove dev installation of VCPKG

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,5 +1,6 @@
 name: Build and publish package to PyPI
 on:
+  pull_request:
   release:
     types: [published]
   schedule:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,6 +1,5 @@
 name: Build and publish package to PyPI
 on:
-  pull_request:
   release:
     types: [published]
   schedule:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -51,14 +51,6 @@ jobs:
       - name: Clone pybind11 repo (no history)
         run: git clone --depth 1 --branch v2.12.0 https://github.com/pybind/pybind11.git -c advice.detachedHead=false
 
-      - name: Install vcpkg on Windows
-        run: |
-          cd C:\
-          rm -r -fo 'C:\vcpkg'
-          git clone https://github.com/microsoft/vcpkg
-          cd vcpkg
-          .\bootstrap-vcpkg.bat
-
       - name: Cache packages installed through vcpkg on Windows
         uses: actions/cache@v4
         env:


### PR DESCRIPTION
# Description

Removes outdated dev installation of VCPKG during the release

Fixes #4632
Related PR: https://github.com/pybamm-team/pybammsolvers/pull/13
Wheel build: https://github.com/kratman/PyBaMM/pull/8

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
