### PR TITLE
Override boundary value and provide constant extrapolation

### DIFF
--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -1043,10 +1043,14 @@ class BoundaryValue(BoundaryOperator):
         The variable whose boundary value to take
     side : str
         Which side to take the boundary value on ("left" or "right")
+    order : str, None
+        The order of the boundary gradient. If None, the order is determined by the
+        spatial method. Can be "constant", "linear" or "quadratic".
     """
 
-    def __init__(self, child, side):
+    def __init__(self, child, side, order=None):
         super().__init__("boundary value", child, side)
+        self.order = order
 
     def _unary_new_copy(self, child, perform_simplifications: bool = True):
         """
@@ -1056,9 +1060,9 @@ class BoundaryValue(BoundaryOperator):
         creating a BoundaryValue object.
         """
         if perform_simplifications:
-            return boundary_value(child, self.side)
+            return boundary_value(child, self.side, self.order)
         else:
-            return BoundaryValue(child, self.side)
+            return BoundaryValue(child, self.side, self.order)
 
     def _sympy_operator(self, child):
         """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
@@ -1126,10 +1130,14 @@ class BoundaryGradient(BoundaryOperator):
         The variable whose boundary flux to take
     side : str
         Which side to take the boundary flux on ("left" or "right")
+    order : str, None
+        The order of the boundary gradient. If None, the order is determined by the
+        spatial method. Can be "constant", "linear" or "quadratic".
     """
 
-    def __init__(self, child, side):
+    def __init__(self, child, side, order=None):
         super().__init__("boundary flux", child, side)
+        self.order = order
 
 
 class EvaluateAt(SpatialOperator):
@@ -1400,7 +1408,7 @@ def surf(symbol):
     return boundary_value(symbol, "right")
 
 
-def boundary_value(symbol, side):
+def boundary_value(symbol, side, order=None):
     """
     convenience function for creating a :class:`pybamm.BoundaryValue`
 
@@ -1439,15 +1447,15 @@ def boundary_value(symbol, side):
         return pybamm.PrimaryBroadcast(boundary_child, symbol.secondary_domain)
     # Otherwise, calculate boundary value
     else:
-        return BoundaryValue(symbol, side)
+        return BoundaryValue(symbol, side, order)
 
 
-def boundary_gradient(symbol, side):
+def boundary_gradient(symbol, side, order=None):
     # Gradient of a broadcast is zero
     if isinstance(symbol, pybamm.Broadcast):
         return 0 * symbol.reduce_one_dimension()
     else:
-        return BoundaryGradient(symbol, side)
+        return BoundaryGradient(symbol, side, order)
 
 
 def sign(symbol):

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -868,8 +868,12 @@ class FiniteVolume(pybamm.SpatialMethod):
         if bcs is None:
             bcs = {}
 
-        extrap_order_gradient = self.options["extrapolation"]["order"]["gradient"]
-        extrap_order_value = self.options["extrapolation"]["order"]["value"]
+        extrap_order_gradient = (
+            symbol.order or self.options["extrapolation"]["order"]["gradient"]
+        )
+        extrap_order_value = (
+            symbol.order or self.options["extrapolation"]["order"]["value"]
+        )
         use_bcs = self.options["extrapolation"]["use bcs"]
 
         nodes = submesh.nodes

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -957,6 +957,14 @@ class FiniteVolume(pybamm.SpatialMethod):
                         additive_multiplicative = pybamm.Scalar(1)
                         multiplicative = pybamm.Scalar(1)
 
+                elif extrap_order_value == "constant":
+                    sub_matrix = csr_matrix(
+                        ([1], ([0], [0])),
+                        shape=(1, prim_pts),
+                    )
+                    additive = pybamm.Scalar(0)
+                    additive_multiplicative = pybamm.Scalar(1)
+                    multiplicative = pybamm.Scalar(1)
                 else:
                     raise NotImplementedError
 
