### PR TITLE
Drop `sphinx-hoverxref` extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,6 @@ extensions = [
     "nbsphinx",  # to be kept below JavaScript-enabled extensions, always
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinx_gallery.load_style",
-    "hoverxref.extension",
 ]
 
 
@@ -434,29 +433,6 @@ inheritance_edge_attrs = dict(
     style='"setlinewidth(0.5)"',
 )
 
-# -- Options for sphinx-hoverxref --------------------------------------------
-
-# Hoverxref settings
-
-hoverxref_default_type = "tooltip"
-hoverxref_auto_ref = True
-
-hoverxref_roles = ["class", "meth", "func", "ref", "term"]
-hoverxref_role_types = dict.fromkeys(hoverxref_roles, "tooltip")
-
-hoverxref_domains = ["py"]
-
-# Currently, only projects that are hosted on readthedocs + CPython, NumPy, and
-# SymPy are supported
-hoverxref_intersphinx = list(intersphinx_mapping.keys())
-
-# Tooltips settings
-hoverxref_tooltip_lazy = False
-hoverxref_tooltip_maxwidth = 750
-hoverxref_tooltip_animation = "fade"
-hoverxref_tooltip_animation_duration = 1
-hoverxref_tooltip_content = "Loading information..."
-hoverxref_tooltip_theme = ["tooltipster-shadow", "tooltipster-shadow-custom"]
 
 # -- Options for Algolia DocSearch (sphinx-docsearch) ------------------------
 

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -125,7 +125,6 @@ Dependency                                                                      
 `ipykernel <https://pypi.org/project/ipykernel/>`__                                               \-                 docs               Provides the IPython kernel for Jupyter.
 `ipywidgets <https://ipywidgets.readthedocs.io/en/latest/>`__                                     \-                 docs               Interactive HTML widgets for Jupyter notebooks and the IPython kernel.
 `sphinx-gallery <https://pypi.org/project/sphinx-gallery/>`__                                     \-                 docs               Builds an HTML gallery of examples from any set of Python scripts.
-`sphinx-hoverxref <https://sphinx-hoverxref.readthedocs.io/en/latest/index.html>`__               \-                 docs               Sphinx extension to show a floating window.
 `sphinx-docsearch <https://sphinx-docsearch.readthedocs.io/>`__                                   \-                 docs               To replaces Sphinx’s built-in search with Algolia DocSearch.
 ================================================================================================= ================== ================== =======================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ docs = [
     "ipykernel",
     "ipywidgets",
     "sphinx-gallery",
-    "sphinx-hoverxref",
     "sphinx-docsearch",
 ]
 # For example notebooks


### PR DESCRIPTION
# Description

I added this extension in 2023 via #3083, and it has been available on the RTD dashboard for a while now. As of 03/04/2025, it is deprecated and users are advised to switch to the server-side one – I'll enable it in the settings. The CSS customisations for the extension I had added to `pybamm.css` have been kept, as the extension doesn't support dark mode well yet.

xref: 
- https://github.com/readthedocs/sphinx-hoverxref/issues/312#issuecomment-2775944738
- https://about.readthedocs.com/blog/2024/07/addons-by-default/

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
