### PR TITLE
Computing Bruggeman coefficient from BPX porosity instead of hardcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
 - Fix a bug in the calculation of "Bulk" OCP terms in hysteresis models ([#5169](https://github.com/pybamm-team/PyBaMM/pull/5169))
 - Fixed a bug where the final duration of a drive cycle would not be inferred correctly. ([#5153](https://github.com/pybamm-team/PyBaMM/pull/5153))
 - Fixes a bug where sensitivities for 1D+ variables calculated using the `output_variables` options were incorrect ([#5118](https://github.com/pybamm-team/PyBaMM/pull/5118))
+- Fix Bruggeman coefficient computation from BPX porosity and transport efficiency instead of hard-coding, remove redundant values, and add a unit test for verification. ([#5196](https://github.com/pybamm-team/PyBaMM/pull/5196))
 
 # [v25.8.0](https://github.com/pybamm-team/PyBaMM/tree/v25.8.0) - 2025-08-04
+
 
 ## Features
 

--- a/src/pybamm/parameters/bpx.py
+++ b/src/pybamm/parameters/bpx.py
@@ -216,10 +216,13 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
     pybamm_dict.update({"Total heat transfer coefficient [W.m-2.K-1]": 0})
 
     # transport efficiency
+    # Compute Bruggeman coefficient from BPX-specified porosity and transport efficiency
     for domain in [negative_electrode, separator, positive_electrode]:
-        pybamm_dict[domain.pre_name + "porosity"] = pybamm_dict[
-            domain.pre_name + "transport efficiency"
-        ] ** (1.0 / 1.5)
+        pybamm_dict[domain.pre_name + "Bruggeman coefficient (electrolyte)"] = (
+          math.log(pybamm_dict[domain.pre_name + "transport efficiency"])
+          / math.log(pybamm_dict[domain.pre_name + "porosity"])
+    )
+
 
     def _get_activation_energy(var_name):
         return pybamm_dict.get(var_name) or 0.0

--- a/src/pybamm/parameters/bpx.py
+++ b/src/pybamm/parameters/bpx.py
@@ -218,11 +218,9 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
     # transport efficiency
     # Compute Bruggeman coefficient from BPX-specified porosity and transport efficiency
     for domain in [negative_electrode, separator, positive_electrode]:
-        pybamm_dict[domain.pre_name + "Bruggeman coefficient (electrolyte)"] = (
-          math.log(pybamm_dict[domain.pre_name + "transport efficiency"])
-          / math.log(pybamm_dict[domain.pre_name + "porosity"])
-    )
-
+        pybamm_dict[domain.pre_name + "Bruggeman coefficient (electrolyte)"] = math.log(
+            pybamm_dict[domain.pre_name + "transport efficiency"]
+        ) / math.log(pybamm_dict[domain.pre_name + "porosity"])
 
     def _get_activation_energy(var_name):
         return pybamm_dict.get(var_name) or 0.0

--- a/src/pybamm/parameters/bpx.py
+++ b/src/pybamm/parameters/bpx.py
@@ -145,10 +145,6 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
     # activity
     pybamm_dict["Thermodynamic factor"] = 1.0
 
-    # assume Bruggeman relation for effective electrolyte properties
-    for domain in [negative_electrode, separator, positive_electrode]:
-        pybamm_dict[domain.pre_name + "Bruggeman coefficient (electrolyte)"] = 1.5
-
     # solid phase properties reported in BPX are already "effective",
     # so no correction is applied
     for domain in [negative_electrode, positive_electrode]:


### PR DESCRIPTION
# Description

This PR fixes an issue where `pybamm.ParameterValues.create_from_bpx()` ignored the porosity specified in BPX files and used a hard-coded Bruggeman coefficient of 1.5 for all domains.  
The BPX importer now correctly reads the specified porosity and calculates the Bruggeman coefficient from the provided transport efficiency and porosity.

Fixes #5193

## Type of change
 Bug fix:  BPX importer now uses correct porosity and Bruggeman coefficient.

# Important checks

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
