### PR TITLE
Bugfix: IDAKLU output variables with Experiments

### DIFF
--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1130,6 +1130,10 @@ def make_cycle_solution(
         sum_sols.all_yps,
         sum_sols.variables_returned,
     )
+
+    if sum_sols.variables_returned:
+        cycle_solution._variables = sum_sols._variables
+
     cycle_solution._all_inputs_casadi = sum_sols.all_inputs_casadi
     cycle_solution._sub_solutions = sum_sols.sub_solutions
 

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -202,3 +202,9 @@ class TestIDAKLUSolver:
         # check summary variables are the same if output variables are specified
         for var in model.summary_variables:
             assert summary_vars[0][var] == summary_vars[1][var]
+
+        # check variables are accessible for each cycle
+        np.testing.assert_array_almost_equal(
+            sols[0].cycles[-1]["Current [A]"].data,
+            sols[1].cycles[-1]["Current [A]"].data,
+        )

--- a/tests/integration/test_solvers/test_idaklu.py
+++ b/tests/integration/test_solvers/test_idaklu.py
@@ -133,23 +133,23 @@ class TestIDAKLUSolver:
         t_combined = np.concatenate((sol3.t, t_interp_dense))
         t_combined = np.unique(t_combined)
         t_combined.sort()
-        np.testing.assert_array_almost_equal(sol3.t, t_combined)
+        np.testing.assert_allclose(sol3.t, t_combined)
 
         # 4. sparse t_eval + sparse t_interp
         sol4 = solver.solve(
             model_disc, t_eval_sparse, t_interp=t_interp_sparse, inputs=inputs
         )
-        np.testing.assert_array_almost_equal(sol4.t, np.array([t0, tf]))
+        np.testing.assert_allclose(sol4.t, np.array([t0, tf]))
 
         sols = [sol1, sol2, sol3, sol4]
         for sol in sols:
             # test that y[0] = to true solution
             true_solution = a_value * sol.t
-            np.testing.assert_array_almost_equal(sol.y[0], true_solution)
+            np.testing.assert_allclose(sol.y[0], true_solution)
 
             # test that y[1:3] = to true solution
             true_solution = b_value * sol.t
-            np.testing.assert_array_almost_equal(sol.y[1:3], true_solution)
+            np.testing.assert_allclose(sol.y[1:3], true_solution)
 
     def test_with_experiments(self):
         summary_vars = []
@@ -195,7 +195,7 @@ class TestIDAKLUSolver:
         np.testing.assert_array_equal(
             sols[0]["Pressure [Pa]"].data, sols[1]["Pressure [Pa]"].data
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             sols[0]["Voltage [V]"].data, sols[1]["Voltage [V]"].data
         )
 
@@ -204,7 +204,7 @@ class TestIDAKLUSolver:
             assert summary_vars[0][var] == summary_vars[1][var]
 
         # check variables are accessible for each cycle
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             sols[0].cycles[-1]["Current [A]"].data,
             sols[1].cycles[-1]["Current [A]"].data,
         )


### PR DESCRIPTION
# Description

Fixes misc bugs relating to the use of the `output_variables` option with the IDAKLU solver and Experiments.

Partly addresses #4743 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
