### PR TITLE
Migrate dev and docs dependencies to dependency-groups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,6 +21,14 @@ build:
   tools:
     python: "3.13"
   jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs --extra all
     pre_build:
       - python -m sphinx -b linkcheck -D linkcheck_timeout=20 docs/ ./linkcheck_output
     # Unshallow the git clone otherwise this may cause issues with Sphinx extensions
@@ -37,12 +45,3 @@ build:
       - cd docs/build/ && latexmk -r latexmkrc -pdf -f -dvi- -ps- -jobname=pybamm -interaction=nonstopmode || true
       - test -f docs/build/pybamm.pdf && echo "pybamm.pdf exists. Copying source file to $READTHEDOCS_OUTPUT/pdf/."
       - cp "docs/build/pybamm.pdf" $READTHEDOCS_OUTPUT/pdf/
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 - Fix a bug with serialising `InputParameter`s. ([#5289](https://github.com/pybamm-team/PyBaMM/pull/5289))
 
+## Breaking changes
+
+- Migrated `docs` and `dev` dependencies from `project.optional-dependencies` to `dependency-groups` per PEP 735. ([#5368](https://github.com/pybamm-team/PyBaMM/pull/5368))
+
 # [v25.12.2](https://github.com/pybamm-team/PyBaMM/tree/v25.12.2) - 2026-01-22
 
 ## Features

--- a/docs/source/user_guide/installation/install-from-source.rst
+++ b/docs/source/user_guide/installation/install-from-source.rst
@@ -123,13 +123,13 @@ tools for development and documentation:
 
 .. code:: bash
 
-	  pip install -e .[all,dev,docs]
+	  pip install -e .[all] --group dev --group docs
 
 If you are using ``zsh`` or ``tcsh``, you would need to use different pattern matching:
 
 .. code:: bash
 
-	  pip install -e '.[all,dev,docs]'
+	  pip install -e '.[all]' --group dev --group docs
 
 Before you start contributing to PyBaMM, please read the `contributing
 guidelines <https://github.com/pybamm-team/PyBaMM/blob/main/CONTRIBUTING.md>`__.

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,8 @@ def run_coverage(session):
     # Using plugin here since coverage runs unit tests on linux with latest python version.
     if "CI" in os.environ:
         session.install("pytest-github-actions-annotate-failures")
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     session.run("pytest", "--cov=pybamm", "--cov-report=xml", "tests/unit")
 
 
@@ -55,7 +56,8 @@ def run_integration(session):
         and sys.platform == "linux"
     ):
         session.install("pytest-github-actions-annotate-failures")
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     session.run("python", "-m", "pytest", "-m", "integration")
 
 
@@ -64,7 +66,8 @@ def run_doctests(session):
     """Run the doctests and generate the output(s) in the docs/build/ directory."""
     # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
-    session.install("-e", ".[all,dev,docs]", silent=False)
+    session.install("-e", ".[all]", silent=False)
+    session.install("--group", "dev", "--group", "docs", silent=False)
     session.run(
         "python",
         "-m",
@@ -78,7 +81,8 @@ def run_doctests(session):
 def run_unit(session):
     """Run the unit tests."""
     set_environment_variables(PYBAMM_ENV, session=session)
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     session.run("python", "-m", "pytest", "-m", "unit")
 
 
@@ -86,7 +90,8 @@ def run_unit(session):
 def run_examples(session):
     """Run the examples tests for Jupyter notebooks."""
     set_environment_variables(PYBAMM_ENV, session=session)
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     notebooks_to_test = session.posargs if session.posargs else []
     session.run(
         "pytest", "--nbmake", *notebooks_to_test, "docs/source/examples/", external=True
@@ -99,7 +104,8 @@ def run_scripts(session):
     set_environment_variables(PYBAMM_ENV, session=session)
     # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     session.run("python", "-m", "pytest", "-m", "scripts")
 
 
@@ -110,7 +116,6 @@ def set_dev(session):
     session.install("virtualenv", "cmake")
     session.run("virtualenv", os.fsdecode(VENV_DIR), silent=True)
     python = os.fsdecode(VENV_DIR.joinpath("bin/python"))
-    components = ["all", "dev", "jax"]
     args = []
     # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.run(python, "-m", "pip", "install", "setuptools", external=True)
@@ -120,7 +125,17 @@ def set_dev(session):
         "pip",
         "install",
         "-e",
-        ".[{}]".format(",".join(components)),
+        ".[all,jax]",
+        *args,
+        external=True,
+    )
+    session.run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        "--group",
+        "dev",
         *args,
         external=True,
     )
@@ -130,7 +145,8 @@ def set_dev(session):
 def run_tests(session):
     """Run the unit tests and integration tests sequentially."""
     set_environment_variables(PYBAMM_ENV, session=session)
-    session.install("-e", ".[all,dev,jax]", silent=False)
+    session.install("-e", ".[all,jax]", silent=False)
+    session.install("--group", "dev", silent=False)
     session.run(
         "python",
         "-m",
@@ -145,7 +161,8 @@ def build_docs(session):
     envbindir = session.bin
     # Fix for Python 3.12 CI. This can be removed after pybtex is replaced.
     session.install("setuptools", silent=False)
-    session.install("-e", ".[all,docs]", silent=False)
+    session.install("-e", ".[all]", silent=False)
+    session.install("--group", "docs", silent=False)
     session.chdir("docs")
     # Local development
     if session.interactive:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,28 @@ Releases = "https://github.com/pybamm-team/PyBaMM/releases"
 Changelog = "https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+# For example notebooks
+examples = ["jupyter"]
+plot = [
+    # Note: matplotlib is loaded for debug plots, but to ensure PyBaMM runs
+    # on systems without an attached display, it should never be imported
+    # outside of plot() methods.
+    "matplotlib>=3.6.0",
+]
+cite = ["pybtex>=0.25.0"]
+# Battery Parameter eXchange format
+bpx = ["bpx>=0.5.0,<0.6.0"]
+# Low-overhead progress bars
+tqdm = ["tqdm"]
+jax = ["jax>=0.4.36,<0.7.0"]
+# Contains all optional dependencies, except for jax, and dev dependencies
+all = [
+    "scikit-fem>=8.1.0",
+    "meshio>=5.3.0",
+    "pybamm[examples,plot,cite,bpx,tqdm]",
+]
+
+[dependency-groups]
 docs = [
     "sphinx>=6",
     "sphinx_rtd_theme>=0.5",
@@ -67,19 +89,6 @@ docs = [
     "sphinx-gallery",
     "sphinx-docsearch",
 ]
-# For example notebooks
-examples = ["jupyter"]
-plot = [
-    # Note: matplotlib is loaded for debug plots, but to ensure PyBaMM runs
-    # on systems without an attached display, it should never be imported
-    # outside of plot() methods.
-    "matplotlib>=3.6.0",
-]
-cite = ["pybtex>=0.25.0"]
-# Battery Parameter eXchange format
-bpx = ["bpx>=0.5.0,<0.6.0"]
-# Low-overhead progress bars
-tqdm = ["tqdm"]
 dev = [
     # For working with pre-commit hooks
     "pre-commit",
@@ -101,13 +110,6 @@ dev = [
     "importlib-metadata; python_version < '3.10'",
     # For property based testing
     "hypothesis",
-]
-jax = ["jax>=0.4.36,<0.7.0"]
-# Contains all optional dependencies, except for jax, and dev dependencies
-all = [
-    "scikit-fem>=8.1.0",
-    "meshio>=5.3.0",
-    "pybamm[examples,plot,cite,bpx,tqdm]",
 ]
 
 [project.entry-points."pybamm_parameter_sets"]

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -28,6 +28,7 @@ RUN uv venv $VIRTUAL_ENV
 RUN #!/bin/bash && source /home/pybamm/venv/bin/activate;
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN uv pip install -e ".[all,dev,docs,jax]";
+RUN uv pip install -e ".[all,jax]";
+RUN uv pip install --group dev --group docs;
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Move docs and dev dependencies from project.optional-dependencies to dependency-groups per PEP 735. These are development-only tools, not user-facing package features.

# Description

This PR migrates development and documentation dependencies from `project.optional-dependencies` to the new `dependency-groups` section as specified in [PEP 735](https://peps.python.org/pep-0735/).
See also [readthedocs' documentation](https://docs.readthedocs.com/platform/latest/build-customization.html#install-dependencies-from-dependency-groups).

What changed:
- Moved `docs` dependencies to `[dependency-groups]`
- Moved `dev` dependencies to `[dependency-groups]`
- Kept user-facing optional dependencies (`examples`, `plot`, `cite`, `bpx`, `tqdm`, `jax`, `all`) in `[project.optional-dependencies]`
Fixes #5327 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
