### PR TITLE
Allow geometric input parameters with concatenation variables

### DIFF
--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -388,7 +388,7 @@ class KroneckerProduct(BinaryOperator):
 
     def _binary_evaluate(self, left, right):
         """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
-        if issparse(left) and issparse(right):
+        if issparse(left) or issparse(right):
             return kron(left, right)
         else:
             return np.kron(left, right)

--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -381,20 +381,7 @@ class KroneckerProduct(BinaryOperator):
 
     def _binary_jac(self, left_jac, right_jac):
         """See :meth:`pybamm.BinaryOperator._binary_jac()`."""
-        left, right = self.orphans
-        if left.is_constant():
-            return pybamm.KroneckerProduct(left, right_jac)
-        elif right.is_constant():
-            return pybamm.KroneckerProduct(left_jac, right)
-        elif left.is_constant() and right.is_constant():
-            m, n = left.shape
-            o, p = right.shape
-            _, v = left_jac.shape
-            return pybamm.Matrix(csr_matrix([], shape=(m * o, n * p)))
-        else:
-            raise NotImplementedError(
-                "jac of 'KroneckerProduct' is only implemented if left or right is constant"
-            )
+        raise NotImplementedError
 
     def _binary_evaluate(self, left, right):
         """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""

--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -8,6 +8,7 @@ import numbers
 from collections.abc import Callable
 from typing import cast
 
+import casadi
 import numpy as np
 import numpy.typing as npt
 import sympy
@@ -476,9 +477,11 @@ class Division(BinaryOperator):
 
     def _binary_evaluate(self, left, right):
         """See :meth:`pybamm.BinaryOperator._binary_evaluate()`."""
-
         if issparse(left):
             return csr_matrix(left.multiply(1 / right))
+        # casadi oversimplifies division of sparse matrices
+        elif isinstance(right, casadi.casadi.MX):
+            return left * (1 / right)
         else:
             return left / right
 

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -86,6 +86,8 @@ class CasadiConverter:
                 return casadi.fmin(converted_left, converted_right)
             if isinstance(symbol, pybamm.Maximum):
                 return casadi.fmax(converted_left, converted_right)
+            if isinstance(symbol, pybamm.KroneckerProduct):
+                return casadi.kron(converted_left, converted_right)
 
             # _binary_evaluate defined in derived classes for specific rules
             return symbol._binary_evaluate(converted_left, converted_right)

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -94,6 +94,8 @@ class CasadiConverter:
 
         elif isinstance(symbol, pybamm.UnaryOperator):
             converted_child = self.convert(symbol.child, t, y, y_dot, inputs)
+            if isinstance(symbol, pybamm.Transpose):
+                return converted_child.T
             if isinstance(symbol, pybamm.AbsoluteValue):
                 return casadi.fabs(converted_child)
             if isinstance(symbol, pybamm.Floor):

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -203,6 +203,40 @@ class AbsoluteValue(UnaryOperator):
             return AbsoluteValue(child)
 
 
+class Transpose(UnaryOperator):
+    """
+    A node in the expression tree representing an `abs` operator.
+    """
+
+    def __init__(self, child):
+        """See :meth:`pybamm.UnaryOperator.__init__()`."""
+        super().__init__("transpose", child)
+
+    def _unary_jac(self, child_jac):
+        """See :meth:`pybamm.UnaryOperator._unary_jac()`."""
+        return child_jac.T
+
+    def _unary_evaluate(self, child):
+        """See :meth:`UnaryOperator._unary_evaluate()`."""
+        return child.T
+
+    def _evaluate_for_shape(self):
+        """See :meth:`pybamm.Symbol._evaluate_for_shape()`."""
+        return self.children[0].evaluate_for_shape().T
+
+    def _unary_new_copy(self, child, perform_simplifications: bool = True):
+        """
+        Creates a new copy of the operator with the child `child`.
+
+        Uses the overridden :meth:`__abs__` to cover scenarios where the child
+        is some specific symbol types.
+        """
+        if perform_simplifications:
+            return child.T
+        else:
+            return Transpose(child)
+
+
 class Sign(UnaryOperator):
     """
     A node in the expression tree representing a `sign` operator.

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -212,10 +212,6 @@ class Transpose(UnaryOperator):
         """See :meth:`pybamm.UnaryOperator.__init__()`."""
         super().__init__("transpose", child)
 
-    def _unary_jac(self, child_jac):
-        """See :meth:`pybamm.UnaryOperator._unary_jac()`."""
-        return child_jac.T
-
     def _unary_evaluate(self, child):
         """See :meth:`UnaryOperator._unary_evaluate()`."""
         return child.T
@@ -223,18 +219,6 @@ class Transpose(UnaryOperator):
     def _evaluate_for_shape(self):
         """See :meth:`pybamm.Symbol._evaluate_for_shape()`."""
         return self.children[0].evaluate_for_shape().T
-
-    def _unary_new_copy(self, child, perform_simplifications: bool = True):
-        """
-        Creates a new copy of the operator with the child `child`.
-
-        Uses the overridden :meth:`__abs__` to cover scenarios where the child
-        is some specific symbol types.
-        """
-        if perform_simplifications:
-            return child.T
-        else:
-            return Transpose(child)
 
 
 class Sign(UnaryOperator):

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -218,7 +218,6 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         # Create 1D matrix using submesh
         n = submesh.npts
-        # e = 1 / submesh.d_nodes
         sub_matrix_minus = pybamm.Matrix(diags([-1], [0], shape=(n - 1, n)))
         sub_matrix_plus = pybamm.Matrix(diags([1], [1], shape=(n - 1, n)))
         sub_matrix = (sub_matrix_minus + sub_matrix_plus) * e

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -120,7 +120,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         """
         # Create appropriate submesh by combining submeshes in primary domain
         submesh = self.mesh[domain]
