### PR TITLE
Fix ReadTheDocs builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ linkcheck_ignore = [
     "https://en.wikipedia.org/wiki/",  # Wikipedia link to ignore
     "https://books.google.co.uk/books",
     "https://docs.scipy.org/doc/scipy",  # SciPy docs timeout intermittently
+    "https://chemrxiv.org",  # ChemRxiv blocks automated link checking
 ]
 
 


### PR DESCRIPTION
ChemRxiv blocks automated link checking with 403 Forbidden responses, causing the Read the Docs build to fail.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
