### PR TITLE
Remove setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,7 @@ plot = [
     "matplotlib>=3.6.0",
 ]
 cite = [
-    "setuptools", # Fix for a pybtex issue
-    "pybtex>=0.24.0",
+    "pybtex>=0.25.0",
 ]
 # Battery Parameter eXchange format
 bpx = [


### PR DESCRIPTION
# Description

Updates the version of pybtex and removes the direct setuptools dependency

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
