### PR TITLE
Add fallback version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,26 +86,14 @@ pyvenv.cfg
 
 # third party
 third-party
-
-# cmakefiles
-CMakeFiles
-Makefile
-cmake_install.cmake
 *.so
 
-third-party/pybind11
-pybind11/
-
-# Build dependencies/
-KLU_module_deps
-
-# setup
-setup.log
 
 # test
 test.c
 test.json
 .pytest_cache/
+.hypothesis
 
 # tox
 .tox/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ Chayambuka2022 = "pybamm.input.parameters.sodium_ion.Chayambuka2022:get_paramete
 
 [tool.hatch]
 version.source = "vcs"
+version.fallback-version = "0.0.0"
 build.targets.sdist.include = [
   "src/pybamm",
   "CITATION.cff",


### PR DESCRIPTION
# Description

I noticed in a different project that the hatch-vcs throws an error for builds outside of a git repo (such as downloading tarballs). This adds an invalid version number for any of those builds, but uses hatch-vcs if built from a git repo.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
