### PR TITLE
Replace np.ndarray with npt.NDArray for improved type hinting

### DIFF
--- a/benchmarks/different_model_options.py
+++ b/benchmarks/different_model_options.py
@@ -1,6 +1,7 @@
 import pybamm
 from benchmarks.benchmark_utils import set_random_seed
 import numpy as np
+import numpy.typing as npt
 
 
 def compute_discretisation(model, param):
@@ -33,8 +34,8 @@ def build_model(parameter, model_, option, value):
 class SolveModel:
     solver: pybamm.BaseSolver
     model: pybamm.BaseModel
-    t_eval: np.ndarray
-    t_interp: np.ndarray | None
+    t_eval: npt.NDArray
+    t_interp: npt.NDArray | None
 
     def solve_setup(self, parameter, model_, option, value, solver_class):
         self.solver = solver_class()

--- a/benchmarks/time_solve_models.py
+++ b/benchmarks/time_solve_models.py
@@ -4,6 +4,7 @@
 import pybamm
 from benchmarks.benchmark_utils import set_random_seed
 import numpy as np
+import numpy.typing as npt
 
 
 def solve_model_once(model, solver, t_eval, t_interp):
@@ -30,8 +31,8 @@ class TimeSolveSPM:
     )
     model: pybamm.BaseModel
     solver: pybamm.BaseSolver
-    t_eval: np.ndarray
-    t_interp: np.ndarray | None
+    t_eval: npt.NDArray
+    t_interp: npt.NDArray | None
 
     def setup(self, solve_first, parameters, solver_class):
         set_random_seed()
@@ -96,7 +97,7 @@ class TimeSolveSPMe:
     )
     model: pybamm.BaseModel
     solver: pybamm.BaseSolver
-    t_eval: np.ndarray
+    t_eval: npt.NDArray
 
     def setup(self, solve_first, parameters, solver_class):
         set_random_seed()
@@ -160,7 +161,7 @@ class TimeSolveDFN:
     )
     model: pybamm.BaseModel
     solver: pybamm.BaseSolver
-    t_eval: np.ndarray
+    t_eval: npt.NDArray
 
     def setup(self, solve_first, parameters, solver_class):
         set_random_seed()

--- a/src/pybamm/expression_tree/array.py
+++ b/src/pybamm/expression_tree/array.py
@@ -3,6 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 from scipy.sparse import csr_matrix, issparse
 
 import pybamm
