### PR TITLE
Removed `linux/arm64` from platforms in the Docker workflow to fix build failures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           file: scripts/Dockerfile
           tags: pybamm/pybamm:latest
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
 
       - name: List built image(s)
         run: docker images


### PR DESCRIPTION
# Description

Fixes a part of #4896 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
