### PR TITLE
add cycle number as a key

### DIFF
--- a/src/pybamm/solvers/summary_variable.py
+++ b/src/pybamm/solvers/summary_variable.py
@@ -41,7 +41,7 @@ class SummaryVariables:
         self.user_inputs = user_inputs or {}
         self.esoh_solver = esoh_solver
         self._variables = {}  # Store computed variables
-        self.cycle_number = None
+        self.cycle_number = np.array([])
 
         model = solution.all_models[0]
         self._possible_variables = model.summary_variables  # minus esoh variables
@@ -122,6 +122,8 @@ class SummaryVariables:
         if key in self._variables:
             # return it if it exists
             return self._variables[key]
+        elif key == "Cycle number":
+            return self.cycle_number
         elif key not in self.all_variables:
             # check it's listed as a summary variable
             raise KeyError(f"Variable '{key}' is not a summary variable.")

--- a/tests/unit/test_solvers/test_summary_variables.py
+++ b/tests/unit/test_solvers/test_summary_variables.py
@@ -167,5 +167,7 @@ class TestSummaryVariables:
         sol = sim.solve()
 
         assert len(sol.summary_variables.cycles) == 10
+        assert sol.summary_variables["Cycle number"][0] == 1
+        assert sol.summary_variables["Cycle number"][9] == 10
         assert len(sol.summary_variables["x_100"]) == 10
         assert np.isclose(sol.summary_variables["x_100"][0], 0.9493)


### PR DESCRIPTION
# Description

Adds cycle number as a key for summary variables (#4765 )

I didn't do the "all summary variables" part as I wasn't sure what the best name for that function was

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
