### PR TITLE
Fix broken link to Contributor's Guide in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,7 @@ explore the effect of different battery designs and modeling assumptions under a
 
       +++
 
-      .. button-link:: ../CONTRIBUTING.md
+      .. button-ref:: source/user_guide/contributing
          :expand:
          :color: secondary
          :click-parent:


### PR DESCRIPTION
# Description

Modifies `docs/index.rst` to use `button-ref` instead of `button-link`, ensuring the Contributor's Guide button links to `source/user_guide/contributing.html`

Fixes: #4911 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
