### PR TITLE
Added type hints to constant_concentration.py

### DIFF
--- a/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
+++ b/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
@@ -4,7 +4,7 @@ from typing import Optional, Any, TYPE_CHECKING
 from .base_electrolyte_diffusion import BaseElectrolyteDiffusion
 
 if TYPE_CHECKING:
-    from pybamm import ParameterValues, Symbol
+    from pybamm import ParameterValues
 
 
 class ConstantConcentration(BaseElectrolyteDiffusion):
@@ -18,7 +18,9 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
         A dictionary of options to be passed to the model.
     """
 
-    def __init__(self, param: "ParameterValues", options: Optional[dict[str, Any]] = None) -> None:
+    def __init__(
+        self, param: "ParameterValues", options: Optional[dict[str, Any]] = None
+    ) -> None:
         super().__init__(param, options)
 
     def get_fundamental_variables(self) -> dict[str, pybamm.Symbol]:
@@ -27,8 +29,8 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
             domain: self.param.domain_params[domain.split()[0]].epsilon_init * c_e_init
             for domain in self.options.whole_cell_domains
         }
-        variables: dict[str, pybamm.Symbol] = self._get_standard_porosity_times_concentration_variables(
-            eps_c_e_dict
+        variables: dict[str, pybamm.Symbol] = (
+            self._get_standard_porosity_times_concentration_variables(eps_c_e_dict)
         )
         N_e: pybamm.Symbol = pybamm.FullBroadcastToEdges(
             0,
@@ -40,12 +42,16 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
 
         return variables
 
-    def get_coupled_variables(self, variables: dict[str, pybamm.Symbol]) -> dict[str, pybamm.Symbol]:
+    def get_coupled_variables(
+        self, variables: dict[str, pybamm.Symbol]
+    ) -> dict[str, pybamm.Symbol]:
         c_e_dict: dict[str, pybamm.Symbol] = {}
         for domain in self.options.whole_cell_domains:
             Domain = domain.capitalize()
             eps_k: pybamm.Symbol = variables[f"{Domain} porosity"]
-            eps_c_e_k: pybamm.Symbol = variables[f"{Domain} porosity times concentration [mol.m-3]"]
+            eps_c_e_k: pybamm.Symbol = variables[
+                f"{Domain} porosity times concentration [mol.m-3]"
+            ]
             c_e_k: pybamm.Symbol = eps_c_e_k / eps_k
             c_e_dict[domain] = c_e_k
 

--- a/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
+++ b/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
@@ -2,10 +2,10 @@
 # Class for leading-order electrolyte diffusion employing stefan-maxwell
 #
 import pybamm
-from typing import Dict, Optional, Any, List, TYPE_CHECKING
+from typing import Dict, Optional, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pybamm import ParameterValues, Symbol
+    from pybamm import ParameterValues
 
 from .base_electrolyte_diffusion import BaseElectrolyteDiffusion
 
@@ -21,7 +21,9 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
         A dictionary of options to be passed to the model.
     """
 
-    def __init__(self, param: "ParameterValues", options: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self, param: "ParameterValues", options: Optional[Dict[str, Any]] = None
+    ) -> None:
         super().__init__(param, options)
 
     def get_fundamental_variables(self) -> Dict[str, pybamm.Symbol]:
@@ -30,8 +32,8 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
             domain: self.param.domain_params[domain.split()[0]].epsilon_init * c_e_init
             for domain in self.options.whole_cell_domains
         }
