### PR TITLE
Add Fuzzydict docstring

### DIFF
--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -36,8 +36,7 @@ class FuzzyDict(dict):
     - Search functionality to find keys containing specific terms.
     - Custom warnings for deprecated key names.
     
-    Methods
-    -------
+    Methods:
     get_best_matches(key)
         Returns a list of the best-matching keys for a given input key.
     
@@ -130,7 +129,6 @@ class FuzzyDict(dict):
         Helper method to find exact and partial matches for a given search key.
 
         Parameters
-        ----------
         search_key : str
             The term to search for in the keys.
         known_keys : list of str
@@ -149,7 +147,6 @@ class FuzzyDict(dict):
         the best matches are printed.
 
         Parameters
-        ----------
         keys : str or list of str
             Search term(s)
         print_values : bool, optional
@@ -225,8 +222,7 @@ class FuzzyDict(dict):
         as the original dictionary. It ensures that the copied dictionary retains 
         the fuzzy matching behavior.
 
-        Returns
-        -------
+        Returns:
         FuzzyDict
             A new FuzzyDict instance with the same data as the original.
         """

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -21,8 +21,42 @@ def root_dir():
     """return the root directory of the PyBaMM install directory"""
     return str(pathlib.Path(pybamm.__path__[0]).parent.parent)
 
-
 class FuzzyDict(dict):
+    """
+    A dictionary with fuzzy matching capabilities for key retrieval and search.
+
+    This class extends the built-in `dict` to provide intelligent key lookup,
+    including approximate string matching and handling of renamed terms. It is 
+    useful when working with parameter dictionaries where keys might have slight
+    variations, renamings, or formatting differences.
+
+    Features:
+    - Fuzzy matching using `difflib.get_close_matches` to suggest the closest keys.
+    - Custom error handling for specific key renamings with informative messages.
+    - Search functionality to find keys containing specific terms.
+    - Custom warnings for deprecated key names.
+    
+    Methods
+    -------
+    get_best_matches(key)
+        Returns a list of the best-matching keys for a given input key.
+    
+    __getitem__(key)
+        Retrieves the value associated with a key, handling renamed terms and 
+        suggesting closest matches if the key is not found.
+    
+    _find_matches(search_key, known_keys)
+        Finds exact and partial matches for a given search term in the dictionary keys.
+    
+    search(keys, print_values=False)
+        Searches the dictionary for keys containing all specified terms. Prints
+        the results and, optionally, the corresponding values.
+    
+    copy()
+        Returns a copy of the FuzzyDict instance.
+
+    """
+
     def get_best_matches(self, key):
         """Get best matches from keys"""
         return difflib.get_close_matches(key, list(self.keys()), n=3, cutoff=0.5)

--- a/src/pybamm/util.py
+++ b/src/pybamm/util.py
@@ -216,7 +216,21 @@ class FuzzyDict(dict):
                 else:
                     print(f"No matches found for '{original_key}'")
 
+    
     def copy(self):
+        """
+        Create and return a copy of the FuzzyDict instance.
+
+        This method returns a new FuzzyDict object containing the same key-value pairs 
+        as the original dictionary. It ensures that the copied dictionary retains 
+        the fuzzy matching behavior.
+
+        Returns
+        -------
+        FuzzyDict
+            A new FuzzyDict instance with the same data as the original.
+        """
+        
         return FuzzyDict(super().copy())
 
 


### PR DESCRIPTION
# Description

In this PR fixed the following bugs in `pybamm.util.py`:

- pybamm.FuzzyDict.copy. needs docstring
- pybamm.FuzzyDict. get_best_matches. document key arg
- pybamm.FuzzyDict. search. document args. format code properly

Fixes #4845 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
