### PR TITLE
Generalise initial state setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Features
+
+- Generalises `set_initial_soc` to `set_initial_state` and adds Thevenin initial state setting. ([#5129](https://github.com/pybamm-team/PyBaMM/pull/5129))
+
 # [v25.8.0](https://github.com/pybamm-team/PyBaMM/tree/v25.8.0) - 2025-08-04
 
 ## Features
 
-- Generalises `set_initial_soc` to `set_initial_state` and adds Thevenin initial state setting. ([#5129](https://github.com/pybamm-team/PyBaMM/pull/5129))
 - Added `plot_3d_cross_section` & `plot_3d_heatmap` functions to support plotting for 3D thermal simulations. ([#5130](https://github.com/pybamm-team/PyBaMM/pull/5130))
 - Added a `Basic3DThermalSPM` with two way coupling. ([#5112](https://github.com/pybamm-team/PyBaMM/pull/5112))
 - Enables the passing of `inputs` throughout `set_initial_soc`. ([#5122](https://github.com/pybamm-team/PyBaMM/pull/5122))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
 ## Features
+- Generalises `set_initial_soc` to `set_initial_state` and adds Thevenin initial state setting. ([#5129](https://github.com/pybamm-team/PyBaMM/pull/5129))
 - Enables the passing of `inputs` throughout `set_initial_soc`. ([#5122](https://github.com/pybamm-team/PyBaMM/pull/5122))
 - Adds `on_failure` option to `BaseSolver` with options for `"warn"`, `"ignore"`, and `"raise"` to change behaviour on solver failure. Defaults to "raise" to retain historic functionality. ([#5105](https://github.com/pybamm-team/PyBaMM/pull/5105))
 - Creates a boundary mesh size object that returns the distance from the center of the leftmost/rightmost control volume to the boundary of the domain ([#5108](https://github.com/pybamm-team/PyBaMM/pull/5108))

--- a/src/pybamm/models/full_battery_models/equivalent_circuit/__init__.py
+++ b/src/pybamm/models/full_battery_models/equivalent_circuit/__init__.py
@@ -1,3 +1,4 @@
+from .initial_state import set_initial_state
 from .thevenin import *
 
 __all__ = ['ecm_model_options', 'thevenin']

--- a/src/pybamm/models/full_battery_models/equivalent_circuit/initial_state.py
+++ b/src/pybamm/models/full_battery_models/equivalent_circuit/initial_state.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+import pybamm
+
+
+def set_initial_state(
+    initial_value,
+    parameter_values,
+    param=None,
+    inplace=True,
+    options=None,
+    inputs=None,
+    tol=1e-6,
+):
+    """
+    Set the value of the initial state of charge.
+
+    Parameters
+    ----------
+    initial_value : float
+        Target initial value.
+        If float, interpreted as SOC, must be between 0 and 1.
+        If string e.g. "4 V", interpreted as voltage, must be between V_min and V_max.
+    parameter_values : :class:`pybamm.ParameterValues`
+        Parameters and their corresponding values.
+    param : :class:`pybamm.LithiumIonParameters`, optional
+        The symbolic parameter set to use for the simulation.
+        If not provided, the default parameter set will be used.
+    inplace: bool, optional
+        If True, replace the parameters values in place. Otherwise, return a new set of
+        parameter values. Default is True.
+    options : dict-like, optional
+        A dictionary of options to be passed to the model, see
+        :class:`pybamm.BatteryModelOptions`.
+    inputs : dict, optional
+        A dictionary of input parameters to pass to the model when solving.
+    tol : float, optional
+        The tolerance for the solver used to compute the initial stoichiometries.
+        A lower value results in higher precision but may increase computation time.
+        Default is 1e-6.
+    """
+    parameter_values = parameter_values if inplace else parameter_values.copy()
+    param = param or pybamm.EcmParameters()
+
+    if isinstance(initial_value, str) and initial_value.endswith("V"):
+        V_init = float(initial_value[:-1])
+        V_min = parameter_values.evaluate(param.voltage_low_cut, inputs=inputs)
+        V_max = parameter_values.evaluate(param.voltage_high_cut, inputs=inputs)
+
+        if not V_min <= V_init <= V_max:
+            raise ValueError(
+                f"Initial voltage {V_init}V is outside the voltage limits "
+                f"({V_min}, {V_max})"
+            )
+
+        # Solve simple model for initial soc based on target voltage
+        soc_model = pybamm.BaseModel()
+        soc = pybamm.Variable("soc")
+        soc_model.algebraic[soc] = param.ocv(soc) - V_init
+
+        # initial guess for soc linearly interpolates between 0 and 1
+        # based on V linearly interpolating between V_max and V_min
+        soc_model.initial_conditions[soc] = (V_init - V_min) / (V_max - V_min)
+        soc_model.variables["soc"] = soc
+        parameter_values.process_model(soc_model)
+        initial_soc = (
+            pybamm.AlgebraicSolver(tol=tol)
+            .solve(soc_model, [0], inputs=inputs)["soc"]
+            .data[0]
+        )
+
+        # Ensure that the result lies between 0 and 1
+        parameter_values["Initial SoC"] = np.minimum(np.maximum(initial_soc, 0.0), 1.0)
+
+    elif isinstance(initial_value, int | float):
+        if not 0 <= initial_value <= 1:
+            raise ValueError("Initial SOC should be between 0 and 1")
+        parameter_values["Initial SoC"] = initial_value
+
+    else:
+        raise ValueError(
+            "Initial value must be a float between 0 and 1, or a string ending in 'V'"
+        )
+
+    return parameter_values

--- a/src/pybamm/models/full_battery_models/lithium_ion/__init__.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/__init__.py
@@ -13,6 +13,7 @@ from .electrode_soh_half_cell import (
     ElectrodeSOHHalfCell,
     get_initial_stoichiometry_half_cell,
 )
+from .initial_state import set_initial_state
 from .spm import SPM
 from .spme import SPMe
 from .dfn import DFN

--- a/src/pybamm/models/full_battery_models/lithium_ion/initial_state.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/initial_state.py
@@ -1,0 +1,105 @@
+import pybamm
+
+
+def set_initial_state(
+    initial_value,
+    parameter_values,
+    param=None,
+    known_value="cyclable lithium capacity",
+    inplace=True,
+    options=None,
+    inputs=None,
+    tol=1e-6,
+):
+    """
+    Set the values of the parameters representing the initial model states.
+
+    Parameters
+    ----------
+    initial_value : float
+        Target initial value.
+        If float, interpreted as SOC, must be between 0 and 1.
+        If string e.g. "4 V", interpreted as voltage, must be between V_min and V_max.
+    parameter_values : :class:`pybamm.ParameterValues`
+        Parameters and their corresponding values.
+    param : :class:`pybamm.LithiumIonParameters`, optional
+        The symbolic parameter set to use for the simulation.
+        If not provided, the default parameter set will be used.
+    known_value : str, optional
+        The known value needed to complete the electrode SOH model.
+        Can be "cyclable lithium capacity" (default) or "cell capacity".
+    inplace: bool, optional
+        If True, replace the parameters values in place. Otherwise, return a new set of
+        parameter values. Default is True.
+    options : dict-like, optional
+        A dictionary of options to be passed to the model, see
+        :class:`pybamm.BatteryModelOptions`.
+    inputs : dict, optional
+        A dictionary of input parameters to pass to the model when solving.
+    tol : float, optional
+        The tolerance for the solver used to compute the initial stoichiometries.
+        A lower value results in higher precision but may increase computation time.
+        Default is 1e-6.
+    """
+    parameter_values = parameter_values if inplace else parameter_values.copy()
+    param = param or pybamm.LithiumIonParameters(options)
+
+    if options is not None and options.get("open-circuit potential", None) == "MSMR":
+        """
+        Set the initial OCP of each electrode, based on the initial SOC or voltage.
+        """
+        Un, Up = pybamm.lithium_ion.get_initial_ocps(
+            initial_value,
+            parameter_values,
+            param=param,
+            known_value=known_value,
+            options=options,
+            inputs=inputs,
+        )
+        parameter_values.update(
+            {
+                "Initial voltage in negative electrode [V]": Un,
+                "Initial voltage in positive electrode [V]": Up,
+            }
+        )
+    elif options is not None and options.get("working electrode", None) == "positive":
+        """
+        Set the initial stoichiometry of the working electrode, based on the initial
+        SOC or voltage.
+        """
+        x = pybamm.lithium_ion.get_initial_stoichiometry_half_cell(
+            initial_value,
+            parameter_values,
+            param=param,
+            known_value=known_value,
+            options=options,
+            inputs=inputs,
+        )
+        c_max = parameter_values.evaluate(param.p.prim.c_max, inputs=inputs)
+        parameter_values.update(
+            {"Initial concentration in positive electrode [mol.m-3]": x * c_max}
+        )
+    else:
+        """
+        Set the initial stoichiometry of each electrode, based on the initial SOC or
+        voltage.
+        """
+        x, y = pybamm.lithium_ion.get_initial_stoichiometries(
+            initial_value,
+            parameter_values,
+            param=param,
+            known_value=known_value,
+            options=options,
+            tol=tol,
+            inputs=inputs,
+        )
+        c_n_max = parameter_values.evaluate(param.n.prim.c_max, inputs=inputs)
+        c_p_max = parameter_values.evaluate(param.p.prim.c_max, inputs=inputs)
+        parameter_values.update(
+            {
+                "Initial concentration in negative electrode [mol.m-3]": x * c_n_max,
+                "Initial concentration in positive electrode [mol.m-3]": y * c_p_max,
+            }
+        )
+
+    return parameter_values

--- a/src/pybamm/parameters/parameter_values.py
+++ b/src/pybamm/parameters/parameter_values.py
@@ -234,6 +234,7 @@ class ParameterValues:
         """Returns a copy of the parameter values. Makes sure to copy the internal
         dictionary."""
         new_copy = ParameterValues(self._dict_items.copy())
+        new_copy._set_initial_state = self._set_initial_state
         return new_copy
 
     def search(self, key, print_values=True):

--- a/src/pybamm/parameters/parameter_values.py
+++ b/src/pybamm/parameters/parameter_values.py
@@ -342,6 +342,71 @@ class ParameterValues:
             inputs=inputs,
         )
 
+    def set_initial_stoichiometry_half_cell(
+        self,
+        initial_value,
+        param=None,
+        known_value="cyclable lithium capacity",
+        inplace=True,
+        options=None,
+        inputs=None,
+    ):
+        msg = "pybamm.parameter_values.set_initial_stoichiometry_half_cell is deprecated, please use set_initial_state."
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._set_initial_state(
+            initial_value,
+            self,
+            param=param,
+            known_value=known_value,
+            inplace=inplace,
+            options=options,
+            inputs=inputs,
+        )
+
+    def set_initial_stoichiometries(
+        self,
+        initial_value,
+        param=None,
+        known_value="cyclable lithium capacity",
+        inplace=True,
+        options=None,
+        inputs=None,
+        tol=1e-6,
+    ):
+        msg = "pybamm.parameter_values.set_initial_stoichiometries is deprecated, please use set_initial_state."
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._set_initial_state(
+            initial_value,
+            self,
+            param=param,
+            known_value=known_value,
+            inplace=inplace,
+            options=options,
+            inputs=inputs,
+            tol=tol,
+        )
+
+    def set_initial_ocps(
+        self,
+        initial_value,
+        param=None,
+        known_value="cyclable lithium capacity",
+        inplace=True,
+        options=None,
+        inputs=None,
+    ):
+        msg = "pybamm.parameter_values.set_initial_ocps is deprecated, please use set_initial_state."
+        warn(msg, DeprecationWarning, stacklevel=2)
+        return self._set_initial_state(
+            initial_value,
+            self,
+            param=param,
+            known_value=known_value,
+            inplace=inplace,
+            options=options,
+            inputs=inputs,
+        )
+
     @staticmethod
     def check_parameter_values(values):
         for param in list(values.keys()):

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -260,7 +260,7 @@ class Simulation:
         self._parameter_values.process_geometry(self._geometry)
         self._model = self._model_with_set_params
 
-    def set_initial_soc(self, initial_soc, inputs=None):
+    def set_initial_state(self, initial_soc, inputs=None):
         if self._built_initial_soc != initial_soc:
             # reset
             self._model_with_set_params = None
@@ -268,38 +268,11 @@ class Simulation:
             self.steps_to_built_models = None
             self.steps_to_built_solvers = None
 
-        options = self._model.options
         param = self._model.param
-        if options["open-circuit potential"] == "MSMR":
-            self._parameter_values = (
-                self._unprocessed_parameter_values.set_initial_ocps(
-                    initial_soc,
-                    param=param,
-                    inplace=False,
-                    options=options,
-                    inputs=inputs,
-                )
-            )
-        elif options["working electrode"] == "positive":
-            self._parameter_values = (
-                self._unprocessed_parameter_values.set_initial_stoichiometry_half_cell(
-                    initial_soc,
-                    param=param,
-                    inplace=False,
-                    options=options,
-                    inputs=inputs,
-                )
-            )
-        else:
-            self._parameter_values = (
-                self._unprocessed_parameter_values.set_initial_stoichiometries(
-                    initial_soc,
-                    param=param,
-                    inplace=False,
-                    options=options,
-                    inputs=inputs,
-                )
-            )
+        options = self._model.options
+        self._parameter_values = self._unprocessed_parameter_values.set_initial_state(
+            initial_soc, param=param, inplace=False, options=options, inputs=inputs
+        )
 
         # Save solved initial SOC in case we need to re-build the model
         self._built_initial_soc = initial_soc
@@ -322,7 +295,7 @@ class Simulation:
             A dictionary of input parameters to pass to the model when solving.
         """
         if initial_soc is not None:
-            self.set_initial_soc(initial_soc, inputs=inputs)
+            self.set_initial_state(initial_soc, inputs=inputs)
 
         if self._built_model:
             return
@@ -347,7 +320,7 @@ class Simulation:
         experiment, where there may be several models and solvers to build.
         """
         if initial_soc is not None:
-            self.set_initial_soc(initial_soc, inputs)
+            self.set_initial_state(initial_soc, inputs=inputs)
 
         if self.steps_to_built_models:
             return

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -277,6 +277,11 @@ class Simulation:
         # Save solved initial SOC in case we need to re-build the model
         self._built_initial_soc = initial_soc
 
+    def set_initial_soc(self, initial_soc, inputs=None):
+        msg = "pybamm.simulation.set_initial_soc is deprecated, please use set_initial_state."
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        return self.set_initial_state(initial_soc=initial_soc, inputs=inputs)
+
     def build(self, initial_soc=None, inputs=None):
         """
         A method to build the model into a system of matrices and vectors suitable for

--- a/tests/unit/test_models/test_full_battery_models/test_equivalent_circuit/test_initial_state.py
+++ b/tests/unit/test_models/test_full_battery_models/test_equivalent_circuit/test_initial_state.py
@@ -1,0 +1,36 @@
+#
+# Tests for equivalent circuit model (ECM) initial states
+#
+
+import pytest
+
+import pybamm
+
+
+class TestSetInitialSOC:
+    def test_initial_soc(self):
+        parameter_values = pybamm.ParameterValues("ECM_Example")
+        V_min = parameter_values["Lower voltage cut-off [V]"]
+        V_max = parameter_values["Upper voltage cut-off [V]"]
+
+        param_0 = parameter_values.set_initial_state(0, inplace=False)
+        param_100 = parameter_values.set_initial_state(1, inplace=False)
+        assert param_0["Initial SoC"] == 0
+        assert param_100["Initial SoC"] == 1
+
+        param_0 = parameter_values.set_initial_state(f"{V_min} V", inplace=False)
+        param_100 = parameter_values.set_initial_state(f"{V_max} V", inplace=False)
+        assert param_0["Initial SoC"] == pytest.approx(0)
+        assert param_100["Initial SoC"] == pytest.approx(1)
+
+    def test_error(self):
+        parameter_values = pybamm.ParameterValues("ECM_Example")
+
+        with pytest.raises(ValueError, match="Initial SOC should be between 0 and 1"):
+            parameter_values.set_initial_state(2)
+
+        with pytest.raises(ValueError, match="outside the voltage limits"):
+            parameter_values.set_initial_state("1 V")
+
+        with pytest.raises(ValueError, match="must be a float"):
+            parameter_values.set_initial_state("5 A")

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -87,9 +87,9 @@ class TestParameterValues:
 
     def test_set_initial_stoichiometries(self):
         param = pybamm.ParameterValues("Chen2020")
-        param.set_initial_stoichiometries(0.4)
-        param_0 = param.set_initial_stoichiometries(0, inplace=False)
-        param_100 = param.set_initial_stoichiometries(1, inplace=False)
+        param.set_initial_state(0.4)
+        param_0 = param.set_initial_state(0, inplace=False)
+        param_100 = param.set_initial_state(1, inplace=False)
 
         # check that the stoichiometry of param is linearly interpolated between
         # the min and max stoichiometries
@@ -107,7 +107,7 @@ class TestParameterValues:
         input_param = "Maximum concentration in positive electrode [mol.m-3]"
         input_value = param[input_param]
         param[input_param] = "[input]"
-        param_0_inputs = param.set_initial_stoichiometries(
+        param_0_inputs = param.set_initial_state(
             0, inplace=False, inputs={input_param: input_value}
         )
         assert (
@@ -119,13 +119,13 @@ class TestParameterValues:
         param = pybamm.lithium_ion.DFN(
             {"working electrode": "positive"}
         ).default_parameter_values
-        param = param.set_initial_stoichiometry_half_cell(
+        param = param.set_initial_state(
             0.4, inplace=False, options={"working electrode": "positive"}
         )
-        param_0 = param.set_initial_stoichiometry_half_cell(
+        param_0 = param.set_initial_state(
             0, inplace=False, options={"working electrode": "positive"}
         )
-        param_100 = param.set_initial_stoichiometry_half_cell(
+        param_100 = param.set_initial_state(
             1, inplace=False, options={"working electrode": "positive"}
         )
 
@@ -138,21 +138,21 @@ class TestParameterValues:
         param_t = pybamm.lithium_ion.DFN(
             {"working electrode": "positive"}
         ).default_parameter_values
-        param_t.set_initial_stoichiometry_half_cell(
+        param_t.set_initial_state(
             0.4, inplace=True, options={"working electrode": "positive"}
         )
         y = param_t["Initial concentration in positive electrode [mol.m-3]"]
         param_0 = pybamm.lithium_ion.DFN(
             {"working electrode": "positive"}
         ).default_parameter_values
-        param_0.set_initial_stoichiometry_half_cell(
+        param_0.set_initial_state(
             0, inplace=True, options={"working electrode": "positive"}
         )
         y_0 = param_0["Initial concentration in positive electrode [mol.m-3]"]
         param_100 = pybamm.lithium_ion.DFN(
             {"working electrode": "positive"}
         ).default_parameter_values
-        param_100.set_initial_stoichiometry_half_cell(
+        param_100.set_initial_state(
             1, inplace=True, options={"working electrode": "positive"}
         )
         y_100 = param_100["Initial concentration in positive electrode [mol.m-3]"]
@@ -162,7 +162,7 @@ class TestParameterValues:
         input_param = "Maximum concentration in positive electrode [mol.m-3]"
         input_value = param[input_param]
         param[input_param] = "[input]"
-        param_0_inputs = param.set_initial_stoichiometry_half_cell(
+        param_0_inputs = param.set_initial_state(
             0,
             inplace=False,
             options={"working electrode": "positive"},
@@ -176,9 +176,7 @@ class TestParameterValues:
         # test error
         param = pybamm.ParameterValues("Chen2020")
         with pytest.raises(OptionError, match="working electrode"):
-            param.set_initial_stoichiometry_half_cell(
-                0.1, options={"working electrode": "negative"}
-            )
+            param.set_initial_state(0.1, options={"working electrode": "negative"})
 
     def test_set_initial_ocps(self):
         options = {
@@ -188,8 +186,8 @@ class TestParameterValues:
             "intercalation kinetics": "MSMR",
         }
         param_100 = pybamm.ParameterValues("MSMR_Example")
-        param_100.set_initial_ocps(1, inplace=True, options=options)
-        param_0 = param_100.set_initial_ocps(0, inplace=False, options=options)
+        param_100.set_initial_state(1, inplace=True, options=options)
+        param_0 = param_100.set_initial_state(0, inplace=False, options=options)
 
         Un_0 = param_0["Initial voltage in negative electrode [V]"]
         Up_0 = param_0["Initial voltage in positive electrode [V]"]
@@ -203,7 +201,7 @@ class TestParameterValues:
         input_param = "Maximum concentration in positive electrode [mol.m-3]"
         input_value = param_100[input_param]
         param_100[input_param] = "[input]"
-        param_0_inputs = param_100.set_initial_ocps(
+        param_0_inputs = param_100.set_initial_state(
             0, inplace=False, options=options, inputs={input_param: input_value}
         )
         assert param_0_inputs["Initial voltage in positive electrode [V]"] == Up_0

--- a/tests/unit/test_parameters/test_parameter_values.py
+++ b/tests/unit/test_parameters/test_parameter_values.py
@@ -103,6 +103,9 @@ class TestParameterValues:
         y_100 = param_100["Initial concentration in positive electrode [mol.m-3]"]
         assert y == pytest.approx(y_0 - 0.4 * (y_0 - y_100))
 
+        with pytest.warns(DeprecationWarning):
+            param.set_initial_stoichiometries(0.4)
+
         # check that passing inputs gives the same result
         input_param = "Maximum concentration in positive electrode [mol.m-3]"
         input_value = param[input_param]
@@ -119,8 +122,8 @@ class TestParameterValues:
         param = pybamm.lithium_ion.DFN(
             {"working electrode": "positive"}
         ).default_parameter_values
-        param = param.set_initial_state(
-            0.4, inplace=False, options={"working electrode": "positive"}
+        param.set_initial_state(
+            0.4, inplace=True, options={"working electrode": "positive"}
         )
         param_0 = param.set_initial_state(
             0, inplace=False, options={"working electrode": "positive"}
@@ -157,6 +160,11 @@ class TestParameterValues:
         )
         y_100 = param_100["Initial concentration in positive electrode [mol.m-3]"]
         assert y == pytest.approx(y_0 - 0.4 * (y_0 - y_100))
+
+        with pytest.warns(DeprecationWarning):
+            param.set_initial_stoichiometry_half_cell(
+                0.4, options={"working electrode": "positive"}
+            )
 
         # check that passing inputs gives the same result
         input_param = "Maximum concentration in positive electrode [mol.m-3]"
@@ -196,6 +204,9 @@ class TestParameterValues:
         Un_100 = param_100["Initial voltage in negative electrode [V]"]
         Up_100 = param_100["Initial voltage in positive electrode [V]"]
         assert Up_100 - Un_100 == pytest.approx(4.2)
+
+        with pytest.warns(DeprecationWarning):
+            param_100.set_initial_ocps("4.2 V", inplace=False, options=options)
 
         # check that passing inputs gives the same result
         input_param = "Maximum concentration in positive electrode [mol.m-3]"

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -305,6 +305,9 @@ class TestSimulation:
         sim.build(initial_soc=0.5)
         assert sim._built_initial_soc == 0.5
 
+        with pytest.warns(DeprecationWarning):
+            sim.set_initial_soc(0.5)
+
     def test_solve_with_initial_soc_with_input_param_in_ocv(self):
         # test having an input parameter in the ocv function
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Moves lithium ion-specific functionality out of the `ParameterValues` class into `pybamm.lithium_ion.set_initial_state` and adds an analogous `pybamm.equivalent_circuit.set_initial_state` function for the Thevenin model.

Fixes #5127 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
