### PR TITLE
fix idaklu jax test issue

### DIFF
--- a/tests/unit/test_solvers/test_idaklu_jax.py
+++ b/tests/unit/test_solvers/test_idaklu_jax.py
@@ -72,28 +72,30 @@ def no_jit(f):
     return f
 
 
-@pytest.fixture(
-    params=[
-        (output_variables[:1], no_jit),
-        (output_variables[:1], jax.jit),
-        (output_variables, no_jit),
-        (output_variables, jax.jit),
-    ],
-    ids=["single-no-jit", "single-jit", "multiple-no-jit", "multiple-jit"],
-)
-def case(request, model):
-    outvars, wrapper = request.param
+if pybamm.has_jax():
 
-    # Build jaxified solver and function
-    idaklu_jax_solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6).jaxify(
-        model,
-        t_eval,
-        output_variables=outvars,
-        calculate_sensitivities=True,
-        t_interp=t_eval,
+    @pytest.fixture(
+        params=[
+            (output_variables[:1], no_jit),
+            (output_variables[:1], jax.jit),
+            (output_variables, no_jit),
+            (output_variables, jax.jit),
+        ],
+        ids=["single-no-jit", "single-jit", "multiple-no-jit", "multiple-jit"],
     )
-    f = idaklu_jax_solver.get_jaxpr()
-    return outvars, idaklu_jax_solver, f, wrapper
+    def case(request, model):
+        outvars, wrapper = request.param
+
+        # Build jaxified solver and function
+        idaklu_jax_solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6).jaxify(
+            model,
+            t_eval,
+            output_variables=outvars,
+            calculate_sensitivities=True,
+            t_interp=t_eval,
+        )
+        f = idaklu_jax_solver.get_jaxpr()
+        return outvars, idaklu_jax_solver, f, wrapper
 
 
 # Check the interface throws an appropriate error if either IDAKLU or JAX not available


### PR DESCRIPTION
# Description

One of the fixtures in #5315 would try and execute with undefined variables if Jax is not installed. This moves that fixture inside the conditional which makes test skipped rather than error for devs without Jax installed.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
