### PR TITLE
Replace CChem link with attribution to John Newman

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,17 +422,12 @@ wherever code is called that uses that citation (for example, in functions or in
 
 ### Installation
 
-Installation of PyBaMM and its dependencies is handled via [pip](https://pip.pypa.io/en/stable/) and [setuptools](http://setuptools.readthedocs.io/). It uses `CMake` to compile C++ extensions using [`pybind11`](https://pybind11.readthedocs.io/en/stable/) and [`casadi`](https://web.casadi.org/). The installation process is described in detail in the [source installation](https://docs.pybamm.org/en/latest/source/user_guide/installation/install-from-source.html) page and is configured through the `CMakeLists.txt` file.
+Installation of PyBaMM and its dependencies is handled via [pip](https://pip.pypa.io/en/stable/)
 
 Configuration files:
-
 ```
-setup.py
 pyproject.toml
-MANIFEST.in
 ```
-
-Note: `MANIFEST.in` is used to include and exclude non-Python files and auxiliary package data for PyBaMM when distributing it. If a file is not included in `MANIFEST.in`, it will not be included in the source distribution (SDist) and subsequently not be included in the binary distribution (wheel).
 
 ### Continuous Integration using GitHub Actions
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,8 +64,7 @@ def run_integration(session):
 @nox.session(name="doctests")
 def run_doctests(session):
     """Run the doctests and generate the output(s) in the docs/build/ directory."""
-    # TODO: Temporary fix for Python 3.12 CI.
-    # See: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
+    # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,docs]", silent=False)
     session.run(
@@ -102,9 +101,7 @@ def run_examples(session):
 def run_scripts(session):
     """Run the scripts tests for Python scripts."""
     set_environment_variables(PYBAMM_ENV, session=session)
-    # Temporary fix for Python 3.12 CI. TODO: remove after
-    # https://bitbucket.org/pybtex-devs/pybtex/issues/169/replace-pkg_resources-with
-    # is fixed
+    # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,dev,jax]", silent=False)
     session.run("python", "-m", "pytest", "-m", "scripts")
@@ -119,9 +116,7 @@ def set_dev(session):
     python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
     components = ["all", "dev", "jax"]
     args = []
-    # Temporary fix for Python 3.12 CI. TODO: remove after
-    # https://bitbucket.org/pybtex-devs/pybtex/issues/169/replace-pkg_resources-with
-    # is fixed
+    # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.run(python, "-m", "pip", "install", "setuptools", external=True)
     session.run(
         python,
@@ -153,8 +148,7 @@ def run_tests(session):
 def build_docs(session):
     """Build the documentation and load it in a browser tab, rebuilding on changes."""
     envbindir = session.bin
-    # TODO: Temporary fix for Python 3.12 CI.
-    # See: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
+    # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
     session.install("-e", ".[all,docs]", silent=False)
     session.chdir("docs")

--- a/src/pybamm/input/parameters/lithium_ion/Ai2020.py
+++ b/src/pybamm/input/parameters/lithium_ion/Ai2020.py
@@ -45,7 +45,7 @@ def graphite_electrolyte_exchange_current_density_Dualfoil1998(
 
     References
     ----------
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -219,7 +219,7 @@ def lico2_diffusivity_Dualfoil1998(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -247,7 +247,7 @@ def lico2_electrolyte_exchange_current_density_Dualfoil1998(c_e, c_s_surf, c_s_m
 
     References
     ----------
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------

--- a/src/pybamm/input/parameters/lithium_ion/Marquis2019.py
+++ b/src/pybamm/input/parameters/lithium_ion/Marquis2019.py
@@ -9,7 +9,7 @@ def graphite_mcmb2528_diffusivity_Dualfoil1998(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -40,7 +40,7 @@ def graphite_mcmb2528_ocp_Dualfoil1998(sto):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
     """
 
     u_eq = (
@@ -68,7 +68,7 @@ def graphite_electrolyte_exchange_current_density_Dualfoil1998(
 
     References
     ----------
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -134,7 +134,7 @@ def lico2_diffusivity_Dualfoil1998(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -166,7 +166,7 @@ def lico2_ocp_Dualfoil1998(sto):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
     .. [2] CM Doyle. Design and simulation of lithium rechargeable batteries,
            1995.
 
@@ -200,7 +200,7 @@ def lico2_electrolyte_exchange_current_density_Dualfoil1998(c_e, c_s_surf, c_s_m
 
     References
     ----------
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -269,7 +269,7 @@ def electrolyte_diffusivity_Capiglia1999(c_e, T):
     .. [1] C Capiglia et al. 7Li and 19F diffusion coefficients and thermal
     properties of non-aqueous electrolyte solutions for rechargeable lithium batteries.
     Journal of power sources 81 (1999): 859-862.
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -302,7 +302,7 @@ def electrolyte_conductivity_Capiglia1999(c_e, T):
     .. [1] C Capiglia et al. 7Li and 19F diffusion coefficients and thermal
     properties of non-aqueous electrolyte solutions for rechargeable lithium batteries.
     Journal of power sources 81 (1999): 859-862.
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------

--- a/src/pybamm/input/parameters/lithium_ion/Mohtat2020.py
+++ b/src/pybamm/input/parameters/lithium_ion/Mohtat2020.py
@@ -9,7 +9,7 @@ def graphite_diffusivity_PeymanMPM(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -63,7 +63,7 @@ def graphite_electrolyte_exchange_current_density_PeymanMPM(c_e, c_s_surf, c_s_m
 
     References
     ----------
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def NMC_diffusivity_PeymanMPM(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -257,7 +257,7 @@ def electrolyte_diffusivity_PeymanMPM(c_e, T):
     .. [1] C Capiglia et al. 7Li and 19F diffusion coefficients and thermal
     properties of non-aqueous electrolyte solutions for rechargeable lithium batteries.
     Journal of power sources 81 (1999): 859-862.
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
 
     Parameters
     ----------
@@ -290,7 +290,7 @@ def electrolyte_conductivity_PeymanMPM(c_e, T):
     .. [1] C Capiglia et al. 7Li and 19F diffusion coefficients and thermal
     properties of non-aqueous electrolyte solutions for rechargeable lithium batteries.
     Journal of power sources 81 (1999): 859-862.
-    .. [2] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [2] John Newman, Dualfoil
     Parameters
     ----------
     c_e: :class:`pybamm.Symbol`

--- a/src/pybamm/input/parameters/lithium_ion/Ramadass2004.py
+++ b/src/pybamm/input/parameters/lithium_ion/Ramadass2004.py
@@ -9,7 +9,7 @@ def graphite_mcmb2528_diffusivity_Dualfoil1998(sto, T):
 
     References
     ----------
-    .. [1] http://www.cchem.berkeley.edu/jsngrp/fortran.html
+    .. [1] John Newman, Dualfoil
 
     Parameters
     ----------


### PR DESCRIPTION
# Description

Linkchecker broke on this website. So instead of using the link, I changed the footnote to reference the program author and program name

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
