### PR TITLE
copyright should only include the year of creation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2025, the PyBaMM team.
+Copyright (c) 2018, the PyBaMM team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.abspath("./sphinxext/"))
 # -- Project information -----------------------------------------------------
 
 project = "PyBaMM"
-copyright = "2018-2025, The PyBaMM Team"
+copyright = "2018, The PyBaMM Team"
 author = "The PyBaMM Team"
 
 # The short X.Y version


### PR DESCRIPTION
# Description

Just found out that our update copyright workflow was removed from the repository but the copyright was never fixed. Quick tip from https://devguide.python.org/getting-started/pull-request-lifecycle/#copyrights:

> Copyright notices are optional and informational, as international treaties have abolished the requirement for them to protect copyrights. However, they still serve an informative role.
>
> According to the US Copyright Office, valid copyright notices include the year of first publication of the work. For example:
>
> > Copyright (C) 2001 Python Software Foundation.
>
> Updating notices to add subsequent years is unnecessary and such PRs will be closed.
>
> See also [python/cpython#126133](https://github.com/python/cpython/issues/126133#issuecomment-2460824052).

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
