### PR TITLE
add model option override

### DIFF
--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -784,7 +784,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                     raise pybamm.OptionError(
                         f"\n'{value}' is not recognized in option '{option}'. "
                         "Values must be strings or (in some cases) "
-                        "2-tuples of strings"
+                        "2-tuples of strings."
                     )
             # flatten value
             value_list = []
@@ -805,10 +805,16 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                         # "number of MSMR reactions" can be a positive integer
                         pass
                     else:
-                        raise pybamm.OptionError(
-                            f"\n'{val}' is not recognized in option '{option}'. "
-                            f"Possible values are {self.possible_options[option]}"
-                        )
+                        if isinstance(val, str) and val.startswith("override:"):
+                            pass
+                        else:
+                            raise pybamm.OptionError(
+                                f"\n'{val}' is not recognized in option '{option}'. "
+                                f"Possible values are {self.possible_options[option]}."
+                                "If you are using a custom submodel, you can use the "
+                                "'override' prefix to avoid this error, such as "
+                                "'override:my_option'."
+                            )
 
         super().__init__(options.items())
 

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -275,6 +275,9 @@ class TestBaseBatteryModel:
                     "total interfacial current density as a state": "false",
                 }
             )
+        # Test override
+        model = pybamm.BaseBatteryModel({"thermal": "override:my_thermal_model"})
+        assert model.options["thermal"] == "override:my_thermal_model"
 
         # loss of active material model
         with pytest.raises(pybamm.OptionError, match="loss of active material"):


### PR DESCRIPTION
# Description

Allows for use of custom submodels by not erroring when a custom model option is detected.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
