### PR TITLE
fix bug with bulk ocp lithiation

### DIFF
--- a/src/pybamm/models/submodels/interface/open_circuit_potential/base_hysteresis_ocp.py
+++ b/src/pybamm/models/submodels/interface/open_circuit_potential/base_hysteresis_ocp.py
@@ -84,7 +84,7 @@ class BaseHysteresisOpenCircuitPotential(BaseOpenCircuitPotential):
             U_eq = self.phase_param.U(sto_surf, T)
             U_eq_x_av = self.phase_param.U(sto_surf, T)
             U_lith = self.phase_param.U(sto_surf, T, "lithiation")
-            U_lith_bulk = self.phase_param.U(sto_bulk, T_bulk)
+            U_lith_bulk = self.phase_param.U(sto_bulk, T_bulk, "lithiation")
             U_delith = self.phase_param.U(sto_surf, T, "delithiation")
             U_delith_bulk = self.phase_param.U(sto_bulk, T_bulk, "delithiation")
 


### PR DESCRIPTION
# Description

Fixes a bug where "lithiation" wasn't passed to the bulk OCP (` U_lith_bulk = self.phase_param.U(sto_bulk, T_bulk, "lithiation")`) which led to incorrect outputs for the "particle concentration overpotential" variables.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
