### PR TITLE
Use winget instead of chocolatey for graphviz on Windows

### DIFF
--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: choco install graphviz --version=8.0.5
+        run: |
+          winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
+          dot -c
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -63,9 +63,7 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: |
-          winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
-          dot -c
+        run: winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -89,9 +89,7 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: |
-          winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
-          dot -c
+        run: winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-python

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -89,7 +89,9 @@ jobs:
 
       - name: Install Windows system dependencies
         if: matrix.os == 'windows-latest'
-        run: choco install graphviz --version=8.0.5
+        run: |
+          winget install --id Graphviz.Graphviz --exact --accept-source-agreements --accept-package-agreements
+          dot -c
 
       - name: Set up Python ${{ matrix.python-version }}
         id: setup-python


### PR DESCRIPTION
# Description

Replace chocolatey with winget for installing graphviz on Windows CI runners. Chocolatey's CDN frequently returns 503 errors causing CI failures.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
