### PR TITLE
 Remove internal use of deprecated `set_parameters` method #2

### DIFF
--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -31,7 +31,7 @@ class TestSimulation:
         assert V.has_symbol_of_classes(pybamm.Parameter)
         assert not V.has_symbol_of_classes(pybamm.Matrix)
 
-        sim._set_parameters()
+        sim.set_parameters()
         assert sim._mesh is None
         assert sim._disc is None
         V = sim.model_with_set_params.variables["Voltage [V]"]
@@ -138,8 +138,8 @@ class TestSimulation:
     def test_reuse_commands(self):
         sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
 
-        sim._set_parameters()
-        sim._set_parameters()
+        sim.set_parameters()
+        sim.set_parameters()
 
         sim.build()
         sim.build()
@@ -149,7 +149,7 @@ class TestSimulation:
 
         sim.build()
         sim.solve([0, 600])
-        sim._set_parameters()
+        sim.set_parameters()
 
     def test_set_crate(self):
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Addressing @kratman's comments following automerge of https://github.com/pybamm-team/PyBaMM/pull/4638

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
