### PR TITLE
Add 'get_summary_variables' function to SummaryVariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added 'get_summary_variables' to return dictionary of computed summary variables ([#4824](https://github.com/pybamm-team/PyBaMM/pull/4824))
 - Added support for particle size distributions combined with particle mechanics. ([#4807](https://github.com/pybamm-team/PyBaMM/pull/4807))
 
 # [v25.1.1](https://github.com/pybamm-team/PyBaMM/tree/v25.1.1) - 2025-01-20

--- a/src/pybamm/solvers/summary_variable.py
+++ b/src/pybamm/solvers/summary_variable.py
@@ -188,3 +188,9 @@ class SummaryVariables:
             ) from error
 
         return esoh_sol
+
+    def get_summary_variables(self):
+        """
+        Computes and returns all the summary values + cycle number, as a dictionary
+        """
+        return {k: self[k] for k in [*self.all_variables, "Cycle number"]}

--- a/tests/unit/test_solvers/test_summary_variables.py
+++ b/tests/unit/test_solvers/test_summary_variables.py
@@ -171,3 +171,13 @@ class TestSummaryVariables:
         assert sol.summary_variables["Cycle number"][9] == 10
         assert len(sol.summary_variables["x_100"]) == 10
         assert np.isclose(sol.summary_variables["x_100"][0], 0.9493)
+
+    def test_summary_vars_get_all_variables(self):
+        # no esoh
+        sum_vars, _ = self.create_sum_vars()
+
+        summary_vars = sum_vars.get_summary_variables()
+
+        assert isinstance(summary_vars, dict)
+        assert list(summary_vars.keys()) == ["2c", "Change in 2c", "Cycle number"]
+        np.isclose(summary_vars["2c"], 0.735758)


### PR DESCRIPTION
Adds a function to return a dictionary of all the summary variables + cycle number from the SummaryVariables class

Fixes #4765