### PR TITLE
Added `print names` for variables in `equivalent circuit model`

### DIFF
--- a/src/pybamm/models/submodels/equivalent_circuit_elements/ocv_element.py
+++ b/src/pybamm/models/submodels/equivalent_circuit_elements/ocv_element.py
@@ -28,9 +28,11 @@ class OCVElement(pybamm.BaseSubModel):
         current = variables["Current [A]"]
 
         ocv = variables["Open-circuit voltage [V]"]
+        ocv.print_name = "OCV"
         T_cell = variables["Cell temperature [degC]"]
 
         dUdT = self.param.dUdT(ocv, T_cell)
+        dUdT.print_name = r"\frac{du}{dt}"
 
         T_cell_kelvin = variables["Cell temperature [K]"]
         Q_rev = -current * T_cell_kelvin * dUdT

--- a/src/pybamm/models/submodels/equivalent_circuit_elements/rc_element.py
+++ b/src/pybamm/models/submodels/equivalent_circuit_elements/rc_element.py
@@ -24,6 +24,7 @@ class RCElement(pybamm.BaseSubModel):
 
     def get_fundamental_variables(self):
         vrc = pybamm.Variable(f"Element-{self.element_number} overpotential [V]")
+        vrc.print_name = "eta"
         variables = {f"Element-{self.element_number} overpotential [V]": vrc}
         return variables
 
@@ -35,7 +36,11 @@ class RCElement(pybamm.BaseSubModel):
         r = self.param.rcr_element(
             f"R{self.element_number} [Ohm]", T_cell, current, soc
         )
-        c = self.param.rcr_element(f"C{self.element_number} [F]", T_cell, current, soc)
+        r.print_name = "R_1"
+        c = self.param.rcr_element(
+            "Capacitence of RC network [F]", T_cell, current, soc
+        )
+        c.print_name = "C_1"
         tau = r * c
 
         vrc = variables[f"Element-{self.element_number} overpotential [V]"]

--- a/src/pybamm/models/submodels/equivalent_circuit_elements/resistor_element.py
+++ b/src/pybamm/models/submodels/equivalent_circuit_elements/resistor_element.py
@@ -23,6 +23,7 @@ class ResistorElement(pybamm.BaseSubModel):
         soc = variables["SoC"]
 
         r = self.param.rcr_element("R0 [Ohm]", T_cell, current, soc)
+        r.print_name = r"R_{0}"
 
         overpotential = -current * r
         Q_irr = current**2 * r

--- a/src/pybamm/models/submodels/equivalent_circuit_elements/thermal.py
+++ b/src/pybamm/models/submodels/equivalent_circuit_elements/thermal.py
@@ -20,8 +20,9 @@ class ThermalSubModel(pybamm.BaseSubModel):
 
     def get_fundamental_variables(self):
         T_cell = pybamm.Variable("Cell temperature [degC]")
+        T_cell.print_name = "T_cell"
         T_jig = pybamm.Variable("Jig temperature [degC]")
-
+        T_jig.print_name = "T_jig"
         # Note this is defined in deg C
         T_amb = self.param.T_amb(pybamm.t)
 

--- a/src/pybamm/parameters/ecm_parameters.py
+++ b/src/pybamm/parameters/ecm_parameters.py
@@ -4,6 +4,7 @@ import pybamm
 class EcmParameters:
     def __init__(self):
         self.cell_capacity = pybamm.Parameter("Cell capacity [A.h]")
+        self.cell_capacity.print_name = "Q"
         self.tau_D = pybamm.Parameter("Diffusion time constant [s]")
 
         self._set_current_parameters()
@@ -16,6 +17,7 @@ class EcmParameters:
         self.current_with_time = pybamm.FunctionParameter(
             "Current function [A]", {"Time [s]": pybamm.t}
         )
+        self.current_with_time.print_name = "I"
 
     def _set_voltage_parameters(self):
         self.voltage_high_cut = pybamm.Parameter("Upper voltage cut-off [V]")
@@ -23,10 +25,13 @@ class EcmParameters:
 
     def _set_thermal_parameters(self):
         self.cth_cell = pybamm.Parameter("Cell thermal mass [J/K]")
+        self.cth_cell.print_name = "m_cell"
         self.k_cell_jig = pybamm.Parameter("Cell-jig heat transfer coefficient [W/K]")
-
+        self.k_cell_jig.print_name = r"h_{cj}"
         self.cth_jig = pybamm.Parameter("Jig thermal mass [J/K]")
+        self.cth_jig.print_name = "m_jig"
         self.k_jig_air = pybamm.Parameter("Jig-air heat transfer coefficient [W/K]")
+        self.k_jig_air.print_name = r"h_{ja}"
 
     def _set_compatibility_parameters(self):
         # These are parameters that for compatibility with
@@ -39,8 +44,11 @@ class EcmParameters:
 
     def _set_initial_condition_parameters(self):
         self.initial_soc = pybamm.Parameter("Initial SoC")
+        self.initial_soc.print_name = r"SoC_{0}"
         self.initial_T_cell = pybamm.Parameter("Initial temperature [K]") - 273.15
+        self.initial_T_cell.print_name = "T_{init}"
         self.initial_T_jig = pybamm.Parameter("Initial temperature [K]") - 273.15
+        self.initial_T_jig.print_name = "T_{init}"
 
     def T_amb(self, t):
         ambient_temperature_K = pybamm.FunctionParameter(
@@ -57,7 +65,7 @@ class EcmParameters:
         return pybamm.FunctionParameter(name, inputs)
 
     def initial_rc_overpotential(self, element_number):
-        return pybamm.Parameter(f"Element-{element_number} initial overpotential [V]")
+        return pybamm.Parameter("eta_0")
 
     def dUdT(self, ocv, T_cell):
         inputs = {"Open-circuit voltage [V]": ocv, "Cell temperature [degC]": T_cell}


### PR DESCRIPTION
# Description
Fixes #3036 

I have given latex friendly symbols to variables in the equivalent circuit model

Initially the output was:
![Screenshot from 2025-03-08 00-49-47](https://github.com/user-attachments/assets/d4365f20-0a3b-4760-a316-f8dd7a2a5076)

After the latex names are given:
![Screenshot from 2025-03-08 00-48-13](https://github.com/user-attachments/assets/bce3f13d-c9f8-4405-acc3-19a7128dfb39)



## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
