### PR TITLE
rename CrateTermination to CRateTermination because the step is CRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Features
 
-- Deprecated `CrateTermination` and renamed it to `CRateTermination`. ([#4834](https://github.com/pybamm-team/PyBaMM/pull/4834))
 - Added 'get_summary_variables' to return dictionary of computed summary variables ([#4824](https://github.com/pybamm-team/PyBaMM/pull/4824))
 - Added support for particle size distributions combined with particle mechanics. ([#4807](https://github.com/pybamm-team/PyBaMM/pull/4807))
+
+## Breaking changes
+
+- Deprecated `CrateTermination` and renamed it to `CRateTermination`. ([#4834](https://github.com/pybamm-team/PyBaMM/pull/4834))
 
 # [v25.1.1](https://github.com/pybamm-team/PyBaMM/tree/v25.1.1) - 2025-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Deprecated `CrateTermination` and renamed it to `CRateTermination`. ([#4834](https://github.com/pybamm-team/PyBaMM/pull/4834))
 - Added 'get_summary_variables' to return dictionary of computed summary variables ([#4824](https://github.com/pybamm-team/PyBaMM/pull/4824))
 - Added support for particle size distributions combined with particle mechanics. ([#4807](https://github.com/pybamm-team/PyBaMM/pull/4807))
 

--- a/docs/source/api/experiment/experiment_steps.rst
+++ b/docs/source/api/experiment/experiment_steps.rst
@@ -37,7 +37,7 @@ Standard step termination events are implemented by the following classes, which
 called when the termination is specified by a specific string. These classes can be
 either be called directly or via the string format specified in the class docstring
 
-.. autoclass:: pybamm.step.CrateTermination
+.. autoclass:: pybamm.step.CRateTermination
     :members:
 
 .. autoclass:: pybamm.step.CurrentTermination

--- a/src/pybamm/experiment/step/__init__.py
+++ b/src/pybamm/experiment/step/__init__.py
@@ -1,5 +1,5 @@
 from .steps import *
 from .base_step import BaseStep, BaseStepExplicit, BaseStepImplicit
-from .step_termination import BaseTermination, CurrentTermination, VoltageTermination, CustomTermination, CrateTermination, _read_termination
+from .step_termination import BaseTermination, CurrentTermination, VoltageTermination, CustomTermination, CRateTermination, CrateTermination, _read_termination
 
 __all__ = ['base_step', 'step_termination', 'steps']

--- a/src/pybamm/experiment/step/step_termination.py
+++ b/src/pybamm/experiment/step/step_termination.py
@@ -1,4 +1,5 @@
 import pybamm
+from warnings import warn
 
 
 class BaseTermination:
@@ -43,7 +44,7 @@ class BaseTermination:
             return False
 
 
-class CrateTermination(BaseTermination):
+class CRateTermination(BaseTermination):
     """
     Termination based on C-rate, created when a string termination of the C-rate type
     (e.g. "C/10") is provided
@@ -58,6 +59,20 @@ class CrateTermination(BaseTermination):
             abs(variables["C-rate"]) - self.value,
         )
         return event
+
+
+class CrateTermination(CRateTermination):
+    """
+    Termination based on C-rate, created when a string termination of the C-rate type
+    (e.g. "C/10") is provided
+    """
+
+    def __init__(self, value, operator=None):
+        super().__init__(value, operator)
+        warning = DeprecationWarning(
+            "CrateTermination is deprecated and will be removed in a future release. Use CRateTermination instead."
+        )
+        warn(warning, stacklevel=2)
 
 
 class CurrentTermination(BaseTermination):
@@ -193,6 +208,6 @@ def _read_termination(termination):
     termination_class = {
         "current": CurrentTermination,
         "voltage": VoltageTermination,
-        "C-rate": CrateTermination,
+        "C-rate": CRateTermination,
     }[typ]
     return termination_class(value)

--- a/tests/unit/test_experiments/test_experiment_step_termination.py
+++ b/tests/unit/test_experiments/test_experiment_step_termination.py
@@ -15,3 +15,16 @@ class TestExperimentStepTermination:
         assert term == pybamm.step.BaseTermination(1)
         assert term != pybamm.step.BaseTermination(2)
         assert term != pybamm.step.CurrentTermination(1)
+
+    def test_c_rate_termination(self):
+        term = pybamm.step.CRateTermination(0.02)
+        assert term.value == 0.02
+        assert term.operator is None
+        variables = {"C-rate": pybamm.Scalar(0.02)}
+        assert term.get_event(variables, None).evaluate() == 0
+        with pytest.warns(DeprecationWarning):
+            term_old = pybamm.step.CrateTermination(0.02)
+            assert (
+                term.get_event(variables, None).evaluate()
+                == term_old.get_event(variables, None).evaluate()
+            )

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -163,7 +163,7 @@ class TestExperimentSteps:
                 "value": 3,
                 "type": "Voltage",
                 "duration": 3600 * 24,
-                "termination": [pybamm.step.CrateTermination(0.02)],
+                "termination": [pybamm.step.CRateTermination(0.02)],
             },
             {
                 "type": "CRate",


### PR DESCRIPTION
# Description

I noticed today that to use a step for c-rate you call `pybamm.step.CRate` but to create a termination you use `pybamm.step.CrateTermination`. This is inconsistent,  so this pr fixes it.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works
