### PR TITLE
Update numpy to 2.0

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
         python-version: ["3.10", "3.11", "3.12"]
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12"]
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get install libopenblas-dev texlive-latex-extra dvipng
 
       - name: Install macOS system dependencies
-        if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+        if: matrix.os == 'macos-13' || matrix.os == 'macos-latest'
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "pybammsolvers",
-    "numpy>=1.23.5,<2.0.0",
+    "numpy>2.0.0",
     "scipy>=1.11.4",
     "casadi==3.6.7",
     "xarray>=2022.6.0",

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1470,7 +1470,7 @@ class BaseSolver:
 
     def get_platform_context(self, system_type: str):
         # Set context for parallel processing depending on the platform
-        if system_type.lower() in ["linux", "darwin"]:
+        if system_type.lower() in ["linux"]:
             return "fork"
         return "spawn"
 

--- a/src/pybamm/solvers/scipy_solver.py
+++ b/src/pybamm/solvers/scipy_solver.py
@@ -130,8 +130,8 @@ class ScipySolver(pybamm.BaseSolver):
         timer = pybamm.Timer()
         sol = it.solve_ivp(
             rhs,
-            (t_eval[0], t_eval[-1]),
-            y0,
+            t_span=(t_eval[0], t_eval[-1]),
+            y0=y0,
             t_eval=t_eval,
             method=self.method,
             dense_output=True,

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -368,7 +368,7 @@ class TestBaseSolver:
         solver = pybamm.BaseSolver()
         assert solver.get_platform_context("Win") == "spawn"
         assert solver.get_platform_context("Linux") == "fork"
-        assert solver.get_platform_context("Darwin") == "fork"
+        assert solver.get_platform_context("Darwin") == "spawn"
 
     def test_sensitivities(self):
         def exact_diff_a(y, a, b):

--- a/tests/unit/test_solvers/test_jax_solver.py
+++ b/tests/unit/test_solvers/test_jax_solver.py
@@ -245,3 +245,31 @@ class TestJaxSolver:
                 model, t_eval, inputs={"rate": 0.1}, calculate_sensitivities=True
             )
             assert len(solution_sens.sensitivities) == 0
+
+    def test_model_solver_multiple_inputs_jax_format(self, subtests):
+        # Create model
+        model = pybamm.BaseModel()
+        model.convert_to_format = "jax"
+        domain = ["negative electrode", "separator", "positive electrode"]
+        var = pybamm.Variable("var", domain=domain)
+        model.rhs = {var: -pybamm.InputParameter("rate") * var}
+        model.initial_conditions = {var: 1}
+        # create discretisation
+        mesh = get_mesh_for_testing()
+        spatial_methods = {"macroscale": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        disc.process_model(model)
+
+        solver = pybamm.JaxSolver(rtol=1e-8, atol=1e-8, method="RK45")
+        t_eval = np.linspace(0, 10, 100)
+        ninputs = 8
+        inputs_list = [{"rate": 0.01 * (i + 1)} for i in range(ninputs)]
+
+        solutions = solver.solve(model, t_eval, inputs=inputs_list, nproc=2)
+        for i in range(ninputs):
+            with subtests.test(i=i):
+                solution = solutions[i]
+                np.testing.assert_array_equal(solution.t, t_eval)
+                np.testing.assert_allclose(
+                    solution.y[0], np.exp(-0.01 * (i + 1) * solution.t)
+                )

--- a/tests/unit/test_solvers/test_scipy_solver.py
+++ b/tests/unit/test_solvers/test_scipy_solver.py
@@ -360,35 +360,6 @@ class TestScipySolver:
         ):
             solver.solve(model, t_eval, inputs=inputs_list, nproc=2)
 
-    def test_model_solver_multiple_inputs_jax_format(self, subtests):
-        if pybamm.has_jax():
-            # Create model
-            model = pybamm.BaseModel()
-            model.convert_to_format = "jax"
-            domain = ["negative electrode", "separator", "positive electrode"]
-            var = pybamm.Variable("var", domain=domain)
-            model.rhs = {var: -pybamm.InputParameter("rate") * var}
-            model.initial_conditions = {var: 1}
-            # create discretisation
-            mesh = get_mesh_for_testing()
-            spatial_methods = {"macroscale": pybamm.FiniteVolume()}
-            disc = pybamm.Discretisation(mesh, spatial_methods)
-            disc.process_model(model)
-
-            solver = pybamm.JaxSolver(rtol=1e-8, atol=1e-8, method="RK45")
-            t_eval = np.linspace(0, 10, 100)
-            ninputs = 8
-            inputs_list = [{"rate": 0.01 * (i + 1)} for i in range(ninputs)]
-
-            solutions = solver.solve(model, t_eval, inputs=inputs_list, nproc=2)
-            for i in range(ninputs):
-                with subtests.test(i=i):
-                    solution = solutions[i]
-                    np.testing.assert_array_equal(solution.t, t_eval)
-                    np.testing.assert_allclose(
-                        solution.y[0], np.exp(-0.01 * (i + 1) * solution.t)
-                    )
-
     def test_model_solver_with_event_with_casadi(self):
         # Create model
         model = pybamm.BaseModel()


### PR DESCRIPTION
# Description

This should allow us to use `numpy>2.0.0` with PyBaMM.

Note: As far as I know everything in here still works with `numpy<2.0.0`, however, we probably don't want to continue maintaining compatibility with older versions. When I attempted this the first time, I had to make a few code changes for some numpy versions between 2.0.0 and 2.10.0, but those issues seem to be gone now

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
