### PR TITLE
Enable UP007 rule for modern type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ ignore = [
     "RET506",      # Unnecessary `elif`
     "B018",        # Found useless expression
     "RUF002",      # Docstring contains ambiguous
-    "UP007",       # For pyupgrade
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/pybamm/expression_tree/concatenations.py
+++ b/src/pybamm/expression_tree/concatenations.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 #
 # Concatenation classes
 #
 from __future__ import annotations
 import copy
 from collections import defaultdict
-from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -470,7 +471,7 @@ class SparseStack(Concatenation):
 class ConcatenationVariable(Concatenation):
     """A Variable representing a concatenation of variables."""
 
-    def __init__(self, *children, name: Optional[str] = None):
+    def __init__(self, *children, name: str | None = None):
         if name is None:
             # Name is the intersection of the children names (should usually make sense
             # if the children have been named consistently)
@@ -526,7 +527,7 @@ def intersect(s1: str, s2: str):
     return intersect.lstrip().rstrip()
 
 
-def simplified_concatenation(*children, name: Optional[str] = None):
+def simplified_concatenation(*children, name: str | None = None):
     """Perform simplifications on a concatenation."""
     # remove children that are None
     children = list(filter(lambda x: x is not None, children))
@@ -556,7 +557,7 @@ def simplified_concatenation(*children, name: Optional[str] = None):
             return concat
 
 
-def concatenation(*children, name: Optional[str] = None):
+def concatenation(*children, name: str | None = None):
     """Helper function to create concatenations."""
     # TODO: add option to turn off simplifications
     return simplified_concatenation(*children, name=name)


### PR DESCRIPTION
# Description

This PR removes `UP007` from ignored rules in `pyproject.toml` and updates type annotations to use `str | None` instead of `Optional[str]`.  

Fixes: #4924  

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
