### PR TITLE
Added a warning admonition to the list of dependencies in the installation guide

### DIFF
--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -47,7 +47,7 @@ Dependencies
 
 .. warning::
 
-    The list of dependencies below may be outdated. Please refer to the official repository or package manager for the most up-to-date versions.
+    The list of dependencies below might be outdated. Please refer to the pyproject.toml file to find all dependencies.
 
 Required dependencies
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -47,7 +47,7 @@ Dependencies
 
 .. warning::
 
-    The list of dependencies below might be outdated. Please refer to the pyproject.toml file to find all dependencies.
+    The list of dependencies below might be outdated. Please refer to the ``pyproject.toml`` file to find all dependencies.
 
 Required dependencies
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -45,6 +45,10 @@ Dependencies
 ------------
 .. _install.required_dependencies:
 
+.. warning::
+
+    The list of dependencies below may be outdated. Please refer to the official repository or package manager for the most up-to-date versions.
+
 Required dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -53,16 +57,16 @@ PyBaMM requires the following dependencies.
 =================================================================== ==========================
 Package                                                             Minimum supported version
 =================================================================== ==========================
-`NumPy <https://numpy.org>`__                                       1.23.5
-`SciPy <https://docs.scipy.org/doc/scipy/>`__                       1.9.3
-`CasADi <https://web.casadi.org/docs/>`__                           3.6.3
-`Xarray <https://docs.xarray.dev/en/stable/>`__                     2022.6.0
-`Anytree <https://anytree.readthedocs.io/en/stable/>`__             2.8.0
-`SymPy <https://docs.sympy.org/latest/index.html>`__                1.9.3
-`typing-extensions <https://pypi.org/project/typing-extensions/>`__ 4.10.0
-`pandas <https://pypi.org/project/pandas/>`__                       1.5.0
-`pooch <https://www.fatiando.org/pooch/>`__                         1.8.1
-`posthog <https://posthog.com/>`__                                  3.6.5
+`NumPy <https://numpy.org>`__                                         1.23.5
+`SciPy <https://docs.scipy.org/doc/scipy/>`__                         1.9.3
+`CasADi <https://web.casadi.org/docs/>`__                             3.6.3
+`Xarray <https://docs.xarray.dev/en/stable/>`__                       2022.6.0
+`Anytree <https://anytree.readthedocs.io/en/stable/>`__               2.8.0
+`SymPy <https://docs.sympy.org/latest/index.html>`__                  1.9.3
+`typing-extensions <https://pypi.org/project/typing-extensions/>`__  4.10.0
+`pandas <https://pypi.org/project/pandas/>`__                         1.5.0
+`pooch <https://www.fatiando.org/pooch/>`__                           1.8.1
+`posthog <https://posthog.com/>`__                                    3.6.5
 `pyyaml <https://pyyaml.org/>`__
 `platformdirs <https://platformdirs.readthedocs.io/en/latest/>`__
 =================================================================== ==========================


### PR DESCRIPTION
# Description

This PR adds a warning admonition in the documentation to notify users about potentially outdated dependencies listed in the `requirements` section. The change helps to ensure that users are aware that the dependencies listed may not be up-to-date and should be verified.

Fixes #4705

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] Documentation update (non-breaking change that modifies documentation)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
![PyBaMM](https://github.com/user-attachments/assets/74fb44c9-e07b-4c16-8602-65fe27f7f7ba)
