### PR TITLE
Remove flaky Jupyter link

### DIFF
--- a/docs/source/examples/notebooks/getting_started/tutorial-1-how-to-run-a-model.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-1-how-to-run-a-model.ipynb
@@ -15,8 +15,6 @@
    "source": [
     "Welcome to PyBaMM! In this notebook, we will run your first PyBaMM model in just a few simple lines. \n",
     "\n",
-    "To run through this jupyter notebook simply shift-enter to run the cells. If you are unfamiliar with Jupyter notebooks we recommend checking out this [cheat sheet](https://www.cheatography.com/weidadeyue/cheat-sheets/jupyter-notebook/pdf_bw/).\n",
-    "\n",
     "The first we need to do is to import PyBaMM, so we can use its capabilities. Note that the very first line is only needed in Google Colab."
    ]
   },
@@ -30,8 +28,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.3.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m A new release of pip is available: \u001B[0m\u001B[31;49m23.3.1\u001B[0m\u001B[39;49m -> \u001B[0m\u001B[32;49m23.3.2\u001B[0m\n",
+      "\u001B[1m[\u001B[0m\u001B[34;49mnotice\u001B[0m\u001B[1;39;49m]\u001B[0m\u001B[39;49m To update, run: \u001B[0m\u001B[32;49mpip install --upgrade pip\u001B[0m\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     },


### PR DESCRIPTION
# Description

This link frequently fails in the CI, and it just tells people how to run Jupyter notebooks

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
