### PR TITLE
add post_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
 ## Features
+
+- Added `Symbol.post_order()` method to return an iterable that steps through the tree in post-order fashion. ([]())
 - Added two more submodels (options) for the SEI: Lars von Kolzenberg (2020) model and Tunneling Limit model ([#4394](https://github.com/pybamm-team/PyBaMM/pull/4394))
+
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Added `Symbol.post_order()` method to return an iterable that steps through the tree in post-order fashion. ([]())
+- Added `Symbol.post_order()` method to return an iterable that steps through the tree in post-order fashion. ([#4684](https://github.com/pybamm-team/PyBaMM/pull/4684))
 - Added two more submodels (options) for the SEI: Lars von Kolzenberg (2020) model and Tunneling Limit model ([#4394](https://github.com/pybamm-team/PyBaMM/pull/4394))
 
 

--- a/src/pybamm/expression_tree/symbol.py
+++ b/src/pybamm/expression_tree/symbol.py
@@ -570,6 +570,13 @@ class Symbol:
         anytree = import_optional_dependency("anytree")
         return anytree.PreOrderIter(self)
 
+    def post_order(self):
+        """
+        returns an iterable that steps through the tree in post-order fashion.
+        """
+        anytree = import_optional_dependency("anytree")
+        return anytree.PostOrderIter(self)
+
     def __str__(self):
         """return a string representation of the node and its children."""
         return self._name

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -230,7 +230,7 @@ class TestSymbol:
         expected_postorder = [
             "a",
             "c",
-            "*", 
+            "*",
             "a",
             "b",
             "*",
@@ -242,7 +242,7 @@ class TestSymbol:
             "a",
             "*",
             "-",
-            "*"
+            "*",
         ]
         for node, expect in zip(exp.pre_order(), expected_preorder):
             assert node.name == expect

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -227,7 +227,26 @@ class TestSymbol:
             "c",
             "a",
         ]
+        expected_postorder = [
+            "a",
+            "c",
+            "*", 
+            "a",
+            "b",
+            "*",
+            "c",
+            "*",
+            "a",
+            "+",
+            "c",
+            "a",
+            "*",
+            "-",
+            "*"
+        ]
         for node, expect in zip(exp.pre_order(), expected_preorder):
+            assert node.name == expect
+        for node, expect in zip(exp.post_order(), expected_postorder):
             assert node.name == expect
 
     def test_symbol_diff(self):


### PR DESCRIPTION
# Description

Add `post_order` method to symbol to return an iterable that steps through the tree in post-order fashion

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
