### PR TITLE
Fix file handle leaks in COMSOL comparison scripts

### DIFF
--- a/examples/scripts/compare_comsol/compare_comsol_DFN.py
+++ b/examples/scripts/compare_comsol/compare_comsol_DFN.py
@@ -24,7 +24,8 @@ comsol_results_path = pybamm.get_parameters_filepath(
     f"{data_loader.get_data(f'comsol_{C_rate}C.json')}"
 )
 
-comsol_variables = json.load(open(comsol_results_path))
+with open(comsol_results_path) as f:
+    comsol_variables = json.load(f)
 
 "-----------------------------------------------------------------------------"
 "Create and solve pybamm model"

--- a/examples/scripts/compare_comsol/discharge_curve.py
+++ b/examples/scripts/compare_comsol/discharge_curve.py
@@ -64,7 +64,8 @@ for key, C_rate in C_rates.items():
     comsol_results_path = pybamm.get_parameters_filepath(
         f"{data_loader.get_data(f'comsol_{key}C.json')}"
     )
-    comsol_variables = json.load(open(comsol_results_path))
+    with open(comsol_results_path) as f:
+        comsol_variables = json.load(f)
     comsol_time = np.array(comsol_variables["time"])
     comsol_voltage = np.array(comsol_variables["voltage"])
 


### PR DESCRIPTION
## Problem

Two example scripts in `examples/scripts/compare_comsol/` open JSON files but never explicitly close them, which can lead to resource leaks.

## Solution

Use context managers (with statements) to ensure files are properly closed after reading.

## Changes

- `compare_comsol_DFN.py`: Wrap `json.load(open(...))` in a `with` statement
- `discharge_curve.py`: Wrap `json.load(open(...))` in a `with` statement

This follows Python best practices and prevents potential resource leaks in example code that users might copy.