### PR TITLE
Add a solver option to change `on_extrapolation` behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Optimizations
 
+- Add a solver option to change `on_extrapolation` behavior to `"error"`, `"warn"`, or `"ignore"` on extrapolation events. ([#4993](https://github.com/pybamm-team/PyBaMM/pull/4993))
 - Improve reliability of `CasadiAlgebraicSolver` and added an option for the `step_tol` of the Newton iteration. ([#4985](https://github.com/pybamm-team/PyBaMM/pull/4985))
 
 ## Bug fixes

--- a/src/pybamm/solvers/casadi_solver.py
+++ b/src/pybamm/solvers/casadi_solver.py
@@ -46,6 +46,9 @@ class CasadiSolver(pybamm.BaseSolver):
         the default value is 600 seconds.
     extrap_tol : float, optional
         The tolerance to assert whether extrapolation occurs or not. Default is 0.
+    on_extrapolation : str, optional
+        What to do if the solver is extrapolating. Options are "warn", "error", or "ignore".
+        Default is "error".
     extra_options_setup : dict, optional
         Any options to pass to the CasADi integrator when creating the integrator.
         Please consult `CasADi documentation <https://web.casadi.org/python-api/#integrator>`_ for
@@ -81,19 +84,22 @@ class CasadiSolver(pybamm.BaseSolver):
         max_step_decrease_count=5,
         dt_max=None,
         extrap_tol=None,
+        on_extrapolation=None,
         extra_options_setup=None,
         extra_options_call=None,
         return_solution_if_failed_early=False,
         perturb_algebraic_initial_conditions=None,
         integrators_maxcount=100,
     ):
+        on_extrapolation = on_extrapolation or "error"
         super().__init__(
-            "problem dependent",
-            rtol,
-            atol,
-            root_method,
-            root_tol,
-            extrap_tol,
+            method="problem dependent",
+            rtol=rtol,
+            atol=atol,
+            root_method=root_method,
+            root_tol=root_tol,
+            extrap_tol=extrap_tol,
+            on_extrapolation=on_extrapolation,
         )
         if mode in ["safe", "fast", "fast with events", "safe without grid"]:
             self.mode = mode
@@ -109,8 +115,6 @@ class CasadiSolver(pybamm.BaseSolver):
         self.extra_options_setup = extra_options_setup or {}
         self.extra_options_call = extra_options_call or {}
         self.return_solution_if_failed_early = return_solution_if_failed_early
-
-        self._on_extrapolation = "error"
 
         # Decide whether to perturb algebraic initial conditions, True by default for
         # "safe" mode, False by default for other modes

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -51,6 +51,9 @@ class IDAKLUSolver(pybamm.BaseSolver):
         The tolerance for the initial-condition solver (default is 1e-6).
     extrap_tol : float, optional
         The tolerance to assert whether extrapolation occurs or not (default is 0).
+    on_extrapolation : str, optional
+        What to do if the solver is extrapolating. Options are "warn", "error", or "ignore".
+        Default is "warn".
     output_variables : list[str], optional
         List of variables to calculate and return. If none are specified then
         the complete state vector is returned (can be very large) (default is [])
@@ -163,6 +166,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
         root_method="casadi",
         root_tol=1e-6,
         extrap_tol=None,
+        on_extrapolation=None,
         output_variables=None,
         options=None,
     ):
@@ -219,13 +223,14 @@ class IDAKLUSolver(pybamm.BaseSolver):
         self.output_variables = [] if output_variables is None else output_variables
 
         super().__init__(
-            "ida",
-            rtol,
-            atol,
-            root_method,
-            root_tol,
-            extrap_tol,
-            output_variables,
+            method="ida",
+            rtol=rtol,
+            atol=atol,
+            root_method=root_method,
+            root_tol=root_tol,
+            extrap_tol=extrap_tol,
+            output_variables=output_variables,
+            on_extrapolation=on_extrapolation,
         )
         self.name = "IDA KLU solver"
         self._supports_interp = True

--- a/src/pybamm/solvers/jax_solver.py
+++ b/src/pybamm/solvers/jax_solver.py
@@ -39,6 +39,9 @@ class JaxSolver(pybamm.BaseSolver):
         The absolute tolerance for the solver (default is 1e-6).
     extrap_tol : float, optional
         The tolerance to assert whether extrapolation occurs or not (default is 0).
+    on_extrapolation : str, optional
+        What to do if the solver is extrapolating. Options are "warn", "error", or "ignore".
+        Default is "warn".
     extra_options : dict, optional
         Any options to pass to the solver.
         Please consult `JAX documentation
@@ -53,6 +56,7 @@ class JaxSolver(pybamm.BaseSolver):
         rtol=1e-6,
         atol=1e-6,
         extrap_tol=None,
+        on_extrapolation=None,
         extra_options=None,
     ):
         if not pybamm.has_jax():
@@ -63,7 +67,12 @@ class JaxSolver(pybamm.BaseSolver):
         # note: bdf solver itself calculates consistent initial conditions so can set
         # root_method to none, allow user to override this behavior
         super().__init__(
-            method, rtol, atol, root_method=root_method, extrap_tol=extrap_tol
+            method=method,
+            rtol=rtol,
+            atol=atol,
+            root_method=root_method,
+            extrap_tol=extrap_tol,
+            on_extrapolation=on_extrapolation,
         )
         method_options = ["RK45", "BDF"]
         if method not in method_options:

--- a/src/pybamm/solvers/scipy_solver.py
+++ b/src/pybamm/solvers/scipy_solver.py
@@ -21,6 +21,9 @@ class ScipySolver(pybamm.BaseSolver):
         The absolute tolerance for the solver (default is 1e-6).
     extrap_tol : float, optional
         The tolerance to assert whether extrapolation occurs or not (default is 0).
+    on_extrapolation : str, optional
+        What to do if the solver is extrapolating. Options are "warn", "error", or "ignore".
+        Default is "warn".
     extra_options : dict, optional
         Any options to pass to the solver.
         Please consult `SciPy documentation
@@ -34,6 +37,7 @@ class ScipySolver(pybamm.BaseSolver):
         rtol=1e-6,
         atol=1e-6,
         extrap_tol=None,
+        on_extrapolation=None,
         extra_options=None,
     ):
         super().__init__(
@@ -41,6 +45,7 @@ class ScipySolver(pybamm.BaseSolver):
             rtol=rtol,
             atol=atol,
             extrap_tol=extrap_tol,
+            on_extrapolation=on_extrapolation,
         )
         self._ode_solver = True
         self.extra_options = extra_options or {}

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -414,3 +414,21 @@ class TestBaseSolver:
             np.testing.assert_allclose(
                 sens_b, exact_diff_b(y, inputs["a"], inputs["b"])
             )
+
+    def test_on_extrapolation_settings(self):
+        # Test setting different on_extrapolation values on BaseSolver
+        base_solver = pybamm.BaseSolver()
+
+        # Test valid values
+        base_solver.on_extrapolation = "warn"
+        assert base_solver.on_extrapolation == "warn"
+        base_solver.on_extrapolation = "error"
+        assert base_solver.on_extrapolation == "error"
+        base_solver.on_extrapolation = "ignore"
+        assert base_solver.on_extrapolation == "ignore"
+
+        # Test invalid value
+        with pytest.raises(
+            ValueError, match="on_extrapolation must be 'warn', 'raise', or 'ignore'"
+        ):
+            base_solver.on_extrapolation = "invalid"

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -2,7 +2,7 @@ from contextlib import redirect_stdout
 import io
 import pytest
 import numpy as np
-
+import warnings
 import pybamm
 from scipy.sparse import eye
 from tests import get_discretisation_for_testing
@@ -1298,3 +1298,47 @@ class TestIDAKLUSolver:
         np.testing.assert_array_equal(solution.t, t_interp)
         np.testing.assert_allclose(solution.y[0], np.exp(0.1 * solution.t))
         np.testing.assert_allclose(solution.y[-1], 2 * np.exp(0.1 * solution.t))
+
+    def test_interpolant_extrapolate(self):
+        x = np.linspace(0, 2)
+        var = pybamm.Variable("var")
+        rhs = pybamm.FunctionParameter("func", {"var": var})
+
+        model = pybamm.BaseModel()
+        model.rhs[var] = rhs
+        model.initial_conditions[var] = pybamm.Scalar(1)
+
+        # Bug: we need to set the interpolant via parameter values for the extrapolation
+        # to be detected
+        def func(var):
+            return pybamm.Interpolant(x, x, var, interpolator="linear")
+
+        parameter_values = pybamm.ParameterValues({"func": func})
+        parameter_values.process_model(model)
+
+        # Test with on_extrapolation="error"
+        solver = pybamm.IDAKLUSolver(on_extrapolation="error")
+        t_eval = [0, 5]
+
+        with pytest.raises(pybamm.SolverError, match="interpolation bounds"):
+            solver.solve(model, t_eval)
+
+        # Test with on_extrapolation="warn"
+        solver = pybamm.IDAKLUSolver(on_extrapolation="warn")
+        t_eval = [0, 5]
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            solver.solve(model, t_eval)
+            assert len(w) > 0
+            assert "extrapolation occurred" in str(w[0].message)
+
+        # Test with on_extrapolation="ignore"
+        solver = pybamm.IDAKLUSolver(on_extrapolation="ignore")
+        t_eval = [0, 5]
+
+        # Should not raise an error or warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            solver.solve(model, t_eval)
+            assert len(w) == 0


### PR DESCRIPTION
# Description

Let's you enable `"error"`, `"warn"`, or `"ignore"` on extrapolation events.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
