### PR TITLE
chore: switch to `np.testing.assert_allclose` for better precision in unit tests

### DIFF
--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -80,20 +80,20 @@ class TestSimulationExperiment:
         assert len(sol.cycles) == 1
 
         # Test outputs
-        np.testing.assert_array_almost_equal(
-            sol.cycles[0].steps[0]["C-rate"].data, 1 / 20
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[0]["C-rate"].data, 1 / 20, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            sol.cycles[0].steps[1]["Current [A]"].data, -1
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[1]["Current [A]"].data, -1, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            sol.cycles[0].steps[2]["Voltage [V]"].data, 4.1, decimal=5
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[2]["Voltage [V]"].data, 4.1, rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            sol.cycles[0].steps[3]["Power [W]"].data, 2, decimal=5
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[3]["Power [W]"].data, 2, rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            sol.cycles[0].steps[4]["Resistance [Ohm]"].data, 4, decimal=5
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[4]["Resistance [Ohm]"].data, 4, rtol=1e-6, atol=1e-5
         )
 
         np.testing.assert_array_equal(
@@ -120,7 +120,9 @@ class TestSimulationExperiment:
             y_right = sol.cycles[0].steps[i + 1].all_ys[0][:len_rhs, 0]
             if isinstance(y_right, casadi.DM):
                 y_right = y_right.full()
-            np.testing.assert_array_almost_equal(y_left.flatten(), y_right.flatten())
+            np.testing.assert_allclose(
+                y_left.flatten(), y_right.flatten(), rtol=1e-7, atol=1e-6
+            )
 
         # Solve again starting from solution
         sol2 = sim.solve(starting_solution=sol)
@@ -184,15 +186,17 @@ class TestSimulationExperiment:
             solution = sim.solve()
             solutions.append(solution)
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solutions[0]["Voltage [V]"].data,
             solutions[1]["Voltage [V]"](solutions[0].t),
-            decimal=1,
+            rtol=1e-2,
+            atol=1e-1,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solutions[0]["Current [A]"].data,
             solutions[1]["Current [A]"](solutions[0].t),
-            decimal=0,
+            rtol=1e-0,
+            atol=1e-0,
         )
         assert solutions[1].termination == "final time"
 
@@ -645,14 +649,15 @@ class TestSimulationExperiment:
             model, parameter_values=parameter_values, experiment=experiment2
         )
         sol2 = sim2.solve()
-        np.testing.assert_array_almost_equal(
-            sol["Voltage [V]"].data, sol2["Voltage [V]"].data, decimal=5
+        np.testing.assert_allclose(
+            sol["Voltage [V]"].data, sol2["Voltage [V]"].data, rtol=1e-6, atol=1e-5
         )
         for idx1, idx2 in [(1, 0), (2, 1), (4, 2)]:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 sol.cycles[0].steps[idx1]["Voltage [V]"].data,
                 sol2.cycles[0].steps[idx2]["Voltage [V]"].data,
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
             )
 
     def test_skipped_step_continuous(self):
@@ -669,7 +674,7 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sim.solve(initial_soc=1)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             sim.solution.cycles[0].last_state.y.full(),
             sim.solution.cycles[1].steps[-1].first_state.y.full(),
         )
@@ -948,8 +953,8 @@ class TestSimulationExperiment:
                 sim = pybamm.Simulation(model, experiment=experiment)
                 sol = sim.solve()
                 # sol.plot()
