### PR TITLE
Adds `on_failure` argument for IDAKLU failure behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
 ## Features
+- Adds `on_failure` option to `BaseSolver` with options for `"warn"`, `"ignore"`, and `"raise"` to change behaviour on solver failure. Defaults to "raise" to retain historic functionality.
 - Creates a boundary mesh size object that returns the distance from the center of the leftmost/rightmost control volume to the boundary of the domain ([#5108](https://github.com/pybamm-team/PyBaMM/pull/5108))
 - Introduced entry points for models, similar to parameter sets, and moved entry point handling to `pybamm.dispatch.entry_points`. There is now experimental support for loading third-party models outside of the PyBaMM framework via `pybamm.Model("model_name")`. This API is currently unstable until further notice and may be subject to change without warning. ([#4490](https://github.com/pybamm-team/PyBaMM/pull/4490))
 - Allow for overriding the spatial method's extrapolation and for using constant extrapolation of boundary values ([#5107](https://github.com/pybamm-team/PyBaMM/pull/5107))

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -42,6 +42,9 @@ class BaseSolver:
     on_extrapolation : str, optional
         What to do if the solver is extrapolating. Options are "warn", "error", or "ignore".
         Default is "warn".
+    on_failure : str, optional
+        What to do if a solver error flag occurs. Options are "warn", "error", or "ignore".
+        Default is "raise".
     """
 
     def __init__(
@@ -53,6 +56,7 @@ class BaseSolver:
         root_tol=1e-6,
         extrap_tol=None,
         on_extrapolation=None,
+        on_failure=None,
         output_variables=None,
     ):
         self.method = method
@@ -62,7 +66,8 @@ class BaseSolver:
         self.root_method = root_method
         self.extrap_tol = extrap_tol or -1e-10
         self.output_variables = [] if output_variables is None else output_variables
-        self.on_extrapolation = on_extrapolation or "warn"
+        self._on_extrapolation = on_extrapolation or "warn"
+        self._on_failure = on_failure or "raise"
         self._model_set_up = {}
 
         # Defaults, can be overwritten by specific solver
@@ -98,6 +103,16 @@ class BaseSolver:
         if value not in ["warn", "error", "ignore"]:
             raise ValueError("on_extrapolation must be 'warn', 'raise', or 'ignore'")
         self._on_extrapolation = value
+
+    @property
+    def on_failure(self):
+        return self._on_failure
+
+    @on_failure.setter
+    def on_failure(self, value):
+        if value not in ["warn", "error", "ignore"]:
+            raise ValueError("on_failure must be 'warn', 'raise', or 'ignore'")
+        self._on_failure = value
 
     @property
     def root_method(self):

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -930,8 +930,9 @@ class BaseSolver:
         solve_time = timer.time()
 
         for i, solution in enumerate(solutions):
-            # Check if extrapolation occurred
+            # Check if extrapolation or failure occurred
             self.check_extrapolation(solution, model.events)
+            solution = self._check_failure(solution)
             # Identify the event that caused termination and update the solution to
             # include the event time and state
             solutions[i], termination = self.get_termination_reason(
@@ -1364,6 +1365,11 @@ class BaseSolver:
                 solution,
                 "the solver successfully reached the end of the integration interval",
             )
+        if solution.termination == "failure":
+            return (
+                solution,
+                "the solver failed to reach end of the integration interval",
+            )
 
         # solution.termination == "event":
         pybamm.logger.debug("Start post-processing events")
@@ -1481,6 +1487,19 @@ class BaseSolver:
                 pybamm.SolverWarning,
                 stacklevel=2,
             )
+
+    def _check_failure(
+        self, solution: pybamm.Solution
+    ) -> pybamm.Solution | pybamm.EmptySolution:
+        """Checks if a solution failed to converge and return either the solution or an EmptySolution"""
+        if solution.termination != "failure":
+            return solution
+
+        match self._on_failure:
+            case "ignore":
+                return pybamm.EmptySolution(termination="failure")
+            case _:
+                return solution
 
     def _check_empty_model(self, model):
         # Make sure model isn't empty

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -881,6 +881,9 @@ class Solution:
 class EmptySolution:
     def __init__(self, termination=None, t=None):
         self.termination = termination
+        self.integration_time = 0
+        self.total_time = 0
+        self.all_ts = [0, 0]
         if t is None:
             t = np.array([0])
         elif isinstance(t, numbers.Number):

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -1205,3 +1205,47 @@ class TestIDAKLUSolver:
             warnings.simplefilter("always")
             solver.solve(model, t_eval)
             assert len(w) == 0
+
+    def test_on_failure_option(self):
+        input_parameters = {"Positive electrode active material volume fraction": 0.01}
+        t_eval = [0, 100]
+        t_interp = np.linspace(t_eval[0], t_eval[-1], 10)
+
+        model = pybamm.lithium_ion.DFN()
+        model.events = []  # Requires events to be off
+        geometry = model.default_geometry
+        param = model.default_parameter_values
+        param.update({key: "[input]" for key in input_parameters})
+        param.process_model(model)
+        param.process_geometry(geometry)
+        mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+        disc = pybamm.Discretisation(
+            mesh,
+            model.default_spatial_methods,
+            remove_independent_variables_from_rhs=True,
+        )
+        disc.process_model(model)
+
+        # Test default "raise"
+        solver = pybamm.IDAKLUSolver()
+        with pytest.raises(pybamm.SolverError):
+            solver.solve(
+                model, t_eval=t_eval, t_interp=t_interp, inputs=input_parameters
+            )
+
+        # Test "ignore"
+        solver = pybamm.IDAKLUSolver(on_failure="ignore")
+        sol = solver.solve(
+            model, t_eval=t_eval, t_interp=t_interp, inputs=input_parameters
+        )
+        assert isinstance(sol, pybamm.EmptySolution)
+
+        # Test "warn"
+        solver = pybamm.IDAKLUSolver(on_failure="warn")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            solver.solve(
+                model, t_eval=t_eval, t_interp=t_interp, inputs=input_parameters
+            )
+            assert len(w) > 0
+            assert "FAILURE" in str(w[0].message)


### PR DESCRIPTION
# Description

Adds "on_failure" option to `BaseSolver` for changing behaviour in the event that the IDAKLU fails. This implementation aligns with the `on_extrapolation` argument. The default is set to "raise" as that matches current behaviour.

- `"raise"`: raises a `Pybamm.SolverError`
- `"warn"`: throws a warning for the `Pybamm.SolverError` and returns a partial solution
- `"ignore"`: returns an `Pybamm.EmptySolution` object

Fixes #5105 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
