### PR TITLE
Only warn about default solver change once

### DIFF
--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -12,6 +12,9 @@ import numpy as np
 import pybamm
 from pybamm.expression_tree.operations.serialise import Serialise
 
+# Only throw the default solver warning once
+warnings.filterwarnings("once", message="The default solver changed to IDAKLUSolver*")
+
 
 class BaseModel:
     """
@@ -418,8 +421,10 @@ class BaseModel:
         if len(self.rhs) == 0 and len(self.algebraic) != 0:
             return pybamm.CasadiAlgebraicSolver()
         else:
-            pybamm.logger.warning(
-                "The default solver changed to IDAKLUSolver after the v25.4.0. release. You can swap back to the previous default by using `pybamm.CasadiSolver()` instead."
+            warnings.warn(
+                "The default solver changed to IDAKLUSolver after the v25.4.0. release. "
+                "You can swap back to the previous default by using `pybamm.CasadiSolver()` instead.",
+                stacklevel=2,
             )
             return pybamm.IDAKLUSolver()
 


### PR DESCRIPTION
# Description

Previously, this was shown every time an ODE/DAE simulation was created. This made some doc examples look messy since they had numerous `Simulation` calls.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
