### PR TITLE
Fix drive cycle duration bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Adds a composite electrode electrode soh model ([#5160](https://github.com/pybamm-team/PyBaMM/pull/5129))
 - Generalises `set_initial_soc` to `set_initial_state` and adds Thevenin initial state setting. ([#5129](https://github.com/pybamm-team/PyBaMM/pull/5129))
 
+## Bug fixes
+
+- Fixed a bug where the final duration of a drive cycle would not be inferred correctly. ([#5153](https://github.com/pybamm-team/PyBaMM/pull/5153))
+
 # [v25.8.0](https://github.com/pybamm-team/PyBaMM/tree/v25.8.0) - 2025-08-04
 
 ## Features

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -346,6 +346,8 @@ class BaseStep:
             # then truncate the drive cycle
             if t_eval[-1] > tf:
                 t_eval = t_eval[t_eval <= tf]
+            if t_eval[-1] != tf:
+                t_eval = np.append(t_eval, tf)
         else:
             t_eval = np.array([0, tf])
 

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1216,9 +1216,15 @@ class BaseSolver:
             t_eval = np.linspace(0, dt, npts)
         elif t_eval is None:
             t_eval = np.array([0, dt])
-        elif t_eval[0] != 0 or t_eval[-1] != dt:
+        elif t_eval[0] != 0:
             raise pybamm.SolverError(
-                "Elements inside array t_eval must lie in the closed interval 0 to dt"
+                f"The first `t_eval` value ({t_eval[0]}) must be 0."
+                "Please correct your `t_eval` array."
+            )
+        elif t_eval[-1] != dt:
+            raise pybamm.SolverError(
+                f"The final `t_eval` value ({t_eval[-1]}) must be equal "
+                f"to the step time `dt` ({dt}). Please correct your `t_eval` array."
             )
         else:
             pass

--- a/tests/integration/test_experiments.py
+++ b/tests/integration/test_experiments.py
@@ -101,3 +101,29 @@ class TestExperiments:
         # Add a small tolerance to account for numerical errors
         V_max = 4.00 - 1e-4
         assert np.all(sol["Terminal voltage [V]"].entries >= V_max)
+
+    def test_drive_cycle_duration(self):
+        # Test that the drive cycle is truncated to duration timespan
+        tf = 1
+        drive_cycle = np.column_stack(
+            (
+                np.array([0, tf + 1]),
+                np.array([0, -1 / 100]),
+            )
+        )
+        c_step = pybamm.step.current(value=drive_cycle, duration=tf)
+        experiment = pybamm.Experiment(
+            [
+                c_step,
+            ],
+        )
+        model = pybamm.lithium_ion.SPM()
+        param = pybamm.ParameterValues("Chen2020")
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            parameter_values=param,
+        )
+        sol = sim.solve()
+
+        assert sol.t[-1] == tf

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -93,14 +93,14 @@ class TestBaseSolver:
         t_eval = np.array([0, 1])
         with pytest.raises(
             pybamm.SolverError,
-            match="Elements inside array t_eval must lie in the closed interval 0 to dt",
+            match="The final `t_eval` value \\(1\\) must be equal to the step time `dt` \\(2\\)",
         ):
             solver.step(None, model, dt, t_eval=t_eval)
 
         t_eval = np.array([1, dt])
         with pytest.raises(
             pybamm.SolverError,
-            match="Elements inside array t_eval must lie in the closed interval 0 to dt",
+            match="The first `t_eval` value \\(1\\) must be 0",
         ):
             solver.step(None, model, dt, t_eval=t_eval)
 


### PR DESCRIPTION
# Description

Fixes a bug where the final duration of a drive cycle would not be inferred correctly.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