-                np.testing.assert_array_almost_equal(
-                    sol["Voltage [V]"].data[2:], 4.2, decimal=3
+                np.testing.assert_allclose(
+                    sol["Voltage [V]"].data[2:], 4.2, rtol=1e-4, atol=1e-3
                 )
 
     def test_experiment_custom_termination(self):

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -687,7 +687,9 @@ class TestBinaryOperators:
         # Do (A/vec) first if it is constant
         expr = (A @ var) / vec
         assert isinstance(expr, pybamm.MatrixMultiplication)
-        np.testing.assert_array_almost_equal(expr.left.evaluate(), (A / vec).evaluate())
+        np.testing.assert_allclose(
+            expr.left.evaluate(), (A / vec).evaluate(), rtol=1e-7, atol=1e-6
+        )
         assert expr.children[1] == var
 
         # simplify additions and subtractions

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -50,15 +50,21 @@ class TestInterpolant:
         # linear
         for interpolator in ["linear", "cubic", "pchip"]:
             interp = pybamm.Interpolant(x, 2 * x, y, interpolator=interpolator)
-            np.testing.assert_array_almost_equal(
-                interp.evaluate(y=np.array([0.397, 1.5]))[:, 0], np.array([0.794, 3])
+            np.testing.assert_allclose(
+                interp.evaluate(y=np.array([0.397, 1.5]))[:, 0],
+                np.array([0.794, 3]),
+                rtol=1e-7,
+                atol=1e-6,
             )
         # square
         y = pybamm.StateVector(slice(0, 1))
         for interpolator in ["linear", "cubic", "pchip"]:
             interp = pybamm.Interpolant(x, x**2, y, interpolator=interpolator)
-            np.testing.assert_array_almost_equal(
-                interp.evaluate(y=np.array([0.397]))[:, 0], np.array([0.397**2])
+            np.testing.assert_allclose(
+                interp.evaluate(y=np.array([0.397]))[:, 0],
+                np.array([0.397**2]),
+                rtol=1e-7,
+                atol=1e-6,
             )
 
         # with extrapolation set to False
@@ -82,8 +88,11 @@ class TestInterpolant:
         # linear
         for interpolator in ["linear", "cubic", "pchip"]:
             interp = pybamm.Interpolant(x, y, var, interpolator=interpolator)
-            np.testing.assert_array_almost_equal(
-                interp.evaluate(y=np.array([0.397])), 0.794 * np.ones((10, 1))
+            np.testing.assert_allclose(
+                interp.evaluate(y=np.array([0.397])),
+                0.794 * np.ones((10, 1)),
+                rtol=1e-7,
+                atol=1e-6,
             )
 
     def test_interpolation_2_x_2d_y(self):
@@ -94,13 +103,13 @@ class TestInterpolant:
         var2 = pybamm.StateVector(slice(1, 2))
         # linear
         interp = pybamm.Interpolant(x, z, (var1, var2), interpolator="linear")
-        np.testing.assert_array_almost_equal(
-            interp.evaluate(y=np.array([0, 0])), 0, decimal=3
+        np.testing.assert_allclose(
+            interp.evaluate(y=np.array([0, 0])), 0, rtol=1e-4, atol=1e-3
         )
         # cubic
         interp = pybamm.Interpolant(x, z, (var1, var2), interpolator="cubic")
-        np.testing.assert_array_almost_equal(
-            interp.evaluate(y=np.array([0, 0])), 0, decimal=3
+        np.testing.assert_allclose(
+            interp.evaluate(y=np.array([0, 0])), 0, rtol=1e-4, atol=1e-3
         )
 
     def test_interpolation_2_x(self):
@@ -311,18 +320,22 @@ class TestInterpolant:
             interp_diff = pybamm.Interpolant(
                 x, 2 * x, y, interpolator=interpolator
             ).diff(y)
-            np.testing.assert_array_almost_equal(
-                interp_diff.evaluate(y=np.array([0.397, 1.5]))[:, 0], np.array([2, 2])
+            np.testing.assert_allclose(
+                interp_diff.evaluate(y=np.array([0.397, 1.5]))[:, 0],
+                np.array([2, 2]),
+                rtol=1e-7,
+                atol=1e-6,
             )
         # square (derivative should be 2*x)
         for interpolator in ["cubic", "pchip"]:
             interp_diff = pybamm.Interpolant(
                 x, x**2, y, interpolator=interpolator
             ).diff(y)
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 interp_diff.evaluate(y=np.array([0.397, 0.806]))[:, 0],
                 np.array([0.794, 1.612]),
-                decimal=3,
+                rtol=1e-4,
+                atol=1e-3,
             )
 
         # test 2D interpolation diff fails

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -163,13 +163,17 @@ class TestCasadiConverter:
             interp = pybamm.Interpolant(x, 2 * x, y, interpolator=interpolator)
             interp_casadi = interp.to_casadi(y=casadi_y)
             f = casadi.Function("f", [casadi_y], [interp_casadi])
-            np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+            np.testing.assert_allclose(
+                interp.evaluate(y=y_test), f(y_test), rtol=1e-7, atol=1e-6
+            )
         # square
         y = pybamm.StateVector(slice(0, 1))
         interp = pybamm.Interpolant(x, x**2, y, interpolator="cubic")
         interp_casadi = interp.to_casadi(y=casadi_y)
         f = casadi.Function("f", [casadi_y], [interp_casadi])
-        np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+        np.testing.assert_allclose(
+            interp.evaluate(y=y_test), f(y_test), rtol=1e-7, atol=1e-6
+        )
 
         # len(x)=1 but y is 2d
         y = pybamm.StateVector(slice(0, 1))
@@ -180,7 +184,9 @@ class TestCasadiConverter:
             interp = pybamm.Interpolant(x, data, y, interpolator=interpolator)
             interp_casadi = interp.to_casadi(y=casadi_y)
             f = casadi.Function("f", [casadi_y], [interp_casadi])
-            np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+            np.testing.assert_allclose(
+                interp.evaluate(y=y_test), f(y_test), rtol=1e-7, atol=1e-6
+            )
 
         # error for pchip interpolator
         interp = pybamm.Interpolant(x, data, y, interpolator="pchip")
@@ -221,14 +227,18 @@ class TestCasadiConverter:
             interp = pybamm.Interpolant(x_, Y, y, interpolator=interpolator)
             interp_casadi = interp.to_casadi(y=casadi_y)
             f = casadi.Function("f", [casadi_y], [interp_casadi])
-            np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+            np.testing.assert_allclose(
+                interp.evaluate(y=y_test), f(y_test), rtol=1e-6, atol=1e-6
+            )
         # square
         y = (pybamm.StateVector(slice(0, 1)), pybamm.StateVector(slice(0, 1)))
         Y = (x**2).sum(axis=1).reshape(*[len(el) for el in x_])
         interp = pybamm.Interpolant(x_, Y, y, interpolator="linear")
         interp_casadi = interp.to_casadi(y=casadi_y)
         f = casadi.Function("f", [casadi_y], [interp_casadi])
-        np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+        np.testing.assert_allclose(
+            interp.evaluate(y=y_test), f(y_test), rtol=1e-7, atol=1e-6
+        )
 
         # # len(x)=1 but y is 2d
         # y = pybamm.StateVector(slice(0, 1), slice(0, 1))
@@ -239,7 +249,7 @@ class TestCasadiConverter:
         #     interp = pybamm.Interpolant(x_, data, y, interpolator=interpolator)
         #     interp_casadi = interp.to_casadi(y=casadi_y)
         #     f = casadi.Function("f", [casadi_y], [interp_casadi])
-        #     np.testing.assert_array_almost_equal(interp.evaluate(y=y_test), f(y_test))
+        #     np.testing.assert_allclose(interp.evaluate(y=y_test), f(y_test), rtol=1e-7, atol=1e-6)
 
         # error for pchip interpolator
         with pytest.raises(ValueError, match="interpolator should be"):

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
@@ -488,7 +488,7 @@ class TestEvaluate:
         expr = pybamm.exp(a * b)
         evaluator = pybamm.EvaluatorJax(expr)
         result = evaluator(t=None, y=np.array([[2], [3]]))
-        np.testing.assert_array_almost_equal(result, np.exp(6), decimal=15)
+        np.testing.assert_allclose(result, np.exp(6), rtol=1e-16, atol=1e-15)
 
         # test a constant expression
         expr = pybamm.Scalar(2) * pybamm.Scalar(3)

--- a/tests/unit/test_expression_tree/test_operations/test_jac.py
+++ b/tests/unit/test_expression_tree/test_operations/test_jac.py
@@ -81,7 +81,7 @@ class TestJacobian:
         func = v**v
         jacobian = [[0, 0, 27 * (1 + np.log(3)), 0], [0, 0, 0, 256 * (1 + np.log(4))]]
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_almost_equal(jacobian, dfunc_dy.toarray())
+        np.testing.assert_allclose(jacobian, dfunc_dy.toarray(), rtol=1e-7, atol=1e-6)
 
         func = u * v
         jacobian = np.array([[3, 0, 1, 0], [0, 4, 0, 2]])

--- a/tests/unit/test_expression_tree/test_operations/test_jac_2D.py
+++ b/tests/unit/test_expression_tree/test_operations/test_jac_2D.py
@@ -124,7 +124,7 @@ class TestJacobian:
             [0, 0, 0, 0, 0, 0, 0, 16777216 * (1 + np.log(8))],
         ]
         dfunc_dy = func.jac(y).evaluate(y=y0)
-        np.testing.assert_array_almost_equal(jacobian, dfunc_dy.toarray())
+        np.testing.assert_allclose(jacobian, dfunc_dy.toarray(), rtol=1e-7, atol=1e-6)
 
         func = u * v
         jacobian = np.array(

--- a/tests/unit/test_expression_tree/test_state_vector.py
+++ b/tests/unit/test_expression_tree/test_state_vector.py
@@ -26,15 +26,19 @@ class TestStateVector:
     def test_evaluate_list(self):
         sv = pybamm.StateVector(slice(0, 11), slice(20, 31))
         y = np.linspace(0, 3, 31)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             sv.evaluate(y=y),
             np.concatenate([np.linspace(0, 1, 11), np.linspace(2, 3, 11)])[
                 :, np.newaxis
             ],
+            rtol=1e-7,
+            atol=1e-6,
         )
         sv = pybamm.StateVector(slice(0, 11), slice(11, 20), slice(20, 31))
         y = np.linspace(0, 3, 31)
-        np.testing.assert_array_almost_equal(sv.evaluate(y=y), y[:, np.newaxis])
+        np.testing.assert_allclose(
+            sv.evaluate(y=y), y[:, np.newaxis], rtol=1e-7, atol=1e-6
+        )
 
     def test_name(self):
         sv = pybamm.StateVector(slice(0, 10))

--- a/tests/unit/test_parameters/test_current_functions.py
+++ b/tests/unit/test_parameters/test_current_functions.py
@@ -77,8 +77,8 @@ class TestCurrentFunctions:
 
         # check output correct value
         time = np.linspace(0, 3600, 600)
-        np.testing.assert_array_almost_equal(
-            user_current(time), 5 * np.sin(2 * np.pi * 3 * time)
+        np.testing.assert_allclose(
+            user_current(time), 5 * np.sin(2 * np.pi * 3 * time), rtol=1e-7, atol=1e-6
         )
 
 

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -618,8 +618,8 @@ class TestParameterValues:
 
         processed_func = parameter_values.process_symbol(func)
         processed_interp = parameter_values.process_symbol(interp)
-        np.testing.assert_array_almost_equal(
-            processed_func.evaluate(), processed_interp.evaluate(), decimal=3
+        np.testing.assert_allclose(
+            processed_func.evaluate(), processed_interp.evaluate(), rtol=1e-4, atol=1e-3
         )
 
     def test_interpolant_2d_from_json(self):
@@ -649,8 +649,8 @@ class TestParameterValues:
 
         processed_func = parameter_values.process_symbol(func)
         processed_interp = parameter_values.process_symbol(interp)
-        np.testing.assert_array_almost_equal(
-            processed_func.evaluate(), processed_interp.evaluate(), decimal=4
+        np.testing.assert_allclose(
+            processed_func.evaluate(), processed_interp.evaluate(), rtol=1e-5, atol=1e-4
         )
 
     def test_process_interpolant_3D_from_csv(self):

--- a/tests/unit/test_plotting/test_plot_thermal_components.py
+++ b/tests/unit/test_plotting/test_plot_thermal_components.py
@@ -17,10 +17,10 @@ class TestPlotThermalComponents:
         for input_data in [sim, sol]:
             _, ax = pybamm.plot_thermal_components(input_data, show_plot=False)
             t, cumul_heat = ax[1].get_lines()[-1].get_data()
-            np.testing.assert_array_almost_equal(t, sol["Time [h]"].data)
+            np.testing.assert_allclose(t, sol["Time [h]"].data, rtol=1e-7, atol=1e-6)
             t, cumul_heat = ax[1].get_lines()[-1].get_data()
             T_sol = sol["X-averaged cell temperature [K]"].data
-            np.testing.assert_array_almost_equal(t, sol["Time [h]"].data)
+            np.testing.assert_allclose(t, sol["Time [h]"].data, rtol=1e-7, atol=1e-6)
             rho_c_p_eff = sol[
                 "Volume-averaged effective heat capacity [J.K-1.m-3]"
             ].data

--- a/tests/unit/test_plotting/test_quick_plot.py
+++ b/tests/unit/test_plotting/test_quick_plot.py
@@ -154,29 +154,44 @@ class TestQuickPlot:
         quick_plot = pybamm.QuickPlot(solution, ["a"], time_unit="seconds")
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 1
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_ydata(),
+            0.2 * t_plot,
+            rtol=1e-7,
+            atol=1e-6,
         )
         quick_plot = pybamm.QuickPlot(solution, ["a"], time_unit="minutes")
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 60
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot / 60
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_xdata(),
+            t_plot / 60,
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_ydata(),
+            0.2 * t_plot,
+            rtol=1e-7,
+            atol=1e-6,
         )
         quick_plot = pybamm.QuickPlot(solution, ["a"], time_unit="hours")
         quick_plot.plot(0)
         assert quick_plot.time_scaling_factor == 3600
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_xdata(), t_plot / 3600
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_xdata(),
+            t_plot / 3600,
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            quick_plot.plots[("a",)][0][0].get_ydata(), 0.2 * t_plot
+        np.testing.assert_allclose(
+            quick_plot.plots[("a",)][0][0].get_ydata(),
+            0.2 * t_plot,
+            rtol=1e-7,
+            atol=1e-6,
         )
         with pytest.raises(ValueError, match="time unit"):
             pybamm.QuickPlot(solution, ["a"], time_unit="bad unit")
@@ -339,13 +354,13 @@ class TestQuickPlot:
                 qp_data = quick_plot.plots[("Electrolyte concentration [mol.m-3]",)][0][
                     0
                 ].get_ydata()
-                np.testing.assert_array_almost_equal(qp_data, c_e[:, 0])
+                np.testing.assert_allclose(qp_data, c_e[:, 0], rtol=1e-7, atol=1e-6)
 
                 quick_plot.slider_update(t_eval[-1] / scale)
                 qp_data = quick_plot.plots[("Electrolyte concentration [mol.m-3]",)][0][
                     0
                 ].get_ydata()
-                np.testing.assert_array_almost_equal(qp_data, c_e[:, 1])
+                np.testing.assert_allclose(qp_data, c_e[:, 1], rtol=1e-7, atol=1e-6)
 
             # test quick plot of particle for spme
             if (
@@ -374,7 +389,7 @@ class TestQuickPlot:
                         ("Negative particle concentration [mol.m-3]",)
                     ][0][1]
                     c_n_eval = c_n(t_eval[0], r=c_n.first_dim_pts, x=c_n.second_dim_pts)
-                    np.testing.assert_array_almost_equal(qp_data, c_n_eval)
+                    np.testing.assert_allclose(qp_data, c_n_eval, rtol=1e-7, atol=1e-6)
                     quick_plot.slider_update(t_eval[-1] / scale)
                     qp_data = quick_plot.plots[
                         ("Negative particle concentration [mol.m-3]",)
@@ -382,7 +397,7 @@ class TestQuickPlot:
                     c_n_eval = c_n(
                         t_eval[-1], r=c_n.first_dim_pts, x=c_n.second_dim_pts
                     )
-                    np.testing.assert_array_almost_equal(qp_data, c_n_eval)
+                    np.testing.assert_allclose(qp_data, c_n_eval, rtol=1e-7, atol=1e-6)
 
         pybamm.close_plots()
 
@@ -412,11 +427,11 @@ class TestQuickPlot:
             quick_plot.plot(0)
             qp_data = quick_plot.plots[("Electrolyte concentration [mol.m-3]",)][0][1]
             c_e_eval = c_e(t_eval[0], x=c_e.first_dim_pts, z=c_e.second_dim_pts)
-            np.testing.assert_array_almost_equal(qp_data.T, c_e_eval)
+            np.testing.assert_allclose(qp_data.T, c_e_eval, rtol=1e-7, atol=1e-6)
             quick_plot.slider_update(t_eval[-1] / scale)
             qp_data = quick_plot.plots[("Electrolyte concentration [mol.m-3]",)][0][1]
             c_e_eval = c_e(t_eval[-1], x=c_e.first_dim_pts, z=c_e.second_dim_pts)
-            np.testing.assert_array_almost_equal(qp_data.T, c_e_eval)
+            np.testing.assert_allclose(qp_data.T, c_e_eval, rtol=1e-7, atol=1e-6)
 
         pybamm.close_plots()
 
@@ -458,12 +473,12 @@ class TestQuickPlot:
             qp_data = quick_plot.plots[("Negative current collector potential [V]",)][
                 0
             ][1]
-            np.testing.assert_array_almost_equal(qp_data.T, phi_n[:, :, 0])
+            np.testing.assert_allclose(qp_data.T, phi_n[:, :, 0], rtol=1e-7, atol=1e-6)
             quick_plot.slider_update(t_eval[-1] / scale)
             qp_data = quick_plot.plots[("Negative current collector potential [V]",)][
                 0
             ][1]
-            np.testing.assert_array_almost_equal(qp_data.T, phi_n[:, :, -1])
+            np.testing.assert_allclose(qp_data.T, phi_n[:, :, -1], rtol=1e-7, atol=1e-6)
 
         with pytest.raises(NotImplementedError, match="Shape not recognized for"):
             pybamm.QuickPlot(solution, ["Negative particle concentration [mol.m-3]"])

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -139,8 +139,8 @@ class TestSerialiseModels:
         new_solution = new_solver.solve(new_model, t)
 
         for x, _ in enumerate(solution.all_ys):
-            np.testing.assert_array_almost_equal(
-                solution.all_ys[x], new_solution.all_ys[x]
+            np.testing.assert_allclose(
+                solution.all_ys[x], new_solution.all_ys[x], rtol=1e-7, atol=1e-6
             )
         os.remove("heat_equation.json")
 

--- a/tests/unit/test_solvers/test_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_algebraic_solver.py
@@ -113,7 +113,7 @@ class TestAlgebraicSolver:
 
         solver = pybamm.AlgebraicSolver()
         solution = solver._integrate(model, np.array([0]))
-        np.testing.assert_array_almost_equal(solution.y, sol)
+        np.testing.assert_allclose(solution.y, sol, rtol=1e-7, atol=1e-6)
 
     def test_model_solver(self):
         # Create model
@@ -167,22 +167,34 @@ class TestAlgebraicSolver:
         # Solve
         solver = pybamm.AlgebraicSolver("lsq")
         solution = solver.solve(model)
-        np.testing.assert_array_almost_equal(
-            model.variables["var1"].evaluate(t=None, y=solution.y), sol[:100]
+        np.testing.assert_allclose(
+            model.variables["var1"].evaluate(t=None, y=solution.y),
+            sol[:100],
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            model.variables["var2"].evaluate(t=None, y=solution.y), sol[100:]
+        np.testing.assert_allclose(
+            model.variables["var2"].evaluate(t=None, y=solution.y),
+            sol[100:],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test without jacobian and with a different method
         model.use_jacobian = False
         solver = pybamm.AlgebraicSolver("lsq__trf")
         solution_no_jac = solver.solve(model)
-        np.testing.assert_array_almost_equal(
-            model.variables["var1"].evaluate(t=None, y=solution_no_jac.y), sol[:100]
+        np.testing.assert_allclose(
+            model.variables["var1"].evaluate(t=None, y=solution_no_jac.y),
+            sol[:100],
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            model.variables["var2"].evaluate(t=None, y=solution_no_jac.y), sol[100:]
+        np.testing.assert_allclose(
+            model.variables["var2"].evaluate(t=None, y=solution_no_jac.y),
+            sol[100:],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_model_solver_minimize(self):
@@ -202,22 +214,34 @@ class TestAlgebraicSolver:
         # Solve
         solver = pybamm.AlgebraicSolver("minimize", tol=1e-8)
         solution = solver.solve(model)
-        np.testing.assert_array_almost_equal(
-            model.variables["var1"].evaluate(t=None, y=solution.y), sol[:100]
+        np.testing.assert_allclose(
+            model.variables["var1"].evaluate(t=None, y=solution.y),
+            sol[:100],
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            model.variables["var2"].evaluate(t=None, y=solution.y), sol[100:]
+        np.testing.assert_allclose(
+            model.variables["var2"].evaluate(t=None, y=solution.y),
+            sol[100:],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test without jacobian and with a different method
         model.use_jacobian = False
         solver = pybamm.AlgebraicSolver("minimize__BFGS")
         solution_no_jac = solver.solve(model)
-        np.testing.assert_array_almost_equal(
-            model.variables["var1"].evaluate(t=None, y=solution_no_jac.y), sol[:100]
+        np.testing.assert_allclose(
+            model.variables["var1"].evaluate(t=None, y=solution_no_jac.y),
+            sol[:100],
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
-            model.variables["var2"].evaluate(t=None, y=solution_no_jac.y), sol[100:]
+        np.testing.assert_allclose(
+            model.variables["var2"].evaluate(t=None, y=solution_no_jac.y),
+            sol[100:],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_model_solver_least_squares_with_bounds(self):
@@ -232,10 +256,11 @@ class TestAlgebraicSolver:
         # Solve
         solver = pybamm.AlgebraicSolver("lsq", tol=1e-5)
         solution = solver.solve(model)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             model.variables["var1"].evaluate(t=None, y=solution.y),
             3 * np.pi / 2,
-            decimal=2,
+            rtol=1e-3,
+            atol=1e-2,
         )
 
     def test_model_solver_minimize_with_bounds(self):
@@ -250,10 +275,11 @@ class TestAlgebraicSolver:
         # Solve
         solver = pybamm.AlgebraicSolver("minimize", tol=1e-16)
         solution = solver.solve(model)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             model.variables["var1"].evaluate(t=None, y=solution.y),
             3 * np.pi / 2,
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
     def test_model_solver_with_time(self):

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -182,10 +182,12 @@ class TestBaseSolver:
 
         model = VectorModel()
         init_states = solver.calculate_consistent_state(model)
-        np.testing.assert_array_almost_equal(init_states.flatten(), vec)
+        np.testing.assert_allclose(init_states.flatten(), vec, rtol=1e-7, atol=1e-6)
         # with casadi
         init_states = solver_with_casadi.calculate_consistent_state(model)
-        np.testing.assert_array_almost_equal(init_states.full().flatten(), vec)
+        np.testing.assert_allclose(
+            init_states.full().flatten(), vec, rtol=1e-7, atol=1e-6
+        )
 
         # With Jacobian
         def jac_dense(t, y, inputs):
@@ -193,7 +195,7 @@ class TestBaseSolver:
 
         model.jac_algebraic_eval = jac_dense
         init_states = solver.calculate_consistent_state(model)
-        np.testing.assert_array_almost_equal(init_states.flatten(), vec)
+        np.testing.assert_allclose(init_states.flatten(), vec, rtol=1e-7, atol=1e-6)
 
         # With sparse Jacobian
         def jac_sparse(t, y, inputs):
@@ -203,7 +205,7 @@ class TestBaseSolver:
 
         model.jac_algebraic_eval = jac_sparse
         init_states = solver.calculate_consistent_state(model)
-        np.testing.assert_array_almost_equal(init_states.flatten(), vec)
+        np.testing.assert_allclose(init_states.flatten(), vec, rtol=1e-7, atol=1e-6)
 
     def test_fail_consistent_initialization(self):
         class Model:

--- a/tests/unit/test_solvers/test_casadi_algebraic_solver.py
+++ b/tests/unit/test_solvers/test_casadi_algebraic_solver.py
@@ -117,9 +117,13 @@ class TestCasadiAlgebraicSolver:
         solution = solver.solve(model, t_eval)
 
         sol = np.vstack((3 * t_eval, 6 * t_eval))
-        np.testing.assert_array_almost_equal(solution.y, sol)
-        np.testing.assert_array_almost_equal(solution["var1"].data.flatten(), sol[0, :])
-        np.testing.assert_array_almost_equal(solution["var2"].data.flatten(), sol[1, :])
+        np.testing.assert_allclose(solution.y, sol, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            solution["var1"].data.flatten(), sol[0, :], rtol=1e-7, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            solution["var2"].data.flatten(), sol[1, :], rtol=1e-7, atol=1e-6
+        )
 
     def test_model_solver_with_time_not_changing(self):
         # Create model
@@ -139,7 +143,7 @@ class TestCasadiAlgebraicSolver:
         solution = solver.solve(model, t_eval)
 
         sol = np.vstack((3 + 0 * t_eval, 6 + 0 * t_eval))
-        np.testing.assert_array_almost_equal(solution.y, sol)
+        np.testing.assert_allclose(solution.y, sol, rtol=1e-7, atol=1e-6)
 
     def test_model_solver_with_bounds(self):
         # Note: we need a better test case to test this functionality properly
@@ -153,7 +157,9 @@ class TestCasadiAlgebraicSolver:
         # Solve
         solver = pybamm.CasadiAlgebraicSolver(tol=1e-12)
         solution = solver.solve(model)
-        np.testing.assert_array_almost_equal(solution["var1"].data, 3 * np.pi / 2)
+        np.testing.assert_allclose(
+            solution["var1"].data, 3 * np.pi / 2, rtol=1e-7, atol=1e-6
+        )
 
     def test_solve_with_input(self):
         # Simple system: a single algebraic equation
@@ -223,7 +229,7 @@ class TestCasadiAlgebraicSolverSensitivity:
 
         # without Jacobian
         lsq_sol = least_squares(objective, [2, 2], method="lm")
-        np.testing.assert_array_almost_equal(lsq_sol.x, [3, 3], decimal=3)
+        np.testing.assert_allclose(lsq_sol.x, [3, 3], rtol=1e-4, atol=1e-3)
 
         def jac(x):
             solution = solver.solve(
@@ -236,7 +242,7 @@ class TestCasadiAlgebraicSolverSensitivity:
 
         # with Jacobian
         lsq_sol = least_squares(objective, [2, 2], jac=jac, method="lm")
-        np.testing.assert_array_almost_equal(lsq_sol.x, [3, 3], decimal=3)
+        np.testing.assert_allclose(lsq_sol.x, [3, 3], rtol=1e-4, atol=1e-3)
 
     def test_solve_with_symbolic_input_1D_scalar_input(self):
         var = pybamm.Variable("var", "negative electrode")
@@ -283,17 +289,17 @@ class TestCasadiAlgebraicSolverSensitivity:
         solution = solver.solve(
             model, [0], inputs={"param": 3 * np.ones(n)}, calculate_sensitivities=True
         )
-        np.testing.assert_array_almost_equal(
-            solution["var"].sensitivities["param"], -np.eye(40)
+        np.testing.assert_allclose(
+            solution["var"].sensitivities["param"], -np.eye(40), rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(solution["var"].data, -3)
+        np.testing.assert_allclose(solution["var"].data, -3, rtol=1e-7, atol=1e-6)
         p = np.linspace(0, 1, n)[:, np.newaxis]
         solution = solver.solve(
             model, [0], inputs={"param": p}, calculate_sensitivities=True
         )
-        np.testing.assert_array_almost_equal(solution["var"].data, -p)
-        np.testing.assert_array_almost_equal(
-            solution["var"].sensitivities["param"], -np.eye(40)
+        np.testing.assert_allclose(solution["var"].data, -p, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            solution["var"].sensitivities["param"], -np.eye(40), rtol=1e-7, atol=1e-6
         )
 
     def test_solve_with_symbolic_input_in_initial_conditions(self):
@@ -345,4 +351,4 @@ class TestCasadiAlgebraicSolverSensitivity:
 
         # without Jacobian
         lsq_sol = least_squares(objective, [2, 2], method="lm")
-        np.testing.assert_array_almost_equal(lsq_sol.x, [3, 3], decimal=3)
+        np.testing.assert_allclose(lsq_sol.x, [3, 3], rtol=1e-4, atol=1e-3)

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -30,8 +30,8 @@ class TestCasadiSolver:
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model_disc, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Safe mode (enforce events that won't be triggered)
@@ -40,8 +40,8 @@ class TestCasadiSolver:
         solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Fast with events
@@ -49,8 +49,8 @@ class TestCasadiSolver:
         solver = pybamm.CasadiSolver(mode="fast with events", rtol=1e-8, atol=1e-8)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
     def test_without_grid(self):
@@ -67,8 +67,8 @@ class TestCasadiSolver:
         solver = pybamm.CasadiSolver(mode="safe without grid", rtol=1e-8, atol=1e-8)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # DAE model
@@ -84,11 +84,11 @@ class TestCasadiSolver:
         solver = pybamm.CasadiSolver(mode="safe without grid", rtol=1e-8, atol=1e-8)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * t_eval), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * t_eval), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[1], np.ones_like(t_eval), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[1], np.ones_like(t_eval), rtol=1e-6, atol=1e-5
         )
 
         # DAE model, errors
@@ -118,8 +118,8 @@ class TestCasadiSolver:
         t_eval = np.linspace(0, 1, 100)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_equal(solution.t, t_eval)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
         pybamm.set_logging_level("WARNING")
 
@@ -182,11 +182,11 @@ class TestCasadiSolver:
         np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
         np.testing.assert_array_equal(solution.y_event[:, 0], solution.y.full()[:, -1])
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Solve using "safe" mode with debug off
@@ -197,12 +197,12 @@ class TestCasadiSolver:
         np.testing.assert_array_less(solution.y.full()[0], 1.5)
         np.testing.assert_array_less(solution.y.full()[-1], 2.5 + 1e-10)
         # test the last entry is exactly 2.5
-        np.testing.assert_array_almost_equal(solution.y[-1, -1], 2.5, decimal=2)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(solution.y[-1, -1], 2.5, rtol=1e-3, atol=1e-2)
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
         pybamm.settings.debug_mode = True
 
@@ -212,11 +212,11 @@ class TestCasadiSolver:
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_less(solution.y.full()[0], 1.5)
         np.testing.assert_array_less(solution.y.full()[-1], 2.5 + 1e-10)
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Solve using "fast with events" mode
@@ -239,14 +239,14 @@ class TestCasadiSolver:
         np.testing.assert_array_less(solution.y.full()[0, :-1], 1.5)
         np.testing.assert_array_less(solution.y.full()[-1, :-1], 2.5)
         np.testing.assert_equal(solution.t_event[0], solution.t[-1])
-        np.testing.assert_array_almost_equal(
-            solution.y_event[:, 0].flatten(), [1.25, 2.5], decimal=5
+        np.testing.assert_allclose(
+            solution.y_event[:, 0].flatten(), [1.25, 2.5], rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 2 * np.exp(0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Test when an event returns nan
@@ -261,7 +261,7 @@ class TestCasadiSolver:
         solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
         solution = solver.solve(model, t_eval)
         np.testing.assert_array_less(solution.y.full()[0], 1.02 + 1e-10)
-        np.testing.assert_array_almost_equal(solution.y[0, -1], 1.02, decimal=2)
+        np.testing.assert_allclose(solution.y[0, -1], 1.02, rtol=1e-3, atol=1e-2)
 
     def test_model_step(self):
         # Create model
@@ -282,8 +282,8 @@ class TestCasadiSolver:
         dt = 1
         step_sol = solver.step(None, model, dt)
         np.testing.assert_array_equal(step_sol.t, [0, dt])
-        np.testing.assert_array_almost_equal(
-            step_sol.y.full()[0], np.exp(0.1 * step_sol.t)
+        np.testing.assert_allclose(
+            step_sol.y.full()[0], np.exp(0.1 * step_sol.t), rtol=1e-7, atol=1e-6
         )
 
         # Step again (return 5 points)
@@ -291,14 +291,16 @@ class TestCasadiSolver:
         np.testing.assert_array_equal(
             step_sol_2.t, np.array([0, 1, np.nextafter(1, np.inf), 1.25, 1.5, 1.75, 2])
         )
-        np.testing.assert_array_almost_equal(
-            step_sol_2.y.full()[0], np.exp(0.1 * step_sol_2.t)
+        np.testing.assert_allclose(
+            step_sol_2.y.full()[0], np.exp(0.1 * step_sol_2.t), rtol=1e-7, atol=1e-6
         )
 
         # Check steps give same solution as solve
         t_eval = step_sol.t
         solution = solver.solve(model, t_eval)
-        np.testing.assert_array_almost_equal(solution.y.full()[0], step_sol.y.full()[0])
+        np.testing.assert_allclose(
+            solution.y.full()[0], step_sol.y.full()[0], rtol=1e-7, atol=1e-6
+        )
 
     def test_model_step_with_input(self):
         # Create model
@@ -319,9 +321,11 @@ class TestCasadiSolver:
 
         # Step again with different inputs
         step_sol_2 = solver.step(step_sol, model, dt, npts=5, inputs={"a": -1})
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             step_sol_2.t,
             np.array([0, 0.025, 0.05, 0.075, 0.1, 0.1 + 1e-9, 0.125, 0.15, 0.175, 0.2]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         np.testing.assert_array_equal(
             step_sol_2["a"].entries,
@@ -366,11 +370,17 @@ class TestCasadiSolver:
         np.testing.assert_array_equal(
             step_solution.y_event[:, 0], step_solution.y.full()[:, -1]
         )
-        np.testing.assert_array_almost_equal(
-            step_solution.y.full()[0], np.exp(0.1 * step_solution.t), decimal=5
+        np.testing.assert_allclose(
+            step_solution.y.full()[0],
+            np.exp(0.1 * step_solution.t),
+            rtol=1e-6,
+            atol=1e-5,
         )
-        np.testing.assert_array_almost_equal(
-            step_solution.y.full()[-1], 2 * np.exp(0.1 * step_solution.t), decimal=4
+        np.testing.assert_allclose(
+            step_solution.y.full()[-1],
+            2 * np.exp(0.1 * step_solution.t),
+            rtol=1e-5,
+            atol=1e-4,
         )
 
     def test_model_solver_with_inputs(self):
@@ -427,22 +437,22 @@ class TestCasadiSolver:
         solution = solver.solve(
             model, t_eval, inputs={"rate": -1, "ic 1": 0.1, "ic 2": 2}
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], 0.1 * np.exp(-solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], 0.1 * np.exp(-solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 0.1 * np.exp(-solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 0.1 * np.exp(-solution.t), rtol=1e-6, atol=1e-5
         )
 
         # Solve again with different initial conditions
         solution = solver.solve(
             model, t_eval, inputs={"rate": -0.1, "ic 1": 1, "ic 2": 3}
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[0], 1 * np.exp(-0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[0], 1 * np.exp(-0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
-        np.testing.assert_array_almost_equal(
-            solution.y.full()[-1], 1 * np.exp(-0.1 * solution.t), decimal=5
+        np.testing.assert_allclose(
+            solution.y.full()[-1], 1 * np.exp(-0.1 * solution.t), rtol=1e-6, atol=1e-5
         )
 
     def test_model_solver_with_non_identity_mass(self):
@@ -573,11 +583,11 @@ class TestCasadiSolver:
         )
         var1_soln = (step_solution.t % a) ** 2 / 2 + a**2 / 2 * (step_solution.t // a)
         var2_soln = 2 * var1_soln
-        np.testing.assert_array_almost_equal(
-            step_solution.y.full()[0], var1_soln, decimal=4
+        np.testing.assert_allclose(
+            step_solution.y.full()[0], var1_soln, rtol=1e-5, atol=1e-4
         )
-        np.testing.assert_array_almost_equal(
-            step_solution.y.full()[-1], var2_soln, decimal=4
+        np.testing.assert_allclose(
+            step_solution.y.full()[-1], var2_soln, rtol=1e-5, atol=1e-4
         )
 
 
@@ -706,15 +716,17 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations:
         solution = solver.solve(
             model, t_eval, inputs={"param": 7}, calculate_sensitivities=["param"]
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["var"].data,
             np.tile(2 * np.exp(-7 * t_eval), (n, 1)),
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["var"].sensitivities["param"],
             np.repeat(-2 * t_eval * np.exp(-7 * t_eval), n)[:, np.newaxis],
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
         # More complicated model
@@ -824,24 +836,30 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations:
             calculate_sensitivities=True,
         )
         l_n = mesh["negative electrode"].edges[-1]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["var"].data,
             np.tile(2 * np.exp(-7 * t_eval), (n, 1)),
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["var"].sensitivities["param"],
             np.vstack([np.eye(n) * -2 * t * np.exp(-7 * t) for t in t_eval]),
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["integral of var"].data,
             2 * np.exp(-7 * t_eval) * l_n,
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["integral of var"].sensitivities["param"],
             np.tile(-2 * t_eval * np.exp(-7 * t_eval) * l_n / n, (n, 1)).T,
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Solve - linspace input
@@ -850,15 +868,20 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations:
             model, t_eval, inputs={"param": p_eval}, calculate_sensitivities=True
         )
         l_n = mesh["negative electrode"].edges[-1]
-        np.testing.assert_array_almost_equal(
-            solution["var"].data, 2 * np.exp(-p_eval[:, np.newaxis] * t_eval), decimal=4
+        np.testing.assert_allclose(
+            solution["var"].data,
+            2 * np.exp(-p_eval[:, np.newaxis] * t_eval),
+            rtol=1e-5,
+            atol=1e-4,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["var"].sensitivities["param"],
             np.vstack([np.diag(-2 * t * np.exp(-p_eval * t)) for t in t_eval]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["integral of var"].data,
             np.sum(
                 2
@@ -866,10 +889,14 @@ class TestCasadiSolverODEsWithForwardSensitivityEquations:
                 * mesh["negative electrode"].d_edges[:, np.newaxis],
                 axis=0,
             ),
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             solution["integral of var"].sensitivities["param"],
             np.vstack([-2 * t * np.exp(-p_eval * t) * l_n / n for t in t_eval]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_solve_sensitivity_then_no_sensitivity(self):

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -1094,8 +1094,8 @@ class TestIDAKLUSolver:
                 np.testing.assert_allclose(
                     sol[varname](t_interp),
                     sol_all[varname](t_interp),
-                    rtol=1e-7,
-                    atol=1e-6,
+                    rtol=tol,
+                    atol=tol,
                     err_msg=f"Failed for {varname} with form {form}",
                 )
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -42,19 +42,21 @@ class TestIDAKLUSolver:
 
             # test that final time is time of event
             # y = 0.1 t + y0 so y=0.2 when t=2
-            np.testing.assert_array_almost_equal(solution.t[-1], 2.0)
+            np.testing.assert_allclose(solution.t[-1], 2.0, rtol=1e-7, atol=1e-6)
 
             # test that final value is the event value
-            np.testing.assert_array_almost_equal(solution.y[0, -1], 0.2)
+            np.testing.assert_allclose(solution.y[0, -1], 0.2, rtol=1e-7, atol=1e-6)
 
             # test that y[1] remains constant
-            np.testing.assert_array_almost_equal(
-                solution.y[1, :], np.ones(solution.t.shape)
+            np.testing.assert_allclose(
+                solution.y[1, :], np.ones(solution.t.shape), rtol=1e-7, atol=1e-6
             )
 
             # test that y[0] = to true solution
             true_solution = 0.1 * solution.t
-            np.testing.assert_array_almost_equal(solution.y[0, :], true_solution)
+            np.testing.assert_allclose(
+                solution.y[0, :], true_solution, rtol=1e-7, atol=1e-6
+            )
 
     def test_multiple_inputs(self):
         model = pybamm.BaseModel()
@@ -130,10 +132,11 @@ class TestIDAKLUSolver:
             np.testing.assert_array_equal(
                 solution.t, t_interp, err_msg=f"Failed for form {form}"
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 solution.y[0],
                 np.exp(0.1 * solution.t),
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
                 err_msg=f"Failed for form {form}",
             )
 
@@ -152,10 +155,11 @@ class TestIDAKLUSolver:
             )
             solution = solver.solve(model_disc, t_eval, t_interp=t_interp)
             np.testing.assert_array_equal(solution.t, t_interp)
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 solution.y[0],
                 np.exp(0.1 * solution.t),
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
                 err_msg=f"Failed for form {form}",
             )
 
@@ -170,10 +174,11 @@ class TestIDAKLUSolver:
             )
             solution = solver.solve(model_disc, t_eval, t_interp=t_interp)
             assert len(solution.t) < len(t_interp)
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 solution.y[0],
                 np.exp(0.1 * solution.t),
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
                 err_msg=f"Failed for form {form}",
             )
 
@@ -204,16 +209,18 @@ class TestIDAKLUSolver:
             np.testing.assert_array_less(solution.y[-1, :-1], 2.5)
             np.testing.assert_equal(solution.t_event[0], solution.t[-1])
             np.testing.assert_array_equal(solution.y_event[:, 0], solution.y[:, -1])
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 solution.y[0],
                 np.exp(0.1 * solution.t),
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
                 err_msg=f"Failed for form {form}",
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 solution.y[-1],
                 2 * np.exp(0.1 * solution.t),
-                decimal=5,
+                rtol=1e-6,
+                atol=1e-5,
                 err_msg=f"Failed for form {form}",
             )
 
@@ -259,20 +266,32 @@ class TestIDAKLUSolver:
             )
 
             # test that y[3] remains constant
-            np.testing.assert_array_almost_equal(
-                sol.y[3], np.ones(sol.t.shape), err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[3],
+                np.ones(sol.t.shape),
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # test that y[0] = to true solution
             true_solution = a_value * sol.t
-            np.testing.assert_array_almost_equal(
-                sol.y[0], true_solution, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[0],
+                true_solution,
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # test that y[1:3] = to true solution
             true_solution = b_value * sol.t
-            np.testing.assert_array_almost_equal(
-                sol.y[1:3], true_solution, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[1:3],
+                true_solution,
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
     def test_sensitivities_initial_condition(self):
@@ -315,10 +334,11 @@ class TestIDAKLUSolver:
                     calculate_sensitivities=True,
                 )
 
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     sol["2v"].sensitivities["a"].full().flatten(),
                     np.exp(-sol.t) * 2,
-                    decimal=4,
+                    rtol=1e-5,
+                    atol=1e-4,
                     err_msg=f"Failed for form {form}",
                 )
 
@@ -364,14 +384,22 @@ class TestIDAKLUSolver:
             )
 
             # test that y[1] remains constant
-            np.testing.assert_array_almost_equal(
-                sol.y[1, :], np.ones(sol.t.shape), err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[1, :],
+                np.ones(sol.t.shape),
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # test that y[0] = to true solution
             true_solution = a_value * sol.t
-            np.testing.assert_array_almost_equal(
-                sol.y[0, :], true_solution, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[0, :],
+                true_solution,
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # should be no sensitivities calculated
@@ -388,14 +416,22 @@ class TestIDAKLUSolver:
             )
 
             # test that y[1] remains constant
-            np.testing.assert_array_almost_equal(
-                sol.y[1, :], np.ones(sol.t.shape), err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[1, :],
+                np.ones(sol.t.shape),
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # test that y[0] = to true solution
             true_solution = a_value * sol.t
-            np.testing.assert_array_almost_equal(
-                sol.y[0, :], true_solution, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[0, :],
+                true_solution,
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # evaluate the sensitivities using idas
@@ -415,16 +451,21 @@ class TestIDAKLUSolver:
             decimal = (
                 2 if form == "iree" else 6
             )  # iree currently operates with single precision
-            np.testing.assert_array_almost_equal(
-                dyda_ida, dyda_fd, decimal=decimal, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                dyda_ida,
+                dyda_fd,
+                err_msg=f"Failed for form {form}",
+                rtol=10 ** (-decimal - 1),
+                atol=10 ** (-decimal),
             )
 
             # get the sensitivities for the variable
             d2uda = sol["2u"].sensitivities["a"]
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 2 * dyda_ida[0:200:2],
                 d2uda,
-                decimal=decimal,
+                rtol=10 ** (-decimal - 1),
+                atol=10 ** (-decimal),
                 err_msg=f"Failed for form {form}",
             )
 
@@ -461,13 +502,21 @@ class TestIDAKLUSolver:
             solver._set_consistent_initialization(model, t0, inputs_dict={})
 
             # u(t0) = 0, v(t0) = 1
-            np.testing.assert_array_almost_equal(
-                model.y0full, [0, 1], err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                model.y0full,
+                [0, 1],
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
             # u'(t0) = 0.1 * v(t0) = 0.1
             # Since v is algebraic, the initial derivative is set to 0
-            np.testing.assert_array_almost_equal(
-                model.ydot0full, [0.1, 0], err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                model.ydot0full,
+                [0.1, 0],
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
     def test_sensitivities_with_events(self):
@@ -516,14 +565,22 @@ class TestIDAKLUSolver:
             )
 
             # test that y[1] remains constant
-            np.testing.assert_array_almost_equal(
-                sol.y[1, :], np.ones(sol.t.shape), err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[1, :],
+                np.ones(sol.t.shape),
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # test that y[0] = to true solution
             true_solution = a_value * sol.t
-            np.testing.assert_array_almost_equal(
-                sol.y[0, :], true_solution, err_msg=f"Failed for form {form}"
+            np.testing.assert_allclose(
+                sol.y[0, :],
+                true_solution,
+                err_msg=f"Failed for form {form}",
+                rtol=1e-7,
+                atol=1e-6,
             )
 
             # evaluate the sensitivities using idas
@@ -551,10 +608,11 @@ class TestIDAKLUSolver:
             decimal = (
                 2 if form == "iree" else 6
             )  # iree currently operates with single precision
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 dyda_ida[: (2 * max_index), :],
                 dyda_fd,
-                decimal=decimal,
+                rtol=10 ** (-decimal - 1),
+                atol=10 ** (-decimal),
                 err_msg=f"Failed for form {form}",
             )
 
@@ -574,10 +632,11 @@ class TestIDAKLUSolver:
             dydb_fd = (sol_plus.y[:, :max_index] - sol_neg.y[:, :max_index]) / h
             dydb_fd = dydb_fd.transpose().reshape(-1, 1)
 
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 dydb_ida[: (2 * max_index), :],
                 dydb_fd,
-                decimal=decimal,
+                rtol=10 ** (-decimal - 1),
+                atol=10 ** (-decimal),
                 err_msg=f"Failed for form {form}",
             )
 
@@ -685,7 +744,7 @@ class TestIDAKLUSolver:
         solver_banded = pybamm.IDAKLUSolver(options=options)
         soln_banded = solver_banded.solve(model, t_eval, t_interp=t_interp)
 
-        np.testing.assert_array_almost_equal(soln.y, soln_banded.y, 5)
+        np.testing.assert_allclose(soln.y, soln_banded.y, rtol=1e-6, atol=1e-5)
 
     def test_setup_options(self):
         model = pybamm.BaseModel()
@@ -764,7 +823,9 @@ class TestIDAKLUSolver:
 
                     if works:
                         soln = solver.solve(model, t_eval, t_interp=t_interp)
-                        np.testing.assert_array_almost_equal(soln.y, soln_base.y, 4)
+                        np.testing.assert_allclose(
+                            soln.y, soln_base.y, rtol=1e-5, atol=1e-4
+                        )
                     else:
                         with pytest.raises(ValueError):
                             soln = solver.solve(model, t_eval, t_interp=t_interp)
@@ -815,7 +876,7 @@ class TestIDAKLUSolver:
             solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6, options=options)
             soln = solver.solve(model, t_eval, t_interp=t_interp)
 
-            np.testing.assert_array_almost_equal(soln.y, soln_base.y, 4)
+            np.testing.assert_allclose(soln.y, soln_base.y, rtol=1e-5, atol=1e-4)
 
         options_fail = {
             "max_order_bdf": -1,
@@ -929,8 +990,8 @@ class TestIDAKLUSolver:
 
         # Compare output to sol_all
         for varname in [*output_variables, *model_vars]:
-            np.testing.assert_array_almost_equal(
-                sol[varname](t_eval), sol_all[varname](t_eval), 3
+            np.testing.assert_allclose(
+                sol[varname](t_eval), sol_all[varname](t_eval), rtol=1e-4, atol=1e-3
             )
 
         # Check that the missing variables are not available in the solution
@@ -1030,10 +1091,11 @@ class TestIDAKLUSolver:
             # Compare output to sol_all
             tol = 1e-5 if form != "iree" else 1e-2  # iree has reduced precision
             for varname in output_variables:
-                np.testing.assert_array_almost_equal(
+                np.testing.assert_allclose(
                     sol[varname](t_interp),
                     sol_all[varname](t_interp),
-                    tol,
+                    rtol=1e-7,
+                    atol=1e-6,
                     err_msg=f"Failed for {varname} with form {form}",
                 )
 
@@ -1103,7 +1165,7 @@ class TestIDAKLUSolver:
         )
         sol = sim.solve()
 
-        np.testing.assert_array_almost_equal(sol.t, np.arange(0, 10.1, 0.1), decimal=4)
+        np.testing.assert_allclose(sol.t, np.arange(0, 10.1, 0.1), rtol=1e-5, atol=1e-5)
 
     def test_interpolate_time_step_start_offset(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_solvers/test_processed_variable.py
+++ b/tests/unit/test_solvers/test_processed_variable.py
@@ -187,8 +187,8 @@ class TestProcessedVariable:
         data = pybamm.DiscreteTimeData(data_t, data_v, "test_data")
 
         # check data interp
-        np.testing.assert_array_almost_equal(
-            data.evaluate(t=t_sol).flatten(), data_v_interp
+        np.testing.assert_allclose(
+            data.evaluate(t=t_sol).flatten(), data_v_interp, rtol=1e-7, atol=1e-6
         )
 
         var = (y - data) ** order
@@ -201,11 +201,11 @@ class TestProcessedVariable:
             [var_casadi],
             self._sol_default(t_sol, y_sol, yp_sol, model),
         )
-        np.testing.assert_array_almost_equal(
-            processed_var.entries, expected_entries.flatten(), decimal=10
+        np.testing.assert_allclose(
+            processed_var.entries, expected_entries.flatten(), rtol=1e-11, atol=1e-10
         )
-        np.testing.assert_array_almost_equal(
-            processed_var(t=data_t), expected.flatten(), decimal=10
+        np.testing.assert_allclose(
+            processed_var(t=data_t), expected.flatten(), rtol=1e-11, atol=1e-10
         )
 
     @pytest.mark.parametrize("hermite_interp", _hermite_args)
@@ -270,15 +270,20 @@ class TestProcessedVariable:
             self._sol_default(t_sol, y_sol, yp_sol),
         )
         np.testing.assert_array_equal(processed_var.entries, y_sol)
-        np.testing.assert_array_almost_equal(processed_var(t_sol, x_sol), y_sol)
+        np.testing.assert_allclose(
+            processed_var(t_sol, x_sol), y_sol, rtol=1e-7, atol=1e-6
+        )
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_eqn = pybamm.process_variable(
             [eqn_sol],
             [eqn_casadi],
             self._sol_default(t_sol, y_sol, yp_sol),
         )
-        np.testing.assert_array_almost_equal(
-            processed_eqn(t_sol, x_sol), t_sol * y_sol + x_sol[:, np.newaxis]
+        np.testing.assert_allclose(
+            processed_eqn(t_sol, x_sol),
+            t_sol * y_sol + x_sol[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test extrapolation
@@ -590,8 +595,8 @@ class TestProcessedVariable:
         # vector
         np.testing.assert_array_equal(processed_var(t_sol), y_sol[0])
         # scalar
-        np.testing.assert_array_almost_equal(processed_var(0.5), 2.5)
-        np.testing.assert_array_almost_equal(processed_var(0.7), 3.5)
+        np.testing.assert_allclose(processed_var(0.5), 2.5, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(processed_var(0.7), 3.5, rtol=1e-7, atol=1e-6)
 
         eqn_casadi = to_casadi(eqn, y_sol)
         processed_eqn = pybamm.process_variable(
@@ -603,7 +608,7 @@ class TestProcessedVariable:
 
         assert processed_eqn(0.5).shape == ()
 
-        np.testing.assert_array_almost_equal(processed_eqn(0.5), 0.5 * 2.5)
+        np.testing.assert_allclose(processed_eqn(0.5), 0.5 * 2.5, rtol=1e-6, atol=1e-6)
         np.testing.assert_array_equal(processed_eqn(2, fill_value=100), 100)
         # Suppress warning for this test
         pybamm.set_logging_level("ERROR")
@@ -651,16 +656,22 @@ class TestProcessedVariable:
         )
 
         # 2 vectors
-        np.testing.assert_array_almost_equal(processed_var(t_sol, x_sol), y_sol)
+        np.testing.assert_allclose(
+            processed_var(t_sol, x_sol), y_sol, rtol=1e-7, atol=1e-6
+        )
         # 1 vector, 1 scalar
-        np.testing.assert_array_almost_equal(processed_var(0.5, x_sol), 2.5 * x_sol)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
+            processed_var(0.5, x_sol), 2.5 * x_sol, rtol=1e-7, atol=1e-6
+        )
+        np.testing.assert_allclose(
             processed_var(t_sol, x_sol[-1]),
             x_sol[-1] * np.linspace(0, 5),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 2 scalars
-        np.testing.assert_array_almost_equal(
-            processed_var(0.5, x_sol[-1]), 2.5 * x_sol[-1]
+        np.testing.assert_allclose(
+            processed_var(0.5, x_sol[-1]), 2.5 * x_sol[-1], rtol=1e-7, atol=1e-6
         )
         eqn_casadi = to_casadi(eqn_sol, y_sol)
         processed_eqn = pybamm.process_variable(
@@ -669,8 +680,11 @@ class TestProcessedVariable:
             self._sol_default(t_sol, y_sol, yp_sol),
         )
         # 2 vectors
-        np.testing.assert_array_almost_equal(
-            processed_eqn(t_sol, x_sol), t_sol * y_sol + x_sol[:, np.newaxis]
+        np.testing.assert_allclose(
+            processed_eqn(t_sol, x_sol),
+            t_sol * y_sol + x_sol[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 1 vector, 1 scalar
         assert processed_eqn(0.5, x_sol[10:30]).shape == (20,)
@@ -687,7 +701,9 @@ class TestProcessedVariable:
             [x_casadi],
             self._sol_default(t_sol, y_sol, yp_sol),
         )
-        np.testing.assert_array_almost_equal(processed_x(t=0, x=x_sol), x_sol)
+        np.testing.assert_allclose(
+            processed_x(t=0, x=x_sol), x_sol, rtol=1e-7, atol=1e-6
+        )
 
         # In particles
         r_n = pybamm.Matrix(
@@ -702,7 +718,9 @@ class TestProcessedVariable:
         )
         np.testing.assert_array_equal(r_n.entries[:, 0], processed_r_n.entries[:, 0])
         r_test = np.linspace(0, 0.5)
-        np.testing.assert_array_almost_equal(processed_r_n(0, r=r_test), r_test)
+        np.testing.assert_allclose(
+            processed_r_n(0, r=r_test), r_test, rtol=1e-7, atol=1e-6
+        )
 
         # On size domain
         R_n = pybamm.Matrix(
@@ -720,7 +738,9 @@ class TestProcessedVariable:
         )
         np.testing.assert_array_equal(R_n.entries[:, 0], processed_R_n.entries[:, 0])
         R_test = np.linspace(0, 1)
-        np.testing.assert_array_almost_equal(processed_R_n(0, R=R_test), R_test)
+        np.testing.assert_allclose(
+            processed_R_n(0, R=R_test), R_test, rtol=1e-7, atol=1e-6
+        )
 
     @pytest.mark.parametrize("hermite_interp", _hermite_args)
     def test_processed_var_1D_fixed_t_interpolation(self, hermite_interp):
@@ -744,11 +764,11 @@ class TestProcessedVariable:
         )
 
         # vector
-        np.testing.assert_array_almost_equal(
-            processed_var(x=x_sol), 2 * x_sol[:, np.newaxis]
+        np.testing.assert_allclose(
+            processed_var(x=x_sol), 2 * x_sol[:, np.newaxis], rtol=1e-7, atol=1e-6
         )
         # scalar
-        np.testing.assert_array_almost_equal(processed_var(x=0.5), 1)
+        np.testing.assert_allclose(processed_var(x=0.5), 1, rtol=1e-7, atol=1e-6)
 
     @pytest.mark.parametrize("hermite_interp", _hermite_args)
     def test_processed_var_wrong_spatial_variable_names(self, hermite_interp):
@@ -833,9 +853,11 @@ class TestProcessedVariable:
         np.testing.assert_array_equal(
             processed_var(t_sol, x_sol, r_sol).shape, (10, 40, 50)
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             processed_var(t_sol, x_sol, r_sol),
             np.reshape(y_sol, [len(r_sol), len(x_sol), len(t_sol)]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 2 vectors, 1 scalar
         np.testing.assert_array_equal(processed_var(0.5, x_sol, r_sol).shape, (10, 40))
@@ -948,9 +970,11 @@ class TestProcessedVariable:
         np.testing.assert_array_equal(
             processed_var(t_sol, x_sol, r_sol).shape, (10, 40, 50)
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             processed_var(t_sol, x_sol, r_sol),
             np.reshape(y_sol, [len(r_sol), len(x_sol), len(t_sol)]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 2 vectors, 1 scalar
         np.testing.assert_array_equal(processed_var(0.5, x_sol, r_sol).shape, (10, 40))
@@ -1012,9 +1036,11 @@ class TestProcessedVariable:
         np.testing.assert_array_equal(
             processed_var(t_sol, y=y_sol, z=z_sol).shape, (15, 15, 50)
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             processed_var(t_sol, y=y_sol, z=z_sol),
             np.reshape(u_sol, [len(y_sol), len(z_sol), len(t_sol)]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 2 vectors, 1 scalar
         np.testing.assert_array_equal(
@@ -1121,9 +1147,11 @@ class TestProcessedVariable:
         np.testing.assert_array_equal(
             processed_var(t=t_sol, x=x_sol, z=z_sol).shape, (20, 10, 50)
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             processed_var(t_sol, x=x_sol, z=z_sol),
             np.reshape(y_sol, [len(z_sol), len(x_sol), len(t_sol)]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # 2 vectors, 1 scalar
         np.testing.assert_array_equal(

--- a/tests/unit/test_solvers/test_processed_variable_computed.py
+++ b/tests/unit/test_solvers/test_processed_variable_computed.py
@@ -174,7 +174,9 @@ class TestProcessedVariableComputed:
         y_sol = y_sol.reshape((y_sol.shape[1], y_sol.shape[0])).transpose()
         np.testing.assert_array_equal(processed_var.entries, y_sol)
         np.testing.assert_array_equal(processed_var.entries, processed_var.data)
-        np.testing.assert_array_almost_equal(processed_var(t_sol, x_sol), y_sol)
+        np.testing.assert_allclose(
+            processed_var(t_sol, x_sol), y_sol, rtol=1e-7, atol=1e-6
+        )
 
         # Check unroll function
         np.testing.assert_array_equal(processed_var.unroll(), y_sol)

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -306,8 +306,8 @@ class TestSolution:
         )
         # check summay variables not in the solve can be evaluated at the final timestep
         # via 'last_state
-        np.testing.assert_array_almost_equal(
-            sol1.last_state["4u"].entries, np.array([4.0])
+        np.testing.assert_allclose(
+            sol1.last_state["4u"].entries, np.array([4.0]), rtol=1e-7, atol=1e-6
         )
 
     def test_cycles(self):
@@ -439,8 +439,12 @@ class TestSolution:
 
             # read csv
             df = pd.read_csv(f"{test_stub}.csv")
-            np.testing.assert_array_almost_equal(df["c"], solution.data["c"])
-            np.testing.assert_array_almost_equal(df["2c"], solution.data["2c"])
+            np.testing.assert_allclose(
+                df["c"], solution.data["c"], rtol=1e-7, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                df["2c"], solution.data["2c"], rtol=1e-7, atol=1e-6
+            )
 
             # to json
             solution.save_data(f"{test_stub}.json", to_format="json")
@@ -453,8 +457,12 @@ class TestSolution:
 
             # check if string has the right values
             json_data = json.loads(json_str)
-            np.testing.assert_array_almost_equal(json_data["c"], solution.data["c"])
-            np.testing.assert_array_almost_equal(json_data["d"], solution.data["d"])
+            np.testing.assert_allclose(
+                json_data["c"], solution.data["c"], rtol=1e-7, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                json_data["d"], solution.data["d"], rtol=1e-7, atol=1e-6
+            )
 
             # raise error if format is unknown
             with pytest.raises(
@@ -551,6 +559,6 @@ class TestSolution:
             sol = solver.solve(model, t_eval=t_eval, inputs={"a": a})
             y_sol = np.exp(-a * data_times)
             expected = np.sum((y_sol - data_values) ** 2)
-            np.testing.assert_array_almost_equal(
-                sol["data_comparison"](), expected, decimal=2
+            np.testing.assert_allclose(
+                sol["data_comparison"](), expected, rtol=1e-3, atol=1e-2
             )

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -154,12 +154,12 @@ class TestExtrapolation:
         r_lin_rates = np.log(r_errors_lin[:-1] / r_errors_lin[1:]) / np.log(
             dx[:-1] / dx[1:]
         )
-        np.testing.assert_array_almost_equal(l_lin_rates, 2)
-        np.testing.assert_array_almost_equal(r_lin_rates, 2)
+        np.testing.assert_allclose(l_lin_rates, 2, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(r_lin_rates, 2, rtol=1e-7, atol=1e-6)
 
         # check quadratic is equal up to machine precision
-        np.testing.assert_array_almost_equal(l_errors_quad, 0, decimal=14)
-        np.testing.assert_array_almost_equal(r_errors_quad, 0, decimal=14)
+        np.testing.assert_allclose(l_errors_quad, 0, rtol=1e-15, atol=1e-14)
+        np.testing.assert_allclose(r_errors_quad, 0, rtol=1e-15, atol=1e-14)
 
         def x_cubed(x):
             y = x**3
@@ -179,8 +179,8 @@ class TestExtrapolation:
             dx[:-1] / dx[1:]
         )
 
-        np.testing.assert_array_almost_equal(l_lin_rates, 2)
-        np.testing.assert_array_almost_equal(r_lin_rates, 2)
+        np.testing.assert_allclose(l_lin_rates, 2, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(r_lin_rates, 2, rtol=1e-7, atol=1e-6)
 
         # quadratic case
         pts = 5 ** np.arange(1, 7, 1)
@@ -197,8 +197,8 @@ class TestExtrapolation:
             dx[:-1] / dx[1:]
         )
 
-        np.testing.assert_array_almost_equal(l_quad_rates, 3)
-        np.testing.assert_array_almost_equal(r_quad_rates, 3, decimal=3)
+        np.testing.assert_allclose(l_quad_rates, 3, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(r_quad_rates, 3, rtol=1e-4, atol=1e-3)
 
     def test_extrapolation_with_bcs_right_neumann(self):
         # simple particle with a flux bc
@@ -270,8 +270,12 @@ class TestExtrapolation:
             np.testing.assert_array_less(r_errors_quad_with_bc, r_errors_quad_no_bc)
 
             # Test that the RIGHT gradient is correct
-            np.testing.assert_array_almost_equal(r_grad_errors_lin_with_bc, 0)
-            np.testing.assert_array_almost_equal(r_grad_errors_quad_with_bc, 0)
+            np.testing.assert_allclose(
+                r_grad_errors_lin_with_bc, 0, rtol=1e-7, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                r_grad_errors_quad_with_bc, 0, rtol=1e-7, atol=1e-6
+            )
 
             # note that with bcs we now obtain the left Dirichlet condition exactly
 
@@ -283,8 +287,8 @@ class TestExtrapolation:
             ) / np.log(dx[:-1] / dx[1:])
 
             # check convergence is about the correct order
-            np.testing.assert_array_almost_equal(r_lin_rates_bc, 2, decimal=2)
-            np.testing.assert_array_almost_equal(r_quad_rates_bc, 3, decimal=1)
+            np.testing.assert_allclose(r_lin_rates_bc, 2, rtol=1e-3, atol=1e-2)
+            np.testing.assert_allclose(r_quad_rates_bc, 3, rtol=1e-2, atol=1e-1)
 
     def test_extrapolation_with_bcs_left_neumann(self):
         # simple particle with a flux bc
@@ -356,8 +360,12 @@ class TestExtrapolation:
             np.testing.assert_array_less(r_errors_quad_with_bc, r_errors_quad_no_bc)
 
             # assert that the LEFT gradient is correct
-            np.testing.assert_array_almost_equal(l_grad_errors_lin_with_bc, 0)
-            np.testing.assert_array_almost_equal(l_grad_errors_quad_with_bc, 0)
+            np.testing.assert_allclose(
+                l_grad_errors_lin_with_bc, 0, rtol=1e-7, atol=1e-6
+            )
+            np.testing.assert_allclose(
+                l_grad_errors_quad_with_bc, 0, rtol=1e-7, atol=1e-6
+            )
 
             # note that with bcs we now obtain the right Dirichlet condition exactly
 
@@ -370,7 +378,7 @@ class TestExtrapolation:
 
             # check convergence is about the correct order
             np.testing.assert_array_less(2, l_lin_rates_bc)
-            np.testing.assert_array_almost_equal(l_quad_rates_bc, 3, decimal=1)
+            np.testing.assert_allclose(l_quad_rates_bc, 3, rtol=1e-2, atol=1e-1)
 
     def test_linear_extrapolate_left_right(self):
         # create discretisation
@@ -409,11 +417,11 @@ class TestExtrapolation:
 
         # check linear variable extrapolates correctly
         linear_y = macro_submesh.nodes
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, linear_y), 0
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, linear_y), 0, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, linear_y), 3
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, linear_y), 3, rtol=1e-7, atol=1e-6
         )
 
         # Fluxes
@@ -444,8 +452,8 @@ class TestExtrapolation:
         # check linear variable extrapolates correctly
         linear_y = micro_submesh.nodes
         y_surf = micro_submesh.edges[-1]
-        np.testing.assert_array_almost_equal(
-            surf_eqn_disc.evaluate(None, linear_y), y_surf
+        np.testing.assert_allclose(
+            surf_eqn_disc.evaluate(None, linear_y), y_surf, rtol=1e-7, atol=1e-6
         )
 
     def test_extrapolate_symbolic(self):
@@ -479,19 +487,19 @@ class TestExtrapolation:
 
         # check linear variable extrapolates correctly
         linear_y = mesh["domain"].nodes
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, linear_y), 0
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, linear_y), 0, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, linear_y), 1
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, linear_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # check gradient extrapolates correctly
-        np.testing.assert_array_almost_equal(
-            extrap_grad_left_disc.evaluate(None, linear_y), 1 / 2
+        np.testing.assert_allclose(
+            extrap_grad_left_disc.evaluate(None, linear_y), 1 / 2, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_grad_right_disc.evaluate(None, linear_y), 1 / 2
+        np.testing.assert_allclose(
+            extrap_grad_right_disc.evaluate(None, linear_y), 1 / 2, rtol=1e-7, atol=1e-6
         )
 
         method_options = {
@@ -514,27 +522,27 @@ class TestExtrapolation:
         extrap_grad_right_disc = disc.process_symbol(extrap_grad_right)
 
         # check constant extrapolates to constant
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # check linear variable extrapolates correctly
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, linear_y), 0
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, linear_y), 0, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, linear_y), 1
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, linear_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # check gradient extrapolates correctly
-        np.testing.assert_array_almost_equal(
-            extrap_grad_left_disc.evaluate(None, linear_y), 1 / 2
+        np.testing.assert_allclose(
+            extrap_grad_left_disc.evaluate(None, linear_y), 1 / 2, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_grad_right_disc.evaluate(None, linear_y), 1 / 2
+        np.testing.assert_allclose(
+            extrap_grad_right_disc.evaluate(None, linear_y), 1 / 2, rtol=1e-7, atol=1e-6
         )
 
     def test_quadratic_extrapolate_left_right(self):
@@ -569,20 +577,20 @@ class TestExtrapolation:
 
         # check constant extrapolates to constant
         constant_y = np.ones_like(macro_submesh.nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, constant_y), 2.0
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, constant_y), 2.0, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, constant_y), 3.0
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, constant_y), 3.0, rtol=1e-7, atol=1e-6
         )
 
         # check linear variable extrapolates correctly
         linear_y = macro_submesh.nodes
-        np.testing.assert_array_almost_equal(
-            extrap_left_disc.evaluate(None, linear_y), 0
+        np.testing.assert_allclose(
+            extrap_left_disc.evaluate(None, linear_y), 0, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(None, linear_y), 3
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(None, linear_y), 3, rtol=1e-7, atol=1e-6
         )
 
         # Fluxes
@@ -592,17 +600,17 @@ class TestExtrapolation:
         extrap_flux_right_disc = disc.process_symbol(extrap_flux_right)
 
         # check constant extrapolates to constant
-        np.testing.assert_array_almost_equal(
-            extrap_flux_left_disc.evaluate(None, constant_y), 0
+        np.testing.assert_allclose(
+            extrap_flux_left_disc.evaluate(None, constant_y), 0, rtol=1e-7, atol=1e-6
         )
         assert extrap_flux_right_disc.evaluate(None, constant_y) == 0
 
         # check linear variable extrapolates correctly
-        np.testing.assert_array_almost_equal(
-            extrap_flux_left_disc.evaluate(None, linear_y), 2
+        np.testing.assert_allclose(
+            extrap_flux_left_disc.evaluate(None, linear_y), 2, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_flux_right_disc.evaluate(None, linear_y), -1
+        np.testing.assert_allclose(
+            extrap_flux_right_disc.evaluate(None, linear_y), -1, rtol=1e-7, atol=1e-6
         )
 
         # Microscale
@@ -614,15 +622,15 @@ class TestExtrapolation:
 
         # check constant extrapolates to constant
         constant_y = np.ones_like(micro_submesh.nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            surf_eqn_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            surf_eqn_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # check linear variable extrapolates correctly
         linear_y = micro_submesh.nodes
         y_surf = micro_submesh.edges[-1]
-        np.testing.assert_array_almost_equal(
-            surf_eqn_disc.evaluate(None, linear_y), y_surf
+        np.testing.assert_allclose(
+            surf_eqn_disc.evaluate(None, linear_y), y_surf, rtol=1e-7, atol=1e-6
         )
 
     def test_extrapolate_on_nonuniform_grid(self):
@@ -657,15 +665,15 @@ class TestExtrapolation:
 
         # check constant extrapolates to constant
         constant_y = np.ones_like(micro_submesh.nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            surf_eqn_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            surf_eqn_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # check linear variable extrapolates correctly
         linear_y = micro_submesh.nodes
         y_surf = micro_submesh.edges[-1]
-        np.testing.assert_array_almost_equal(
-            surf_eqn_disc.evaluate(None, linear_y), y_surf
+        np.testing.assert_allclose(
+            surf_eqn_disc.evaluate(None, linear_y), y_surf, rtol=1e-7, atol=1e-6
         )
 
     def test_extrapolate_2d_models(self):
@@ -700,8 +708,8 @@ class TestExtrapolation:
         y_micro = mesh["negative particle"].nodes
         y = np.outer(y_macro, y_micro).reshape(-1, 1)
         # extrapolate to r=0.5 --> should evaluate to 0.5*y_macro
-        np.testing.assert_array_almost_equal(
-            extrap_right_disc.evaluate(y=y)[:, 0], 0.5 * y_macro
+        np.testing.assert_allclose(
+            extrap_right_disc.evaluate(y=y)[:, 0], 0.5 * y_macro, rtol=1e-7, atol=1e-6
         )
 
         var = pybamm.Variable("var", domain="positive particle")

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_grad_div_shapes.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_grad_div_shapes.py
@@ -59,15 +59,19 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_cylindrical_grad_div_shapes_Dirichlet_bcs(self):
@@ -117,16 +121,18 @@ class TestFiniteVolumeGradDiv:
         # grad(r) == 1
         y_linear = submesh.nodes
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, y_linear), np.ones((npts_edges, 1))
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, y_linear),
+            np.ones((npts_edges, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad r^2) = 4
         y_squared = submesh.nodes**2
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
-        np.testing.assert_array_almost_equal(
-            div_eval[1:-1],
-            4 * np.ones((npts - 2, 1)),
+        np.testing.assert_allclose(
+            div_eval[1:-1], 4 * np.ones((npts - 2, 1)), rtol=1e-7, atol=1e-6
         )
 
     def test_spherical_grad_div_shapes_Dirichlet_bcs(self):
@@ -178,8 +184,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, y_linear), np.ones((total_npts_edges, 1))
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, y_linear),
+            np.ones((total_npts_edges, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -197,9 +206,8 @@ class TestFiniteVolumeGradDiv:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_npts, npts])
-        np.testing.assert_array_almost_equal(
-            div_eval[:, :-1],
-            6 * np.ones([sec_npts, npts - 1]),
+        np.testing.assert_allclose(
+            div_eval[:, :-1], 6 * np.ones([sec_npts, npts - 1]), rtol=1e-7, atol=1e-6
         )
 
     def test_p2d_spherical_grad_div_shapes_Dirichlet_bcs(self):
@@ -251,8 +259,8 @@ class TestFiniteVolumeGradDiv:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_pts, prim_pts])
-        np.testing.assert_array_almost_equal(
-            div_eval[:, :-1], 6 * np.ones([sec_pts, prim_pts - 1])
+        np.testing.assert_allclose(
+            div_eval[:, :-1], 6 * np.ones([sec_pts, prim_pts - 1]), rtol=1e-7, atol=1e-6
         )
 
     def test_grad_div_shapes_Neumann_bcs(self):
@@ -298,15 +306,19 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_grad_div_shapes_Dirichlet_and_Neumann_bcs(self):
@@ -343,9 +355,11 @@ class TestFiniteVolumeGradDiv:
         )
         # div(grad(1)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test gradient and divergence of linear x
@@ -359,15 +373,19 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_cylindrical_grad_div_shapes_Neumann_bcs(self):
@@ -411,8 +429,11 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, y_linear), np.ones((npts_edges, 1))
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, y_linear),
+            np.ones((npts_edges, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence
@@ -428,9 +449,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, y_squared),
             4 * np.ones((npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_cylindrical_grad_div_shapes_Neumann_bcs_symbolic(self):
@@ -458,9 +481,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(pybamm.div(grad_eqn))
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, constant_y),
             np.zeros((15, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -477,9 +502,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, y_squared),
             4 * np.ones((15, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_spherical_grad_div_shapes_Neumann_bcs(self):
@@ -521,9 +548,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -539,9 +568,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, quadratic_y),
             6 * np.ones((submesh.npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_spherical_grad_div_shapes_Neumann_bcs_symbolic(self):
@@ -570,11 +601,13 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         div_eqn_disc = disc.process_symbol(pybamm.div(grad_eqn))
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(
                 None, np.ones_like(mesh["spherical domain"].nodes[:, np.newaxis])
             ),
             np.zeros_like(mesh["spherical domain"].nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -591,9 +624,11 @@ class TestFiniteVolumeGradDiv:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, quadratic_y),
             6 * np.ones_like(mesh["spherical domain"].nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_p2d_spherical_grad_div_shapes_Neumann_bcs(self):
@@ -646,7 +681,9 @@ class TestFiniteVolumeGradDiv:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_pts, prim_pts])
-        np.testing.assert_array_almost_equal(div_eval, 6 * np.ones([sec_pts, prim_pts]))
+        np.testing.assert_allclose(
+            div_eval, 6 * np.ones([sec_pts, prim_pts]), rtol=1e-7, atol=1e-6
+        )
 
     def test_grad_div_shapes_mixed_domain(self):
         # Create discretisation
@@ -687,15 +724,19 @@ class TestFiniteVolumeGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_grad_1plus1d(self):
@@ -737,8 +778,8 @@ class TestFiniteVolumeGradDiv:
         expected = np.outer(np.linspace(0, 1, 15), np.ones_like(submesh.edges)).reshape(
             -1, 1
         )
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, linear_y), expected
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, linear_y), expected, rtol=1e-7, atol=1e-6
         )
 
     def test_grad_div_shapes_symbolic_mesh(self):
@@ -764,8 +805,8 @@ class TestFiniteVolumeGradDiv:
         dom = ("domain_left ghost cell", "domain", "domain_right ghost cell")
         linear_y = mesh[dom].nodes * mesh[dom].length + mesh[dom].min
         expected = np.ones((16, 1))
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, linear_y), expected
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, linear_y), expected, rtol=1e-7, atol=1e-6
         )
 
         # Evaluate div
@@ -773,4 +814,4 @@ class TestFiniteVolumeGradDiv:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, linear_y)
         div_eval = np.reshape(div_eval, [15, 1])
-        np.testing.assert_array_almost_equal(div_eval, np.zeros([15, 1]))
+        np.testing.assert_allclose(div_eval, np.zeros([15, 1]), rtol=1e-7, atol=1e-6)

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_integration.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_integration.py
@@ -42,12 +42,18 @@ class TestFiniteVolumeIntegration:
         constant_y = np.ones_like(submesh.nodes[:, np.newaxis])
         assert integral_eqn_disc.evaluate(None, constant_y) == ln + ls
         linear_y = submesh.nodes
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, linear_y), (ln + ls) ** 2 / 2
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, linear_y),
+            (ln + ls) ** 2 / 2,
+            rtol=1e-7,
+            atol=1e-6,
         )
         cos_y = np.cos(submesh.nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, cos_y), np.sin(ln + ls), decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, cos_y),
+            np.sin(ln + ls),
+            rtol=1e-5,
+            atol=1e-4,
         )
 
         # domain not starting at zero
@@ -65,8 +71,11 @@ class TestFiniteVolumeIntegration:
             (1 - (ln) ** 2) / 2
         )
         cos_y = np.cos(submesh.nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, cos_y), np.sin(1) - np.sin(ln), decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, cos_y),
+            np.sin(1) - np.sin(ln),
+            rtol=1e-5,
+            atol=1e-4,
         )
 
         # microscale variable
@@ -78,18 +87,25 @@ class TestFiniteVolumeIntegration:
 
         constant_y = np.ones_like(mesh["negative particle"].nodes[:, np.newaxis])
         r_end = mesh["negative particle"].edges[-1]
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, constant_y), 4 * np.pi * r_end**3 / 3
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, constant_y),
+            4 * np.pi * r_end**3 / 3,
+            rtol=1e-7,
+            atol=1e-6,
         )
         linear_y = mesh["negative particle"].nodes
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, linear_y), np.pi * r_end**4, decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, linear_y),
+            np.pi * r_end**4,
+            rtol=1e-5,
+            atol=1e-4,
         )
         one_over_y = 1 / mesh["negative particle"].nodes
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc.evaluate(None, one_over_y),
             2 * np.pi * r_end**2,
-            decimal=3,
+            rtol=1e-4,
+            atol=1e-3,
         )
 
         # cylindrical coordinates
@@ -106,20 +122,25 @@ class TestFiniteVolumeIntegration:
         r0 = mesh["current collector"].edges[0]
 
         constant_y = np.ones_like(pts[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, constant_y), np.pi * (1 - r0**2)
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, constant_y),
+            np.pi * (1 - r0**2),
+            rtol=1e-7,
+            atol=1e-6,
         )
         linear_y = pts
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc.evaluate(None, linear_y),
             2 * np.pi / 3 * (1 - r0**3),
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
         one_over_y = 1 / pts
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc.evaluate(None, one_over_y),
             2 * np.pi * (1 - r0),
-            decimal=3,
+            rtol=1e-4,
+            atol=1e-3,
         )
 
         # test failure for secondary dimension column form
@@ -141,8 +162,8 @@ class TestFiniteVolumeIntegration:
         disc.set_variable_slices([var])
         integral_eqn_disc = disc.process_symbol(integral_eqn)
         const_y = np.ones_like(mesh["domain"].nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, const_y), 2.0, decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, const_y), 2.0, rtol=1e-5, atol=1e-4
         )
 
         mesh = get_cylindrical_mesh_for_testing_symbolic()
@@ -156,8 +177,11 @@ class TestFiniteVolumeIntegration:
         disc.set_variable_slices([var])
         integral_eqn_disc = disc.process_symbol(integral_eqn)
         const_y = np.ones_like(mesh["cylindrical domain"].nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, const_y), 2 * np.pi * 2.0, decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, const_y),
+            2 * np.pi * 2.0,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
         mesh = get_spherical_mesh_for_testing_symbolic()
@@ -169,8 +193,11 @@ class TestFiniteVolumeIntegration:
         disc.set_variable_slices([var])
         integral_eqn_disc = disc.process_symbol(integral_eqn)
         const_y = np.ones_like(mesh["spherical domain"].nodes[:, np.newaxis])
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, const_y), 4 * np.pi * 2.0**3 / 3, decimal=4
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, const_y),
+            4 * np.pi * 2.0**3 / 3,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
     def test_integral_secondary_tertiary_domain(self):
@@ -215,48 +242,59 @@ class TestFiniteVolumeIntegration:
             )
         )
         # Test with constant y
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_secondary.evaluate(None, constant_y),
             lp * np.ones((submesh.npts * mesh["current collector"].npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_tertiary.evaluate(None, constant_y),
             lc * np.ones((submesh.npts * mesh["positive electrode"].npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # Test with linear
         linear_in_x = np.tile(
             np.repeat(mesh["positive electrode"].nodes, submesh.npts),
             mesh["current collector"].npts,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_secondary.evaluate(None, linear_in_x),
             (1 - (ln + ls) ** 2)
             / 2
             * np.ones((submesh.npts * mesh["current collector"].npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
         linear_in_r = np.tile(
             submesh.nodes,
             mesh["positive electrode"].npts * mesh["current collector"].npts,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_secondary.evaluate(None, linear_in_r).flatten(),
             lp * np.tile(submesh.nodes, mesh["current collector"].npts),
+            rtol=1e-7,
+            atol=1e-6,
         )
         cos_y = np.cos(linear_in_x)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_secondary.evaluate(None, cos_y),
             (np.sin(1) - np.sin(ln + ls))
             * np.ones((submesh.npts * mesh["current collector"].npts, 1)),
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
         # test tertiary integration with linear function in y
         linear_in_z = np.repeat(
             mesh["current collector"].nodes,
             submesh.npts * mesh["positive electrode"].npts,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc_tertiary.evaluate(None, linear_in_z),
             (lc**2 / 2) * np.ones((submesh.npts * mesh["positive electrode"].npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_integral_primary_then_secondary_same_result(self):
@@ -298,10 +336,11 @@ class TestFiniteVolumeIntegration:
                 mesh["positive electrode"].npts * mesh["current collector"].npts,
             )
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_x_then_r_disc.evaluate(None, cos_y),
             integral_eqn_r_then_x_disc.evaluate(None, cos_y),
-            decimal=4,
+            rtol=1e-5,
+            atol=1e-4,
         )
 
     def test_integral_secondary_domain_on_edges_in_primary_domain(self):
@@ -334,13 +373,15 @@ class TestFiniteVolumeIntegration:
 
         submesh = mesh["positive particle"]
         r_end = submesh.edges[-1]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             integral_eqn_disc.evaluate().flatten(),
             lp
             * r_end
             * np.tile(
                 np.linspace(0, 1, submesh.npts + 1), mesh["current collector"].npts
             ),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_definite_integral_vector(self):
@@ -403,22 +444,22 @@ class TestFiniteVolumeIntegration:
         phi_exact = np.ones((submesh.npts, 1))
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += 1  # add constant of integration
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
         assert left_boundary_value_disc.evaluate(y=phi_exact) == 0
         # linear case
         phi_exact = submesh.nodes[:, np.newaxis]
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=phi_exact), 0, decimal=16
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-17, atol=1e-16
         )
 
         # sine case
         phi_exact = np.sin(submesh.nodes[:, np.newaxis])
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=phi_exact), 0, decimal=16
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-17, atol=1e-16
         )
 
         # --------------------------------------------------------------------
@@ -443,23 +484,23 @@ class TestFiniteVolumeIntegration:
         phi_exact = np.ones((submesh.npts, 1))
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += 1  # add constant of integration
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
         assert left_boundary_value_disc.evaluate(y=phi_exact) == 0
 
         # linear case
         phi_exact = submesh.nodes[:, np.newaxis] - submesh.edges[0]
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=phi_exact), 0
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-7, atol=1e-6
         )
 
         # sine case
         phi_exact = np.sin(submesh.nodes[:, np.newaxis] - submesh.edges[0])
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=phi_exact), 0
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-7, atol=1e-6
         )
 
         # --------------------------------------------------------------------
@@ -504,23 +545,23 @@ class TestFiniteVolumeIntegration:
         c_exact = np.ones((submesh.npts, 1))
         c_approx = c_integral_disc.evaluate(None, c_exact)
         c_approx += 1  # add constant of integration
-        np.testing.assert_array_almost_equal(c_exact, c_approx)
+        np.testing.assert_allclose(c_exact, c_approx, rtol=1e-7, atol=1e-6)
         assert left_boundary_value_disc.evaluate(y=c_exact) == 0
 
         # linear case
         c_exact = submesh.nodes[:, np.newaxis]
         c_approx = c_integral_disc.evaluate(None, c_exact)
-        np.testing.assert_array_almost_equal(c_exact, c_approx)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=c_exact), 0
+        np.testing.assert_allclose(c_exact, c_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=c_exact), 0, rtol=1e-7, atol=1e-6
         )
 
         # sine case
         c_exact = np.sin(submesh.nodes[:, np.newaxis])
         c_approx = c_integral_disc.evaluate(None, c_exact)
-        np.testing.assert_array_almost_equal(c_exact, c_approx, decimal=3)
-        np.testing.assert_array_almost_equal(
-            left_boundary_value_disc.evaluate(y=c_exact), 0
+        np.testing.assert_allclose(c_exact, c_approx, rtol=1e-4, atol=1e-3)
+        np.testing.assert_allclose(
+            left_boundary_value_disc.evaluate(y=c_exact), 0, rtol=1e-7, atol=1e-6
         )
 
     def test_backward_indefinite_integral(self):
@@ -552,23 +593,23 @@ class TestFiniteVolumeIntegration:
         phi_exact = np.ones((submesh.npts, 1))
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact)
         phi_approx += 1  # add constant of integration
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
         assert right_boundary_value_disc.evaluate(y=phi_exact) == 0
 
         # linear case
         phi_exact = submesh.nodes - submesh.edges[-1]
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(phi_exact, -phi_approx)
-        np.testing.assert_array_almost_equal(
-            right_boundary_value_disc.evaluate(y=phi_exact), 0
+        np.testing.assert_allclose(phi_exact, -phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            right_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-7, atol=1e-6
         )
 
         # sine case
         phi_exact = np.sin(submesh.nodes - submesh.edges[-1])
         phi_approx = int_grad_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(phi_exact, -phi_approx)
-        np.testing.assert_array_almost_equal(
-            right_boundary_value_disc.evaluate(y=phi_exact), 0
+        np.testing.assert_allclose(phi_exact, -phi_approx, rtol=1e-7, atol=1e-6)
+        np.testing.assert_allclose(
+            right_boundary_value_disc.evaluate(y=phi_exact), 0, rtol=1e-7, atol=1e-6
         )
 
     def test_indefinite_integral_of_broadcasted_to_cell_edges(self):
@@ -600,12 +641,12 @@ class TestFiniteVolumeIntegration:
         # constant case
         phi_exact = np.ones_like(submesh.nodes)
         phi_approx = int_int_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(x_end**2 / 2, phi_approx)
+        np.testing.assert_allclose(x_end**2 / 2, phi_approx, rtol=1e-7, atol=1e-6)
 
         # linear case
         phi_exact = submesh.nodes[:, np.newaxis]
         phi_approx = int_int_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(x_end**3 / 6, phi_approx, decimal=4)
+        np.testing.assert_allclose(x_end**3 / 6, phi_approx, rtol=1e-5, atol=1e-4)
 
     def test_indefinite_integral_on_edges_symbolic(self):
         mesh = get_mesh_for_testing_symbolic()
@@ -630,7 +671,7 @@ class TestFiniteVolumeIntegration:
         # constant case
         phi_exact = np.ones_like(submesh.nodes)
         phi_approx = int_int_phi_disc.evaluate(None, phi_exact)
-        np.testing.assert_array_almost_equal(x_end**2 / 2, phi_approx)
+        np.testing.assert_allclose(x_end**2 / 2, phi_approx, rtol=1e-7, atol=1e-6)
 
     def test_indefinite_integral_on_nodes(self):
         mesh = get_mesh_for_testing()
@@ -650,17 +691,17 @@ class TestFiniteVolumeIntegration:
         phi_exact = np.ones((submesh.npts, 1))
         int_phi_exact = submesh.edges
         int_phi_approx = int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(int_phi_exact, int_phi_approx)
+        np.testing.assert_allclose(int_phi_exact, int_phi_approx, rtol=1e-7, atol=1e-6)
         # linear case
         phi_exact = submesh.nodes
         int_phi_exact = submesh.edges**2 / 2
         int_phi_approx = int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(int_phi_exact, int_phi_approx)
+        np.testing.assert_allclose(int_phi_exact, int_phi_approx, rtol=1e-7, atol=1e-6)
         # cos case
         phi_exact = np.cos(submesh.nodes)
         int_phi_exact = np.sin(submesh.edges)
         int_phi_approx = int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(int_phi_exact, int_phi_approx, decimal=5)
+        np.testing.assert_allclose(int_phi_exact, int_phi_approx, rtol=1e-6, atol=1e-5)
 
         # microscale case should fail
         mesh = get_mesh_for_testing()
@@ -693,7 +734,7 @@ class TestFiniteVolumeIntegration:
         constant_y = np.ones((submesh.npts, 1))
         phi_exact = submesh.edges * submesh.length + submesh.min
         phi_approx = int_phi_disc.evaluate(None, constant_y).flatten()
-        np.testing.assert_array_almost_equal(phi_exact, phi_approx)
+        np.testing.assert_allclose(phi_exact, phi_approx, rtol=1e-7, atol=1e-6)
 
     def test_backward_indefinite_integral_on_nodes(self):
         mesh = get_mesh_for_testing()
@@ -714,18 +755,22 @@ class TestFiniteVolumeIntegration:
         phi_exact = np.ones((submesh.npts, 1))
         back_int_phi_exact = edges[-1] - edges
         back_int_phi_approx = back_int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(back_int_phi_exact, back_int_phi_approx)
+        np.testing.assert_allclose(
+            back_int_phi_exact, back_int_phi_approx, rtol=1e-7, atol=1e-6
+        )
         # linear case
         phi_exact = submesh.nodes
         back_int_phi_exact = edges[-1] ** 2 / 2 - edges**2 / 2
         back_int_phi_approx = back_int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(back_int_phi_exact, back_int_phi_approx)
+        np.testing.assert_allclose(
+            back_int_phi_exact, back_int_phi_approx, rtol=1e-7, atol=1e-6
+        )
         # cos case
         phi_exact = np.cos(submesh.nodes)
         back_int_phi_exact = np.sin(edges[-1]) - np.sin(edges)
         back_int_phi_approx = back_int_phi_disc.evaluate(None, phi_exact).flatten()
-        np.testing.assert_array_almost_equal(
-            back_int_phi_exact, back_int_phi_approx, decimal=5
+        np.testing.assert_allclose(
+            back_int_phi_exact, back_int_phi_approx, rtol=1e-6, atol=1e-5
         )
 
     def test_forward_plus_backward_integral(self):
@@ -757,7 +802,9 @@ class TestFiniteVolumeIntegration:
             submesh.nodes,
             np.cos(submesh.nodes),
         ]:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 full_int_phi_disc.evaluate(y=phi_exact).flatten(),
                 int_plus_back_int_phi_disc.evaluate(y=phi_exact).flatten(),
+                rtol=1e-7,
+                atol=1e-6,
             )

--- a/tests/unit/test_spatial_methods/test_scikit_finite_element.py
+++ b/tests/unit/test_spatial_methods/test_scikit_finite_element.py
@@ -142,13 +142,17 @@ class TestScikitFiniteElement:
         grad_disc = disc.process_symbol(gradient)
         grad_disc_y, grad_disc_z = grad_disc.children
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_disc_y.evaluate(None, 5 * y + 6 * z),
             5 * np.ones_like(y)[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_disc_z.evaluate(None, 5 * y + 6 * z),
             6 * np.ones_like(z)[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # check grad_squared positive
@@ -170,20 +174,28 @@ class TestScikitFiniteElement:
         disc.set_variable_slices([var])
         var_disc = disc.process_symbol(var)
         z_vertices = mesh["current collector"].coordinates[1, :]
-        np.testing.assert_array_almost_equal(
-            var_disc.evaluate(None, z_vertices), z_vertices[:, np.newaxis]
+        np.testing.assert_allclose(
+            var_disc.evaluate(None, z_vertices),
+            z_vertices[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # linear u = 6*y (to test coordinates to degree of freedom mapping)
         y_vertices = mesh["current collector"].coordinates[0, :]
-        np.testing.assert_array_almost_equal(
-            var_disc.evaluate(None, 6 * y_vertices), 6 * y_vertices[:, np.newaxis]
+        np.testing.assert_allclose(
+            var_disc.evaluate(None, 6 * y_vertices),
+            6 * y_vertices[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # mixed u = y*z (to test coordinates to degree of freedom mapping)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             var_disc.evaluate(None, y_vertices * z_vertices),
             y_vertices[:, np.newaxis] * z_vertices[:, np.newaxis],
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # laplace of u = sin(pi*z)
@@ -204,8 +216,11 @@ class TestScikitFiniteElement:
         mass = pybamm.Mass(var)
         mass_disc = disc.process_symbol(mass)
         soln = -(np.pi**2) * u
-        np.testing.assert_array_almost_equal(
-            eqn_zz_disc.evaluate(None, u), mass_disc.entries @ soln, decimal=3
+        np.testing.assert_allclose(
+            eqn_zz_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            rtol=1e-4,
+            atol=1e-3,
         )
 
         # laplace of u = cos(pi*y)*sin(pi*z)
@@ -227,8 +242,11 @@ class TestScikitFiniteElement:
         mass = pybamm.Mass(var)
         mass_disc = disc.process_symbol(mass)
         soln = -(np.pi**2) * u
-        np.testing.assert_array_almost_equal(
-            laplace_eqn_disc.evaluate(None, u), mass_disc.entries @ soln, decimal=2
+        np.testing.assert_allclose(
+            laplace_eqn_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            rtol=1e-2,
+            atol=1e-1,
         )
 
     def test_manufactured_solution_cheb_grid(self):
@@ -288,8 +306,11 @@ class TestScikitFiniteElement:
         mass = pybamm.Mass(var)
         mass_disc = disc.process_symbol(mass)
         soln = -(np.pi**2) * u
-        np.testing.assert_array_almost_equal(
-            laplace_eqn_disc.evaluate(None, u), mass_disc.entries @ soln, decimal=1
+        np.testing.assert_allclose(
+            laplace_eqn_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            rtol=1e-2,
+            atol=1e-1,
         )
 
     def test_manufactured_solution_exponential_grid(self):
@@ -351,8 +372,11 @@ class TestScikitFiniteElement:
         mass = pybamm.Mass(var)
         mass_disc = disc.process_symbol(mass)
         soln = -(np.pi**2) * u
-        np.testing.assert_array_almost_equal(
-            laplace_eqn_disc.evaluate(None, u), mass_disc.entries @ soln, decimal=1
+        np.testing.assert_allclose(
+            laplace_eqn_disc.evaluate(None, u),
+            mass_disc.entries @ soln,
+            rtol=1e-2,
+            atol=1e-1,
         )
 
     def test_definite_integral(self):
@@ -372,8 +396,8 @@ class TestScikitFiniteElement:
         fem_mesh = mesh["current collector"]
         ly = fem_mesh.coordinates[0, -1]
         lz = fem_mesh.coordinates[1, -1]
-        np.testing.assert_array_almost_equal(
-            integral_eqn_disc.evaluate(None, y_test), 6 * ly * lz
+        np.testing.assert_allclose(
+            integral_eqn_disc.evaluate(None, y_test), 6 * ly * lz, rtol=1e-7, atol=1e-6
         )
 
     def test_definite_integral_vector(self):
@@ -414,11 +438,11 @@ class TestScikitFiniteElement:
         extrap_pos_disc = disc.process_symbol(extrap_pos)
         # check constant returns constant at tab
         constant_y = np.ones(mesh["current collector"].npts)[:, np.newaxis]
-        np.testing.assert_array_almost_equal(
-            extrap_neg_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            extrap_neg_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
-        np.testing.assert_array_almost_equal(
-            extrap_pos_disc.evaluate(None, constant_y), 1
+        np.testing.assert_allclose(
+            extrap_pos_disc.evaluate(None, constant_y), 1, rtol=1e-7, atol=1e-6
         )
 
         # test BoundaryGradient not implemented
@@ -450,16 +474,16 @@ class TestScikitFiniteElement:
         l_tab_p = 0.1
         constant_y = np.ones(mesh["current collector"].npts)
         # Integral around boundary is exact
-        np.testing.assert_array_almost_equal(
-            full_disc.evaluate(None, constant_y), perimeter
+        np.testing.assert_allclose(
+            full_disc.evaluate(None, constant_y), perimeter, rtol=1e-7, atol=1e-6
         )
         # Ideally mesh edges should line up with tab edges.... then we would get
         # better agreement between actual and numerical tab width
-        np.testing.assert_array_almost_equal(
-            neg_disc.evaluate(None, constant_y), l_tab_n, decimal=1
+        np.testing.assert_allclose(
+            neg_disc.evaluate(None, constant_y), l_tab_n, rtol=1e-2, atol=1e-1
         )
-        np.testing.assert_array_almost_equal(
-            pos_disc.evaluate(None, constant_y), l_tab_p, decimal=1
+        np.testing.assert_allclose(
+            pos_disc.evaluate(None, constant_y), l_tab_p, rtol=1e-2, atol=1e-1
         )
 
     def test_pure_neumann_poisson(self):
@@ -499,7 +523,7 @@ class TestScikitFiniteElement:
 
         z = mesh["current collector"].coordinates[1, :][:, np.newaxis]
         u_exact = z**2 / 2 - 1 / 6
-        np.testing.assert_array_almost_equal(solution.y[:-1], u_exact, decimal=1)
+        np.testing.assert_allclose(solution.y[:-1], u_exact, rtol=1e-2, atol=1e-1)
 
     def test_dirichlet_bcs(self):
         # manufactured solution u = a*z^2 + b*z + c
@@ -536,7 +560,9 @@ class TestScikitFiniteElement:
         # indepedent of y, so just check values for one y
         z = mesh["current collector"].edges["z"][:, np.newaxis]
         u_exact = a * z**2 + b * z + c
-        np.testing.assert_array_almost_equal(solution.y[0 : len(z)], u_exact)
+        np.testing.assert_allclose(
+            solution.y[0 : len(z)], u_exact, rtol=1e-7, atol=1e-6
+        )
 
     def test_disc_spatial_var(self):
         mesh = get_unit_2p1D_mesh_for_testing(ypts=4, zpts=5, include_particles=False)

--- a/tests/unit/test_spatial_methods/test_spectral_volume.py
+++ b/tests/unit/test_spatial_methods/test_spectral_volume.py
@@ -140,9 +140,11 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test operations on linear x
@@ -158,15 +160,19 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_spherical_grad_div_shapes_Dirichlet_bcs(self):
@@ -205,8 +211,11 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, constant_y), np.zeros((total_npts_edges, 1))
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, constant_y),
+            np.zeros((total_npts_edges, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # grad(r) == 1
         y_linear = np.tile(
@@ -222,8 +231,11 @@ class TestSpectralVolume:
         }
         disc.bcs = boundary_conditions
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, y_linear), np.ones((total_npts_edges, 1))
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, y_linear),
+            np.ones((total_npts_edges, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -244,8 +256,8 @@ class TestSpectralVolume:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_npts, npts])
-        np.testing.assert_array_almost_equal(
-            div_eval[:, 2:-2], 6 * np.ones([sec_npts, npts - 4])
+        np.testing.assert_allclose(
+            div_eval[:, 2:-2], 6 * np.ones([sec_npts, npts - 4]), rtol=1e-7, atol=1e-6
         )
 
     def test_p2d_spherical_grad_div_shapes_Dirichlet_bcs(self):
@@ -284,8 +296,8 @@ class TestSpectralVolume:
         grad_eqn_disc = disc.process_symbol(grad_eqn)
         grad_eval = grad_eqn_disc.evaluate(None, constant_y)
         grad_eval = np.reshape(grad_eval, [sec_pts, prim_pts + 1])
-        np.testing.assert_array_almost_equal(
-            grad_eval, np.zeros([sec_pts, prim_pts + 1])
+        np.testing.assert_allclose(
+            grad_eval, np.zeros([sec_pts, prim_pts + 1]), rtol=1e-7, atol=1e-6
         )
 
         # Test divergence of gradient
@@ -303,8 +315,11 @@ class TestSpectralVolume:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_pts, prim_pts])
-        np.testing.assert_array_almost_equal(
-            div_eval[:, 2:-2], 6 * np.ones([sec_pts, prim_pts - 4])
+        np.testing.assert_allclose(
+            div_eval[:, 2:-2],
+            6 * np.ones([sec_pts, prim_pts - 4]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_grad_div_shapes_Neumann_bcs(self):
@@ -332,9 +347,11 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test operations on linear x
@@ -350,15 +367,19 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_grad_div_shapes_Dirichlet_and_Neumann_bcs(self):
@@ -389,15 +410,19 @@ class TestSpectralVolume:
         disc.set_variable_slices([var])
         # grad(1) = 0
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(1)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test gradient and divergence of linear x
@@ -411,15 +436,19 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_spherical_grad_div_shapes_Neumann_bcs(self):
@@ -447,9 +476,11 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # grad(r) == 1
         linear_y = submesh.nodes
@@ -461,9 +492,11 @@ class TestSpectralVolume:
         }
         disc.bcs = boundary_conditions
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test divergence of gradient
@@ -479,9 +512,11 @@ class TestSpectralVolume:
         }
         disc.bcs = boundary_conditions
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, quadratic_y),
             6 * np.ones((submesh.npts, 1)),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_p2d_spherical_grad_div_shapes_Neumann_bcs(self):
@@ -534,7 +569,9 @@ class TestSpectralVolume:
         div_eqn_disc = disc.process_symbol(div_eqn)
         div_eval = div_eqn_disc.evaluate(None, y_squared)
         div_eval = np.reshape(div_eval, [sec_pts, prim_pts])
-        np.testing.assert_array_almost_equal(div_eval, 6 * np.ones([sec_pts, prim_pts]))
+        np.testing.assert_allclose(
+            div_eval, 6 * np.ones([sec_pts, prim_pts]), rtol=1e-7, atol=1e-6
+        )
 
     def test_grad_div_shapes_mixed_domain(self):
         # Create discretisation
@@ -557,9 +594,11 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, constant_y),
             np.zeros_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
         # Test operations on linear x
@@ -575,15 +614,19 @@ class TestSpectralVolume:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.evaluate(None, linear_y),
             np.ones_like(submesh.edges[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y),
             np.zeros_like(submesh.nodes[:, np.newaxis]),
+            rtol=1e-7,
+            atol=1e-6,
         )
 
     def test_grad_1plus1d(self):
@@ -625,6 +668,6 @@ class TestSpectralVolume:
         expected = np.outer(np.linspace(0, 1, 15), np.ones_like(submesh.edges)).reshape(
             -1, 1
         )
-        np.testing.assert_array_almost_equal(
-            grad_eqn_disc.evaluate(None, linear_y), expected
+        np.testing.assert_allclose(
+            grad_eqn_disc.evaluate(None, linear_y), expected, rtol=1e-7, atol=1e-6
         )


### PR DESCRIPTION
# Description

This PR refactors the testing methods in the codebase(unit tests directory) by replacing the`np.testing.assert_array_almost_equal` method with `np.testing.assert_allclose` for better precision and flexibility in comparison.

Related to #4488 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
