### PR TITLE
Add options to terminate `IDAKLUSolver` early when there's little progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added the `num_steps_no_progress` and `t_no_progress` options in the `IDAKLUSolver` to early terminate the simulation if little progress is detected. ([#5201](https://github.com/pybamm-team/PyBaMM/pull/5201))
 - Added helper functions to import external 3D meshes in PyBaMM ([#5162](https://github.com/pybamm-team/PyBaMM/pull/5162))
 - Added support for algebraic and differential surface form in composite models. ([#5165](https://github.com/pybamm-team/PyBaMM/pull/5165))
 - Adds a composite electrode electrode soh model ([#5160](https://github.com/pybamm-team/PyBaMM/pull/5129))

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -195,8 +195,8 @@ class IDAKLUSolver(pybamm.BaseSolver):
             "linesearch_off_ic": False,
             "init_all_y_ic": False,
             "calc_ic": True,
-            "num_steps_no_progress": 1000,
-            "t_no_progress": 1.0,
+            "num_steps_no_progress": 0,
+            "t_no_progress": 0.0,
         }
         if options is None:
             options = default_options

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -133,6 +133,15 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 "init_all_y_ic": False,
                 # Calculate consistent initial conditions
                 "calc_ic": True,
+                ## Early termination
+                # Maximum number of consecutive steps allowed without advancing
+                # the solution time by at least `t_no_progress` seconds.
+                # If set to 0, this feature is disabled.
+                "num_steps_no_progress": 0,
+                # Minimum required time advancement (in seconds) after
+                # `num_steps_no_progress` consecutive steps.
+                # If set to 0.0, this feature is disabled.
+                "t_no_progress": 0.0,
             }
 
         Note: These options only have an effect if model.convert_to_format == 'casadi'
@@ -186,6 +195,8 @@ class IDAKLUSolver(pybamm.BaseSolver):
             "linesearch_off_ic": False,
             "init_all_y_ic": False,
             "calc_ic": True,
+            "num_steps_no_progress": 1000,
+            "t_no_progress": 1.0,
         }
         if options is None:
             options = default_options

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -1249,3 +1249,47 @@ class TestIDAKLUSolver:
             )
             assert len(w) > 0
             assert "FAILURE" in str(w[0].message)
+
+    def test_no_progress_early_termination(self):
+        # SPM at rest
+        model = pybamm.lithium_ion.SPM()
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        parameter_values.update({"Current function [A]": 0})
+
+        t_eval = [0, 10000]
+
+        options_successes = [
+            # Case 1: feature disabled because num_steps_no_progress is default (0)
+            # even if t_no_progress is huge
+            {
+                "t_no_progress": 1e10,
+                "num_steps_no_progress": 0,
+            },
+            # Case 2: feature disabled because t_no_progress is default (0.0)
+            # even if num_steps_no_progress is positive
+            {
+                "num_steps_no_progress": 5,
+                "t_no_progress": 0.0,
+            },
+        ]
+
+        for options in options_successes:
+            solver = pybamm.IDAKLUSolver(on_failure="ignore", options=options)
+            sim = pybamm.Simulation(
+                model, parameter_values=parameter_values, solver=solver
+            )
+            sol = sim.solve(t_eval)
+            assert sol.termination == "final time"
+
+        ## Check failure
+        options_failures = {
+            "num_steps_no_progress": 5,
+            "t_no_progress": 1e10,
+        }
+        solver = pybamm.IDAKLUSolver(on_failure="ignore", options=options_failures)
+        sim = pybamm.Simulation(model, parameter_values=parameter_values, solver=solver)
+        sol = sim.solve(t_eval)
+        assert sol.termination == "failure"
+
+        assert len(sol.t) == options_failures["num_steps_no_progress"]
+        assert sol.t[-1] < options_failures["t_no_progress"]


### PR DESCRIPTION
# Description

Companion PR to https://github.com/pybamm-team/pybammsolvers/pull/57

> Adds an optional method to fail the simulation if the solver is not making progress. This is useful when the parameters are ill-conditioned and the solver is making very slow progress, such as in optimization


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
