### PR TITLE
ParameterSubstitutor bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Bug fixes
 
+- Fixed a bug where `ExpressionFunctionParameter` children were not properly substituted after JSON deserialization, causing `ElectrodeSOHSolver` to fail with "Variable not implemented" errors. ([#5352](https://github.com/pybamm-team/PyBaMM/pull/5352))
+
 # [v25.12.0](https://github.com/pybamm-team/PyBaMM/tree/v25.12.0) - 2026-01-15
 
 ## Features

--- a/src/pybamm/parameters/parameter_substitutor.py
+++ b/src/pybamm/parameters/parameter_substitutor.py
@@ -297,7 +297,7 @@ class ParameterSubstitutor:
             inputs = {
                 arg: child
                 for arg, child in zip(
-                    function_parameter.func_args, symbol.children, strict=False
+                    function_parameter.func_args, new_children, strict=False
                 )
             }
 
@@ -315,9 +315,6 @@ class ParameterSubstitutor:
             combined_store = ParameterStore(dict(self._store._data))
             combined_store.update(inputs)
             combined_processor = ParameterSubstitutor(combined_store)
-
-            # Copy parent cache to combined processor
-            combined_processor._cache.update(self._cache)
 
             # Process any FunctionParameter children first to avoid recursion
             for child in expression.pre_order():
@@ -345,12 +342,6 @@ class ParameterSubstitutor:
 
             # Process function with combined processor to get a symbolic expression
             function = combined_processor.process_symbol(expression)
-
-            # Propagate newly cached symbols back to parent cache for reuse
-            # Only propagate symbols that don't depend on the local inputs
-            for sym, processed in combined_processor._cache.items():
-                if sym not in self._cache and sym not in inputs.values():
-                    self._cache[sym] = processed
 
             # Differentiate if necessary
             if symbol.diff_variable is None:


### PR DESCRIPTION
# Description

Fixes inputs dict bug w/ unprocessed child parameters and cache collision problem with `ExpressionFunctionParameter`

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
