### PR TITLE
Switch to `npt.assert_allclose` in unit tests

### DIFF
--- a/tests/unit/test_experiments/test_experiment.py
+++ b/tests/unit/test_experiments/test_experiment.py
@@ -239,7 +239,7 @@ class TestExperiment:
 
         current = solution["Current [A]"].entries
 
-        assert np.allclose(current, 1, atol=1e-3)
+        np.testing.assert_allclose(current, 1, atol=1e-3)
 
     def test_current_step_raises_error_without_operator_with_input_parameters(self):
         pybamm.lithium_ion.SPM()
@@ -288,7 +288,7 @@ class TestExperiment:
         solution = sim.solution
 
         voltage = solution["Terminal voltage [V]"].entries
-        assert np.allclose(voltage, 2.5, atol=1e-3, rtol=1e-3)
+        np.testing.assert_allclose(voltage, 2.5, atol=1e-3, rtol=1e-3)
 
     def test_pchip_interpolation_experiment(self):
         x = np.linspace(0, 1, 11)

--- a/tests/unit/test_expression_tree/test_symbolic_diff.py
+++ b/tests/unit/test_expression_tree/test_symbolic_diff.py
@@ -21,7 +21,7 @@ class TestSymbolicDifferentiation:
         assert func.diff(b).evaluate(y=y) == -2 / 9
         #
         func = a * b**a
