### PR TITLE
Fix non-deterministic ShapeError in 3D FEM gradient method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ## Bug fixes
 
+- Fix non-deterministic ShapeError in 3D FEM gradient method ([#5143](https://github.com/pybamm-team/PyBaMM/pull/5143))
 - Fixes negative electrode boundary values for half-cell voltage contributions. ([#5139](https://github.com/pybamm-team/PyBaMM/pull/5139))
 - Makes `A_cc` L_z * L_y * number of layers ([#5138](https://github.com/pybamm-team/PyBaMM/pull/5138))
 - Fixes `TimeIntegral` expression node summation when dependent on an input parameter. ([#5119](https://github.com/pybamm-team/PyBaMM/pull/5119))

--- a/src/pybamm/spatial_methods/scikit_finite_element_3d.py
+++ b/src/pybamm/spatial_methods/scikit_finite_element_3d.py
@@ -82,6 +82,7 @@ class ScikitFiniteElement3D(pybamm.SpatialMethod):
         :class:`pybamm.Concatenation`
             The 3D gradient as concatenation of x, y, z or z, r, theta components
         """
+
         skfem = import_optional_dependency("skfem")
         domain = symbol.domain[0]
         mesh = self.mesh[domain]
@@ -97,6 +98,12 @@ class ScikitFiniteElement3D(pybamm.SpatialMethod):
 
         mass = skfem.asm(mass_form, mesh.basis)
         mass_inv = pybamm.Matrix(inv(csc_matrix(mass)))
+
+        if isinstance(discretised_symbol, pybamm.Scalar):  # pragma: no cover
+            zeros = pybamm.Vector(np.zeros((mesh.npts, 1)))
+            grad = pybamm.Concatenation(zeros, zeros, zeros, check_domain=False)
+            grad.copy_domains(symbol)
+            return grad
 
         grad_x = mass_inv @ (grad_x_matrix @ discretised_symbol)
         grad_y = mass_inv @ (grad_y_matrix @ discretised_symbol)


### PR DESCRIPTION
# Description

This PR resolves a non-deterministic `ShapeError` that occurred in the `ScikitFiniteElement3D` spatial method when simulating 3D thermal models.

The problem was when evaluating the gradient of a constant parameter, like thermal conductivity (lambda_eff), which PyBaMM simplifies to a pybamm.Scalar. The gradient method was not designed to handle a scalar input and would attempt an invalid matrix-scalar multiplication. 

Fixes #5142 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- [x] No style issues: `nox -s pre-commit`
- [x] All tests pass: `nox -s tests`
- [x] The documentation builds: `nox -s doctests`
- [x] Code is commented for hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
