### PR TITLE
Add `dt_min` option for `IDAKLUSolver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added a `dt_min` option to the (`IDAKLUSolver`). ([#4736](https://github.com/pybamm-team/PyBaMM/pull/4736))
 - Enabled using SEI models with particle size distributions. ([#4693](https://github.com/pybamm-team/PyBaMM/pull/4693))
 - Added symbolic mesh which allows for using InputParameters for geometric parameters ([#4665](https://github.com/pybamm-team/PyBaMM/pull/4665))
 - Enhanced the `search` method to accept multiple search terms in the form of a string or a list. ([#4650](https://github.com/pybamm-team/PyBaMM/pull/4650))

--- a/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
+++ b/src/pybamm/solvers/c_solvers/idaklu/IDAKLUSolverOpenMP.inl
@@ -192,6 +192,9 @@ void IDAKLUSolverOpenMP<ExprSet>::SetSolverOptions() {
   // Initial step size
   CheckErrors(IDASetInitStep(ida_mem, solver_opts.dt_init));
 
+  // Minimum absolute step size
+  CheckErrors(IDASetMinStep(ida_mem, solver_opts.dt_min));
+
   // Maximum absolute step size
   CheckErrors(IDASetMaxStep(ida_mem, solver_opts.dt_max));
 

--- a/src/pybamm/solvers/c_solvers/idaklu/Options.cpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/Options.cpp
@@ -142,6 +142,7 @@ SolverOptions::SolverOptions(py::dict &py_opts)
       max_order_bdf(py_opts["max_order_bdf"].cast<int>()),
       max_num_steps(py_opts["max_num_steps"].cast<int>()),
       dt_init(RCONST(py_opts["dt_init"].cast<double>())),
+      dt_min(RCONST(py_opts["dt_min"].cast<double>())),
       dt_max(RCONST(py_opts["dt_max"].cast<double>())),
       max_error_test_failures(py_opts["max_error_test_failures"].cast<int>()),
       max_nonlinear_iterations(py_opts["max_nonlinear_iterations"].cast<int>()),

--- a/src/pybamm/solvers/c_solvers/idaklu/Options.hpp
+++ b/src/pybamm/solvers/c_solvers/idaklu/Options.hpp
@@ -31,6 +31,7 @@ struct SolverOptions {
   int max_order_bdf;
   int max_num_steps;
   double dt_init;
+  double dt_min;
   double dt_max;
   int max_error_test_failures;
   int max_nonlinear_iterations;

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -119,6 +119,9 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 "max_num_steps": 100000,
                 # Initial step size. The solver default is used if this is left at 0.0
                 "dt_init": 0.0,
+                # Minimum absolute step size. The solver default is used if this is
+                # left at 0.0
+                "dt_min": 0.0,
                 # Maximum absolute step size. The solver default is used if this is
                 # left at 0.0
                 "dt_max": 0.0,
@@ -200,6 +203,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             "max_order_bdf": 5,
             "max_num_steps": 100000,
             "dt_init": 0.0,
+            "dt_min": 0.0,
             "dt_max": 0.0,
             "max_error_test_failures": 10,
             "max_nonlinear_iterations": 40,

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -794,6 +794,7 @@ class TestIDAKLUSolver:
             "max_order_bdf": 4,
             "max_num_steps": 490,
             "dt_init": 0.01,
+            "dt_min": 1e-6,
             "dt_max": 1000.9,
             "max_error_test_failures": 11,
             "max_nonlinear_iterations": 5,


### PR DESCRIPTION
# Description

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [x] New feature (non-breaking change which adds functionality)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
