### PR TITLE
Fix typo in Butler-Volmer equation docstring

### DIFF
--- a/src/pybamm/models/submodels/interface/kinetics/butler_volmer.py
+++ b/src/pybamm/models/submodels/interface/kinetics/butler_volmer.py
@@ -12,7 +12,7 @@ class SymmetricButlerVolmer(BaseKinetics):
     Submodel which implements the symmetric forward Butler-Volmer equation:
 
     .. math::
-        j = 2 * j_0(c) * \\sinh(ne * F * \\eta_r(c) / RT)
+        j = 2 * j_0(c) * \\sinh(ne * F * \\eta_r(c) / 2RT)
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- Corrected typo in Butler-Volmer equation documentation
- Changed denominator from `RT` to `2RT` in the `SymmetricButlerVolmer` class docstring

## Rationale
The docstring incorrectly showed the Butler-Volmer equation as:
```
j = 2 * j_0(c) * sinh(ne * F * η_r(c) / RT)
```

The correct form is:
```
j = 2 * j_0(c) * sinh(ne * F * η_r(c) / 2RT)
```

The code implementation (line 37) was already correct: `ne * 0.5 * Feta_RT`, which is mathematically equivalent to the corrected formula.

## Changes
- **File modified:** `src/pybamm/models/submodels/interface/kinetics/butler_volmer.py`
- **Line 15:** Added `2` in denominator of the equation in docstring

## Test Plan
- This is a documentation-only change
- The code implementation was already correct and remains unchanged
- No functional changes to test

Fixes #5278