### PR TITLE
changed dispatch-action for repository-dispatch (#4643)

### DIFF
--- a/.github/workflows/validation_benchmarks.yml
+++ b/.github/workflows/validation_benchmarks.yml
@@ -13,13 +13,14 @@ jobs:
     name: Dispatch to `pybamm-validation`
     runs-on: ubuntu-latest
     steps:
-      - uses: mvasigh/dispatch-action@7d246d27377b345bd9c58646c51641bec9c7435c # 1.1.6
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.BENCHMARKS_ACCESS_TOKEN }}
-          repo: pybamm-validation
-          owner: pybamm-team
-          event_type: ${{ github.event_name }}
-          message: |
+          repository: pybamm-team/pybamm-validation
+          event-type: ${{ github.event_name }}
+          client-payload: |-
             {
-              "commit_hash": "$GITHUB_SHA"
+              "message": {
+                "commit_hash": "$GITHUB_SHA"
+              }
             }


### PR DESCRIPTION
# Description

Migrates `.github/workflows/validation_benchmarks.yml` from `mvasigh/dispatch-action` to `peter-evans/repository-dispatch`. There are some minor differences in syntax between these two GHAs, which should all be handled by this PR

Fixes #4643 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
