### PR TITLE
Moved concentration inside average when calculating LLI due to LAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ## Bug fixes
 
+- Moved concentration inside x-averaged when calculating LLI due to LAM variables ([#4858](https://github.com/pybamm-team/PyBaMM/pull/4858))
 - Fixed a bug which caused the ec-reaction limited SEI model to give
   incorrect results ([#4774](https://github.com/pybamm-team/PyBaMM/pull/4774))
 

--- a/src/pybamm/models/submodels/active_material/loss_active_material.py
+++ b/src/pybamm/models/submodels/active_material/loss_active_material.py
@@ -161,14 +161,14 @@ class LossActiveMaterial(BaseModel):
             f"in {domain} electrode [mol]"
         ]
         # Multiply by mol.m-3 * m3 to get mol
-        c_s_av = variables[
-            f"Average {domain} {phase_name}particle concentration [mol.m-3]"
+        c_s_rav = variables[
+            f"R-averaged {domain} {phase_name}particle concentration [mol.m-3]"
         ]
         V = self.domain_param.L * self.param.A_cc
 
         self.rhs = {
             # minus sign because eps_solid is decreasing and LLI measures positive
-            lli_due_to_lam: -c_s_av * V * pybamm.x_average(deps_solid_dt),
+            lli_due_to_lam: -V * pybamm.x_average(c_s_rav * deps_solid_dt),
             eps_solid: deps_solid_dt,
         }
 


### PR DESCRIPTION
# Description

Moved particle concentration inside the x-average when calculating the LLI due to LAM variables. This will improve accuracy when using DFN.