### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,22 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Please include a summary of the change and which issue is fixed. Please also
+include relevant motivation and context. List any dependencies that are required
+for this change.
 
 Fixes # (issue)
 
 ## Type of change
 
-Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #) - note reverse order of PR #s. If necessary, also add to the list of breaking changes.
+Please add a line in the relevant section of
+[CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md)
+to document the change (include PR #)
 
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Optimization (back-end change that speeds up the code)
-- [ ] Bug fix (non-breaking change which fixes an issue)
+# Important checks:
 
-# Key checklist:
-
-- [ ] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
-- [ ] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
-- [ ] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)
-
-You can run integration tests, unit tests, and doctests together at once, using `$ nox -s quick`.
-
-## Further checks:
-
-- [ ] Code is commented, particularly in hard-to-understand areas
-- [ ] Tests added that prove fix is effective or that feature works
+Please confirm the following before marking the PR as ready for review:
+- No style issues: `nox -s pre-commit`
+- All tests pass: `nox -s tests`
+- The documentation builds: `nox -s doctests`
+- Code is commented for hard-to-understand areas
+- Tests added that prove fix is effective or that feature works

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,12 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also
-include relevant motivation and context. List any dependencies that are required
-for this change.
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
 
 Fixes # (issue)
 
 ## Type of change
 
-Please add a line in the relevant section of
-[CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md)
-to document the change (include PR #)
+Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)
 
 # Important checks:
 


### PR DESCRIPTION
It seems like a lot of the developers do not fill in the checkboxes on the PR or were confused about who should check the boxes, so I simplified the template.

Changes:
- My new template is shown below, unmodified
- I removed the check boxes, since forgetting to check them shows the PR as having incomplete items in the PR tab. This is especially annoying for the "Type of change" section, where you would only check a single box, so 2 would be unchecked for all PRs

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works