### PR TITLE
Fix `QuickPlot` extrapolation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- Fixed a bug in the `QuickPlot` which would return empty values for 1D variables at the beginning and end of a timespan. 
+- Fixed a bug in the `QuickPlot` which would return empty values for 1D variables at the beginning and end of a timespan. ([#4991](https://github.com/pybamm-team/PyBaMM/pull/4991))
 - Fixed a bug in the `Exponential1DSubMesh` where the mesh was not being created correctly for non-zero minimum values. ([#4989](https://github.com/pybamm-team/PyBaMM/pull/4989))
 
 # [v25.4.2](https://github.com/pybamm-team/PyBaMM/tree/v25.4.2) - 2025-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- Fixed a bug in the `QuickPlot` which would return empty values for 1D variables at the beginning and end of a timespan. 
 - Fixed a bug in the `Exponential1DSubMesh` where the mesh was not being created correctly for non-zero minimum values. ([#4989](https://github.com/pybamm-team/PyBaMM/pull/4989))
 
 # [v25.4.2](https://github.com/pybamm-team/PyBaMM/tree/v25.4.2) - 2025-04-17

--- a/src/pybamm/plotting/quick_plot.py
+++ b/src/pybamm/plotting/quick_plot.py
@@ -717,6 +717,9 @@ class QuickPlot:
         from matplotlib import cm, colors
 
         time_in_seconds = t * self.time_scaling_factor
+        time_in_seconds = np.clip(
+            time_in_seconds, self.min_t_unscaled, self.max_t_unscaled
+        )
         for k, (key, plot) in enumerate(self.plots.items()):
             ax = self.axes[k]
             if self.variables[key][0][0].dimensions == 0:


### PR DESCRIPTION
# Description

Fixes an issue where updating the slider of a quickplot could produce `NaN` values at the beginning or end of a timespan due to slight extrapolation because of floating point arithmetic issues.

For example, try running this simulation and moving the slider to the final time:
```python
import pybamm

model = pybamm.lithium_ion.SPM()
parameter_values = pybamm.ParameterValues("Chen2020")
parameter_values.update({"Current function [A]": 0})

solver = pybamm.IDAKLUSolver()
sim = pybamm.Simulation(model, parameter_values=parameter_values, solver=solver)

tf = 3600.04

sol = sim.solve([0, tf])

# This breaks because of issues with floating point precision
# when we normalize and rescale the time
# tf < (tf / 3600.0) * 3600.0

sol.plot()
```

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