-        testing.assert_array_almost_equal(
+        testing.assert_allclose(
             func.diff(a).evaluate(y=y)[0], 3**5 * (5 * np.log(3) + 1)
         )
         assert func.diff(b).evaluate(y=y) == 5**2 * 3**4

--- a/tests/unit/test_meshes/test_two_dimensional_submesh.py
+++ b/tests/unit/test_meshes/test_two_dimensional_submesh.py
@@ -248,8 +248,8 @@ class TestUniform2DSubMesh:
         expected_dx = 2.0 / 10  # (max - min) / npts
         expected_dy = 4.0 / 15  # (max - min) / npts
 
-        np.testing.assert_array_almost_equal(submesh.d_edges_lr, expected_dx)
-        np.testing.assert_array_almost_equal(submesh.d_edges_tb, expected_dy)
+        np.testing.assert_allclose(submesh.d_edges_lr, expected_dx)
+        np.testing.assert_allclose(submesh.d_edges_tb, expected_dy)
 
         # Test that nodes are at cell centers
         expected_nodes_lr = np.linspace(
@@ -259,15 +259,15 @@ class TestUniform2DSubMesh:
             -1.0 + expected_dy / 2, 3.0 - expected_dy / 2, 15
         )
 
-        np.testing.assert_array_almost_equal(submesh.nodes_lr, expected_nodes_lr)
-        np.testing.assert_array_almost_equal(submesh.nodes_tb, expected_nodes_tb)
+        np.testing.assert_allclose(submesh.nodes_lr, expected_nodes_lr)
+        np.testing.assert_allclose(submesh.nodes_tb, expected_nodes_tb)
 
         # Test d_nodes (spacing between node centers)
         expected_d_nodes_lr = np.full(9, expected_dx)  # npts - 1
         expected_d_nodes_tb = np.full(14, expected_dy)  # npts - 1
 
-        np.testing.assert_array_almost_equal(submesh.d_nodes_lr, expected_d_nodes_lr)
-        np.testing.assert_array_almost_equal(submesh.d_nodes_tb, expected_d_nodes_tb)
+        np.testing.assert_allclose(submesh.d_nodes_lr, expected_d_nodes_lr)
+        np.testing.assert_allclose(submesh.d_nodes_tb, expected_d_nodes_tb)
 
     def test_uniform_2d_submesh_with_tabs(self, x, y):
         """
@@ -406,8 +406,8 @@ class TestUniform2DSubMesh:
         assert "tabs" in json_dict
 
         # Test that edges are correctly serialized
-        np.testing.assert_array_almost_equal(json_dict["edges_lr"], submesh.edges_lr)
-        np.testing.assert_array_almost_equal(json_dict["edges_tb"], submesh.edges_tb)
+        np.testing.assert_allclose(json_dict["edges_lr"], submesh.edges_lr)
+        np.testing.assert_allclose(json_dict["edges_tb"], submesh.edges_tb)
 
         # Test that coordinate system is correct
         assert json_dict["coord_sys"] == "cartesian"

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -52,8 +52,8 @@ class TestBaseSolver:
             [0, 3600], inputs=[{"Current function [A]": 1}, {"Current function [A]": 2}]
         )[0]["Voltage [V]"].entries
         # check that the solutions are the same
-        np.testing.assert_array_almost_equal(sol1, sol2)
-        np.testing.assert_array_almost_equal(sol2, sol3)
+        np.testing.assert_allclose(sol1, sol2)
+        np.testing.assert_allclose(sol2, sol3)
 
     def test_step_or_solve_empty_model(self):
         model = pybamm.BaseModel()

--- a/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume/test_finite_volume.py
@@ -403,9 +403,7 @@ class TestFiniteVolume:
         assert delta_fn_left_disc.domains == delta_fn_left.domains
         assert isinstance(delta_fn_left_disc, pybamm.Multiplication)
         assert isinstance(delta_fn_left_disc.left, pybamm.Symbol)
-        np.testing.assert_array_almost_equal(
-            delta_fn_left_disc.left.evaluate()[:, 1:], 0
-        )
+        np.testing.assert_allclose(delta_fn_left_disc.left.evaluate()[:, 1:], 0)
         assert delta_fn_left_disc.shape == y.shape
         # Right
         assert delta_fn_right_disc.domains == delta_fn_right.domains
@@ -442,9 +440,7 @@ class TestFiniteVolume:
         assert delta_fn_left_disc.domains == delta_fn_left.domains
         assert isinstance(delta_fn_left_disc, pybamm.Multiplication)
         assert isinstance(delta_fn_left_disc.left, pybamm.Symbol)
-        np.testing.assert_array_almost_equal(
-            delta_fn_left_disc.left.evaluate()[:, 1:], 0
-        )
+        np.testing.assert_allclose(delta_fn_left_disc.left.evaluate()[:, 1:], 0)
         assert delta_fn_left_disc.shape == y.shape
         # Right
         assert delta_fn_right_disc.domains == delta_fn_right.domains

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_2d_finite_volume_integration.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_2d_finite_volume_integration.py
@@ -264,7 +264,7 @@ class TestFiniteVolumeIntegration:
         result_left = boundary_integral_left_disc.evaluate(
             None, y=np.ones(submesh.npts)
         )
-        np.testing.assert_array_almost_equal(result_left, 0.0)
+        np.testing.assert_allclose(result_left, 0.0, atol=1e-6)
 
     def test_one_dimensional_integral(self):
         mesh = get_mesh_for_testing_2d()

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_extrapolation.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_extrapolation.py
@@ -136,33 +136,37 @@ class TestExtrapolationFiniteVolume2D:
             )
 
         for direction in directions:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_extrapolations_LR[direction]
                 .evaluate(y=LR.flatten())
                 .flatten(),
                 solutions_LR[direction],
+                atol=1e-6,
             )
         for direction in directions:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_extrapolations_LR_neumann[direction]
                 .evaluate(y=LR.flatten())
                 .flatten(),
                 solutions_LR[direction],
+                atol=1e-6,
             )
 
         for direction in directions:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_extrapolations_TB[direction]
                 .evaluate(y=TB.flatten())
                 .flatten(),
                 solutions_TB[direction],
+                atol=1e-6,
             )
         for direction in directions:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_extrapolations_TB_neumann[direction]
                 .evaluate(y=TB.flatten())
                 .flatten(),
                 solutions_TB[direction],
+                atol=1e-6,
             )
 
     @pytest.mark.parametrize("use_bcs", [True, False])
@@ -281,11 +285,11 @@ class TestExtrapolationFiniteVolume2D:
 
         # Check results for linear x function
         for direction in directions_LR:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_LR[direction].evaluate(y=LR.flatten()).flatten(),
                 solutions_LR[direction],
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_LR_neumann[direction]
                 .evaluate(y=LR.flatten())
                 .flatten(),
@@ -294,11 +298,11 @@ class TestExtrapolationFiniteVolume2D:
 
         # Check results for linear z function
         for direction in directions_TB:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_TB[direction].evaluate(y=TB.flatten()).flatten(),
                 solutions_TB[direction],
             )
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_TB_neumann[direction]
                 .evaluate(y=TB.flatten())
                 .flatten(),
@@ -433,22 +437,22 @@ class TestExtrapolationFiniteVolume2D:
 
         # Check results for quadratic x^2 function
         for direction in directions_LR:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_LR[direction]
                 .evaluate(y=x_squared_data)
                 .flatten(),
                 solutions_LR[direction],
-                decimal=5,
+                atol=1e-5,
             )
 
         # Check results for quadratic z^2 function
         for direction in directions_TB:
-            np.testing.assert_array_almost_equal(
+            np.testing.assert_allclose(
                 discretised_gradients_TB[direction]
                 .evaluate(y=z_squared_data)
                 .flatten(),
                 solutions_TB[direction],
-                decimal=5,
+                atol=1e-5,
             )
 
     def test_boundary_value_constant_extrapolation(self):
@@ -492,34 +496,34 @@ class TestExtrapolationFiniteVolume2D:
         boundary_value_left = pybamm.BoundaryValue(var, "left")
         discretised_left = disc.process_symbol(boundary_value_left)
         result_left = discretised_left.evaluate(y=lr).flatten()
-        np.testing.assert_array_almost_equal(result_left, expected_left)
+        np.testing.assert_allclose(result_left, expected_left)
 
         # Test right boundary
         boundary_value_right = pybamm.BoundaryValue(var, "right")
         discretised_right = disc.process_symbol(boundary_value_right)
         result_right = discretised_right.evaluate(y=lr).flatten()
-        np.testing.assert_array_almost_equal(result_right, expected_right)
+        np.testing.assert_allclose(result_right, expected_right)
 
         # Test top-left (s/b same as left)
         boundary_value_top_left = pybamm.BoundaryValue(var, "top-left")
         discretised_top_left = disc.process_symbol(boundary_value_top_left)
         result_top_left = discretised_top_left.evaluate(y=lr).flatten()
-        np.testing.assert_array_almost_equal(result_top_left, submesh.nodes_lr[0])
+        np.testing.assert_allclose(result_top_left, submesh.nodes_lr[0])
 
         # Test bottom-right (s/b same as right)
         boundary_value_bottom_right = pybamm.BoundaryValue(var, "bottom-right")
         discretised_bottom_right = disc.process_symbol(boundary_value_bottom_right)
         result_bottom_right = discretised_bottom_right.evaluate(y=lr).flatten()
-        np.testing.assert_array_almost_equal(result_bottom_right, submesh.nodes_lr[-1])
+        np.testing.assert_allclose(result_bottom_right, submesh.nodes_lr[-1])
 
         # Test top boundary
         boundary_value_top = pybamm.BoundaryValue(var, "top")
         discretised_top = disc.process_symbol(boundary_value_top)
         result_top = discretised_top.evaluate(y=tb).flatten()
-        np.testing.assert_array_almost_equal(result_top, expected_top)
+        np.testing.assert_allclose(result_top, expected_top)
 
         # Test bottom boundary
         boundary_value_bottom = pybamm.BoundaryValue(var, "bottom")
         discretised_bottom = disc.process_symbol(boundary_value_bottom)
         result_bottom = discretised_bottom.evaluate(y=tb).flatten()
-        np.testing.assert_array_almost_equal(result_bottom, expected_bottom)
+        np.testing.assert_allclose(result_bottom, expected_bottom)

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_finite_volume_2d.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_finite_volume_2d.py
@@ -88,10 +88,10 @@ class TestFiniteVolume2D:
         right_grad = fin_vol.edge_to_node(
             disc_symbol.tb_field, method="arithmetic", direction="tb"
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             left_grad.evaluate(None, lr).flatten(), np.ones(n_lr * n_tb)
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             right_grad.evaluate(None, tb).flatten(), np.ones(n_lr * n_tb)
         )
 
@@ -386,8 +386,8 @@ class TestFiniteVolume2D:
         lr_direct = node_to_edge_lr.evaluate(None, test_values)
         tb_direct = node_to_edge_tb.evaluate(None, test_values)
 
-        np.testing.assert_array_almost_equal(lr_result.flatten(), lr_direct.flatten())
-        np.testing.assert_array_almost_equal(tb_result.flatten(), tb_direct.flatten())
+        np.testing.assert_allclose(lr_result.flatten(), lr_direct.flatten())
+        np.testing.assert_allclose(tb_result.flatten(), tb_direct.flatten())
 
         # Test 1b: Test with only lr_direction=None (tb_direction should be ignored when None)
         result_lr_none = spatial_method.upwind_or_downwind(
@@ -398,8 +398,8 @@ class TestFiniteVolume2D:
         lr_result_b = result_lr_none.lr_field.evaluate(None, test_values)
         tb_result_b = result_lr_none.tb_field.evaluate(None, test_values)
 
-        np.testing.assert_array_almost_equal(lr_result_b.flatten(), lr_direct.flatten())
-        np.testing.assert_array_almost_equal(tb_result_b.flatten(), tb_direct.flatten())
+        np.testing.assert_allclose(lr_result_b.flatten(), lr_direct.flatten())
+        np.testing.assert_allclose(tb_result_b.flatten(), tb_direct.flatten())
 
         # Test 1c: Test with only tb_direction=None (lr_direction should be ignored when None)
         result_tb_none = spatial_method.upwind_or_downwind(
@@ -410,8 +410,8 @@ class TestFiniteVolume2D:
         lr_result_c = result_tb_none.lr_field.evaluate(None, test_values)
         tb_result_c = result_tb_none.tb_field.evaluate(None, test_values)
 
-        np.testing.assert_array_almost_equal(lr_result_c.flatten(), lr_direct.flatten())
-        np.testing.assert_array_almost_equal(tb_result_c.flatten(), tb_direct.flatten())
+        np.testing.assert_allclose(lr_result_c.flatten(), lr_direct.flatten())
+        np.testing.assert_allclose(tb_result_c.flatten(), tb_direct.flatten())
 
         # Test 2: Error cases - missing boundary conditions for upwind
         # Should raise error when upwinding without left Dirichlet BC

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_grad_div_shapes.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_grad_div_shapes.py
@@ -65,13 +65,15 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
@@ -98,13 +100,15 @@ class TestFiniteVolume2DGradDiv:
         grad_eqn_disc = disc.process_symbol(grad_eqn)
         linear_y = TB_neg.flatten()
         submesh = mesh["negative electrode"]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         # Now do linear in y direction but with a variable BC
@@ -128,13 +132,15 @@ class TestFiniteVolume2DGradDiv:
         grad_eqn_disc = disc.process_symbol(grad_eqn)
         linear_y = np.concatenate([[0], [1], TB_neg.flatten()])
         submesh = mesh["negative electrode"]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         # Now do linear in x direction but with a variable BC
@@ -152,13 +158,15 @@ class TestFiniteVolume2DGradDiv:
         grad_eqn_disc = disc.process_symbol(grad_eqn)
         linear_y = np.concatenate([[0], [1 / 3], LR_neg.flatten()])
         submesh = mesh["negative electrode"]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_tb + 1) * (submesh.npts_lr)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_tb) * (submesh.npts_lr + 1)),
+            atol=1e-6,
         )
 
     def test_grad_div_shapes_Neumann_bcs(self):
@@ -188,13 +196,15 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         disc.set_variable_slices([var])
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         ## Test operations on linear x
@@ -213,19 +223,22 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
         ## Test operations on linear y
@@ -244,19 +257,22 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
         ## Test operations on linear y with input parameter BC's
@@ -280,25 +296,28 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = disc.process_boundary_conditions(myclass)
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.zeros((submesh.npts_tb + 1) * (submesh.npts_lr)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.ones((submesh.npts_tb) * (submesh.npts_lr + 1)),
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.zeros((submesh.npts_tb) * (submesh.npts_lr)),
+            atol=1e-6,
         )
 
         ## Test operations on linear y with input parameter BC's
@@ -322,25 +341,28 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = disc.process_boundary_conditions(myclass)
         # grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         # div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(
                 inputs={"top_bc": 1, "bottom_bc": 1}, y=linear_y
             ).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
     @pytest.mark.parametrize(
@@ -380,19 +402,22 @@ class TestFiniteVolume2DGradDiv:
         disc.set_variable_slices([var])
         # grad(1) = 0
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         # div(grad(1)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
         ## Test gradient and divergence of linear x
@@ -410,19 +435,22 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         ## grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         ## div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
         ## Test gradient and divergence of linear y
@@ -439,19 +467,22 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         ## grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         ## div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
         ## Test gradient and divergence of linear y
@@ -468,19 +499,22 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
         ## grad(x) = 1
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_y).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
         ## div(grad(x)) = 0
         div_eqn_disc = disc.process_symbol(div_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             div_eqn_disc.evaluate(None, linear_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb)),
+            atol=1e-6,
         )
 
     def test_grad_div_shapes_concatenation(self):
@@ -532,13 +566,15 @@ class TestFiniteVolume2DGradDiv:
         constant_p = np.ones(submesh_p.npts)
         constant_y = np.concatenate([constant_n, constant_s, constant_p])
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, constant_y).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         submesh = mesh[("negative electrode", "separator", "positive electrode")]
@@ -559,13 +595,15 @@ class TestFiniteVolume2DGradDiv:
 
         # grad(x) = 1 in lr direction, 0 in tb direction
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_x).flatten(),
             np.ones((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_x).flatten(),
             np.zeros((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         # div(grad(x)) = 0
@@ -593,13 +631,15 @@ class TestFiniteVolume2DGradDiv:
 
         # grad(z) = 0 in lr direction, 1 in tb direction
         grad_eqn_disc = disc.process_symbol(grad_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.lr_field.evaluate(None, linear_z).flatten(),
             np.zeros((submesh.npts_lr + 1) * (submesh.npts_tb)),
+            atol=1e-6,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             grad_eqn_disc.tb_field.evaluate(None, linear_z).flatten(),
             np.ones((submesh.npts_lr) * (submesh.npts_tb + 1)),
+            atol=1e-6,
         )
 
         # div(grad(z)) = 0
@@ -660,9 +700,10 @@ class TestFiniteVolume2DGradDiv:
         constant_p = np.ones(submesh_p.npts)
         constant_y = np.concatenate([constant_n, constant_s, constant_p])
 
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             laplacian_eqn_disc.evaluate(None, constant_y).flatten(),
             np.zeros(submesh.npts),
+            atol=1e-6,
         )
 
         # Test Laplacian of linear x is zero
@@ -681,9 +722,10 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
 
         laplacian_eqn_disc = disc.process_symbol(laplacian_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             laplacian_eqn_disc.evaluate(None, linear_x).flatten(),
             np.zeros(submesh.npts),
+            atol=1e-6,
         )
 
         # Test Laplacian of linear z is zero
@@ -701,9 +743,10 @@ class TestFiniteVolume2DGradDiv:
         disc.bcs = boundary_conditions
 
         laplacian_eqn_disc = disc.process_symbol(laplacian_eqn)
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             laplacian_eqn_disc.evaluate(None, linear_z).flatten(),
             np.zeros(submesh.npts),
+            atol=1e-6,
         )
 
     def test_internal_neumann_condition(self):

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_tensor_field.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_tensor_field.py
@@ -553,15 +553,15 @@ class TestTensorAccuracy:
         disc_grad = disc.process_symbol(grad_var)
 
         # Verify gradient is [1, 0]
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_grad.lr_field.evaluate(None, linear_x).flatten(),
             np.ones((n_lr + 1) * n_tb),
-            decimal=5,
+            atol=1e-5,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_grad.tb_field.evaluate(None, linear_x).flatten(),
             np.zeros(n_lr * (n_tb + 1)),
-            decimal=5,
+            atol=1e-5,
         )
 
         # Compute tensor product
@@ -572,25 +572,25 @@ class TestTensorAccuracy:
         # T[0,1] = lr * tb = 1 * 0 = 0
         # T[1,0] = tb * lr = 0 * 1 = 0
         # T[1,1] = tb * tb = 0 * 0 = 0
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_tp[0, 0].evaluate(None, linear_x).flatten(),
             np.ones(n_lr * n_tb),
-            decimal=5,
+            atol=1e-5,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_tp[0, 1].evaluate(None, linear_x).flatten(),
             np.zeros(n_lr * n_tb),
-            decimal=5,
+            atol=1e-5,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_tp[1, 0].evaluate(None, linear_x).flatten(),
             np.zeros(n_lr * n_tb),
-            decimal=5,
+            atol=1e-5,
         )
-        np.testing.assert_array_almost_equal(
+        np.testing.assert_allclose(
             disc_tp[1, 1].evaluate(None, linear_x).flatten(),
             np.zeros(n_lr * n_tb),
-            decimal=5,
+            atol=1e-5,
         )
 
     def test_tensor_divergence_of_constant_tensor(self, setup_accuracy_test):


### PR DESCRIPTION
Re-implements some of the changes made in #4829 which seem to have since been reverted (probably during merge commits).

Fixes #4488 
