### PR TITLE
Fix incorrect error message

### DIFF
--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -94,9 +94,15 @@ class FuzzyDict(dict):
                 ) from error
             best_matches = self.get_best_matches(key)
             for k in best_matches:
-                if key in k and k.endswith("]"):
+                if key in k and k.endswith("]") and not key.endswith("]"):
                     raise KeyError(
                         f"'{key}' not found. Use the dimensional version '{k}' instead."
+                    ) from error
+                elif key in k and (
+                    k.startswith("Primary") or k.startswith("Secondary")
+                ):
+                    raise KeyError(
+                        f"'{key}' not found. If you are using a composite model, you may need to use {k} instead. Otherwise, best matches are {best_matches}"
                     ) from error
             raise KeyError(
                 f"'{key}' not found. Best matches are {best_matches}"

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -35,6 +35,7 @@ class TestUtil:
                 "Lithium plating current": 4,
                 "A dimensional variable [m]": 5,
                 "Positive particle diffusivity [m2.s-1]": 6,
+                "Primary: Open circuit voltage [V]": 7,
             }
         )
         d2 = pybamm.FuzzyDict(
@@ -51,6 +52,9 @@ class TestUtil:
 
         with pytest.raises(KeyError, match="dimensional version"):
             d.__getitem__("A dimensional variable")
+
+        with pytest.raises(KeyError, match="composite model"):
+            d.__getitem__("Open circuit voltage [V]")
 
         with pytest.raises(KeyError, match="open circuit voltage"):
             d.__getitem__("Measured open circuit voltage [V]")


### PR DESCRIPTION
# Description

When the `parameters` dictionary is called with a key of `Primary: Some parameter [some unit]`, pybamm directs the user to use the dimensional version of that parameter. This is inconsequential but I find it annoying.

this PR simply corrects that logic. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
