### PR TITLE
Fix typo in concentration description in notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - Fixed a bug where simulations whose initial conditions violated the events could continue solving. ([#5260](https://github.com/pybamm-team/PyBaMM/pull/5260))
 - Fixed an issues with composite electrode and "swelling only" mechanics sub-models, which were not creating the cell thickness variable. ([#5272](https://github.com/pybamm-team/PyBaMM/pull/5272))
-- Removed $ character in `docs/source/examples/notebooks/creating_models/4-comparing-full-and-reduced-order-models.ipynb` that breaks latex rendering. ([#5284](https://github.com/pybamm-team/PyBaMM/pull/5284))
 
 # [v25.10.0](https://github.com/pybamm-team/PyBaMM/tree/v25.10.0) - 2025-10-29
 


### PR DESCRIPTION
# Description

Fixes a typo in latex code of in docs/source/examples/notebooks/creating_models/4-comparing-full-and-reduced-order-models.ipynb 

Fixes # #5283

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
