### PR TITLE
add option to skip experiment steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added `skip_ok` option to `step` to allow for steps to be skipped if they are infeasible at initial conditions. ([#4839](https://github.com/pybamm-team/PyBaMM/pull/4839))
 - Creates a 'calc_esoh' property in battery models ([#4825](https://github.com/pybamm-team/PyBaMM/pull/4825))
 - Added 'get_summary_variables' to return dictionary of computed summary variables ([#4824](https://github.com/pybamm-team/PyBaMM/pull/4824))
 - Added support for particle size distributions combined with particle mechanics. ([#4807](https://github.com/pybamm-team/PyBaMM/pull/4807))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Features
 
-- Added `skip_ok` option to `step` to allow for steps to be skipped if they are infeasible at initial conditions. ([#4839](https://github.com/pybamm-team/PyBaMM/pull/4839))
 - Creates a 'calc_esoh' property in battery models ([#4825](https://github.com/pybamm-team/PyBaMM/pull/4825))
 - Added 'get_summary_variables' to return dictionary of computed summary variables ([#4824](https://github.com/pybamm-team/PyBaMM/pull/4824))
 - Added support for particle size distributions combined with particle mechanics. ([#4807](https://github.com/pybamm-team/PyBaMM/pull/4807))
 
 ## Breaking changes
 
+- Added `skip_ok` option to `step` to allow for steps to be skipped if they are infeasible at initial conditions. ([#4839](https://github.com/pybamm-team/PyBaMM/pull/4839))
 - Deprecated `CrateTermination` and renamed it to `CRateTermination`. ([#4834](https://github.com/pybamm-team/PyBaMM/pull/4834))
 
 ## Bug fixes

--- a/src/pybamm/callbacks.py
+++ b/src/pybamm/callbacks.py
@@ -195,7 +195,7 @@ class LoggingCallback(Callback):
                 )
 
     def on_cycle_end(self, logs):
-        cap_stop = logs["stopping conditions"]["capacity"]
+        cap_stop = logs["stopping conditions"].get("capacity")
         if cap_stop is not None:
             cap_now = logs["summary variables"]["Capacity [A.h]"]
             cap_start = logs["start capacity"]

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -55,6 +55,9 @@ class BaseStep:
         A description of the step.
     direction : str, optional
         The direction of the step, e.g. "Charge" or "Discharge" or "Rest".
+    skip_ok : bool, optional
+        If True, the step will be skipped if it is infeasible at the initial conditions.
+        Default is False.
     """
 
     def __init__(

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -68,6 +68,7 @@ class BaseStep:
         start_time=None,
         description=None,
         direction: str | None = None,
+        skip_ok: bool = False,
     ):
         potential_directions = ["charge", "discharge", "rest", None]
         if direction not in potential_directions:
@@ -77,6 +78,7 @@ class BaseStep:
         self.input_duration = duration
         self.input_duration = duration
         self.input_value = value
+        self.skip_ok = skip_ok
         # Check if drive cycle
         is_drive_cycle = isinstance(value, np.ndarray)
         is_python_function = callable(value)
@@ -213,6 +215,7 @@ class BaseStep:
             start_time=self.start_time,
             description=self.description,
             direction=self.direction,
+            skip_ok=self.skip_ok,
         )
 
     def __str__(self):

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -57,7 +57,7 @@ class BaseStep:
         The direction of the step, e.g. "Charge" or "Discharge" or "Rest".
     skip_ok : bool, optional
         If True, the step will be skipped if it is infeasible at the initial conditions.
-        Default is False.
+        Default is True.
     """
 
     def __init__(
@@ -71,7 +71,7 @@ class BaseStep:
         start_time=None,
         description=None,
         direction: str | None = None,
-        skip_ok: bool = False,
+        skip_ok: bool = True,
     ):
         potential_directions = ["charge", "discharge", "rest", None]
         if direction not in potential_directions:

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -779,7 +779,8 @@ class Simulation:
                             and "[experiment]" in error.message
                         ):
                             step_solution = pybamm.EmptySolution(
-                                "Event exceeded in initial conditions", t=start_time
+                                "Event exceeded in initial conditions",
+                                t=start_time,
                             )
                         else:
                             logs["error"] = error
@@ -877,19 +878,28 @@ class Simulation:
                 # At the final step of the inner loop we save the cycle
                 if len(steps) > 0:
                     # Check for EmptySolution
-                    if all(isinstance(step, pybamm.EmptySolution) for step in steps):
+                    if all(
+                        isinstance(step_solution, pybamm.EmptySolution)
+                        for step_solution in steps
+                    ):
                         if len(steps) == 1:
-                            raise pybamm.SolverError(
-                                f"Step '{step_str}' is infeasible "
-                                "due to exceeded bounds at initial conditions. "
-                                "If this step is part of a longer cycle, "
-                                "round brackets should be used to indicate this, "
-                                "e.g.:\n pybamm.Experiment([(\n"
-                                "\tDischarge at C/5 for 10 hours or until 3.3 V,\n"
-                                "\tCharge at 1 A until 4.1 V,\n"
-                                "\tHold at 4.1 V until 10 mA\n"
-                                "])"
-                            )
+                            if step.skip_ok:
+                                pybamm.logger.warning(
+                                    f"Step '{step_str}' is infeasible at initial conditions, but skip_ok is True. Skipping step."
+                                )
+                                continue
+                            else:
+                                raise pybamm.SolverError(
+                                    f"Step '{step_str}' is infeasible "
+                                    "due to exceeded bounds at initial conditions. "
+                                    "If this step is part of a longer cycle, "
+                                    "round brackets should be used to indicate this, "
+                                    "e.g.:\n pybamm.Experiment([(\n"
+                                    "\tDischarge at C/5 for 10 hours or until 3.3 V,\n"
+                                    "\tCharge at 1 A until 4.1 V,\n"
+                                    "\tHold at 4.1 V until 10 mA\n"
+                                    "])"
+                                )
                         else:
                             this_cycle = self.experiment.cycles[cycle_num - 1]
                             raise pybamm.SolverError(
@@ -924,6 +934,8 @@ class Simulation:
                     else:
                         capacity_stop = None
                     logs["stopping conditions"]["capacity"] = capacity_stop
+                else:
+                    capacity_stop = logs["stopping conditions"].get("capacity")
 
                 logs["elapsed time"] = timer.time()
 

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -898,14 +898,27 @@ class Simulation:
                                     "\tDischarge at C/5 for 10 hours or until 3.3 V,\n"
                                     "\tCharge at 1 A until 4.1 V,\n"
                                     "\tHold at 4.1 V until 10 mA\n"
-                                    "])"
+                                    "])\n"
+                                    "Otherwise, set skip_ok=True when instantiating the step to skip this step."
                                 )
                         else:
                             this_cycle = self.experiment.cycles[cycle_num - 1]
-                            raise pybamm.SolverError(
-                                f"All steps in the cycle {this_cycle} are infeasible "
-                                "due to exceeded bounds at initial conditions."
+                            all_steps_skipped = all(
+                                this_step.skip_ok
+                                for this_step in this_cycle
+                                if isinstance(this_step, pybamm.step.BaseStep)
                             )
+                            if all_steps_skipped:
+                                raise pybamm.SolverError(
+                                    f"All steps in the cycle {this_cycle} are infeasible "
+                                    "due to exceeded bounds at initial conditions, though "
+                                    "skip_ok is True for all steps. Please recheck the experiment."
+                                )
+                            else:
+                                raise pybamm.SolverError(
+                                    f"All steps in the cycle {this_cycle} are infeasible "
+                                    "due to exceeded bounds at initial conditions."
+                                )
                     cycle_sol = pybamm.make_cycle_solution(
                         steps,
                         esoh_solver=esoh_solver,

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -187,6 +187,21 @@ class TestSimulationExperiment:
         with pytest.raises(pybamm.SolverError, match="skip_ok is True for all steps"):
             sim.solve()
 
+    def test_all_empty_solution_errors(self):
+        model = pybamm.lithium_ion.SPM()
+        parameter_values = pybamm.ParameterValues("Chen2020")
+
+        # One step exceeded, suggests making a cycle
+        steps = [
+            (pybamm.step.Current(-5, termination="4.2 V", skip_ok=False),) * 5,
+        ]
+        experiment = pybamm.Experiment(steps)
+        sim = pybamm.Simulation(
+            model, experiment=experiment, parameter_values=parameter_values
+        )
+        with pytest.raises(pybamm.SolverError, match="All steps in the cycle"):
+            sim.solve()
+
     def test_run_experiment_multiple_times(self):
         s = pybamm.step.string
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -176,6 +176,15 @@ class TestSimulationExperiment:
         with pytest.raises(pybamm.SolverError):
             sim.solve()
 
+        # make sure we raise an error if all steps are infeasible
+        steps = [
+            (pybamm.step.Current(-5, termination="4.2 V", skip_ok=True),) * 5,
+        ]
+        experiment = pybamm.Experiment(steps)
+        sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
+        with pytest.raises(pybamm.SolverError, match="skip_ok is True for all steps"):
+            sim.solve()
+
     def test_run_experiment_multiple_times(self):
         s = pybamm.step.string
         experiment = pybamm.Experiment(


### PR DESCRIPTION
# Description

Adds an option to skip experiment steps. This is useful in CCCV if you start with too high of an initial SOC to run the CC step.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
