### PR TITLE
Drive cycle: infer `duration` from data by default + fix `period` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Features
 
+- Drive cycle durations are now automatically inferred from the final time of the drive cycle data by default instead of requiring `duration` as an argument. ([#5090](https://github.com/pybamm-team/PyBaMM/pull/5090))
 - Added a `Constant` symbol for named constants. This is a subclass of `Scalar` and is used to represent named constants such as the gas constant. This avoids constants being simplified out when constructing expressions. ([#5070](https://github.com/pybamm-team/PyBaMM/pull/5070))
 - Generalise `pybamm.DiscreteTimeSum` to allow it to be embedded in other expressions ([#5044](https://github.com/pybamm-team/PyBaMM/pull/5044))
 - Adds `all` key-value pair to `output_variables` sensitivity dictionaries, accessible through `solution[var].sensitivities['all']`. Aligns shape with conventional solution sensitivities object. ([#5067](https://github.com/pybamm-team/PyBaMM/pull/5067))
 
 ## Bug fixes
 
+- Fixed a bug preventing custom periods for drive cycles. ([#5090](https://github.com/pybamm-team/PyBaMM/pull/5090))
 - Converts sensitivities to numpy objects, fixing bug in `DiscreteTimeSum` sensitivity calculation ([#5037](https://github.com/pybamm-team/PyBaMM/pull/5037))
 - Raises error if `pybamm.Interpolant` given 1D x values that are not strictly increasing ([#5061](https://github.com/pybamm-team/PyBaMM/pull/5061))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## Features
 
-- Drive cycle durations are now automatically inferred from the final time of the drive cycle data by default instead of requiring `duration` as an argument. ([#5090](https://github.com/pybamm-team/PyBaMM/pull/5090))
 - Added a `Constant` symbol for named constants. This is a subclass of `Scalar` and is used to represent named constants such as the gas constant. This avoids constants being simplified out when constructing expressions. ([#5070](https://github.com/pybamm-team/PyBaMM/pull/5070))
 - Generalise `pybamm.DiscreteTimeSum` to allow it to be embedded in other expressions ([#5044](https://github.com/pybamm-team/PyBaMM/pull/5044))
 - Adds `all` key-value pair to `output_variables` sensitivity dictionaries, accessible through `solution[var].sensitivities['all']`. Aligns shape with conventional solution sensitivities object. ([#5067](https://github.com/pybamm-team/PyBaMM/pull/5067))
 
 ## Bug fixes
 
-- Fixed a bug preventing custom periods for drive cycles. ([#5090](https://github.com/pybamm-team/PyBaMM/pull/5090))
+- Fixed a bug that ignored the default duration of drive cycles for `CRate` steps and a bug that overwrote custom `period` arguments for drive cycles. ([#5090](https://github.com/pybamm-team/PyBaMM/pull/5090))
 - Converts sensitivities to numpy objects, fixing bug in `DiscreteTimeSum` sensitivity calculation ([#5037](https://github.com/pybamm-team/PyBaMM/pull/5037))
 - Raises error if `pybamm.Interpolant` given 1D x values that are not strictly increasing ([#5061](https://github.com/pybamm-team/PyBaMM/pull/5061))
 

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -149,7 +149,12 @@ class BaseStep:
                 pybamm.t - pybamm.InputParameter("start time"),
                 name="Drive Cycle",
             )
-            self.period = np.diff(t).min()
+            if period is None:
+                # Infer the period from the drive cycle
+                self.period = np.diff(t).min()
+            else:
+                self.period = _convert_time_to_seconds(period)
+
         elif is_python_function:
             t = pybamm.t - pybamm.InputParameter("start time")
             self.value = value(t)

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -99,8 +99,6 @@ class BaseStep:
             t = value[:, 0]
             if t[0] != 0:
                 raise ValueError("Drive cycle must start at t=0")
-            if duration is None:
-                duration = t[-1]
         elif is_python_function:
             t0 = 0
             # Check if the function is only a function of t
@@ -279,6 +277,12 @@ class BaseStep:
     def __hash__(self):
         return hash(self.basic_repr())
 
+    def _default_timespan(self, value):
+        """
+        Default timespan for the step is one day (24 hours).
+        """
+        return 24 * 3600
+
     def default_duration(self, value):
         """
         Default duration for the step is one day (24 hours) or the duration of the
@@ -288,7 +292,7 @@ class BaseStep:
             t = value[:, 0]
             return t[-1]
         else:
-            return 24 * 3600  # one day in seconds
+            return self._default_timespan(value)
 
     @staticmethod
     def default_period():

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -99,6 +99,8 @@ class BaseStep:
             t = value[:, 0]
             if t[0] != 0:
                 raise ValueError("Drive cycle must start at t=0")
+            if duration is None:
+                duration = t[-1]
         elif is_python_function:
             t0 = 0
             # Check if the function is only a function of t

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -157,7 +157,7 @@ class CRate(BaseStepExplicit):
     def current_value(self, variables):
         return self.value * pybamm.Parameter("Nominal cell capacity [A.h]")
 
-    def default_duration(self, value):
+    def _default_timespan(self, value):
         # "value" is C-rate, so duration is "1 / value" hours in seconds
         # with a 2x safety factor
         return 1 / abs(value) * 3600 * 2

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -228,6 +228,20 @@ class TestExperimentSteps:
         assert drive_cycle_step.period == 1
         assert drive_cycle_step.temperature == 273.15 - 5
 
+        # Check that the default duration is the length of the drive cycle
+        drive_cycle_step_no_duration = pybamm.step.current(drive_cycle)
+        assert drive_cycle_step_no_duration.duration == 9
+
+    def test_drive_cycle_period(self):
+        # Import drive cycle from file
+        drive_cycle = np.array([np.arange(10), np.arange(10)]).T
+
+        drive_cycle_step = pybamm.step.current(drive_cycle, period=0.01)
+        assert drive_cycle_step.period == 0.01
+
+        drive_cycle_step_no_period = pybamm.step.current(drive_cycle)
+        assert drive_cycle_step_no_period.period == 1
+
     def test_bad_strings(self):
         with pytest.raises(TypeError, match="Input to step.string"):
             pybamm.step.string(1)

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -228,9 +228,9 @@ class TestExperimentSteps:
         assert drive_cycle_step.period == 1
         assert drive_cycle_step.temperature == 273.15 - 5
 
-        # Check that the default duration is the length of the drive cycle
-        drive_cycle_step_no_duration = pybamm.step.current(drive_cycle)
-        assert drive_cycle_step_no_duration.duration == 9
+        # Check that the default c_rate duration is the length of the drive cycle
+        drive_cycle_step_c_rate = pybamm.step.c_rate(drive_cycle)
+        assert drive_cycle_step_c_rate.duration == 9
 
     def test_drive_cycle_period(self):
         # Import drive cycle from file

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -9,7 +9,7 @@ import pybamm
 
 
 class ShortDurationCRate(pybamm.step.CRate):
-    def default_duration(self, value):
+    def _default_timespan(self, value):
         # Set a short default duration for testing early stopping due to infeasible time
         return 1
 


### PR DESCRIPTION
# Description

Fixes a bug that ignored the default duration of drive cycles for `CRate` steps and a bug that overwrote custom `period` arguments for drive cycles.

Fixes https://github.com/pybamm-team/PyBaMM/issues/5086 and https://github.com/pybamm-team/PyBaMM/issues/5087

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
