### PR TITLE
bug: enforce sensitivity shape consistency

### DIFF
--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -480,7 +480,10 @@ class ProcessedVariable(BaseProcessedVariable):
         start = 0
         for name, inp in self.all_inputs[0].items():
             end = start + inp.shape[0]
-            sensitivities[name] = S_var[:, start:end]
+            if end - start == 1:
+                sensitivities[name] = S_var[:, start:end].reshape(-1)
+            else:
+                sensitivities[name] = S_var[:, start:end]
             start = end
 
         # Save attribute

--- a/src/pybamm/solvers/processed_variable_time_integral.py
+++ b/src/pybamm/solvers/processed_variable_time_integral.py
@@ -36,11 +36,12 @@ class ProcessedVariableTimeIntegral:
         """
         the_integral = self.postfix_sum(entries, t_pts)
         if self.post_sum_node is None:
-            return the_integral
+            ret = the_integral
         elif self.post_sum is None:
-            return self.post_sum_node.evaluate(0.0, the_integral, inputs)
+            ret = self.post_sum_node.evaluate(0.0, the_integral, inputs).reshape(-1)
         else:
-            return self.post_sum(0.0, the_integral, inputs).full()
+            ret = self.post_sum(0.0, the_integral, inputs).full().reshape(-1)
+        return ret
 
     def postfix_sensitivities(
         self,

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -587,6 +587,7 @@ class TestSolution:
                 sol["data_comparison"](), expected, rtol=1e-3, atol=1e-2
             )
             assert isinstance(sol["data_comparison"].data, np.ndarray)
+            assert sol["data_comparison"].data.shape == (1,)
 
             # sensitivity calculation only supported for IDAKLUSolver
             if solver_class == pybamm.IDAKLUSolver:
@@ -633,6 +634,7 @@ class TestSolution:
                     atol=1e-2,
                 )
                 assert isinstance(sol["data_comparison"].sensitivities["a"], np.ndarray)
+                assert sol["data_comparison"].sensitivities["a"].shape == (1,)
 
                 # should raise error if t_interp is not equal to data_times
                 with pytest.raises(


### PR DESCRIPTION
# Description

This fixes an inconsistency in the shape of the value and sensitivities of a discrete time sum or explicit time integral depending on if output_variables was set or not

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
