### PR TITLE
Fix a bug where the usage of the CasADi solver breaks reproducibility

### DIFF
--- a/docs/source/examples/notebooks/models/half-cell.ipynb
+++ b/docs/source/examples/notebooks/models/half-cell.ipynb
@@ -39,6 +39,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2b2e62ad",
+   "metadata": {},
+   "source": [
+    "First, we introduce a random seed to ensure reproducibility of the results before running the simulation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f30409c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "np.random.seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f372aa29",
    "metadata": {},
    "source": [

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import pickle
 import pybamm
 import numpy as np
-import hashlib
 import warnings
 from functools import lru_cache
 from datetime import timedelta
@@ -133,9 +132,6 @@ class Simulation:
         self._solution = None
         self.quick_plot = None
 
-        # Initialise instances of Simulation class with the same random seed
-        self._set_random_seed()
-
         # ignore runtime warnings in notebooks
         if is_notebook():  # pragma: no cover
             import warnings
@@ -158,18 +154,6 @@ class Simulation:
         """
         self.__dict__ = state
         self.get_esoh_solver = lru_cache()(self._get_esoh_solver)
-
-    # If the solver being used is CasadiSolver or its variants, set a fixed
-    # random seed during class initialization to the SHA-256 hash of the class
-    # name for purposes of reproducibility.
-    def _set_random_seed(self):
-        if isinstance(self._solver, pybamm.CasadiSolver) or isinstance(
-            self._solver, pybamm.CasadiAlgebraicSolver
-        ):
-            np.random.seed(
-                int(hashlib.sha256(self.__class__.__name__.encode()).hexdigest(), 16)
-                % (2**32)
-            )
 
     def set_up_and_parameterise_experiment(self, solve_kwargs=None):
         msg = "pybamm.simulation.set_up_and_parameterise_experiment is deprecated and not meant to be accessed by users."


### PR DESCRIPTION
# Description

This is an issue that I highlighted during our presence at the PyBaMM conference around a week ago: in #3494 (which closed #3415), I introduced a bug wherein a NumPy random seed was set when using the `CasadiSolver` to solve a simulation. It is discouraged to add a random seed in library/module code – it breaks reproducibility by overriding randomness that may have been set by user-level code in researchers' scripts and simulations (it is acceptable for test code, though).

As the PR was supposed to fix stochastic behaviour for the hall-cell model, I have moved the random seed to the notebook instead which used to fail at that time in the repository's development. Usually, this should be present for all notebooks, but one should be enough for now to keep the diff minimal.

Another potential fix is to look at the `globals()` and `locals()` to find if a seed has been set already and use that, but that seems to be a bit over-engineered.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

## Important checks

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works

## Additional context

[Stop Using NumPy's Global Random Seed](https://arc.net/l/quote/fnaijdko) – while the article mentions using `np.random.default_rng()` is a better way, `np.random.seed()` should be sufficient for now. The rationale is that we don't want to be one of those packages that resets the global random seed set by a user at the top of their script (or by another library that sets it).

