### PR TITLE
Remove internal use of deprecated `set_parameters` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Separated extrapolation options for `pybamm.BoundaryValue` and `pybamm.BoundaryGradient`, and updated the default to be "linear" for the value and "quadratic" for the gradient. ([#4614](https://github.com/pybamm-team/PyBaMM/pull/4614))
 - Double-layer SEI models have been removed (with the corresponding parameters). All models assume now a single SEI layer. ([#4470](https://github.com/pybamm-team/PyBaMM/pull/4470))
 
+## Bug fixes
+
+- Remove internal use of deprecated `set_parameters` function in the `Simulation` class which caused warnings. ([#4638](https://github.com/pybamm-team/PyBaMM/pull/4638))
+
 # [v24.11.2](https://github.com/pybamm-team/PyBaMM/tree/v24.11.2) - 2024-11-27
 
 ## Bug fixes

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -344,7 +344,7 @@ class Simulation:
             self._model_with_set_params = self._model
             self._built_model = self._model
         else:
-            self.set_parameters()
+            self._set_parameters()
             self._mesh = pybamm.Mesh(self._geometry, self._submesh_types, self._var_pts)
             self._disc = pybamm.Discretisation(
                 self._mesh, self._spatial_methods, **self._discretisation_kwargs

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -31,7 +31,7 @@ class TestSimulation:
         assert V.has_symbol_of_classes(pybamm.Parameter)
         assert not V.has_symbol_of_classes(pybamm.Matrix)
 
-        sim.set_parameters()
+        sim._set_parameters()
         assert sim._mesh is None
         assert sim._disc is None
         V = sim.model_with_set_params.variables["Voltage [V]"]
@@ -138,8 +138,8 @@ class TestSimulation:
     def test_reuse_commands(self):
         sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
 
-        sim.set_parameters()
-        sim.set_parameters()
+        sim._set_parameters()
+        sim._set_parameters()
 
         sim.build()
         sim.build()
@@ -149,7 +149,7 @@ class TestSimulation:
 
         sim.build()
         sim.solve([0, 600])
-        sim.set_parameters()
+        sim._set_parameters()
 
     def test_set_crate(self):
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

The `set_parameters` method in `Simulation` was deprecated, but it was still used internally, which caused warnings.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
