### PR TITLE
Deprecation warning and function cleanup before 25.1

### DIFF
--- a/docs/source/api/util.rst
+++ b/docs/source/api/util.rst
@@ -1,8 +1,6 @@
 Utility functions
 =================
 
-.. autofunction:: pybamm.get_git_commit_info
-
 .. autofunction:: pybamm.root_dir
 
 .. autoclass:: pybamm.Timer

--- a/examples/scripts/minimal_example_of_lookup_tables.py
+++ b/examples/scripts/minimal_example_of_lookup_tables.py
@@ -19,7 +19,7 @@ def process_2D(name, data):
     return formatted_data
 
 
-parameter_values = pybamm.ParameterValues(pybamm.parameter_sets.Chen2020)
+parameter_values = pybamm.ParameterValues("Chen2020")
 
 # overwrite the diffusion coefficient with a 2D lookup table
 D_s_n = parameter_values["Negative particle diffusivity [m2.s-1]"]

--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -16,7 +16,6 @@ from .util import (
     has_jax,
     import_optional_dependency,
     is_jax_compatible,
-    get_git_commit_info,
 )
 from .logger import logger, set_logging_level, get_new_logger
 from .settings import settings

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -1151,7 +1151,7 @@ class BaseModel:
 
         Parameters
         ----------
-        parameter_name : str
+        symbol_name : str
         """
         # Should we deprecate this? Not really sure how it's used?
 

--- a/src/pybamm/parameters/parameter_sets.py
+++ b/src/pybamm/parameters/parameter_sets.py
@@ -1,5 +1,4 @@
 import sys
-import warnings
 import importlib.metadata
 import textwrap
 from collections.abc import Mapping
@@ -78,22 +77,6 @@ class ParameterSets(Mapping):
     def get_docstring(self, key):
         """Return the docstring for the ``key`` parameter set"""
         return textwrap.dedent(self.__load_entry_point__(key).__doc__)
-
-    def __getattribute__(self, name):
-        try:
-            return super().__getattribute__(name)
-        except AttributeError as error:
-            # For backwards compatibility, parameter sets that used to be defined in
-            # this file now return the name as a string, which will load the same
-            # parameter set as before when passed to `ParameterValues`
-            if name in self:
-                msg = (
-                    f"Parameter sets should be called directly by their name ({name}), "
-                    f"instead of via pybamm.parameter_sets (pybamm.parameter_sets.{name})."
-                )
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
-                return name
-            raise error
 
 
 #: Singleton Instance of :class:ParameterSets """

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -5,7 +5,6 @@ import numbers
 import os
 import pathlib
 import pickle
-import subprocess
 import timeit
 import difflib
 from warnings import warn
@@ -21,23 +20,6 @@ JAXLIB_VERSION = "0.4.27"
 def root_dir():
     """return the root directory of the PyBaMM install directory"""
     return str(pathlib.Path(pybamm.__path__[0]).parent.parent)
-
-
-def get_git_commit_info():
-    """
-    Get the git commit info for the current PyBaMM version, e.g. v22.8-39-gb25ce8c41
-    (version 22.8, commit b25ce8c41)
-    """
-    try:
-        # Get the latest git commit hash
-        return str(
-            subprocess.check_output(["git", "describe", "--tags"], cwd=root_dir())
-            .strip()
-            .decode()
-        )
-    except subprocess.CalledProcessError:  # pragma: no cover
-        # Not a git repository so just return the version number
-        return f"v{pybamm.__version__}"
 
 
 class FuzzyDict(dict):
@@ -370,7 +352,6 @@ def is_constant_and_can_evaluate(symbol):
         return False
 
 
-# https://docs.pybamm.org/en/latest/source/user_guide/contributing.html#managing-optional-dependencies-and-their-imports
 def import_optional_dependency(module_name, attribute=None):
     err_msg = f"Optional dependency {module_name} is not available. See https://docs.pybamm.org/en/latest/source/user_guide/installation/index.html#optional-dependencies for more details."
     try:

--- a/tests/unit/test_parameters/test_parameter_sets_class.py
+++ b/tests/unit/test_parameters/test_parameter_sets_class.py
@@ -11,10 +11,6 @@ class TestParameterSets:
         """Test that pybamm.parameters_sets.<ParameterSetName> returns
         the name of the parameter set and a depreciation warning
         """
-        with pytest.warns(DeprecationWarning):
-            out = pybamm.parameter_sets.Marquis2019
-            assert out == "Marquis2019"
-
         # Expect an error for parameter sets that aren't real
         with pytest.raises(AttributeError):
             pybamm.parameter_sets.not_a_real_parameter_set

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -96,11 +96,6 @@ class TestUtil:
     def test_is_jax_compatible(self):
         assert pybamm.is_jax_compatible()
 
-    def test_git_commit_info(self):
-        git_commit_info = pybamm.get_git_commit_info()
-        assert isinstance(git_commit_info, str)
-        assert git_commit_info[:2] == "v2"
-
     def test_import_optional_dependency(self):
         optional_distribution_deps = get_optional_distribution_deps("pybamm")
         present_optional_import_deps = get_present_optional_import_deps(


### PR DESCRIPTION
# Description

Checking for outdated deprecation warnings before the 25.1 release. I did some other minor cleanup seen along the way as well.

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
