### PR TITLE
Temporarily Disable Failing Memory Benchmarks

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -87,12 +87,11 @@
       "sympy": [],
       "bpx": [],
       "tqdm": [],
-      "matplotlib": [],
+      "matplotlib": []
     },
     "env": {
       "LD_LIBRARY_PATH": "/home/runner/.local/lib"
     }
-  }
 
   // Combinations of libraries/python versions can be excluded/included
   // from the set to test. Each entry is a dictionary containing additional
@@ -174,4 +173,15 @@
   //    "some_benchmark": 0.01,     // Threshold of 1%
   //    "another_benchmark": 0.5,   // Threshold of 50%
   // },
+  },
+  "exclude": [
+    {"benchmark": "memory_sims.MemSPMSimulationCCCV.*"},
+    {"benchmark": "memory_sims.MemDFNSimulationCCCV.*"},
+    {"benchmark": "memory_sims.MemSPMSimulationGITT.*"},
+    {"benchmark": "memory_sims.MemDFNSimulationGITT.*"},
+    {"benchmark": "memory_unit_benchmarks.MemCreateExpression.*"},
+    {"benchmark": "memory_unit_benchmarks.MemParameteriseModel.*"},
+    {"benchmark": "memory_unit_benchmarks.MemDiscretiseModel.*"},
+    {"benchmark": "memory_unit_benchmarks.MemSolveModel.*"}
+  ]
 }


### PR DESCRIPTION
# Description

This PR temporarily disables failing memory benchmarks in `asv.conf.json` to resolve `Pympler`  related failures, ensuring workflow stability.

Fixes: #4938

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
