### PR TITLE
Disable skipCI for all-contribs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,4 +1,5 @@
 {
+  "skipCi": false,
   "files": [
     "all_contributors.md"
   ],


### PR DESCRIPTION
# Description

Makes all-contributors PRs run CI. This will allow us to have required checks and we can start to explicitly require tests to pass.

Fixes #4671 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
