### PR TITLE
Make bot ignore auto-updated files

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,6 @@
 {
   "files": [
     "all_contributors.md",
-    "README.md"
   ],
   "imageSize": 100,
   "commit": false,

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -3,6 +3,7 @@ name: PyBaMM
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore: [".all-contributorsrc", "all_contributors.md"]
 
 env:
   PYBAMM_DISABLE_TELEMETRY: "true"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
 [![code style](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/pybamm-team/PyBaMM/badge)](https://scorecard.dev/viewer/?uri=github.com/pybamm-team/PyBaMM)
 
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-94-orange.svg)](#-contributors)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
-
 </div>
 
 # PyBaMM

--- a/all_contributors.md
+++ b/all_contributors.md
@@ -1,3 +1,8 @@
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-94-orange.svg)](#-contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
# Description

An attempt to make the all-contrib bot skip required checks.

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
