### PR TITLE
perf: precalculate state mapper for mapping between experimental steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve the performance of matrix multiplication with CasADi expressions. ([#5351](https://github.com/pybamm-team/PyBaMM/pull/5351))
 - Adds option for lists of inputs to `solve` to include input parameters which are used
 as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311))
+- Optimize state mapper for multi-step experiments by pre-calculating mapper during setup. ([#5380](https://github.com/pybamm-team/PyBaMM/pull/5380))
 
 ## Bug fixes
 

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -1454,14 +1454,6 @@ class BaseModel:
             from_var = from_vars_by_id.get(target_var.id)
             if from_var is None:
                 from_var = from_vars_by_name.get(target_var.name)
-            if from_var is None:
-                if target_var.name == "Current variable [A]":
-                    return None
-                raise pybamm.ModelError(
-                    "To map initial conditions, each variable in "
-                    "model.initial_conditions must appear in the source model "
-                    "with the same id or name."
-                )
             return from_var
 
         entries = []
@@ -1506,7 +1498,8 @@ class BaseModel:
             physical_parts = []
             for from_var, from_slice in child_entries:
                 if from_var is None:
-                    physical_parts.append(pybamm.InputParameter("Current variable [A]"))
+                    # not in the previous model, so just use current ic
+                    physical_parts.append(self.initial_conditions[target_var])
                 else:
                     physical_parts.append(
                         from_var.reference

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -483,7 +483,11 @@ class Simulation:
             if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
             f, _jac, _jacp, _jac_action = process(mapper, "mapper", vars_for_processing)
-            self._model_state_mappers[(previous_model, next_model)] = f
+            # Store both the compiled mapper and the input keys used
+            self._model_state_mappers[(previous_model, next_model)] = (
+                f,
+                list(inputs_copy.keys()),
+            )
 
     def _get_state_mapper_for_solution(self, solution, model):
         if not self._model_state_mappers or isinstance(solution, pybamm.EmptySolution):

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -449,14 +449,9 @@ class Simulation:
             if previous_model is not None and previous_model is not model:
                 key = (previous_model, model)
                 if key not in self._model_state_mappers:
-                    try:
-                        self._model_state_mappers[key] = (
-                            model.build_initial_state_mapper(previous_model)
-                        )
-                    except pybamm.ModelError:
-                        pybamm.logger.debug(
-                            "Skipping state mapper build for experiment step pair."
-                        )
+                    self._model_state_mappers[key] = model.build_initial_state_mapper(
+                        previous_model
+                    )
             previous_model = model
 
         rest_model = self.steps_to_built_models.get("Rest for padding")
@@ -469,24 +464,14 @@ class Simulation:
                 continue
             to_rest_key = (model, rest_model)
             if to_rest_key not in self._model_state_mappers:
-                try:
-                    self._model_state_mappers[to_rest_key] = (
-                        rest_model.build_initial_state_mapper(model)
-                    )
-                except pybamm.ModelError:
-                    pybamm.logger.debug(
-                        "Skipping state mapper build for rest step target."
-                    )
+                self._model_state_mappers[to_rest_key] = (
+                    rest_model.build_initial_state_mapper(model)
+                )
             from_rest_key = (rest_model, model)
             if from_rest_key not in self._model_state_mappers:
-                try:
-                    self._model_state_mappers[from_rest_key] = (
-                        model.build_initial_state_mapper(rest_model)
-                    )
-                except pybamm.ModelError:
-                    pybamm.logger.debug(
-                        "Skipping state mapper build for rest step source."
-                    )
+                self._model_state_mappers[from_rest_key] = (
+                    model.build_initial_state_mapper(rest_model)
+                )
 
     def _get_state_mapper_for_solution(self, solution, model):
         if not self._model_state_mappers or isinstance(solution, pybamm.EmptySolution):

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -474,20 +474,15 @@ class Simulation:
 
         # compile all the mappers
         for (previous_model, next_model), mapper in self._model_state_mappers.items():
-            # add "Current function [A]" to the inputs if it's an input parameter, since this is needed for the mappers
-            inputs_copy = inputs.copy() if inputs else {}
-            inputs_copy["Current variable [A]"] = 1.0
             vars_for_processing = pybamm.BaseSolver._get_vars_for_processing(
-                previous_model, inputs_copy
+                previous_model, inputs
             )
             if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
-            f, _jac, _jacp, _jac_action = process(mapper, "mapper", vars_for_processing)
+            f, jac, jacp, _jac_action = process(mapper, "mapper", vars_for_processing)
             # Store both the compiled mapper and the input keys used
-            self._model_state_mappers[(previous_model, next_model)] = (
-                f,
-                list(inputs_copy.keys()),
-            )
+            # we don't need jac and jacp yet, but should use them for sensitivity calculations in the future
+            self._model_state_mappers[(previous_model, next_model)] = (f, jac, jacp)
 
     def _get_state_mapper_for_solution(self, solution, model):
         if not self._model_state_mappers or isinstance(solution, pybamm.EmptySolution):

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -480,7 +480,7 @@ class Simulation:
             vars_for_processing = pybamm.BaseSolver._get_vars_for_processing(
                 previous_model, inputs_copy
             )
-            if not hasattr(next_model, "calculate_sensitivities"):
+            if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
             f, _jac, _jacp, _jac_action = process(mapper, "mapper", vars_for_processing)
             self._model_state_mappers[(previous_model, next_model)] = f

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -161,7 +161,6 @@ class Simulation:
         result = self.__dict__.copy()
         result["get_esoh_solver"] = None  # Exclude LRU cache
         result["model_state_mappers"] = {}
-        result["_model_state_mappers"] = {}
         result["_compiled_model_state_mappers"] = {}
         return result
 

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1390,12 +1390,21 @@ class BaseSolver:
                 model_inputs_copy["Current variable [A]"] = old_solution[
                     "Current variable [A]"
                 ].data[-1]
+
+                # Extract the function and input keys from the mapper tuple
+                mapper_func, mapper_input_keys = state_mapper
+                # Only use the inputs that were present when compiling the mapper
+                filtered_inputs = {
+                    k: model_inputs_copy[k]
+                    for k in mapper_input_keys
+                    if k in model_inputs_copy
+                }
                 p_casadi_stacked = casadi.vertcat(
-                    *[p for p in model_inputs_copy.values()]
+                    *[p for p in filtered_inputs.values()]
                 )
 
                 model.y0_list = [
-                    state_mapper(
+                    mapper_func(
                         t_start_shifted,
                         y_from,
                         p_casadi_stacked,

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1260,6 +1260,11 @@ class BaseSolver:
         t_interp : None, list or ndarray, optional
             The times (in seconds) at which to interpolate the solution. Defaults to None.
             Only valid for solvers that support intra-solve interpolation (`IDAKLUSolver`).
+        state_mapper : tuple of (function, jacobian, jacobian_p), optional
+            A tuple containing a function and its Jacobians to map the state from the old solution to the new solution.
+            `function`, `jacobian` and `jacobian_p` are casadi/jax/python functions that have been processed using `BaseSolver.process`.
+            If not provided, then `BaseModel.set_initial_conditions_from` is used to map the state from the old solution to the new solution
+
         Raises
         ------
         :class:`pybamm.ModelError`

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1384,7 +1384,14 @@ class BaseSolver:
             if state_mapper is not None:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
-                model.y0_list = [state_mapper(y_from, inputs=model_inputs)]
+                current_value = old_solution["Current variable [A]"].data[-1]
+                model.y0_list = [
+                    state_mapper(
+                        y_from,
+                        current_value,
+                        inputs=model_inputs,
+                    )
+                ]
             else:
                 _, concatenated_initial_conditions = model.set_initial_conditions_from(
                     old_solution,

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1384,12 +1384,21 @@ class BaseSolver:
             if state_mapper is not None:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
-                current_value = old_solution["Current variable [A]"].data[-1]
+
+                # add the current variable to the model inputs if it's not already there, as this is needed for the state mapping
+                model_inputs_copy = model_inputs.copy()
+                model_inputs_copy["Current variable [A]"] = old_solution[
+                    "Current variable [A]"
+                ].data[-1]
+                p_casadi_stacked = casadi.vertcat(
+                    *[p for p in model_inputs_copy.values()]
+                )
+
                 model.y0_list = [
                     state_mapper(
+                        t_start_shifted,
                         y_from,
-                        current_value,
-                        inputs=model_inputs,
+                        p_casadi_stacked,
                     )
                 ]
             else:

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1384,24 +1384,8 @@ class BaseSolver:
             if state_mapper is not None:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
-
-                # add the current variable to the model inputs if it's not already there, as this is needed for the state mapping
-                model_inputs_copy = model_inputs.copy()
-                model_inputs_copy["Current variable [A]"] = old_solution[
-                    "Current variable [A]"
-                ].data[-1]
-
-                # Extract the function and input keys from the mapper tuple
-                mapper_func, mapper_input_keys = state_mapper
-                # Only use the inputs that were present when compiling the mapper
-                filtered_inputs = {
-                    k: model_inputs_copy[k]
-                    for k in mapper_input_keys
-                    if k in model_inputs_copy
-                }
-                p_casadi_stacked = casadi.vertcat(
-                    *[p for p in filtered_inputs.values()]
-                )
+                mapper_func, _mapper_jac, _mapper_jacp = state_mapper
+                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1260,9 +1260,9 @@ class BaseSolver:
         t_interp : None, list or ndarray, optional
             The times (in seconds) at which to interpolate the solution. Defaults to None.
             Only valid for solvers that support intra-solve interpolation (`IDAKLUSolver`).
-        state_mapper : tuple of (function, jacobian, jacobian_p), optional
+        state_mapper : tuple of (function, jacobian_y, jacobian_p), optional
             A tuple containing a function and its Jacobians to map the state from the old solution to the new solution.
-            `function`, `jacobian` and `jacobian_p` are casadi/jax/python functions that have been processed using `BaseSolver.process`.
+            `function`, `jacobian_y` and `jacobian_p` are casadi/jax/python functions that have been processed using `BaseSolver.process`.
             If not provided, then `BaseModel.set_initial_conditions_from` is used to map the state from the old solution to the new solution
 
         Raises

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1224,6 +1224,7 @@ class BaseSolver:
         save=True,
         calculate_sensitivities=False,
         t_interp=None,
+        state_mapper=None,
     ):
         """
         Step the solution of the model forward by a given time increment. The
@@ -1380,14 +1381,19 @@ class BaseSolver:
                 ]
 
         else:
-            _, concatenated_initial_conditions = model.set_initial_conditions_from(
-                old_solution,
-                inputs=model_inputs,
-                return_type="ics",
-            )
-            model.y0_list = [
-                concatenated_initial_conditions.evaluate(0, inputs=model_inputs)
-            ]
+            if state_mapper is not None:
+                last_state = old_solution.last_state
+                y_from = last_state.all_ys[0]
+                model.y0_list = [state_mapper(y_from, inputs=model_inputs)]
+            else:
+                _, concatenated_initial_conditions = model.set_initial_conditions_from(
+                    old_solution,
+                    inputs=model_inputs,
+                    return_type="ics",
+                )
+                model.y0_list = [
+                    concatenated_initial_conditions.evaluate(0, inputs=model_inputs)
+                ]
 
             if using_sensitivities:
                 model.y0S_list = [

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -882,7 +882,14 @@ class Solution:
         # update variables which were derived at the solver stage
         if any([self.variables_returned, other.variables_returned]):
             vars = {*self._variables.keys(), *other._variables.keys()}
-            new_sol._variables = {v: self[v].update(other[v], new_sol) for v in vars}
+            new_sol._variables = {}
+            for v in vars:
+                try:
+                    new_sol._variables[v] = self[v].update(other[v], new_sol)
+                except KeyError:
+                    # Skip variables that contain StateVector references and
+                    # weren't part of the output_variables
+                    pass
             new_sol.variables_returned = True
 
         return new_sol

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -882,14 +882,7 @@ class Solution:
         # update variables which were derived at the solver stage
         if any([self.variables_returned, other.variables_returned]):
             vars = {*self._variables.keys(), *other._variables.keys()}
-            new_sol._variables = {}
-            for v in vars:
-                try:
-                    new_sol._variables[v] = self[v].update(other[v], new_sol)
-                except KeyError:
-                    # Skip variables that contain StateVector references and
-                    # weren't part of the output_variables
-                    pass
+            new_sol._variables = {v: self[v].update(other[v], new_sol) for v in vars}
             new_sol.variables_returned = True
 
         return new_sol

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -73,13 +73,8 @@ class TestSimulationExperiment:
         model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
         model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
 
-        assert (model_0, model_1) in sim._model_state_mappers
-        # The mapper is now a tuple of (function, input_keys)
-        mapper_data = sim._model_state_mappers[(model_0, model_1)]
-        assert isinstance(mapper_data, tuple)
-        assert len(mapper_data) == 2
-        assert callable(mapper_data[0])
-        assert isinstance(mapper_data[1], list)
+        key = (model_0, model_1)
+        assert key in sim.model_state_mappers
 
     def test_run_experiment(self):
         s = pybamm.step.string

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -74,7 +74,12 @@ class TestSimulationExperiment:
         model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
 
         assert (model_0, model_1) in sim._model_state_mappers
-        assert callable(sim._model_state_mappers[(model_0, model_1)])
+        # The mapper is now a tuple of (function, input_keys)
+        mapper_data = sim._model_state_mappers[(model_0, model_1)]
+        assert isinstance(mapper_data, tuple)
+        assert len(mapper_data) == 2
+        assert callable(mapper_data[0])
+        assert isinstance(mapper_data[1], list)
 
     def test_run_experiment(self):
         s = pybamm.step.string

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -61,6 +61,21 @@ class TestSimulationExperiment:
         sim.build_for_experiment()
         assert len(sim.experiment.steps) == 2
 
+    def test_experiment_state_mappers_built(self):
+        model = pybamm.lithium_ion.SPM()
+        experiment = pybamm.Experiment(
+            ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
+        )
+        sim = pybamm.Simulation(model, experiment=experiment)
+        sim.build_for_experiment()
+
+        steps = sim.experiment.steps
+        model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
+        model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
+
+        assert (model_0, model_1) in sim._model_state_mappers
+        assert callable(sim._model_state_mappers[(model_0, model_1)])
+
     def test_run_experiment(self):
         s = pybamm.step.string
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -76,6 +76,24 @@ class TestSimulationExperiment:
         key = (model_0, model_1)
         assert key in sim.model_state_mappers
 
+    def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
+        model = pybamm.lithium_ion.DFN(
+            {"current collector": "potential pair", "dimensionality": 2}
+        )
+        experiment = pybamm.Experiment(
+            ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
+        )
+        var_pts = {"x_n": 6, "x_s": 6, "x_p": 6, "r_n": 6, "r_p": 6, "y": 6, "z": 6}
+        sim = pybamm.Simulation(model, experiment=experiment, var_pts=var_pts)
+        sim.build_for_experiment()
+
+        steps = sim.experiment.steps
+        model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
+        model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
+        mapper = sim.model_state_mappers[(model_0, model_1)]
+
+        assert mapper.shape[0] == model_1.len_rhs_and_alg
+
     def test_run_experiment(self):
         s = pybamm.step.string
         experiment = pybamm.Experiment(


### PR DESCRIPTION
# Description

## Summary

Pre-calculate state mapper during simulation setup instead of on-demand at each step. performance gains mainly for smaller models (SPM)

## Changes

| File | Changes |
|------|---------|
| `base_model.py` | New `build_initial_state_mapper()` method |
| `simulation.py` | Cache mapper during experiment setup |
| `base_solver.py` | Use cached mapper when available |
| `test_simulation_with_experiment.py` | Mapper validation tests |

## Benchmark Results (10 repeats)

| Case | Setup | Solve 1 | Solve 2 | Total |
|------|-------|---------|---------|-------|
| CCCV · Chen2020 · DFN · CasadiSolver | -8.09% | -0.67% | -1.09% | -0.95% |
| CCCV · Chen2020 · DFN · IDAKLUSolver | -12.04% | +2.00% | +2.37% | +1.37% |
| CCCV · Chen2020 · SPM · CasadiSolver | +10.27% | +1.04% | +0.48% | +2.08% |
| CCCV · Chen2020 · SPM · IDAKLUSolver | +13.81% | -0.49% | +12.36% | +1.73% |
| CCCV · Marquis2019 · DFN · IDAKLUSolver | +0.82% | +0.48% | +1.70% | +0.58% |
| CCCV · Marquis2019 · SPM · CasadiSolver | -16.35% | +1.80% | +4.55% | +0.59% |
| CCCV · Marquis2019 · SPM · IDAKLUSolver | -5.81% | +2.43% | +10.43% | +1.89% |
| GITT · Chen2020 · DFN · CasadiSolver | -6.91% | +6.50% | +8.58% | +7.22% |
| GITT · Chen2020 · DFN · IDAKLUSolver | +2.27% | -1.08% | -5.93% | -1.84% |
| GITT · Chen2020 · SPM · CasadiSolver | +22.71% | +3.08% | +18.76% | +9.79% |
| GITT · Chen2020 · SPM · IDAKLUSolver | +1.90% | +6.95% | +19.84% | +7.63% |
| GITT · Marquis2019 · DFN · IDAKLUSolver | +3.06% | -0.95% | -5.91% | -1.61% |
| GITT · Marquis2019 · SPM · CasadiSolver | -14.97% | +9.40% | +19.61% | +9.30% |
| GITT · Marquis2019 · SPM · IDAKLUSolver | +12.25% | +0.15% | +20.21% | +4.51% |
| **Average** | **+0.21%** | **+2.19%** | **+7.57%** | **+3.02%** |

**Note:** Positive values indicate speedup (mapper is faster). 10 repeats per case.





## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
