### PR TITLE
perf: speed up time loop in processed var init sens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a solver option to change `on_extrapolation` behavior to `"error"`, `"warn"`, or `"ignore"` on extrapolation events. ([#4993](https://github.com/pybamm-team/PyBaMM/pull/4993))
 - Improve reliability of `CasadiAlgebraicSolver` and added an option for the `step_tol` of the Newton iteration. ([#4985](https://github.com/pybamm-team/PyBaMM/pull/4985))
+- Speed up calculation of variable sensitivities in `ProcessedVariable` ([#5000](https://github.com/pybamm-team/PyBaMM/pull/5000))
 
 ## Bug fixes
 

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -443,16 +443,18 @@ class ProcessedVariable:
             dvar_dp_func = casadi.Function(
                 "dvar_dp", [t_casadi, y_casadi, p_casadi_stacked], [dvar_dp]
             )
-            for idx, t in enumerate(ts):
-                u = ys[:, idx]
-                next_dvar_dy_eval = dvar_dy_func(t, u, inputs_stacked)
-                next_dvar_dp_eval = dvar_dp_func(t, u, inputs_stacked)
-                if idx == 0:
-                    dvar_dy_eval = next_dvar_dy_eval
-                    dvar_dp_eval = next_dvar_dp_eval
-                else:
-                    dvar_dy_eval = casadi.diagcat(dvar_dy_eval, next_dvar_dy_eval)
-                    dvar_dp_eval = casadi.vertcat(dvar_dp_eval, next_dvar_dp_eval)
+            dvar_dy_eval = casadi.diagcat(
+                *[
+                    dvar_dy_func(t, ys[:, idx], inputs_stacked)
+                    for idx, t in enumerate(ts)
+                ]
+            )
+            dvar_dp_eval = casadi.vertcat(
+                *[
+                    dvar_dp_func(t, ys[:, idx], inputs_stacked)
+                    for idx, t in enumerate(ts)
+                ]
+            )
 
             # Compute sensitivity
             S_var = dvar_dy_eval @ dy_dp + dvar_dp_eval


### PR DESCRIPTION
# Description

Speeds up initial sensitivitiy calculation in ProcessedVariable. The diagcat and vertcat is done once instead of every timestep

I did a simple test using the DFN model and one input paramter (current), before the change the timings were (over 10 runs)

```
(env-pybammsolvers) ➜  PyBaMM git:(develop) ✗ python test.py
Time taken to compute sensitivities: 0.05452 seconds
Time taken to compute sensitivities: 0.04619 seconds
Time taken to compute sensitivities: 0.04333 seconds
Time taken to compute sensitivities: 0.04116 seconds
Time taken to compute sensitivities: 0.04146 seconds
Time taken to compute sensitivities: 0.04142 seconds
Time taken to compute sensitivities: 0.04156 seconds
Time taken to compute sensitivities: 0.04135 seconds
Time taken to compute sensitivities: 0.04133 seconds
Time taken to compute sensitivities: 0.04186 seconds
```

After the change the timings were:

```
(env-pybammsolvers) ➜  PyBaMM git:(develop) ✗ python test.py
Time taken to compute sensitivities: 0.02355 seconds
Time taken to compute sensitivities: 0.02262 seconds
Time taken to compute sensitivities: 0.02266 seconds
Time taken to compute sensitivities: 0.02286 seconds
Time taken to compute sensitivities: 0.02309 seconds
Time taken to compute sensitivities: 0.02277 seconds
Time taken to compute sensitivities: 0.02158 seconds
Time taken to compute sensitivities: 0.01918 seconds
Time taken to compute sensitivities: 0.01988 seconds
Time taken to compute sensitivities: 0.02149 seconds
```

## Type of change



# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
