### PR TITLE
Fix docs for releases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,6 +321,9 @@ nbsphinx_requirejs_path = ""
 # made to a notebook, if any.
 # On local builds, the version is not set, so we use "latest".
 
+notebooks_version = version
+append_to_url = f"blob/v{notebooks_version}"
+
 if (os.environ.get("READTHEDOCS_VERSION") == "latest") or (
     os.environ.get("READTHEDOCS_VERSION") is None
 ):


### PR DESCRIPTION
# Description

I needed an old version of the docs, and I noticed this:
![image](https://github.com/user-attachments/assets/4462913b-a918-422c-81b4-14317bcafa2e)

No release after from 24.1 onwards has documentation.

I traced the problem here:
```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pybamm/envs/v25.1.1/lib/python3.12/site-packages/sphinx/config.py", line 529, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/pybamm/checkouts/v25.1.1/docs/conf.py", line 338, in <module>
    github_download_url = f"https://github.com/pybamm-team/PyBaMM/{append_to_url}"
                                                                   ^^^^^^^^^^^^^
NameError: name 'append_to_url' is not defined
```

IDE inspections also highlight this problem:
![image](https://github.com/user-attachments/assets/6af0723a-bb13-478c-b906-ad0bac05be49)


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
