### PR TITLE
Fix docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,8 @@ name: Build and push Docker images to Docker Hub
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - develop
+  release:
+    types: [published]
 
 permissions: {}
 
@@ -45,7 +44,7 @@ jobs:
           file: scripts/Dockerfile
           tags: pybamm/pybamm:latest
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           no-cache: true
 
       - name: List built image(s)


### PR DESCRIPTION
# Description

Changes:
- Docker images are built on release instead of each time a PR is merged
- Linux ARM64 images are disabled for now

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
