### PR TITLE
[WIP] Allow 3D process variables

### DIFF
--- a/src/pybamm/discretisations/discretisation.py
+++ b/src/pybamm/discretisations/discretisation.py
@@ -783,6 +783,13 @@ class Discretisation:
                 ]
             else:
                 discretised_symbol.secondary_mesh = None
+
+            # Assign tertiary mesh
+            if symbol.domains["tertiary"] != []:
+                discretised_symbol.tertiary_mesh = self.mesh[symbol.domains["tertiary"]]
+            else:
+                discretised_symbol.tertiary_mesh = None
+
             return discretised_symbol
 
     def _process_symbol(self, symbol):

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -122,6 +122,11 @@ class BaseModel:
                 else:
                     var.secondary_mesh = None
 
+                if var.domains["tertiary"] != []:
+                    var.tertiary_mesh = properties["mesh"][var.domains["tertiary"]]
+                else:
+                    var.tertiary_mesh = None
+
             if properties["geometry"]:
                 instance._geometry = pybamm.Geometry(properties["geometry"])
         else:
@@ -875,8 +880,10 @@ class BaseModel:
                     final_state_eval = final_state[:, -1]
                 elif final_state.ndim == 3:
                     final_state_eval = final_state[:, :, -1].flatten(order="F")
+                elif final_state.ndim == 4:
+                    final_state_eval = final_state[:, :, :, -1].flatten(order="F")
                 else:
-                    raise NotImplementedError("Variable must be 0D, 1D, or 2D")
+                    raise NotImplementedError("Variable must be 0D, 1D, 2D, or 3D")
             elif isinstance(var, pybamm.Concatenation):
                 children = []
                 for child in var.orphans:


### PR DESCRIPTION
# Description
Allow 3D (in space) processed variables. There is a lot of code duplication in the processed variables code, but we can fix that in a separate PR.

This currently covers the case of variables that are 3D and have a tertiary domain (e.g. particle -> particle size -> electrode) but doesn't work for the special case of 3D variables that only have a primary and secondary domain (e.g. electrode -> current collector, when using the 2D current collector mesh).

Still needs tests.

Fixes #4776 

With a little work, this could fully fix https://github.com/pybamm-team/PyBaMM/issues/2394. Also see https://github.com/pybamm-team/PyBaMM/issues/1549

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
