### PR TITLE
Fix IDAKLU bug with non-identity inverse mass matrices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ## Bug fixes
 
+- Fixed a bug in simulating FEM models with the `IDAKLUSolver`. ([#4879](https://github.com/pybamm-team/PyBaMM/pull/4879))
 - Moved concentration inside x-averaged when calculating LLI due to LAM variables ([#4858](https://github.com/pybamm-team/PyBaMM/pull/4858))
 - Fixed a bug that caused the variable `"Loss of lithium due to {domain} lithium plating"`to have the domain `"current collector"` (should not have any domain at all) if the `"x-average side reactions"` option was set to `"true"`. ([#4844](https://github.com/pybamm-team/PyBaMM/pull/4844))
 - Fixed interpolation bug in `pybamm.QuickPlot` with spatial variables. ([#4841](https://github.com/pybamm-team/PyBaMM/pull/4841))

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -560,6 +560,30 @@ class BaseModel:
 
         return max_name_length, max_type_length
 
+    def _check_standard_form_dae(self):
+        """
+        Check if the model is a DAE in standard form with a mass matrix that is all
+        zeros except for along the diagonal, which is either ones or zeros.
+
+        For example, the following is standard form:
+        M*y' = f(y, y', t)
+
+        M = [I 0
+             0 0]
+
+        The following explicit ODE is also a standard form DAE:
+        M = I
+
+        The following is not standard form:
+        M = [2I 0
+             0 0]
+        """
+        if self.mass_matrix is None or self.mass_matrix_inv is None:
+            return False
+        # Check that the mass matrix inverse is an identity matrix
+        mass_matrix_inv = self.mass_matrix_inv.entries.toarray()
+        return np.allclose(mass_matrix_inv, np.eye(mass_matrix_inv.shape[0]))
+
     def _format_table_row(
         self, param_name, param_type, max_name_length, max_type_length
     ):
@@ -1163,30 +1187,6 @@ class BaseModel:
             raise pybamm.ModelError(
                 f"Multiple equations specified for variables {rhs_keys.intersection(alg_keys)}"
             )
-
-    def _check_standard_form_dae(self):
-        """
-        Check if the model is a DAE in standard form with a mass matrix that is all
-        zeros except for along the diagonal, which is either ones or zeros.
-
-        For example, the following is standard form:
-        M*y' = f(y, y', t)
-
-        M = [I 0
-             0 0]
-
-        The following explicit ODE is also a standard form DAE:
-        M = I
-
-        The following is not standard form:
-        M = [2I 0
-             0 0]
-        """
-        if self.mass_matrix is None or self.mass_matrix_inv is None:
-            return False
-        # Check that the mass matrix inverse is an identity matrix
-        mass_matrix_inv = self.mass_matrix_inv.entries.toarray()
-        return np.allclose(mass_matrix_inv, np.eye(mass_matrix_inv.shape[0]))
 
     def info(self, symbol_name):
         """

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -633,6 +633,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             "ids": ids,  # array
             "sensitivity_names": sensitivity_names,
             "number_of_sensitivity_parameters": number_of_sensitivity_parameters,
+            "standard_form_dae": model.is_standard_form_dae,  # bool
             "output_variables": self.output_variables,
             "var_fcns": self.computed_var_fcns,
             "var_idaklu_fcns": self.var_idaklu_fcns,
@@ -990,8 +991,12 @@ class IDAKLUSolver(pybamm.BaseSolver):
         rhs0 = rhs0.flatten()
 
         # for the differential terms, ydot = M^-1 * (rhs)
-        # M^-1 is the identity matrix, so we can just use rhs
-        ydot0[: model.len_rhs] = rhs0
+        if model.is_standard_form_dae:
+            # M^-1 is the identity matrix, so we can just use rhs
+            ydot0[: model.len_rhs] = rhs0
+        else:
+            # M^-1 is not the identity matrix, so we need to use the mass matrix
+            ydot0[: model.len_rhs] = model.mass_matrix_inv.entries @ rhs0
 
         return ydot0
 

--- a/tests/unit/test_discretisations/test_discretisation.py
+++ b/tests/unit/test_discretisations/test_discretisation.py
@@ -470,6 +470,8 @@ class TestDiscretise:
             np.eye(submesh.nodes.shape[0]), model.mass_matrix.entries.toarray()
         )
 
+        assert model.is_standard_form_dae
+
         # Create StateVector to differentiate model with respect to
         y = pybamm.StateVector(slice(0, submesh.npts))
 
@@ -526,6 +528,8 @@ class TestDiscretise:
         np.testing.assert_array_equal(
             np.eye(np.size(y0)), model.mass_matrix.entries.toarray()
         )
+
+        assert model.is_standard_form_dae
 
         # Create StateVector to differentiate model with respect to
         y = pybamm.StateVector(slice(0, np.size(y0)))
@@ -640,6 +644,7 @@ class TestDiscretise:
         np.testing.assert_array_equal(
             mass.toarray(), model.mass_matrix.entries.toarray()
         )
+        assert model.is_standard_form_dae
 
         # jacobian
         y = pybamm.StateVector(slice(0, np.size(y0)))
@@ -722,6 +727,8 @@ class TestDiscretise:
         # mass matrix is identity upper left, zeros elsewhere
         mass = np.zeros((np.size(submesh.nodes), np.size(submesh.nodes)))
         np.testing.assert_array_equal(mass, model.mass_matrix.entries.toarray())
+
+        assert not model.is_standard_form_dae
 
         # jacobian
         y = pybamm.StateVector(slice(0, np.size(y0)))

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -476,6 +476,8 @@ class TestCasadiSolver:
         mass_matrix_inv = 0.1 * eye(int(mass_matrix.shape[0] / 2))
         model.mass_matrix_inv = pybamm.Matrix(mass_matrix_inv)
 
+        assert not model.is_standard_form_dae
+
         # Solve
         solver = pybamm.CasadiSolver(rtol=1e-8, atol=1e-8)
         t_eval = np.linspace(0, 1, 100)


### PR DESCRIPTION
# Description

For more info, see: https://github.com/pybamm-team/PyBaMM/pull/4878#discussion_r1972113603

This is a minor bug that practically only affects FEM simulations using the `IDAKLUSolver`

I will make a followup PR in `pybammsolvers` to address a related issue there: https://github.com/pybamm-team/pybammsolvers/issues/31

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
