### PR TITLE
Remove harmonic mean regularization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Remove a regularization term in the harmonic mean.  ([#4977](https://github.com/pybamm-team/PyBaMM/pull/4977))
+
 # [v25.4.0](https://github.com/pybamm-team/PyBaMM/tree/v25.4.0) - 2025-04-02
 
 ## Features

--- a/src/pybamm/expression_tree/parameter.py
+++ b/src/pybamm/expression_tree/parameter.py
@@ -217,8 +217,8 @@ class FunctionParameter(pybamm.Symbol):
         Returns the sum of the evaluated children
         See :meth:`pybamm.Symbol.evaluate_for_shape()`
         """
-        # add 1e-16 to avoid division by zero
-        return sum(child.evaluate_for_shape() for child in self.children) + 1e-16
+        # add 1e-300 to avoid division by zero
+        return sum(child.evaluate_for_shape() for child in self.children) + 1e-300
 
     def to_equation(self) -> sympy.Symbol:
         """Convert the node and its subtree into a SymPy equation."""

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -1334,7 +1334,7 @@ class FiniteVolume(pybamm.SpatialMethod):
             The harmonic mean is computed as
 
             .. math::
-                D_{eff} = \\frac{D_1  D_2}{\\beta D_2 + (1 - \\beta) D_1},
+                D_{eff} = \\frac{1}{\\frac{\\beta}{D_1} + \\frac{1 - \\beta}{D_2}},
 
             where
 
@@ -1409,8 +1409,7 @@ class FiniteVolume(pybamm.SpatialMethod):
 
                 # dx_real = dx * length, therefore, beta is unchanged
                 # Compute harmonic mean on internal edges
-                # Note: add small number to denominator to regularise D_eff
-                D_eff = D1 * D2 / (D2 * beta + D1 * (1 - beta) + 1e-16)
+                D_eff = 1 / (beta / D1 + (1 - beta) / D2)
 
                 # Matrix to pad zeros at the beginning and end of the array where
                 # the exterior edge values will be added
@@ -1452,8 +1451,7 @@ class FiniteVolume(pybamm.SpatialMethod):
                 beta = pybamm.Array(np.kron(np.ones((second_dim_repeats, 1)), sub_beta))
 
                 # Compute harmonic mean on nodes
-                # Note: add small number to denominator to regularise D_eff
-                D_eff = D1 * D2 / (D2 * beta + D1 * (1 - beta) + 1e-16)
+                D_eff = 1 / (beta / D1 + (1 - beta) / D2)
 
                 return D_eff
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
@@ -13,14 +13,15 @@ class TestCompareBasicModels:
         dfn = pybamm.lithium_ion.DFN()
 
         # Solve basic DFN
-        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values)
+        solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
+        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values, solver=solver)
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)
         basic_sol = basic_sim.solution
 
         # Solve main DFN
-        sim = pybamm.Simulation(dfn, parameter_values=parameter_values)
+        sim = pybamm.Simulation(dfn, parameter_values=parameter_values, solver=solver)
         sim.solve(t_eval=t_eval, t_interp=t_interp)
         sol = sim.solution
 
@@ -43,7 +44,8 @@ class TestCompareBasicModels:
         parameter_values = pybamm.ParameterValues("Chen2020_composite")
 
         # Solve basic DFN
-        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values)
+        solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
+        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values, solver=solver)
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)
@@ -69,14 +71,15 @@ class TestCompareBasicModels:
         spm = pybamm.lithium_ion.SPM()
 
         # Solve basic SPM
-        basic_sim = pybamm.Simulation(basic_spm, parameter_values=parameter_values)
+        solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
+        basic_sim = pybamm.Simulation(basic_spm, parameter_values=parameter_values, solver=solver)
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)
         basic_sol = basic_sim.solution
 
         # Solve main SPM
-        sim = pybamm.Simulation(spm, parameter_values=parameter_values)
+        sim = pybamm.Simulation(spm, parameter_values=parameter_values, solver=solver)
         sim.solve(t_eval=t_eval, t_interp=t_interp)
         sol = sim.solution
 

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_compare_basic_models.py
@@ -14,7 +14,9 @@ class TestCompareBasicModels:
 
         # Solve basic DFN
         solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
-        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values, solver=solver)
+        basic_sim = pybamm.Simulation(
+            basic_dfn, parameter_values=parameter_values, solver=solver
+        )
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)
@@ -45,7 +47,9 @@ class TestCompareBasicModels:
 
         # Solve basic DFN
         solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
-        basic_sim = pybamm.Simulation(basic_dfn, parameter_values=parameter_values, solver=solver)
+        basic_sim = pybamm.Simulation(
+            basic_dfn, parameter_values=parameter_values, solver=solver
+        )
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)
@@ -72,7 +76,9 @@ class TestCompareBasicModels:
 
         # Solve basic SPM
         solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
-        basic_sim = pybamm.Simulation(basic_spm, parameter_values=parameter_values, solver=solver)
+        basic_sim = pybamm.Simulation(
+            basic_spm, parameter_values=parameter_values, solver=solver
+        )
         t_eval = [0, 3600]
         t_interp = np.linspace(0, 3600)
         basic_sim.solve(t_eval=t_eval, t_interp=t_interp)

--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -276,7 +276,8 @@ class TestExperiment:
         step = pybamm.step.voltage(2.5, termination="2.5 V")
         experiment = pybamm.Experiment([step])
 
-        sim = pybamm.Simulation(model, experiment=experiment)
+        solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
+        sim = pybamm.Simulation(model, experiment=experiment, solver=solver)
 
         sim.solve()
         solution = sim.solution

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -73,7 +73,8 @@ class TestSimulationExperiment:
             temperature="-14oC",
         )
         model = pybamm.lithium_ion.SPM()
-        sim = pybamm.Simulation(model, experiment=experiment)
+        solver = pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8)
+        sim = pybamm.Simulation(model, experiment=experiment, solver=solver)
         # test the callback here
         sol = sim.solve(callbacks=pybamm.callbacks.Callback())
         assert sol.termination == "final time"


### PR DESCRIPTION
# Description

Removes a regularization factor of `1e-16` in the diffusion coefficient harmonic mean. I believe this term was included when pybamm still used normalized variables, but now it's unnecessary and causes noticeable error.

Minor things:
- Changes harmonic mean functional form to reduce the number of diffusion variables in codegen
- Reduces the size of a magic number in `FunctionParameter` from `1e-16` to `1e-300`

Fixes https://github.com/pybamm-team/PyBaMM/issues/4976

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
