### PR TITLE
Restructure idaklu jax tests

### DIFF
--- a/tests/unit/test_solvers/test_idaklu_jax.py
+++ b/tests/unit/test_solvers/test_idaklu_jax.py
@@ -16,6 +16,12 @@ if pybamm.has_jax():
     output_variables = ["v", "u1", "u2"]
 
 
+@pytest.fixture(autouse=True)
+def clear_lru_cache():
+    yield
+    pybamm.IDAKLUJax._cached_solve.cache_clear()
+
+
 @pytest.fixture(scope="module")
 def sim():
     model = pybamm.BaseModel()


### PR DESCRIPTION
Restructures the `test_idaklu_jax` file to use pytest fixtures rather than running code during test collection.

Also clears the cached solve after every test.