@@ -1027,6 +1035,14 @@ class FiniteVolume(pybamm.SpatialMethod):
                         additive = pybamm.Scalar(0)
                         additive_multiplicative = pybamm.Scalar(1)
                         multiplicative = pybamm.Scalar(1)
+                elif extrap_order_value == "constant":
+                    sub_matrix = csr_matrix(
+                        ([1], ([0], [prim_pts - 1])),
+                        shape=(1, prim_pts),
+                    )
+                    additive = pybamm.Scalar(0)
+                    additive_multiplicative = pybamm.Scalar(1)
+                    multiplicative = pybamm.Scalar(1)
                 else:
                     raise NotImplementedError
 

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -86,6 +86,39 @@ def get_errors(
 
 
 class TestExtrapolation:
+    def test_constant_extrapolation(self):
+        linear = {
+            "extrapolation": {"order": {"gradient": "linear", "value": "constant"}}
+        }
+
+        geometry = {"domain": {"x": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}}}
+        submesh_types = {"domain": pybamm.Uniform1DSubMesh}
+        var_pts = {"x": 10}
+        mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
+
+        spatial_methods_linear = {"domain": pybamm.FiniteVolume(linear)}
+
+        disc_linear = pybamm.Discretisation(mesh, spatial_methods_linear)
+
+        var = pybamm.Variable("var", domain="domain")
+        left_extrap_linear = pybamm.BoundaryValue(var, "left")
+        right_extrap_linear = pybamm.BoundaryValue(var, "right")
+
+        disc_linear.set_variable_slices([var])
+
+        submesh = mesh["domain"]
+        y = submesh.nodes
+
+        left_extrap_linear_disc = disc_linear.process_symbol(left_extrap_linear)
+        right_extrap_linear_disc = disc_linear.process_symbol(right_extrap_linear)
+
+        np.testing.assert_allclose(
+            left_extrap_linear_disc.evaluate(None, y), y[0], rtol=1e-7, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            right_extrap_linear_disc.evaluate(None, y), y[-1], rtol=1e-7, atol=1e-6
+        )
+
     def test_order_override(self):
         linear = {"extrapolation": {"order": {"gradient": "linear", "value": "linear"}}}
 

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_extrapolation.py
@@ -86,6 +86,29 @@ def get_errors(
 
 
 class TestExtrapolation:
+    def test_order_override(self):
+        linear = {"extrapolation": {"order": {"gradient": "linear", "value": "linear"}}}
+
+        geometry = {"domain": {"x": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}}}
+        submesh_types = {"domain": pybamm.Uniform1DSubMesh}
+        var_pts = {"x": 10}
+        mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
+
+        spatial_methods_linear = {"domain": pybamm.FiniteVolume(linear)}
+
+        disc_linear = pybamm.Discretisation(mesh, spatial_methods_linear)
+
+        var = pybamm.Variable("var", domain="domain")
+        left_extrap_cubic = pybamm.BoundaryValue(var, "left", order="cubic")
+        left_grad_cubic = pybamm.BoundaryGradient(var, "left", order="cubic")
+
+        disc_linear.set_variable_slices([var])
+
+        with pytest.raises(NotImplementedError):
+            disc_linear.process_symbol(left_extrap_cubic)
+        with pytest.raises(NotImplementedError):
+            disc_linear.process_symbol(left_grad_cubic)
+
     def test_raises_error_for_high_order_extrapolation(self):
         value_cubic = {
             "extrapolation": {"order": {"gradient": "linear", "value": "cubic"}}


### PR DESCRIPTION
# Description

Allows for constant extrapolation of boundary values (i.e. using the value of the last node) and allows the user to override the spatial method's extrapolation method. This is useful for geometric input parameters, if one wants to calculate the harmonic mean of the diffusivity at the interface. A follow up PR (separating because they are pretty unrelated) will finish this capability by creating a node in the expression tree to retrieve the mesh size at the boundary.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
