### PR TITLE
Ensure stress-induced diffusion is only enabled on electrodes that have particle mechanics

### DIFF
--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -425,6 +425,21 @@ class BatteryModelOptions(pybamm.FuzzyDict):
             and default_options["particle mechanics"] == "none"
         ):
             default_options["stress-induced diffusion"] = "false"
+        elif (
+            mechanics_option == ("none", "swelling only")
+            and default_options["particle mechanics"] == "none"
+        ):
+            default_options["stress-induced diffusion"] = ("false", "true")
+        elif (
+            mechanics_option == ("swelling only", "none")
+            and default_options["particle mechanics"] == "none"
+        ):
+            default_options["stress-induced diffusion"] = ("true", "false")
+        elif (
+            mechanics_option == ("swelling and cracking", "none")
+            and default_options["particle mechanics"] == "none"
+        ):
+            default_options["stress-induced diffusion"] = ("true", "false")
         else:
             default_options["stress-induced diffusion"] = "true"
         # The "stress-induced diffusion" option will still be overridden by


### PR DESCRIPTION
# Description

If particle mechanics is enabled on one electrode, stress-induced diffusion is enabled on both by default. I added some code to base_battery_model to catch most instances where this might happen.

Fixes #4943 