### PR TITLE
Fix non-deterministic plotting CI issues

### DIFF
--- a/src/pybamm/spatial_methods/scikit_finite_element_3d.py
+++ b/src/pybamm/spatial_methods/scikit_finite_element_3d.py
@@ -629,3 +629,52 @@ class ScikitFiniteElement3D(pybamm.SpatialMethod):
         M.indices = M_csr.indices
         M.indptr = M_csr.indptr
         M._shape = M_csr._shape
+
+    def process_binary_operators(self, bin_op, left, right, disc_left, disc_right):
+        """
+        Process binary operators, with a specific fix for Inner products
+        involving Concatenations that may have been created without a
+        concatenation_function.
+
+        Parameters
+        ----------
+        bin_op : :class:`pybamm.BinaryOperator`
+            The binary operator to process.
+        left : :class:`pybamm.Symbol`
+            The left child of the operator.
+        right : :class:`pybamm.Symbol`
+            The right child of the operator.
+        disc_left : :class:`pybamm.Symbol`
+            The discretised left child of the operator.
+        disc_right : :class:`pybamm.Symbol`
+            The discretised right child of the operator.
+
+        Returns
+        -------
+        :class:`pybamm.Symbol`
+            The discretised binary operator.
+        """
+        if isinstance(bin_op, pybamm.Inner):
+            if (
+                isinstance(disc_left, pybamm.Concatenation)
+                and disc_left.concatenation_function is None
+            ):
+                new_disc_left = pybamm.Concatenation(
+                    *disc_left.children, concat_fun=np.hstack
+                )
+                new_disc_left.copy_domains(disc_left)
+                disc_left = new_disc_left
+
+            if (
+                isinstance(disc_right, pybamm.Concatenation)
+                and disc_right.concatenation_function is None
+            ):
+                new_disc_right = pybamm.Concatenation(
+                    *disc_right.children, concat_fun=np.hstack
+                )
+                new_disc_right.copy_domains(disc_right)
+                disc_right = new_disc_right
+
+        return super().process_binary_operators(
+            bin_op, left, right, disc_left, disc_right
+        )


### PR DESCRIPTION
# Description

I've added a patch for fixing a non-deterministic CI issues which we are facing again see:
https://github.com/pybamm-team/PyBaMM/actions/runs/16773282222/job/47493305155?pr=5149

Again the issue seems to be some race conditions during simplification in expression tree. This patch should fix it for now but we need to see what's actually causing these race conditions so often, its happening in quite a few tests of PyBaMM.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- [x] No style issues: `nox -s pre-commit`
- [x] All tests pass: `nox -s tests`
- [x] The documentation builds: `nox -s doctests`
- [x] Code is commented for hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works
