### PR TITLE
Temporarily pin casadi<3.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pybammsolvers",
     "numpy>=1.23.5,<2.0.0",
     "scipy>=1.11.4",
-    "casadi>=3.6.7",
+    "casadi>=3.6.7,<3.7.0",
     "xarray>=2022.6.0",
     "anytree>=2.8.0",
     "sympy>=1.12",


### PR DESCRIPTION
# Description

Temporary pin as CasADi 3.7.0 was released today and causes segfaults with Python as we don't support the new changes yet here and in https://github.com/pybamm-team/pybammsolvers. Noticed in #4935.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
