### PR TITLE
Remove unused cylindrical battery geometry support

### DIFF
--- a/src/pybamm/geometry/battery_geometry.py
+++ b/src/pybamm/geometry/battery_geometry.py
@@ -20,7 +20,7 @@ def battery_geometry(
         Dictionary of model options. Necessary for "particle-size geometry",
         relevant for lithium-ion chemistries.
     form_factor : str, optional
-        The form factor of the cell. Can be "pouch" (default) or "cylindrical".
+        The form factor of the cell. Can be "pouch" (default).
 
     Returns
     -------
@@ -150,21 +150,9 @@ def battery_geometry(
                     },
                 },
             }
-    elif form_factor == "cylindrical":
-        if current_collector_dimension == 0:
-            geometry["current collector"] = {"r_macro": {"position": 1}}
-        elif current_collector_dimension == 1:
-            geometry["current collector"] = {
-                "r_macro": {"min": geo.r_inner, "max": 1},
-            }
-        else:
-            raise pybamm.GeometryError(
-                f"Invalid current collector dimension '{current_collector_dimension}' (should be 0 or 1 for "
-                "a 'cylindrical' battery geometry)"
-            )
     else:
         raise pybamm.GeometryError(
-            f"Invalid form factor '{form_factor}' (should be 'pouch' or 'cylindrical'"
+            f"Invalid form factor '{form_factor}' (should be 'pouch')"
         )
 
     return pybamm.Geometry(geometry)


### PR DESCRIPTION
# Description

This PR removes the handling for cylindrical battery geometry from the `battery_geometry` function, as it is not used anywhere within the repository and was initially meant for future thermal model extensions.

Fixes: #4856 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
