### PR TITLE
Drive cycle discontinuities in experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ## Breaking changes
 
+- Changed behavior of drive cycle steps in `pybamm.Experiment`s to treat each time point as a discontinuity, consistent with how input interpolants work. This ensures more accurate simulation of drive cycles with rapid changes. ([#5141](https://github.com/pybamm-team/PyBaMM/pull/5141))
 - Removed the IREE code from the IDAKLU solver ([#5080](https://github.com/pybamm-team/PyBaMM/pull/5080))
 - Removed support for Python 3.9 ([#5052](https://github.com/pybamm-team/PyBaMM/pull/5052))
 - In OCP hysteresis models, users need to explicitly give the equilibrium, delithiation, and lithiation OCPs when using a hysteresis model. E.g., you must provide all three of "Negative electrode OCP [V]", "Negative electrode delithiation OCP [V]", and "Negative electrode lithiation OCP [V]". ([#4893](https://github.com/pybamm-team/PyBaMM/pull/4893))

--- a/examples/scripts/drive_cycle.py
+++ b/examples/scripts/drive_cycle.py
@@ -22,11 +22,11 @@ drive_cycle = pd.read_csv(
 current_interpolant = pybamm.Interpolant(drive_cycle[:, 0], drive_cycle[:, 1], pybamm.t)
 
 # set drive cycle
-param["Current function [A]"] = current_interpolant
+experiment = pybamm.Experiment([pybamm.step.current(drive_cycle)])
 
 
 # create and run simulation with the updated parameters
-sim = pybamm.Simulation(model, parameter_values=param)
+sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
 sim.solve()
 sim.plot(
     [

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -148,19 +148,13 @@ class BaseStep:
                 pybamm.t - pybamm.InputParameter("start time"),
                 name="Drive Cycle",
             )
-            if period is None:
-                # Infer the period from the drive cycle
-                self.period = _convert_time_to_seconds(period)
-            else:
-                self.period = _convert_time_to_seconds(period)
 
         elif self.is_python_function:
             t = pybamm.t - pybamm.InputParameter("start time")
             self.value = value(t)
-            self.period = _convert_time_to_seconds(period)
         else:
             self.value = value
-            self.period = _convert_time_to_seconds(period)
+        self.period = _convert_time_to_seconds(period)
 
         self.repr_args, self.hash_args = self.record_tags(
             value,

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -197,7 +197,7 @@ class TestExperimentSteps:
         drive_cycle_step = pybamm.step.current(drive_cycle, temperature="-5oC")
         # Check drive cycle operating conditions
         assert drive_cycle_step.duration == 9
-        assert drive_cycle_step.period == 1
+        assert drive_cycle_step.period is None
         assert drive_cycle_step.temperature == 273.15 - 5
 
         bad_drive_cycle = np.ones((10, 3))
@@ -215,7 +215,7 @@ class TestExperimentSteps:
         )
         # Check drive cycle operating conditions
         assert drive_cycle_step.duration == 20
-        assert drive_cycle_step.period == 1
+        assert drive_cycle_step.period is None
         assert drive_cycle_step.temperature == 273.15 - 5
 
         # Check duration shorter than drive cycle data
@@ -225,7 +225,7 @@ class TestExperimentSteps:
         )
         # Check drive cycle operating conditions
         assert drive_cycle_step.duration == 5
-        assert drive_cycle_step.period == 1
+        assert drive_cycle_step.period is None
         assert drive_cycle_step.temperature == 273.15 - 5
 
         # Check that the default c_rate duration is the length of the drive cycle
@@ -240,7 +240,7 @@ class TestExperimentSteps:
         assert drive_cycle_step.period == 0.01
 
         drive_cycle_step_no_period = pybamm.step.current(drive_cycle)
-        assert drive_cycle_step_no_period.period == 1
+        assert drive_cycle_step_no_period.period is None
 
     def test_bad_strings(self):
         with pytest.raises(TypeError, match="Input to step.string"):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -372,6 +372,21 @@ class TestSimulationExperiment:
             list(sim.experiment_unique_steps_to_model.keys())
         )
 
+    def test_run_experiment_drive_cycle_experiment(self):
+        time = [0, 5, 10]
+        current = [-1, -2, -1]
+        drive_cycle = np.column_stack([time, current])
+        experiment = pybamm.Experiment([pybamm.step.current(drive_cycle)])
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(model, experiment=experiment)
+        sol = sim.solve()
+        assert sol.termination == "final time"
+
+        assert all(t in sol.t for t in time)
+        assert len(sol.t) > len(time)
+
+        np.testing.assert_allclose(sol["Current [A]"](time), current)
+
     def test_run_experiment_breaks_early_infeasible(self):
         experiment = pybamm.Experiment(["Discharge at 2 C for 1 hour"])
         model = pybamm.lithium_ion.SPM()


### PR DESCRIPTION
# Description

Passes a `t_eval` array to the `IDAKLUSolver` for drive cycles within experiments.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
