### PR TITLE
Drop dependence on `wheel` at build time

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -77,7 +77,7 @@ jobs:
             CMAKE_GENERATOR_PLATFORM=x64
             CMAKE_BUILD_PARALLEL_LEVEL=${{ steps.get_num_cores.outputs.count }}
           CIBW_ARCHS: AMD64
-          CIBW_BEFORE_BUILD: python -m pip install setuptools wheel delvewheel # skip CasADi and CMake
+          CIBW_BEFORE_BUILD: python -m pip install setuptools delvewheel # skip CasADi and CMake
           # Fix access violation because GHA runners have modified PATH that picks wrong
           # msvcp140.dll, see https://github.com/adang1345/delvewheel/issues/54
           CIBW_REPAIR_WHEEL_COMMAND: delvewheel repair --add-path C:/Windows/System32 -w {dest_dir} {wheel}
@@ -243,7 +243,7 @@ jobs:
           # 10.13 for Intel (macos-13), 11.0 for Apple Silicon (macos-14 and macos-latest)
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '11.0' || '10.13' }}
           CIBW_ARCHS_MACOS: auto
-          CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools wheel delocate
+          CIBW_BEFORE_BUILD: python -m pip install cmake casadi setuptools delocate
           CIBW_REPAIR_WHEEL_COMMAND: |
             if [[ $(uname -m) == "x86_64" ]]; then
               delocate-listdeps {wheel} && delocate-wheel -v -w {dest_dir} {wheel}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=64",
-    "wheel",
+    "setuptools>=70.1.1",
     # On Windows, use the CasADi vcpkg registry and CMake bundled from MSVC
     "casadi>=3.6.7; platform_system!='Windows'",
     # Note: the version of CasADi as a build-time dependency should be matched
@@ -270,11 +269,6 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 [tool.coverage.run]
 source = ["src/pybamm"]
 concurrency = ["multiprocessing"]
-
-[tool.repo-review]
-ignore = [
-    "PP003"  # list wheel as a build-dep
-]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -28,7 +28,7 @@ RUN uv venv $VIRTUAL_ENV
 RUN #!/bin/bash && source /home/pybamm/venv/bin/activate;
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN uv pip install --upgrade setuptools wheel wget cmake
+RUN uv pip install --upgrade setuptools wget cmake
 
 RUN python scripts/install_KLU_Sundials.py && \
 rm -rf pybind11 && \

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,11 @@ import subprocess
 from multiprocessing import cpu_count
 from pathlib import Path
 from platform import system
-import wheel.bdist_wheel as orig
 
 from setuptools import setup, Extension
 from setuptools.command.install import install
 from setuptools.command.build_ext import build_ext
+from setuptools.command.bdist_wheel import bdist_wheel
 
 
 default_lib_dir = (
@@ -230,29 +230,29 @@ class CustomInstall(install):
 # ---------- Custom class for building wheels ------------------------------------------
 
 
-class bdist_wheel(orig.bdist_wheel):
+class PyBaMMWheel(bdist_wheel):
     """A custom install command to add 2 build options"""
 
     user_options = [
-        *orig.bdist_wheel.user_options,
+        *bdist_wheel.user_options,
         ("suitesparse-root=", None, "suitesparse source location"),
         ("sundials-root=", None, "sundials source location"),
     ]
 
     def initialize_options(self):
-        orig.bdist_wheel.initialize_options(self)
+        bdist_wheel.initialize_options(self)
         self.suitesparse_root = None
         self.sundials_root = None
 
     def finalize_options(self):
-        orig.bdist_wheel.finalize_options(self)
+        bdist_wheel.finalize_options(self)
         if not self.suitesparse_root:
             self.suitesparse_root = default_lib_dir
         if not self.sundials_root:
             self.sundials_root = default_lib_dir
 
     def run(self):
-        orig.bdist_wheel.run(self)
+        bdist_wheel.run(self)
 
 
 def compile_KLU():
@@ -342,7 +342,7 @@ setup(
     ext_modules=ext_modules,
     cmdclass={
         "build_ext": CMakeBuild,
-        "bdist_wheel": bdist_wheel,
+        "bdist_wheel": PyBaMMWheel,
         "install": CustomInstall,
     },
 )


### PR DESCRIPTION
# Description

From https://github.com/conda-forge/pybamm-feedstock/pull/70. This allows us to simplify a few things, though it is only temporary until the time we migrate from the current system.

cc: @Saransh-cpp

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
