### PR TITLE
Fix plotting interpolation bug with spatial variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Deprecated `CrateTermination` and renamed it to `CRateTermination`. ([#4834](https://github.com/pybamm-team/PyBaMM/pull/4834))
 
+## Bug fixes
+
+- Fixed interpolation bug in `pybamm.QuickPlot` with spatial variables. ([#4841](https://github.com/pybamm-team/PyBaMM/pull/4841))
+
 # [v25.1.1](https://github.com/pybamm-team/PyBaMM/tree/v25.1.1) - 2025-01-20
 
 ## Features

--- a/src/pybamm/plotting/quick_plot.py
+++ b/src/pybamm/plotting/quick_plot.py
@@ -211,8 +211,8 @@ class QuickPlot:
         else:
             raise ValueError(f"time unit '{time_unit}' not recognized")
         self.time_scaling_factor = time_scaling_factor
-        self.min_t = min_t / time_scaling_factor
-        self.max_t = max_t / time_scaling_factor
+        self.min_t_unscaled = min_t
+        self.max_t_unscaled = max_t
 
         # Prepare dictionary of variables
         # output_variables is a list of strings or lists, e.g.
@@ -496,6 +496,7 @@ class QuickPlot:
         colors = import_optional_dependency("matplotlib", "colors")
 
         t_in_seconds = t * self.time_scaling_factor
+        t_in_seconds = np.clip(t_in_seconds, self.min_t_unscaled, self.max_t_unscaled)
         self.fig = plt.figure(figsize=self.figsize)
 
         self.gridspec = gridspec.GridSpec(self.n_rows, self.n_cols)
@@ -542,10 +543,7 @@ class QuickPlot:
                 y_min, y_max = ax.get_ylim()
                 ax.set_ylim(y_min, y_max)
                 (self.time_lines[key],) = ax.plot(
-                    [
-                        t_in_seconds / self.time_scaling_factor,
-                        t_in_seconds / self.time_scaling_factor,
-                    ],
+                    [t, t],
                     [y_min, y_max],
                     "k--",
                     lw=1.5,
@@ -811,6 +809,14 @@ class QuickPlot:
             frames=number_of_images,
         )
         ani.save(output_filename, dpi=300)
+
+    @property
+    def min_t(self):
+        return self.min_t_unscaled / self.time_scaling_factor
+
+    @property
+    def max_t(self):
+        return self.max_t_unscaled / self.time_scaling_factor
 
 
 class QuickPlotAxes:


### PR DESCRIPTION
# Description

When the time axis changes scale (e.g., from seconds to hours or days), minor floating-point arithmetic issues at the initial and final times can cause interpolation outside the timespan. As a result, the spatial variables could return `NaN` at the initial and final time points

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