-        variables: Dict[str, pybamm.Symbol] = self._get_standard_porosity_times_concentration_variables(
-            eps_c_e_dict
+        variables: Dict[str, pybamm.Symbol] = (
+            self._get_standard_porosity_times_concentration_variables(eps_c_e_dict)
         )
         N_e: pybamm.Symbol = pybamm.FullBroadcastToEdges(
             0,
@@ -43,12 +45,16 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
 
         return variables
 
-    def get_coupled_variables(self, variables: Dict[str, pybamm.Symbol]) -> Dict[str, pybamm.Symbol]:
+    def get_coupled_variables(
+        self, variables: Dict[str, pybamm.Symbol]
+    ) -> Dict[str, pybamm.Symbol]:
         c_e_dict: Dict[str, pybamm.Symbol] = {}
         for domain in self.options.whole_cell_domains:
             Domain = domain.capitalize()
             eps_k: pybamm.Symbol = variables[f"{Domain} porosity"]
-            eps_c_e_k: pybamm.Symbol = variables[f"{Domain} porosity times concentration [mol.m-3]"]
+            eps_c_e_k: pybamm.Symbol = variables[
+                f"{Domain} porosity times concentration [mol.m-3]"
+            ]
             c_e_k: pybamm.Symbol = eps_c_e_k / eps_k
             c_e_dict[domain] = c_e_k
 

--- a/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
+++ b/src/pybamm/models/submodels/electrolyte_diffusion/constant_concentration.py
@@ -1,13 +1,10 @@
-#
-# Class for leading-order electrolyte diffusion employing stefan-maxwell
-#
 import pybamm
-from typing import Dict, Optional, Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pybamm import ParameterValues
+from typing import Optional, Any, TYPE_CHECKING
 
 from .base_electrolyte_diffusion import BaseElectrolyteDiffusion
+
+if TYPE_CHECKING:
+    from pybamm import ParameterValues, Symbol
 
 
 class ConstantConcentration(BaseElectrolyteDiffusion):
@@ -21,19 +18,17 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
         A dictionary of options to be passed to the model.
     """
 
-    def __init__(
-        self, param: "ParameterValues", options: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def __init__(self, param: "ParameterValues", options: Optional[dict[str, Any]] = None) -> None:
         super().__init__(param, options)
 
-    def get_fundamental_variables(self) -> Dict[str, pybamm.Symbol]:
+    def get_fundamental_variables(self) -> dict[str, pybamm.Symbol]:
         c_e_init: float = self.param.c_e_init
-        eps_c_e_dict: Dict[str, pybamm.Symbol] = {
+        eps_c_e_dict: dict[str, pybamm.Symbol] = {
             domain: self.param.domain_params[domain.split()[0]].epsilon_init * c_e_init
             for domain in self.options.whole_cell_domains
         }
-        variables: Dict[str, pybamm.Symbol] = (
-            self._get_standard_porosity_times_concentration_variables(eps_c_e_dict)
+        variables: dict[str, pybamm.Symbol] = self._get_standard_porosity_times_concentration_variables(
+            eps_c_e_dict
         )
         N_e: pybamm.Symbol = pybamm.FullBroadcastToEdges(
             0,
@@ -45,16 +40,12 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
 
         return variables
 
-    def get_coupled_variables(
-        self, variables: Dict[str, pybamm.Symbol]
-    ) -> Dict[str, pybamm.Symbol]:
-        c_e_dict: Dict[str, pybamm.Symbol] = {}
+    def get_coupled_variables(self, variables: dict[str, pybamm.Symbol]) -> dict[str, pybamm.Symbol]:
+        c_e_dict: dict[str, pybamm.Symbol] = {}
         for domain in self.options.whole_cell_domains:
             Domain = domain.capitalize()
             eps_k: pybamm.Symbol = variables[f"{Domain} porosity"]
-            eps_c_e_k: pybamm.Symbol = variables[
-                f"{Domain} porosity times concentration [mol.m-3]"
-            ]
+            eps_c_e_k: pybamm.Symbol = variables[f"{Domain} porosity times concentration [mol.m-3]"]
             c_e_k: pybamm.Symbol = eps_c_e_k / eps_k
             c_e_dict[domain] = c_e_k
 
@@ -70,7 +61,7 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
 
         return variables
 
-    def set_boundary_conditions(self, variables: Dict[str, pybamm.Symbol]) -> None:
+    def set_boundary_conditions(self, variables: dict[str, pybamm.Symbol]) -> None:
         """
         We provide boundary conditions even though the concentration is constant
         so that the gradient of the concentration has the correct shape after
@@ -86,6 +77,6 @@ class ConstantConcentration(BaseElectrolyteDiffusion):
             }
         }
 
-    def add_events_from(self, variables: Dict[str, pybamm.Symbol]) -> None:
+    def add_events_from(self, variables: dict[str, pybamm.Symbol]) -> None:
         # No event since the concentration is constant
         pass


### PR DESCRIPTION
# Description

This is a trial PR to test adding type hints. I’ve verified that it doesn’t change any mypy behavior at this stage, but it’s intended to gather feedback on approach and clarity. Happy to change this to a draft if needed.
Fixes #4954 

## Type of change

This PR focuses on:

Adding type hints to helper functions that return basic types.

Adding hints to class methods with simple input/output signatures.

Ensuring compatibility with existing code and mypy.

## Motivation
I’d like to familiarize myself with PyBaMM’s contribution process and get early feedback on:

Type hinting conventions

Review expectations

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
