### PR TITLE
add symbolic mesh to docs reference

### DIFF
--- a/docs/source/api/meshes/one_dimensional_submeshes.rst
+++ b/docs/source/api/meshes/one_dimensional_submeshes.rst
@@ -7,6 +7,9 @@
 .. autoclass:: pybamm.Uniform1DSubMesh
     :members:
 
+.. autoclass:: pybamm.SymbolicUniform1DSubMesh
+    :members:
+
 .. autoclass:: pybamm.Exponential1DSubMesh
     :members:
 


### PR DESCRIPTION
# Description

This PR just adds the SymbolicUniform1DSubMesh to the docs reference, which I forgot to do in #4665 


Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