-        if len(domain) > 1 and hasattr(submesh, "length"):
+        if len(domain) > 1:
             submeshes = [self.mesh[domain_] for domain_ in domain]
             dx_list = []
             for submesh_ in submeshes:
@@ -197,7 +197,7 @@ class FiniteVolume(pybamm.SpatialMethod):
         """
         # Create appropriate submesh by combining submeshes in domain
         submesh = self.mesh[domains["primary"]]
-        if len(domains["primary"]) > 1 and hasattr(submesh, "length"):
+        if len(domains["primary"]) > 1:
             submeshes = [self.mesh[domain] for domain in domains["primary"]]
             edges_list = []
             for i, submesh_ in enumerate(submeshes):
@@ -234,9 +234,9 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         # Create matrix using submesh
         n = submesh.npts + 1
-        sub_matrix_minus = pybamm.Matrix(diags([-1], [0], shape=(n - 1, n))) * e
-        sub_matrix_plus = pybamm.Matrix(diags([1], [1], shape=(n - 1, n))) * e
-        sub_matrix = sub_matrix_minus + sub_matrix_plus
+        sub_matrix_minus = pybamm.Matrix(diags([-1], [0], shape=(n - 1, n)))
+        sub_matrix_plus = pybamm.Matrix(diags([1], [1], shape=(n - 1, n)))
+        sub_matrix = (sub_matrix_minus + sub_matrix_plus) * e
 
         # repeat matrix for each node in secondary dimensions
         second_dim_repeats = self._get_auxiliary_domain_repeats(domains)

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -991,21 +991,25 @@ class FiniteVolume(pybamm.SpatialMethod):
 
         return new_gradient
 
+    def _get_boundary_submesh_length(self, side: str, domains: list[str]):
+        if side == "left":
+            return self.mesh[domains[0]].length
+        elif side == "right":
+            return self.mesh[domains[-1]].length
+
     def _boundary_mesh_size(self, child, side):
         """
         Get the mesh size at the boundary of a variable's domain.
         """
         submesh = self.mesh[child.domain]
+        if hasattr(submesh, "length"):
+            length = self._get_boundary_submesh_length("left", child.domain)
+        else:
+            length = 1
         if side == "left":
-            if hasattr(submesh, "length"):
-                val = submesh.length * pybamm.Scalar(submesh.d_nodes[0])
-            else:
-                val = pybamm.Scalar(submesh.d_nodes[0])
+            val = length * pybamm.Scalar(submesh.d_nodes[0])
         elif side == "right":
-            if hasattr(submesh, "length"):
-                val = submesh.length * pybamm.Scalar(submesh.d_nodes[-1])
-            else:
-                val = pybamm.Scalar(submesh.d_nodes[-1])
+            val = length * pybamm.Scalar(submesh.d_nodes[-1])
         else:
             raise ValueError(f"Invalid side: {side}")
         return val
@@ -1075,7 +1079,9 @@ class FiniteVolume(pybamm.SpatialMethod):
 
                         additive = -dx0 * bcs[child][symbol.side][0]
                         if hasattr(submesh, "length"):
-                            additive_multiplicative = submesh.length
+                            additive_multiplicative = self._get_boundary_submesh_length(
+                                "left", child.domain
+                            )
                         else:
                             additive_multiplicative = pybamm.Scalar(1)
                         multiplicative = pybamm.Scalar(1)
@@ -1102,7 +1108,9 @@ class FiniteVolume(pybamm.SpatialMethod):
                         )
                         additive = alpha * bcs[child][symbol.side][0]
                         if hasattr(submesh, "length"):
-                            additive_multiplicative = submesh.length
+                            additive_multiplicative = self._get_boundary_submesh_length(
+                                "left", child.domain
+                            )
                         else:
                             additive_multiplicative = pybamm.Scalar(1)
                         multiplicative = pybamm.Scalar(1)
@@ -1143,8 +1151,12 @@ class FiniteVolume(pybamm.SpatialMethod):
                         )
                         additive = dxN * bcs[child][symbol.side][0]
                         if hasattr(submesh, "length"):
-                            multiplicative = submesh.length
-                            additive_multiplicative = submesh.length
+                            multiplicative = self._get_boundary_submesh_length(
+                                "right", child.domain
+                            )
+                            additive_multiplicative = self._get_boundary_submesh_length(
+                                "right", child.domain
+                            )
                         else:
                             multiplicative = pybamm.Scalar(1)
                             additive_multiplicative = pybamm.Scalar(1)
@@ -1175,7 +1187,9 @@ class FiniteVolume(pybamm.SpatialMethod):
 
                         additive = alpha * bcs[child][symbol.side][0]
                         if hasattr(submesh, "length"):
-                            additive_multiplicative = submesh.length
+                            additive_multiplicative = self._get_boundary_submesh_length(
+                                "right", child.domain
+                            )
                         else:
                             additive_multiplicative = pybamm.Scalar(1)
                         multiplicative = pybamm.Scalar(1)
@@ -1226,7 +1240,9 @@ class FiniteVolume(pybamm.SpatialMethod):
                     additive = pybamm.Scalar(0)
                     additive_multiplicative = pybamm.Scalar(1)
                     if hasattr(submesh, "length"):
-                        multiplicative = 1 / submesh.length
+                        multiplicative = 1 / self._get_boundary_submesh_length(
+                            "left", child.domain
+                        )
                     else:
                         multiplicative = pybamm.Scalar(1)
 
@@ -1241,7 +1257,9 @@ class FiniteVolume(pybamm.SpatialMethod):
                     additive = pybamm.Scalar(0)
                     additive_multiplicative = pybamm.Scalar(1)
                     if hasattr(submesh, "length"):
-                        multiplicative = 1 / submesh.length
+                        multiplicative = 1 / self._get_boundary_submesh_length(
+                            "left", child.domain
+                        )
                     else:
                         multiplicative = pybamm.Scalar(1)
 
@@ -1259,7 +1277,9 @@ class FiniteVolume(pybamm.SpatialMethod):
                     additive = pybamm.Scalar(0)
                     additive_multiplicative = pybamm.Scalar(1)
                     if hasattr(submesh, "length"):
-                        multiplicative = 1 / submesh.length
+                        multiplicative = 1 / self._get_boundary_submesh_length(
+                            "right", child.domain
+                        )
                     else:
                         multiplicative = pybamm.Scalar(1)
 
@@ -1278,7 +1298,9 @@ class FiniteVolume(pybamm.SpatialMethod):
                     additive = pybamm.Scalar(0)
                     additive_multiplicative = pybamm.Scalar(1)
                     if hasattr(submesh, "length"):
-                        multiplicative = 1 / submesh.length
+                        multiplicative = 1 / self._get_boundary_submesh_length(
+                            "right", child.domain
+                        )
                     else:
                         multiplicative = pybamm.Scalar(1)
                 else:

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -389,12 +389,14 @@ class FiniteVolume(pybamm.SpatialMethod):
                     n_lower_pts *= lower_submesh.npts + 1
                 else:
                     n_lower_pts *= lower_submesh.npts
-            if hasattr(submesh, "length"):
-                raise NotImplementedError("Length not implemented for integration")
+            if d_edges.shape[0] == 1:
+                int_matrix = pybamm.KroneckerProduct(
+                    d_edges, pybamm.Matrix(eye(n_lower_pts))
+                )
             else:
-                d_edges_ = submesh.d_edges
-                int_matrix = hstack([d_edge * eye(n_lower_pts) for d_edge in d_edges_])
-                int_matrix = pybamm.Matrix(int_matrix)
+                int_matrix = pybamm.KroneckerProduct(
+                    pybamm.Transpose(d_edges), pybamm.Matrix(eye(n_lower_pts))
+                )
 
             # Higher dimensions should be tiled, so repeat the matrix for each higher dimension.
             higher_repeats = self._get_auxiliary_domain_repeats(

--- a/src/pybamm/spatial_methods/finite_volume.py
+++ b/src/pybamm/spatial_methods/finite_volume.py
@@ -1345,6 +1345,11 @@ class FiniteVolume(pybamm.SpatialMethod):
         domain = discretised_child.domain
         mesh = self.mesh[domain]
         nodes = mesh.nodes
+        if hasattr(mesh, "length"):
+            domain = discretised_child.domain
+            raise NotImplementedError(
+                f"The symbolic submesh does not support `EvaluateAt` because we are unable to find the position of the node in the symbolic submesh. Please use one of the other submeshes for domain {domain}"
+            )
         repeats = self._get_auxiliary_domain_repeats(discretised_child.domains)
 
         # Find the index of the node closest to the value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,7 @@ from .shared import (
     get_3d_mesh_for_testing,
     get_unit_3d_mesh_for_testing,
     get_mesh_for_testing_symbolic,
+    get_mesh_for_testing_symbolic_concatenation,
     get_p2d_mesh_for_testing,
     get_size_distribution_mesh_for_testing,
     get_1p1d_mesh_for_testing,

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -488,6 +488,20 @@ def get_mesh_for_testing_symbolic():
     return mesh
 
 
+def get_mesh_for_testing_symbolic_concatenation():
+    submesh_types = {
+        "domain 1": pybamm.SymbolicUniform1DSubMesh,
+        "domain 2": pybamm.SymbolicUniform1DSubMesh,
+    }
+    geometry = {
+        "domain 1": {"x": {"min": pybamm.Scalar(0), "max": pybamm.Scalar(2)}},
+        "domain 2": {"x": {"min": pybamm.Scalar(2), "max": pybamm.Scalar(4)}},
+    }
+    var_pts = {"x": 15}
+    mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
+    return mesh
+
+
 def get_spherical_mesh_for_testing_symbolic():
     submesh_types = {"spherical domain": pybamm.SymbolicUniform1DSubMesh}
     geometry = {

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -81,7 +81,8 @@ class TestCasadiConverter:
         # Arrays
         a = np.array([1, 2, 3, 4, 5])
         pybamm_a = pybamm.Array(a)
-        self.assert_casadi_equal(pybamm_a.to_casadi(), casadi.MX(a))
+        casadi_a = casadi.MX(a)
+        self.assert_casadi_equal(pybamm_a.to_casadi(), casadi_a)
 
         casadi_t = casadi.MX.sym("t")
         casadi_y = casadi.MX.sym("y", 10)
@@ -153,6 +154,22 @@ class TestCasadiConverter:
                 decimal=15,
                 evalf=True,
             )
+
+    def test_kronecker_product(self):
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.array([[1, 2, 3], [4, 5, 6]])
+        pybamm_a = pybamm.Vector(a)
+        pybamm_b = pybamm.Matrix(b)
+        symbol_pybamm = pybamm.KroneckerProduct(pybamm_a, pybamm_b)
+        symbol_casadi = casadi.kron(casadi.MX(a), casadi.MX(b))
+        self.assert_casadi_equal(symbol_pybamm.to_casadi(), symbol_casadi, evalf=True)
+
+    def test_transpose(self):
+        a = np.array([[1, 2, 3], [4, 5, 6]])
+        pybamm_a = pybamm.Matrix(a)
+        symbol_pybamm = pybamm.Transpose(pybamm_a)
+        symbol_casadi = casadi.MX(a).T
+        self.assert_casadi_equal(symbol_pybamm.to_casadi(), symbol_casadi, evalf=True)
 
     def test_interpolation(self):
         x = np.linspace(0, 1)

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -111,8 +111,11 @@ class TestParameterValues:
             0, inplace=False, inputs={input_param: input_value}
         )
         assert (
-            param_0_inputs["Initial concentration in positive electrode [mol.m-3]"]
-            == y_0
+            abs(
+                param_0_inputs["Initial concentration in positive electrode [mol.m-3]"]
+                - y_0
+            )
+            < 1e-10
         )
 
     def test_set_initial_stoichiometry_half_cell(self):

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -360,14 +360,18 @@ class TestFiniteVolume:
         # Left
         assert delta_fn_left_disc.domains == delta_fn_left.domains
         assert isinstance(delta_fn_left_disc, pybamm.Multiplication)
-        assert isinstance(delta_fn_left_disc.left, pybamm.Matrix)
-        np.testing.assert_array_equal(delta_fn_left_disc.left.evaluate()[:, 1:], 0)
+        assert isinstance(delta_fn_left_disc.left, pybamm.Symbol)
+        np.testing.assert_array_almost_equal(
+            delta_fn_left_disc.left.evaluate()[:, 1:].toarray(), 0
+        )
         assert delta_fn_left_disc.shape == y.shape
         # Right
         assert delta_fn_right_disc.domains == delta_fn_right.domains
         assert isinstance(delta_fn_right_disc, pybamm.Multiplication)
-        assert isinstance(delta_fn_right_disc.left, pybamm.Matrix)
-        np.testing.assert_array_equal(delta_fn_right_disc.left.evaluate()[:, :-1], 0)
+        assert isinstance(delta_fn_right_disc.left, pybamm.Symbol)
+        np.testing.assert_array_equal(
+            delta_fn_right_disc.left.evaluate()[:, :-1].toarray(), 0
+        )
         assert delta_fn_right_disc.shape == y.shape
 
         # Value tests

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -58,6 +58,37 @@ class TestFiniteVolume:
         with pytest.raises(ValueError, match="method"):
             fin_vol.shift(c, "shift key", "bad method")
 
+    def test_node_to_edge_to_node_symbolic(self):
+        # Create discretisation
+        mesh = get_mesh_for_testing_symbolic()
+        fin_vol = pybamm.FiniteVolume()
+        fin_vol.build(mesh)
+        n = mesh["domain"].npts
+
+        # node to edge
+        c = pybamm.StateVector(slice(0, n), domain=["domain"])
+        y_test = np.ones(n)
+        diffusivity_c_ari = fin_vol.node_to_edge(c, method="arithmetic")
+        np.testing.assert_array_equal(
+            diffusivity_c_ari.evaluate(None, y_test), np.ones((n + 1, 1))
+        )
+        diffusivity_c_har = fin_vol.node_to_edge(c, method="harmonic")
+        np.testing.assert_array_equal(
+            diffusivity_c_har.evaluate(None, y_test), np.ones((n + 1, 1))
+        )
+
+        # edge to node
+        d = pybamm.StateVector(slice(0, n + 1), domain=["domain"])
+        y_test = np.ones(n + 1)
+        diffusivity_d_ari = fin_vol.edge_to_node(d, method="arithmetic")
+        np.testing.assert_array_equal(
+            diffusivity_d_ari.evaluate(None, y_test), np.ones((n, 1))
+        )
+        diffusivity_d_har = fin_vol.edge_to_node(d, method="harmonic")
+        np.testing.assert_array_equal(
+            diffusivity_d_har.evaluate(None, y_test), np.ones((n, 1))
+        )
+
     def test_concatenation(self):
         mesh = get_mesh_for_testing()
         fin_vol = pybamm.FiniteVolume()
@@ -186,6 +217,17 @@ class TestFiniteVolume:
         np.testing.assert_array_equal(
             x_disc.evaluate(),
             mesh["domain"].nodes[:, np.newaxis] * mesh["domain"].length,
+        )
+
+        # test spatial variable on edges
+        x = pybamm.SpatialVariable("x", ["domain"])
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        x._evaluates_on_edges = lambda _: True
+        x_edges_disc = disc.process_symbol(x)
+        assert isinstance(x_edges_disc, pybamm.Vector)
+        np.testing.assert_array_equal(
+            x_edges_disc.evaluate(),
+            mesh["domain"].edges[:, np.newaxis] * mesh["domain"].length,
         )
 
     def test_mass_matrix_shape(self):
@@ -379,6 +421,46 @@ class TestFiniteVolume:
         delta_fn_int_disc = disc.process_symbol(pybamm.Integral(delta_fn_left, x))
         np.testing.assert_allclose(
             var_disc.evaluate(y=y) * mesh["negative electrode"].edges[-1],
+            np.sum(delta_fn_int_disc.evaluate(y=y)),
+        )
+
+    def test_delta_function_symbolic(self):
+        mesh = get_mesh_for_testing_symbolic()
+        spatial_methods = {"domain": pybamm.FiniteVolume()}
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+
+        var = pybamm.Variable("var")
+        delta_fn_left = pybamm.DeltaFunction(var, "left", "domain")
+        delta_fn_right = pybamm.DeltaFunction(var, "right", "domain")
+        disc.set_variable_slices([var])
+        delta_fn_left_disc = disc.process_symbol(delta_fn_left)
+        delta_fn_right_disc = disc.process_symbol(delta_fn_right)
+
+        # Basic shape and type tests
+        y = np.ones_like(mesh["domain"].nodes[:, np.newaxis])
+        # Left
+        assert delta_fn_left_disc.domains == delta_fn_left.domains
+        assert isinstance(delta_fn_left_disc, pybamm.Multiplication)
+        assert isinstance(delta_fn_left_disc.left, pybamm.Symbol)
+        np.testing.assert_array_almost_equal(
+            delta_fn_left_disc.left.evaluate()[:, 1:], 0
+        )
+        assert delta_fn_left_disc.shape == y.shape
+        # Right
+        assert delta_fn_right_disc.domains == delta_fn_right.domains
+        assert isinstance(delta_fn_right_disc, pybamm.Multiplication)
+        assert isinstance(delta_fn_right_disc.left, pybamm.Symbol)
+        np.testing.assert_array_equal(delta_fn_right_disc.left.evaluate()[:, :-1], 0)
+        assert delta_fn_right_disc.shape == y.shape
+
+        # Value tests
+        # Delta function should integrate to the same thing as variable
+        var_disc = disc.process_symbol(var)
+        x = pybamm.SpatialVariable("x", ["domain"])
+        delta_fn_int_disc = disc.process_symbol(pybamm.Integral(delta_fn_left, x))
+        np.testing.assert_allclose(
+            var_disc.evaluate(y=y) * mesh["domain"].edges[-1] * mesh["domain"].length
+            + mesh["domain"].min,
             np.sum(delta_fn_int_disc.evaluate(y=y)),
         )
 
@@ -590,6 +672,14 @@ class TestFiniteVolume:
 
         y = np.arange(n)[:, np.newaxis]
         assert evaluate_at_disc.evaluate(y=y) == y[idx]
+
+        mesh = get_mesh_for_testing_symbolic()
+        spatial_methods = {"domain": pybamm.FiniteVolume()}
+        var = pybamm.Variable("var", domain="domain")
+        disc = pybamm.Discretisation(mesh, spatial_methods)
+        evaluate_at = pybamm.EvaluateAt(var, position)
+        with pytest.raises(pybamm.ModelError):
+            disc.process_symbol(evaluate_at)
 
     def test_inner(self):
         # standard

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -272,7 +272,7 @@ class TestFiniteVolume:
         jacobian = eqn_jac.evaluate(y=y_test)
         grad_matrix = spatial_method.gradient_matrix(
             whole_cell, {"primary": whole_cell}
-        ).entries
+        ).evaluate()
         np.testing.assert_allclose(jacobian.toarray()[1:-1], grad_matrix.toarray())
         np.testing.assert_allclose(
             jacobian.toarray()[0, 0], grad_matrix.toarray()[0][0] * -2
@@ -362,16 +362,14 @@ class TestFiniteVolume:
         assert isinstance(delta_fn_left_disc, pybamm.Multiplication)
         assert isinstance(delta_fn_left_disc.left, pybamm.Symbol)
         np.testing.assert_array_almost_equal(
-            delta_fn_left_disc.left.evaluate()[:, 1:].toarray(), 0
+            delta_fn_left_disc.left.evaluate()[:, 1:], 0
         )
         assert delta_fn_left_disc.shape == y.shape
         # Right
         assert delta_fn_right_disc.domains == delta_fn_right.domains
         assert isinstance(delta_fn_right_disc, pybamm.Multiplication)
         assert isinstance(delta_fn_right_disc.left, pybamm.Symbol)
-        np.testing.assert_array_equal(
-            delta_fn_right_disc.left.evaluate()[:, :-1].toarray(), 0
-        )
+        np.testing.assert_array_equal(delta_fn_right_disc.left.evaluate()[:, :-1], 0)
         assert delta_fn_right_disc.shape == y.shape
 
         # Value tests


### PR DESCRIPTION
# Description

Allows for geometric input parameters with concatenation variables.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
