### PR TITLE
Plating particle size distribution

### DIFF
--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -525,6 +525,11 @@ class BatteryModelOptions(pybamm.FuzzyDict):
 
         # Options not yet compatible with particle-size distributions
         if options["particle size"] == "distribution":
+            if options["lithium plating porosity change"] != "false":
+                raise NotImplementedError(
+                    "Lithium plating porosity change not yet supported for particle-size"
+                    " distributions."
+                )
             if options["heat of mixing"] != "false":
                 raise NotImplementedError(
                     "Heat of mixing submodels do not yet support particle-size "

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -530,11 +530,6 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                     "Heat of mixing submodels do not yet support particle-size "
                     "distributions."
                 )
-            if options["lithium plating"] != "none":
-                raise NotImplementedError(
-                    "Lithium plating submodels do not yet support particle-size "
-                    "distributions."
-                )
             if options["particle"] in ["quadratic profile", "quartic profile"]:
                 raise NotImplementedError(
                     "'quadratic' and 'quartic' concentration profiles have not yet "

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_mpm.py
@@ -123,6 +123,18 @@ class TestMPM:
         model = pybamm.lithium_ion.MPM(options)
         model.check_well_posedness()
 
+    def test_mpm_with_lithium_plating(self):
+        options = {
+            "lithium plating": "irreversible",
+        }
+        model = pybamm.lithium_ion.MPM(options)
+        model.check_well_posedness()
+        options = {
+            "lithium plating": "reversible",
+        }
+        model = pybamm.lithium_ion.MPM(options)
+        model.check_well_posedness()
+
 
 class TestMPMExternalCircuits:
     def test_well_posed_voltage(self):
@@ -194,17 +206,5 @@ class TestMPMWithMechanics:
 
     def test_well_posed_both_swelling_only_not_implemented(self):
         options = {"particle mechanics": "swelling only"}
-        with pytest.raises(NotImplementedError):
-            pybamm.lithium_ion.MPM(options)
-
-
-class TestMPMWithPlating:
-    def test_well_posed_reversible_plating_not_implemented(self):
-        options = {"lithium plating": "reversible"}
-        with pytest.raises(NotImplementedError):
-            pybamm.lithium_ion.MPM(options)
-
-    def test_well_posed_irreversible_plating_not_implemented(self):
-        options = {"lithium plating": "irreversible"}
         with pytest.raises(NotImplementedError):
             pybamm.lithium_ion.MPM(options)


### PR DESCRIPTION
# Description

enables plating for particle size distribution models.

pending #4687 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