@@ -38,7 +39,7 @@ class Array(pybamm.Symbol):
 
     def __init__(
         self,
-        entries: np.ndarray | list[float] | csr_matrix,
+        entries: npt.NDArray | list[float] | csr_matrix,
         name: str | None = None,
         domain: DomainType = None,
         auxiliary_domains: AuxiliaryDomainType = None,
@@ -144,8 +145,8 @@ class Array(pybamm.Symbol):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol._base_evaluate()`."""

--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import numbers
 
 import numpy as np
+import numpy.typing as npt
 import sympy
 from scipy.sparse import csr_matrix, issparse
 import functools
@@ -152,8 +153,8 @@ class BinaryOperator(pybamm.Symbol):
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol.evaluate()`."""

--- a/src/pybamm/expression_tree/concatenations.py
+++ b/src/pybamm/expression_tree/concatenations.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from typing import Optional
 
 import numpy as np
+import numpy.typing as npt
 import sympy
 from scipy.sparse import issparse, vstack
 from collections.abc import Sequence
@@ -112,7 +113,7 @@ class Concatenation(pybamm.Symbol):
 
         return domains
 
-    def _concatenation_evaluate(self, children_eval: list[np.ndarray]):
+    def _concatenation_evaluate(self, children_eval: list[npt.NDArray]):
         """See :meth:`Concatenation._concatenation_evaluate()`."""
         if len(children_eval) == 0:
             return np.array([])
@@ -122,8 +123,8 @@ class Concatenation(pybamm.Symbol):
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol.evaluate()`."""
@@ -367,7 +368,7 @@ class DomainConcatenation(Concatenation):
                 start = end
         return slices
 
-    def _concatenation_evaluate(self, children_eval: list[np.ndarray]):
+    def _concatenation_evaluate(self, children_eval: list[npt.NDArray]):
         """See :meth:`Concatenation._concatenation_evaluate()`."""
         # preallocate vector
         vector = np.empty((self._size, 1))

--- a/src/pybamm/expression_tree/discrete_time_sum.py
+++ b/src/pybamm/expression_tree/discrete_time_sum.py
@@ -1,5 +1,5 @@
 import pybamm
-import numpy as np
+import numpy.typing as npt
 
 
 class DiscreteTimeData(pybamm.Interpolant):
@@ -19,7 +19,7 @@ class DiscreteTimeData(pybamm.Interpolant):
 
     """
 
-    def __init__(self, time_points: np.ndarray, data: np.ndarray, name: str):
+    def __init__(self, time_points: npt.NDArray, data: npt.NDArray, name: str):
         super().__init__(time_points, data, pybamm.t, name)
 
     def create_copy(self, new_children=None, perform_simplifications=True):

--- a/src/pybamm/expression_tree/functions.py
+++ b/src/pybamm/expression_tree/functions.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 from scipy import special
 import sympy
 from typing import Callable
@@ -122,8 +123,8 @@ class Function(pybamm.Symbol):
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol.evaluate()`."""

--- a/src/pybamm/expression_tree/independent_variable.py
+++ b/src/pybamm/expression_tree/independent_variable.py
@@ -3,8 +3,7 @@
 #
 from __future__ import annotations
 import sympy
-import numpy as np
-
+import numpy.typing as npt
 import pybamm
 from pybamm.type_definitions import DomainType, AuxiliaryDomainType, DomainsType
 
@@ -94,8 +93,8 @@ class Time(IndependentVariable):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol._base_evaluate()`."""

--- a/src/pybamm/expression_tree/input_parameter.py
+++ b/src/pybamm/expression_tree/input_parameter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 import numbers
 import numpy as np
+import numpy.typing as npt
 import scipy.sparse
 import pybamm
 
@@ -88,8 +89,8 @@ class InputParameter(pybamm.Symbol):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         # inputs should be a dictionary

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -3,6 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 from scipy import interpolate
 from collections.abc import Sequence
 import numbers
@@ -43,8 +44,8 @@ class Interpolant(pybamm.Function):
 
     def __init__(
         self,
-        x: np.ndarray | Sequence[np.ndarray],
-        y: np.ndarray,
+        x: npt.NDArray | Sequence[npt.NDArray],
+        y: npt.NDArray,
         children: Sequence[pybamm.Symbol] | pybamm.Time,
         name: str | None = None,
         interpolator: str | None = "linear",
@@ -96,7 +97,7 @@ class Interpolant(pybamm.Function):
                 x1 = x[0]
             else:
                 x1 = x
-                x: list[np.ndarray] = [x]  # type: ignore[no-redef]
+                x: list[npt.NDArray] = [x]  # type: ignore[no-redef]
             x2 = None
             if x1.shape[0] != y.shape[0]:
                 raise ValueError(

--- a/src/pybamm/expression_tree/matrix.py
+++ b/src/pybamm/expression_tree/matrix.py
@@ -3,6 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 from scipy.sparse import csr_matrix, issparse
 
 import pybamm
@@ -16,7 +17,7 @@ class Matrix(pybamm.Array):
 
     def __init__(
         self,
-        entries: np.ndarray | list[float] | csr_matrix,
+        entries: npt.NDArray | list[float] | csr_matrix,
         name: str | None = None,
         domain: DomainType = None,
         auxiliary_domains: AuxiliaryDomainType = None,

--- a/src/pybamm/expression_tree/scalar.py
+++ b/src/pybamm/expression_tree/scalar.py
@@ -3,6 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 import sympy
 from typing import Literal
 
@@ -66,8 +67,8 @@ class Scalar(pybamm.Symbol):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol._base_evaluate()`."""

--- a/src/pybamm/expression_tree/state_vector.py
+++ b/src/pybamm/expression_tree/state_vector.py
@@ -3,6 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
+import numpy.typing as npt
 from scipy.sparse import csr_matrix, vstack
 
 import pybamm
@@ -281,8 +282,8 @@ class StateVector(StateVectorBase):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol._base_evaluate()`."""
@@ -365,8 +366,8 @@ class StateVectorDot(StateVectorBase):
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol._base_evaluate()`."""

--- a/src/pybamm/expression_tree/symbol.py
+++ b/src/pybamm/expression_tree/symbol.py
@@ -6,6 +6,7 @@ import numbers
 import warnings
 
 import numpy as np
+import numpy.typing as npt
 import sympy
 from scipy.sparse import csr_matrix, issparse
 from functools import cached_property
@@ -769,8 +770,8 @@ class Symbol:
     def _base_evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """
@@ -801,8 +802,8 @@ class Symbol:
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ) -> ChildValue:
         """Evaluate expression tree (wrapper to allow using dict of known values).

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import numpy as np
+import numpy.typing as npt
 from scipy.sparse import csr_matrix, issparse
 import sympy
 import pybamm
@@ -93,8 +94,8 @@ class UnaryOperator(pybamm.Symbol):
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | str | None = None,
     ):
         """See :meth:`pybamm.Symbol.evaluate()`."""

--- a/src/pybamm/expression_tree/vector.py
+++ b/src/pybamm/expression_tree/vector.py
@@ -3,7 +3,7 @@
 #
 from __future__ import annotations
 import numpy as np
-
+import numpy.typing as npt
 import pybamm
 from pybamm.type_definitions import DomainType, AuxiliaryDomainType, DomainsType
 
@@ -15,7 +15,7 @@ class Vector(pybamm.Array):
 
     def __init__(
         self,
-        entries: np.ndarray | list[float] | np.matrix,
+        entries: npt.NDArray | list[float] | np.matrix,
         name: str | None = None,
         domain: DomainType = None,
         auxiliary_domains: AuxiliaryDomainType = None,

--- a/src/pybamm/models/event.py
+++ b/src/pybamm/models/event.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-import numpy as np
-
+import numpy.typing as npt
 from typing import TypeVar
 
 
@@ -75,8 +74,8 @@ class Event:
     def evaluate(
         self,
         t: float | None = None,
-        y: np.ndarray | None = None,
-        y_dot: np.ndarray | None = None,
+        y: npt.NDArray | None = None,
+        y_dot: npt.NDArray | None = None,
         inputs: dict | None = None,
     ):
         """

--- a/src/pybamm/solvers/idaklu_jax.py
+++ b/src/pybamm/solvers/idaklu_jax.py
@@ -1,5 +1,6 @@
 import pybamm
 import numpy as np
+import numpy.typing as npt
 import logging
 import warnings
 import numbers
@@ -258,7 +259,7 @@ class IDAKLUJax:
 
     def jax_value(
         self,
-        t: np.ndarray = None,
+        t: npt.NDArray = None,
         inputs: Union[dict, None] = None,
         output_variables: Union[list[str], None] = None,
     ):
@@ -291,7 +292,7 @@ class IDAKLUJax:
 
     def jax_grad(
         self,
-        t: np.ndarray = None,
+        t: npt.NDArray = None,
         inputs: Union[dict, None] = None,
         output_variables: Union[list[str], None] = None,
     ):
@@ -395,9 +396,9 @@ class IDAKLUJax:
 
     def _jax_solve(
         self,
-        t: Union[float, np.ndarray],
+        t: Union[float, npt.NDArray],
         *inputs,
-    ) -> np.ndarray:
+    ) -> npt.NDArray:
         """Solver implementation used by f-bind"""
         logger.info("jax_solve")
         logger.debug(f"  t: {type(t)}, {t}")
@@ -409,7 +410,7 @@ class IDAKLUJax:
 
     def _jax_jvp_impl(
         self,
-        *args: Union[np.ndarray],
+        *args: Union[npt.NDArray],
     ):
         """JVP implementation used by f_jvp bind"""
         primals = args[: len(args) // 2]
@@ -454,9 +455,9 @@ class IDAKLUJax:
 
     def _jax_vjp_impl(
         self,
-        y_bar: np.ndarray,
+        y_bar: npt.NDArray,
         invar: Union[str, int],  # index or name of input variable
-        *primals: np.ndarray,
+        *primals: npt.NDArray,
     ):
         """VJP implementation used by f_vjp bind"""
         logger.info("py:f_vjp_p_impl")

--- a/src/pybamm/solvers/processed_variable_time_integral.py
+++ b/src/pybamm/solvers/processed_variable_time_integral.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 from typing import Literal, Optional, Union
-import numpy as np
+import numpy.typing as npt
 import pybamm
 
 
 @dataclass
 class ProcessedVariableTimeIntegral:
     method: Literal["discrete", "continuous"]
-    initial_condition: np.ndarray
-    discrete_times: Optional[np.ndarray]
+    initial_condition: npt.NDArray
+    discrete_times: Optional[npt.NDArray]
 
     @staticmethod
     def from_pybamm_var(

--- a/src/pybamm/type_definitions.py
+++ b/src/pybamm/type_definitions.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 from typing import Union
 from typing_extensions import TypeAlias
 import numpy as np
+import numpy.typing as npt
 import pybamm
 
 # numbers.Number should not be used for type hints
 Numeric: TypeAlias = Union[int, float, np.number]
 
 # expression tree
-ChildValue: TypeAlias = Union[float, np.ndarray]
-ChildSymbol: TypeAlias = Union[float, np.ndarray, pybamm.Symbol]
+ChildValue: TypeAlias = Union[float, npt.NDArray]
+ChildSymbol: TypeAlias = Union[float, npt.NDArray, pybamm.Symbol]
 
 DomainType: TypeAlias = Union[list[str], str, None]
 AuxiliaryDomainType: TypeAlias = Union[dict[str, str], None]


### PR DESCRIPTION
# Description

This PR updates the type hints by replacing np.ndarray with npt.NDArray from numpy.typing. It was necessary because using npt.NDArray is the recommended way to define NumPy arrays in type hints.

Fixes #4512

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:

- [x] - No style issues: `nox -s pre-commit`
- [x] - All tests pass: `nox -s tests`
- [x] - The documentation builds: `nox -s doctests`
- [ ] - Code is commented for hard-to-understand areas
- [ ] - Tests added that prove fix is effective or that feature works