### PR TITLE
Added support for time series temperature in an experiment step

### DIFF
--- a/src/pybamm/experiment/experiment.py
+++ b/src/pybamm/experiment/experiment.py
@@ -63,6 +63,8 @@ class Experiment:
 
         steps_unprocessed = [cond for cycle in cycles for cond in cycle]
 
+        self.temperature_interpolant = None
+
         # Convert strings to pybamm.step.BaseStep objects
         # We only do this once per unique step, to avoid unnecessary conversions
         # Assign experiment period and temperature if not specified in step
@@ -75,6 +77,10 @@ class Experiment:
 
         self.steps = [processed_steps[repr(step)] for step in steps_unprocessed]
         self.steps = self._set_next_start_time(self.steps)
+        for step in self.steps:
+            if getattr(step, "has_time_series_temperature", False):
+                self.temperature_interpolant = step.temperature
+                break
 
         # Save the processed unique steps and the processed operating conditions
         # for every step

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -176,7 +176,10 @@ class Voltage(BaseStepImplicit):
     """
 
     def get_parameter_values(self, variables):
-        return {"Voltage function [V]": self.value}
+        params = {"Voltage function [V]": self.value}
+        if self.temperature is not None:
+            params["Ambient temperature [K]"] = self.temperature
+        return params
 
     def get_submodel(self, model):
         return pybamm.external_circuit.VoltageFunctionControl(

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -318,6 +318,15 @@ class Simulation:
         if initial_soc is not None:
             self.set_initial_soc(initial_soc, inputs=inputs)
 
+        if (
+            getattr(self, "experiment", None)
+            and hasattr(self.experiment, "temperature_interpolant")
+            and self.experiment.temperature_interpolant is not None
+        ):
+            self.parameter_values.update(
+                {"Ambient temperature [K]": self.experiment.temperature_interpolant}
+            )
+
         if self._built_model:
             return
         elif self._model.is_discretised:
@@ -444,6 +453,14 @@ class Simulation:
             See :meth:`pybamm.BaseSolver.solve`.
         """
         pybamm.telemetry.capture("simulation-solved")
+        if (
+            getattr(self, "experiment", None)
+            and hasattr(self.experiment, "temperature_interpolant")
+            and self.experiment.temperature_interpolant is not None
+        ):
+            self.parameter_values.update(
+                {"Ambient temperature [K]": self.experiment.temperature_interpolant}
+            )
 
         # Setup
         if solver is None:


### PR DESCRIPTION
# Description
Added support for time series temperature in an experiment step, now it can be passed something like this:
```python
    experiment = pybamm.Experiment(
        [pybamm.step.voltage(voltage_profile, temperature=temperature_profile)]
    )
```

Fixes #4200

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- [x] No style issues: `nox -s pre-commit`
- [x] All tests pass: `nox -s tests`
- [x] The documentation builds: `nox -s doctests`
- [x] Code is commented for hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
