### PR TITLE
Remove failing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,8 +374,8 @@ PyBaMM is documented in several ways.
 
 First and foremost, every method and every class should have a [docstring](https://www.python.org/dev/peps/pep-0257/) that describes in plain terms what it does, and what the expected input and output is.
 
-These docstrings can be fairly simple, but can also make use of 
-`reStructuredText`, a markup language designed specifically for writing 
+These docstrings can be fairly simple, but can also make use of
+`reStructuredText`, a markup language designed specifically for writing
 technical documentation. For example, you can link to other classes and methods
 by writing ``:class:`pybamm.Model` `` and ``:meth:`run()` ``.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,7 +374,10 @@ PyBaMM is documented in several ways.
 
 First and foremost, every method and every class should have a [docstring](https://www.python.org/dev/peps/pep-0257/) that describes in plain terms what it does, and what the expected input and output is.
 
-These docstrings can be fairly simple, but can also make use of [reStructuredText](http://docutils.sourceforge.net/docs/user/rst/quickref.html), a markup language designed specifically for writing [technical documentation](https://en.wikipedia.org/wiki/ReStructuredText). For example, you can link to other classes and methods by writing ``:class:`pybamm.Model` `` and ``:meth:`run()` ``.
+These docstrings can be fairly simple, but can also make use of 
+`reStructuredText`, a markup language designed specifically for writing 
+technical documentation. For example, you can link to other classes and methods
+by writing ``:class:`pybamm.Model` `` and ``:meth:`run()` ``.
 
 In addition, we write a (very) small bit of documentation in separate reStructuredText files in the `docs` directory. Most of what these files do is simply import docstrings from the source code. But they also do things like add tables and indexes. If you've added a new class to a module, search the `docs` directory for that module's `.rst` file and add your class (in alphabetical order) to its index. If you've added a whole new module, copy-paste another module's file and add a link to your new file in the appropriate `index.rst` file.
 


### PR DESCRIPTION
# Description

The restructured text guide links have been failing in ReadTheDocs. I think our users can look up documentation on it without wikipedia or a direct guide, so it should be fine to remove this link

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
