### PR TITLE
Added warning about installation through conda to docs and suggested installation via pip 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 
 ## Bug fixes
 
-- Added explicit warning in installation docs about unmaintained Conda recipe due to pybammsolvers split (Fixes #5155). See pull request [#5206](https://github.com/pybamm-team/PyBaMM/pull/5206)
 - Fixed non-deterministic plotting CI issues ([#5150](https://github.com/pybamm-team/PyBaMM/pull/5150))
 - Fix non-deterministic ShapeError in 3D FEM gradient method ([#5143](https://github.com/pybamm-team/PyBaMM/pull/5143))
 - Fixes negative electrode boundary values for half-cell voltage contributions. ([#5139](https://github.com/pybamm-team/PyBaMM/pull/5139))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,11 @@
 
 ## Bug fixes
 
+<<<<<<< HEAD
 - Fixed non-deterministic plotting CI issues ([#5150](https://github.com/pybamm-team/PyBaMM/pull/5150))
+=======
+ Added explicit warning in installation docs about unmaintained Conda recipe due to pybammsolvers split (Fixes #5155). See pull request [#5206](https://github.com/pybamm-team/PyBaMM/pull/5206)
+>>>>>>> c217e5bff (added changelog entry for conda installation error)
 - Fix non-deterministic ShapeError in 3D FEM gradient method ([#5143](https://github.com/pybamm-team/PyBaMM/pull/5143))
 - Fixes negative electrode boundary values for half-cell voltage contributions. ([#5139](https://github.com/pybamm-team/PyBaMM/pull/5139))
 - Makes `A_cc` L_z * L_y * number of layers ([#5138](https://github.com/pybamm-team/PyBaMM/pull/5138))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- Added explicit warning in installation docs about unmaintained Conda recipe due to pybammsolvers split (Fixes #5155). See pull request [#5206](https://github.com/pybamm-team/PyBaMM/pull/5206)
 - Fixed a bug where time-based Heaviside or modulo discontinuities could trigger out-of-bounds errors in time arrays. ([#5205](https://github.com/pybamm-team/PyBaMM/pull/5205))
 - Fixed a bug using a time-varying input with heaviside or modulo functions using the `IDAKLUSolver`. ([#4994](https://github.com/pybamm-team/PyBaMM/pull/4994))
 - Fix a bug in setting initial stoichiometries where the reference temperature was used instead of the initial temperature. ([#5189](https://github.com/pybamm-team/PyBaMM/pull/5189))
@@ -41,11 +42,8 @@
 
 ## Bug fixes
 
-<<<<<<< HEAD
+- Added explicit warning in installation docs about unmaintained Conda recipe due to pybammsolvers split (Fixes #5155). See pull request [#5206](https://github.com/pybamm-team/PyBaMM/pull/5206)
 - Fixed non-deterministic plotting CI issues ([#5150](https://github.com/pybamm-team/PyBaMM/pull/5150))
-=======
- Added explicit warning in installation docs about unmaintained Conda recipe due to pybammsolvers split (Fixes #5155). See pull request [#5206](https://github.com/pybamm-team/PyBaMM/pull/5206)
->>>>>>> c217e5bff (added changelog entry for conda installation error)
 - Fix non-deterministic ShapeError in 3D FEM gradient method ([#5143](https://github.com/pybamm-team/PyBaMM/pull/5143))
 - Fixes negative electrode boundary values for half-cell voltage contributions. ([#5139](https://github.com/pybamm-team/PyBaMM/pull/5139))
 - Makes `A_cc` L_z * L_y * number of layers ([#5138](https://github.com/pybamm-team/PyBaMM/pull/5138))

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -5,6 +5,8 @@ Installation
 PyBaMM is available on GNU/Linux, MacOS and Windows.
 It can be installed using ``pip`` or ``conda``, or from source.
 
+Warning: The PyBaMM Conda recipe is not currently maintained and lags several releases behind. As a result, installations via Conda may provide an outdated version. To access the latest version, consider installing PyBaMM using pip.
+
 .. tab:: pip
 
    PyBaMM can be installed via pip from `PyPI <https://pypi.org/project/pybamm>`__.

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -5,8 +5,6 @@ Installation
 PyBaMM is available on GNU/Linux, MacOS and Windows.
 It can be installed using ``pip`` or ``conda``, or from source.
 
-Warning: The PyBaMM Conda recipe is not currently maintained and lags several releases behind. As a result, installations via Conda may provide an outdated version. To access the latest version, consider installing PyBaMM using pip.
-
 .. tab:: pip
 
    PyBaMM can be installed via pip from `PyPI <https://pypi.org/project/pybamm>`__.
@@ -31,6 +29,11 @@ Warning: The PyBaMM Conda recipe is not currently maintained and lags several re
 
       conda install -c conda-forge pybamm-base
 
+.. warning::
+
+   The PyBaMM Conda recipe is not currently maintained and lags several releases behind.
+   As a result, installations via Conda may provide an outdated version.
+   To access the latest version, consider installing PyBaMM using pip.
 
 Optional solvers
 ----------------
@@ -62,8 +65,8 @@ PyBaMM requires the following dependencies.
 =================================================================== ==========================
 Package                                                             Supported version(s)
 =================================================================== ==========================
-`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     >= 0.2.0, <0.4.0
-`NumPy <https://numpy.org>`__                                         Whatever recent versions work
+`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     0.0.4
+`NumPy <https://numpy.org>`__                                         >= 1.23.5, <2
 `SciPy <https://docs.scipy.org/doc/scipy/>`__                         Whatever recent versions work. >= 1.9.3
 `CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.6.7
 `Xarray <https://docs.xarray.dev/en/stable/>`__                       Whatever recent versions work. >= 2022.6.0

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -66,7 +66,7 @@ PyBaMM requires the following dependencies.
 Package                                                             Supported version(s)
 =================================================================== ==========================
 `PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     0.0.4
-`NumPy <https://numpy.org>`__                                         >= 1.23.5, <2
+`NumPy <https://numpy.org>`__                                         Whatever recent versions work
 `SciPy <https://docs.scipy.org/doc/scipy/>`__                         Whatever recent versions work. >= 1.9.3
 `CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.6.7
 `Xarray <https://docs.xarray.dev/en/stable/>`__                       Whatever recent versions work. >= 2022.6.0

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -65,7 +65,7 @@ PyBaMM requires the following dependencies.
 =================================================================== ==========================
 Package                                                             Supported version(s)
 =================================================================== ==========================
-`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     0.0.4
+`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     >= 0.2.0, <0.4.0
 `NumPy <https://numpy.org>`__                                         Whatever recent versions work
 `SciPy <https://docs.scipy.org/doc/scipy/>`__                         Whatever recent versions work. >= 1.9.3
 `CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.6.7

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -32,7 +32,7 @@ It can be installed using ``pip`` or ``conda``, or from source.
 .. warning::
 
    The PyBaMM Conda recipe is not currently maintained and lags several releases behind.
-   As a result, installations via Conda may provide an outdated version.
+   As a result, installations via Conda will provide an outdated version.
    To access the latest version, consider installing PyBaMM using pip.
 
 Optional solvers


### PR DESCRIPTION
## Description

This PR adds an explicit warning to the installation documentation (`index.rst`) about the Conda recipe being unmaintained and several releases behind, as discussed in issue #5155. The warning advises users to install PyBaMM using pip for the latest features and solvers, following the guidance from the maintainers.

## Type of change

  Documentation update

## Checklist

- [x] Locally built the documentation with `nox -s docs` to verify the warning renders correctly
- [x] No pre-commit or formatting issues (`nox -s pre-commit`)
- [x] Tests pass as usual (`nox -s tests`)
- [x] Added a line to the changelog as required

---


<img width="772" height="258" alt="image" src="https://github.com/user-attachments/assets/42df0f44-e5e6-4e07-be38-cd9ef9acee12" />


