### PR TITLE
Hermite knot reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Eliminated the mass matrix inverse and temporary dense matrix objects when building the simulation. ([#5391](https://github.com/pybamm-team/PyBaMM/pull/5391))
+- Added the `hermite_reduction_factor` option to the `IDAKLUSolver`, which dynamically compresses solution size by removing redundant points in the Hermite interpolant. ([#5390](https://github.com/pybamm-team/PyBaMM/pull/5390))
 - Added support for Python 3.14. ([#5374](https://github.com/pybamm-team/PyBaMM/pull/5374))
 - Added regularisation to the kinetics and OCPs so they are more numerically stable. ([#5371](https://github.com/pybamm-team/PyBaMM/pull/5371))
 - Improve the performance of matrix multiplication with CasADi expressions. ([#5351](https://github.com/pybamm-team/PyBaMM/pull/5351))

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -65,7 +65,7 @@ PyBaMM requires the following dependencies.
 =================================================================== ==========================
 Package                                                             Supported version(s)
 =================================================================== ==========================
-`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     >= 0.5.0, <0.6.0
+`PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     >= 0.6.0, <0.7.0
 `NumPy <https://numpy.org>`__                                         Whatever recent versions work
 `SciPy <https://docs.scipy.org/doc/scipy/>`__                         Whatever recent versions work. >= 1.9.3
 `CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.7.2

--- a/docs/source/user_guide/installation/index.rst
+++ b/docs/source/user_guide/installation/index.rst
@@ -68,7 +68,7 @@ Package                                                             Supported ve
 `PyBaMM solvers <https://github.com/pybamm-team/pybammsolvers>`__     >= 0.5.0, <0.6.0
 `NumPy <https://numpy.org>`__                                         Whatever recent versions work
 `SciPy <https://docs.scipy.org/doc/scipy/>`__                         Whatever recent versions work. >= 1.9.3
-`CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.6.7
+`CasADi <https://web.casadi.org/docs/>`__                             Whatever recent versions work. >= 3.7.2
 `Xarray <https://docs.xarray.dev/en/stable/>`__                       Whatever recent versions work. >= 2022.6.0
 `Anytree <https://anytree.readthedocs.io/en/stable/>`__               Whatever recent versions work. >= 2.8.0
 `SymPy <https://docs.sympy.org/latest/index.html>`__                  Whatever recent versions work. >= 1.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "pybammsolvers>=0.5.0,<0.6.0",
+    "pybammsolvers>=0.6.0,<0.7.0",
     "black",
     "numpy",
     "scipy>=1.11.4",

--- a/src/pybamm/solvers/algebraic_solver.py
+++ b/src/pybamm/solvers/algebraic_solver.py
@@ -289,7 +289,12 @@ class AlgebraicSolver(pybamm.BaseSolver):
         y_sol = np.r_[y_diff, y_alg]
         # Return solution object (no events, so pass None to t_event, y_event)
         sol = pybamm.Solution(
-            t_eval, y_sol, model, inputs_dict, termination="final time"
+            t_eval,
+            y_sol,
+            model,
+            inputs_dict,
+            termination="final time",
+            all_t_evals=t_eval,
         )
         sol.integration_time = integration_time
         return sol

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -46,7 +46,7 @@ class BaseSolver:
         Default is "warn".
     on_failure : str, optional
         What to do if a solver error flag occurs. Options are "warn", "error", or "ignore".
-        Default is "raise".
+        Default is "error".
     """
 
     def __init__(
@@ -68,8 +68,8 @@ class BaseSolver:
         self.root_method = root_method
         self.extrap_tol = extrap_tol or -1e-10
         self.output_variables = [] if output_variables is None else output_variables
-        self._on_extrapolation = on_extrapolation or "warn"
-        self._on_failure = on_failure or "raise"
+        self.on_extrapolation = on_extrapolation or "warn"
+        self.on_failure = on_failure or "error"
         self._model_set_up = {}
 
         # Defaults, can be overwritten by specific solver
@@ -104,7 +104,7 @@ class BaseSolver:
     @on_extrapolation.setter
     def on_extrapolation(self, value):
         if value not in ["warn", "error", "ignore"]:
-            raise ValueError("on_extrapolation must be 'warn', 'raise', or 'ignore'")
+            raise ValueError("on_extrapolation must be 'warn', 'error', or 'ignore'")
         self._on_extrapolation = value
 
     @property
@@ -114,7 +114,7 @@ class BaseSolver:
     @on_failure.setter
     def on_failure(self, value):
         if value not in ["warn", "error", "ignore"]:
-            raise ValueError("on_failure must be 'warn', 'raise', or 'ignore'")
+            raise ValueError("on_failure must be 'warn', 'error', or 'ignore'")
         self._on_failure = value
 
     @property

--- a/src/pybamm/solvers/casadi_algebraic_solver.py
+++ b/src/pybamm/solvers/casadi_algebraic_solver.py
@@ -270,6 +270,7 @@ class CasadiAlgebraicSolver(pybamm.BaseSolver):
             model,
             inputs_dict,
             termination="final time",
+            all_t_evals=[t_eval],
         )
         sol.integration_time = integration_time
         return sol

--- a/src/pybamm/solvers/casadi_solver.py
+++ b/src/pybamm/solvers/casadi_solver.py
@@ -490,6 +490,7 @@ class CasadiSolver(pybamm.BaseSolver):
             np.array([t_event]),
             y_event[:, np.newaxis],
             "event",
+            all_t_evals=t_sol,
         )
         solution.integration_time = (
             coarse_solution.integration_time + dense_step_sol.integration_time
@@ -687,6 +688,7 @@ class CasadiSolver(pybamm.BaseSolver):
                 model,
                 inputs_dict,
                 check_solution=False,
+                all_t_evals=t_eval,
             )
             sol.integration_time = integration_time
             return sol
@@ -725,6 +727,7 @@ class CasadiSolver(pybamm.BaseSolver):
                 y_sol,
                 model,
                 inputs_dict,
+                all_t_evals=t_eval,
                 check_solution=False,
             )
             sol.integration_time = integration_time

--- a/src/pybamm/solvers/dummy_solver.py
+++ b/src/pybamm/solvers/dummy_solver.py
@@ -35,7 +35,12 @@ class DummySolver(pybamm.BaseSolver):
         """
         y_sol = np.zeros((1, t_eval.size))
         sol = pybamm.Solution(
-            t_eval, y_sol, model, inputs_dict, termination="final time"
+            t_eval,
+            y_sol,
+            model,
+            inputs_dict,
+            termination="final time",
+            all_t_evals=t_eval,
         )
         sol.integration_time = 0
         return sol

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -173,9 +173,9 @@ class IDAKLUSolver(pybamm.BaseSolver):
         on_failure=None,
         options=None,
     ):
-        self._options = self._check_and_combine_options(options)
-
         self.output_variables = [] if output_variables is None else output_variables
+
+        self._options = self._combine_options(options)
 
         super().__init__(
             method="ida",
@@ -195,9 +195,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
         pybamm.citations.register("Hindmarsh2000")
         pybamm.citations.register("Hindmarsh2005")
 
-        # set default options,
-
-    def _check_and_combine_options(self, user_options: dict | None) -> dict:
+    def _combine_options(self, user_options: dict | None) -> dict:
         num_solvers = user_options.get("num_threads", 1) if user_options else 1
         default_options = {
             "print_stats": False,
@@ -239,7 +237,29 @@ class IDAKLUSolver(pybamm.BaseSolver):
         if not user_options:
             return default_options
 
-        return default_options | user_options
+        options = default_options | user_options
+
+        self._check_options(options)
+
+        return options
+
+    def _check_options(self, options: dict):
+        hermite_reduction_factor = options["hermite_reduction_factor"]
+        if hermite_reduction_factor > 1.0:
+            if self.output_variables:
+                raise pybamm.SolverError(
+                    "hermite_reduction_factor cannot be used with "
+                    "output_variables. Both are memory-saving options "
+                    "that are mutually exclusive."
+                )
+            if not options["hermite_interpolation"]:
+                raise pybamm.SolverError(
+                    "hermite_reduction_factor requires "
+                    "hermite_interpolation to be enabled."
+                )
+        else:
+            if hermite_reduction_factor < 1.0:
+                raise pybamm.SolverError("hermite_reduction_factor must be >= 1.0.")
 
     def _check_atol_type(self, atol, model):
         if isinstance(atol, float):
@@ -356,7 +376,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
         alg_ids = np.zeros(len(y0) - len(rhs_ids))
         ids = np.concatenate((rhs_ids, alg_ids))
 
-        number_of_sensitivity_parameters = 0
         if model.jacp_rhs_algebraic_eval is not None:
             sensitivity_names = model.calculate_sensitivities
             if model.convert_to_format == "casadi":
@@ -364,6 +383,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             else:
                 number_of_sensitivity_parameters = len(sensitivity_names)
         else:
+            number_of_sensitivity_parameters = 0
             sensitivity_names = []
 
         # for the casadi solver we just give it dFdp_i
@@ -419,6 +439,18 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 self.dvar_dp_idaklu_fcns.append(
                     idaklu.generate_function(self.dvar_dp_idaklu_fcns_pkl[-1])
                 )
+
+        if (
+            self._options["hermite_reduction_factor"] > 1.0
+            and number_of_sensitivity_parameters > 0
+        ):
+            warnings.warn(
+                "Setting hermite_reduction_factor > 1.0 is not currently supported "
+                "with sensitivities. The hermite_reduction_factor option will be "
+                "ignored.",
+                pybamm.SolverWarning,
+                stacklevel=2,
+            )
 
         self._setup = {
             "number_of_states": len(y0),
@@ -582,7 +614,6 @@ class IDAKLUSolver(pybamm.BaseSolver):
         Overloads the _integrate method from BaseSolver to use the IDAKLU solver
         """
         if model.convert_to_format != "casadi":  # pragma: no cover
-            # Shouldn't ever reach this point
             raise pybamm.SolverError("Unsupported IDAKLU solver configuration.")
 
         inputs_list = inputs_list or [{}]

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -1075,7 +1075,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             new_ys.append(np.asarray(red_ys[i]).reshape(K, N).T)
             new_yps.append(np.asarray(red_yps[i]).reshape(K, N).T)
 
-        return pybamm.Solution(
+        new_sol = pybamm.Solution(
             all_ts=new_ts,
             all_ys=new_ys,
             all_yps=new_yps,
@@ -1088,3 +1088,13 @@ class IDAKLUSolver(pybamm.BaseSolver):
             all_t_evals=solution.all_t_evals,
             variables_returned=solution.variables_returned,
         )
+
+        # Propagate metadata from the original solution
+        new_sol._all_inputs_casadi = solution.all_inputs_casadi
+        new_sol.closest_event_idx = solution.closest_event_idx
+
+        new_sol.solve_time = solution.solve_time
+        new_sol.integration_time = solution.integration_time
+        new_sol.set_up_time = solution.set_up_time
+
+        return new_sol

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -113,7 +113,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 "hermite_interpolation": True,
                 # Setting hermite_reduction_factor > 1.0 compresses the solution size
                 # by introducing a small amount of error to the Hermite spline
-                # interpolant. A value of `M = 2.0` roughly corresponds to a maximum 2x
+                # interpolant. A value of `2.0` roughly corresponds to a maximum 2x
                 # increase in error (practically the error is much smaller), while
                 # reducing the number of saved states by around 5-6x. This option is
                 # only active if `hermite_interpolation` is True and sensitivities

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -38,7 +38,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
         Default is "warn".
     on_failure : str, optional
         What to do if a solver error flag occurs. Options are "warn", "error", or "ignore".
-        Default is "raise".
+        Default is "error".
     output_variables : list[str], optional
         List of variables to calculate and return. If none are specified then
         the complete state vector is returned (can be very large) (default is [])
@@ -111,6 +111,14 @@ class IDAKLUSolver(pybamm.BaseSolver):
                 # Note: this option is always disabled if output_variables are given
                 # or if t_interp values are specified
                 "hermite_interpolation": True,
+                # Setting hermite_reduction_factor > 1.0 compresses the solution size
+                # by introducing a small amount of error to the Hermite spline
+                # interpolant. A value of `M = 2.0` roughly corresponds to a maximum 2x
+                # increase in error (practically the error is much smaller), while
+                # reducing the number of saved states by around 5-6x. This option is
+                # only active if `hermite_interpolation` is True and sensitivities
+                # are disabled.
+                "hermite_reduction_factor": 1.0,
                 ## Initial conditions calculation
                 # Positive constant in the Newton iteration convergence test within the
                 # initial condition calculation
@@ -165,53 +173,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
         on_failure=None,
         options=None,
     ):
-        # set default options,
-        # (only if user does not supply)
-        default_options = {
-            "print_stats": False,
-            "jacobian": "sparse",
-            "preconditioner": "BBDP",
-            "precon_half_bandwidth": 5,
-            "precon_half_bandwidth_keep": 5,
-            "num_threads": 1,
-            "num_solvers": 1,
-            "linear_solver": "SUNLinSol_KLU",
-            "linsol_max_iterations": 5,
-            "epsilon_linear_tolerance": 0.05,
-            "increment_factor": 1.0,
-            "linear_solution_scaling": True,
-            "silence_sundials_errors": False,
-            "max_order_bdf": 5,
-            "max_num_steps": 100000,
-            "dt_init": 0.0,
-            "dt_min": 0.0,
-            "dt_max": 0.0,
-            "max_error_test_failures": 10,
-            "max_nonlinear_iterations": 40,
-            "max_convergence_failures": 100,
-            "nonlinear_convergence_coefficient": 0.33,
-            "suppress_algebraic_error": False,
-            "hermite_interpolation": True,
-            "nonlinear_convergence_coefficient_ic": 0.0033,
-            "max_num_steps_ic": 50,
-            "max_num_jacobians_ic": 40,
-            "max_num_iterations_ic": 100,
-            "max_linesearch_backtracks_ic": 100,
-            "linesearch_off_ic": False,
-            "init_all_y_ic": False,
-            "calc_ic": True,
-            "num_steps_no_progress": 0,
-            "t_no_progress": 0.0,
-        }
-        if options is None:
-            options = default_options
-        else:
-            if "num_threads" in options and "num_solvers" not in options:
-                options["num_solvers"] = options["num_threads"]
-            for key, value in default_options.items():
-                if key not in options:
-                    options[key] = value
-        self._options = options
+        self._options = self._check_and_combine_options(options)
 
         self.output_variables = [] if output_variables is None else output_variables
 
@@ -233,30 +195,61 @@ class IDAKLUSolver(pybamm.BaseSolver):
         pybamm.citations.register("Hindmarsh2000")
         pybamm.citations.register("Hindmarsh2005")
 
+        # set default options,
+
+    def _check_and_combine_options(self, user_options: dict | None) -> dict:
+        num_solvers = user_options.get("num_threads", 1) if user_options else 1
+        default_options = {
+            "print_stats": False,
+            "jacobian": "sparse",
+            "preconditioner": "BBDP",
+            "precon_half_bandwidth": 5,
+            "precon_half_bandwidth_keep": 5,
+            "num_threads": 1,
+            "num_solvers": num_solvers,
+            "linear_solver": "SUNLinSol_KLU",
+            "linsol_max_iterations": 5,
+            "epsilon_linear_tolerance": 0.05,
+            "increment_factor": 1.0,
+            "linear_solution_scaling": True,
+            "silence_sundials_errors": False,
+            "max_order_bdf": 5,
+            "max_num_steps": 100000,
+            "dt_init": 0.0,
+            "dt_min": 0.0,
+            "dt_max": 0.0,
+            "max_error_test_failures": 10,
+            "max_nonlinear_iterations": 40,
+            "max_convergence_failures": 100,
+            "nonlinear_convergence_coefficient": 0.33,
+            "suppress_algebraic_error": False,
+            "hermite_interpolation": True,
+            "hermite_reduction_factor": 1.0,
+            "nonlinear_convergence_coefficient_ic": 0.0033,
+            "max_num_steps_ic": 50,
+            "max_num_jacobians_ic": 40,
+            "max_num_iterations_ic": 100,
+            "max_linesearch_backtracks_ic": 100,
+            "linesearch_off_ic": False,
+            "init_all_y_ic": False,
+            "calc_ic": True,
+            "num_steps_no_progress": 0,
+            "t_no_progress": 0.0,
+        }
+        if not user_options:
+            return default_options
+
+        return default_options | user_options
+
     def _check_atol_type(self, atol, model):
-        """
-        This method checks that the atol vector is of the right shape and
-        type.
-
-        Parameters
-        ----------
-        atol: double or np.array or list
-            Absolute tolerances. If this is a vector then each entry corresponds to
-            the absolute tolerance of one entry in the state vector.
-        model: pybamm.BaseModel
-            The model to check the atol for.
-        stacked_inputs: np.ndarray
-            The stacked inputs.
-        """
-
         if isinstance(atol, float):
-            atol = np.full(model.len_rhs_and_alg, atol)
-        elif not isinstance(atol, np.ndarray):
+            return np.full(model.len_rhs_and_alg, atol)
+        elif isinstance(atol, np.ndarray):
+            return atol
+        else:
             raise pybamm.SolverError(
                 "Absolute tolerances must be a numpy array or float"
             )
-
-        return atol
 
     def set_up(self, model, inputs=None, t_eval=None, ics_only=False):
         base_set_up_return = super().set_up(model, inputs, t_eval, ics_only)
@@ -632,11 +625,13 @@ class IDAKLUSolver(pybamm.BaseSolver):
         integration_time = timer.time()
 
         return [
-            self._post_process_solution(soln, model, integration_time, inputs_dict)
+            self._post_process_solution(
+                soln, model, integration_time, inputs_dict, t_eval
+            )
             for soln, inputs_dict in zip(solns, inputs_list, strict=False)
         ]
 
-    def _post_process_solution(self, sol, model, integration_time, inputs_dict):
+    def _post_process_solution(self, sol, model, integration_time, inputs_dict, t_eval):
         number_of_sensitivity_parameters = self._setup[
             "number_of_sensitivity_parameters"
         ]
@@ -682,7 +677,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
                         msg + ", returning a partial solution.",
                         stacklevel=2,
                     )
-                case "raise":
+                case "error":
                     raise pybamm.SolverError(msg)
 
         if sol.yp.size > 0:
@@ -690,8 +685,18 @@ class IDAKLUSolver(pybamm.BaseSolver):
         else:
             yp = None
 
+        t = sol.t
+        t_eval = np.array(t_eval)
+        if t[-1] != t_eval[-1]:
+            idx_final = np.searchsorted(t_eval, t[-1]) + 1
+            t_eval = t_eval[:idx_final]
+
+            # the final index may differ due to an event;
+            # manually set it to the true final time
+            t_eval[-1] = t[-1]
+
         newsol = pybamm.Solution(
-            sol.t,
+            t,
             np.transpose(y_out),
             model,
             inputs_dict,
@@ -700,6 +705,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
             termination,
             all_sensitivities=yS_out,
             all_yps=yp,
+            all_t_evals=t_eval,
             variables_returned=bool(save_outputs_only),
         )
 
@@ -952,3 +958,102 @@ class IDAKLUSolver(pybamm.BaseSolver):
             t_interp=t_interp,
         )
         return obj
+
+    def reduce_solution(
+        self,
+        solution,
+        hermite_reduction_factor=2.0,
+    ) -> pybamm.Solution:
+        """Reduce knots in a pybamm.Solution using Hermite spline compression.
+
+        The multiplier M controls the total error budget relative to the
+        solver's own WRMS tolerance.  The knot reducer is allowed an
+        additional WRMS error of (M-1), so the total error satisfies
+        ``||e_total||_WRMS <= M``.  M = 2 (default) means the reduced
+        solution may have up to 2x the solver's local error.
+
+        Parameters
+        ----------
+        solution : :class:`pybamm.Solution`
+            The solution to reduce. Must have hermite interpolation data
+            (all_yps is not None).
+        hermite_reduction_factor : float, optional
+            Total error multiplier (>= 1.0, default 2.0). The knot
+            reducer's WRMS threshold is N * (M-1)^2. Larger values
+            allow more aggressive reduction.
+
+        Returns
+        -------
+        :class:`pybamm.Solution`
+            The modified solution.
+        """
+        if not solution.hermite_interpolation:
+            raise pybamm.SolverError(
+                "reduce_solution requires Hermite interpolation data (all_yps)."
+            )
+        if self.options["hermite_reduction_factor"] != 1.0:
+            raise pybamm.SolverError(
+                "reduce_solution requires the original solver to have "
+                "`hermite_reduction_factor = 1.0`"
+            )
+
+        all_ts = solution.all_ts
+        all_ys = solution.all_ys
+        all_yps = solution.all_yps
+        all_models = solution.all_models
+        n_seg = len(all_ts)
+
+        rtol = self.rtol
+        atol = self.atol
+
+        # Build flat time-major arrays for the C++ reducer.
+        # all_ys[i] is (n_states, M) transposed view whose underlying
+        # buffer is already time-major (M * n_states,).  .T.ravel()
+        # returns a 1D view of that buffer -- no copy.
+        flat_ys = [all_ys[i].T.ravel() for i in range(n_seg)]
+        flat_yps = [all_yps[i].T.ravel() for i in range(n_seg)]
+
+        # Build per-segment atol vectors
+        atol_vecs = [None] * n_seg
+        for i, model in enumerate(all_models):
+            atol_vecs[i] = self._check_atol_type(atol, model)
+
+        ts_vec = idaklu.VectorRealtypeNdArray(all_ts)
+        ys_vec = idaklu.VectorRealtypeNdArray(flat_ys)
+        yps_vec = idaklu.VectorRealtypeNdArray(flat_yps)
+        atols_vec = idaklu.VectorRealtypeNdArray(atol_vecs)
+        t_evals_vec = idaklu.VectorRealtypeNdArray(solution.all_t_evals)
+
+        red_ts, red_ys, red_yps = idaklu.reduce_knots(
+            ts_vec,
+            ys_vec,
+            yps_vec,
+            atols_vec,
+            t_evals_vec,
+            float(rtol),
+            float(hermite_reduction_factor),
+        )
+
+        # Reshape reduced flat arrays back to (n_states, K) convention
+        new_ts = [np.asarray(red_ts[i]) for i in range(n_seg)]
+        new_ys = []
+        new_yps = []
+        for i in range(n_seg):
+            K = len(new_ts[i])
+            N = all_ys[i].shape[0]
+            new_ys.append(np.asarray(red_ys[i]).reshape(K, N).T)
+            new_yps.append(np.asarray(red_yps[i]).reshape(K, N).T)
+
+        return pybamm.Solution(
+            all_ts=new_ts,
+            all_ys=new_ys,
+            all_yps=new_yps,
+            all_models=all_models,
+            all_inputs=solution.all_inputs,
+            t_event=solution.t_event,
+            y_event=solution.y_event,
+            termination=solution.termination,
+            all_sensitivities=solution._all_sensitivities,
+            all_t_evals=solution.all_t_evals,
+            variables_returned=solution.variables_returned,
+        )

--- a/tests/unit/test_solvers/test_base_solver.py
+++ b/tests/unit/test_solvers/test_base_solver.py
@@ -456,12 +456,12 @@ class TestBaseSolver:
 
         # Test invalid value
         with pytest.raises(
-            ValueError, match=r"on_extrapolation must be 'warn', 'raise', or 'ignore'"
+            ValueError, match=r"on_extrapolation must be 'warn', 'error', or 'ignore'"
         ):
             base_solver.on_extrapolation = "invalid"
 
         with pytest.raises(
-            ValueError, match=r"on_failure must be 'warn', 'raise', or 'ignore'"
+            ValueError, match=r"on_failure must be 'warn', 'error', or 'ignore'"
         ):
             base_solver.on_failure = "invalid"
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 from scipy.integrate import quad_vec
 from scipy.interpolate import CubicHermiteSpline
-from scipy.sparse import eye
 
 import pybamm
 from tests import get_discretisation_for_testing, no_internet_connection

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -3,10 +3,75 @@ import warnings
 from contextlib import redirect_stdout
 
 import numpy as np
+import pandas as pd
 import pytest
+from scipy.integrate import quad_vec
+from scipy.interpolate import CubicHermiteSpline
+from scipy.sparse import eye
 
 import pybamm
-from tests import get_discretisation_for_testing
+from tests import get_discretisation_for_testing, no_internet_connection
+
+
+def _hermite_wrms(sol_base, sol_reduced, atol, rtol) -> list[tuple[int, float]]:
+    """
+    Compute the integral L2 WRMS error between two Hermite-interpolated solutions
+    using Gauss quadrature
+
+    Parameters
+    ----------
+    sol_base : pybamm.Solution
+    sol_reduced : pybamm.Solution
+    atol : float
+    rtol : float
+
+    Returns
+    -------
+    list[tuple[int, float]]
+        A list of tuples, each containing the segment index and the WRMS error
+    """
+    n_states = sol_base.all_ys[0].shape[0]
+    atol_vec = np.full(n_states, atol)
+    wrms_values = []
+
+    def cubic_hermite_spline(sol):
+        tb = np.asarray(sol.all_ts[0])
+        yb = np.asarray(sol.all_ys[0])
+        ypb = np.asarray(sol.all_yps[0])
+        return CubicHermiteSpline(tb, yb.T, ypb.T)
+
+    for seg in range(len(sol_base.all_ts)):
+        tb = sol_base.all_ts[seg]
+        tr = sol_reduced.all_ts[seg]
+
+        if len(tb) < 2 or len(tr) < 2:
+            continue
+        sub = sol_base.sub_solutions[seg]
+        itp_base = cubic_hermite_spline(sub)
+        itp_red = cubic_hermite_spline(sol_reduced.sub_solutions[seg])
+
+        t_span = tb[-1] - tb[0]
+
+        def integrand(t, itp_base, itp_red, atol_vec, rtol):
+            y_b = itp_base(t)
+            y_r = itp_red(t)
+            w = 1.0 / (atol_vec + rtol * np.abs(y_b))
+            return (w * (y_b - y_r)) ** 2
+
+        t_evals = np.asarray(sub.all_t_evals[0])
+        points = t_evals[(t_evals > tb[0]) & (t_evals < tb[-1])]
+
+        integral, _ = quad_vec(
+            integrand,
+            tb[0],
+            tb[-1],
+            points=points,
+            args=(itp_base, itp_red, atol_vec, rtol),
+        )
+        wrms = np.sqrt(np.mean(integral) / t_span)
+        wrms_values.append((seg, wrms))
+
+    return wrms_values
 
 
 class TestIDAKLUSolver:
@@ -751,6 +816,7 @@ class TestIDAKLUSolver:
             "epsilon_linear_tolerance": 0.06,
             "increment_factor": 0.99,
             "linear_solution_scaling": False,
+            "hermite_reduction_factor": 1.1,
         }
 
         # test everything works
@@ -760,7 +826,7 @@ class TestIDAKLUSolver:
             soln = solver.solve(model, t_eval, t_interp=t_interp)
 
             # Asserts
-            assert options == solver.options
+            assert all(v == solver.options[k] for k, v in options.items())
             np.testing.assert_allclose(soln.y, soln_base.y, rtol=1e-5, atol=1e-4)
 
         options_fail = {
@@ -771,6 +837,7 @@ class TestIDAKLUSolver:
             "max_linesearch_backtracks_ic": -1,
             "epsilon_linear_tolerance": -1.0,
             "increment_factor": -1.0,
+            "hermite_reduction_factor": -1.0,
         }
 
         # test that the solver throws a warning
@@ -778,7 +845,7 @@ class TestIDAKLUSolver:
             options = {option: options_fail[option]}
             solver = pybamm.IDAKLUSolver(options=options)
 
-            with pytest.raises(pybamm.SolverError):
+            with pytest.raises((pybamm.SolverError, ValueError)):
                 solver.solve(model, t_eval)
 
     def test_with_output_variables(self):
@@ -1413,3 +1480,209 @@ class TestIDAKLUSolver:
 
         assert len(sol.t) == options_failures["num_steps_no_progress"]
         assert sol.t[-1] < options_failures["t_no_progress"]
+
+    @pytest.mark.skipif(
+        no_internet_connection(),
+        reason="Network not available to download files from registry",
+    )
+    def test_drive_cycle_knot_reduction(self):
+        """Test knot reduction with a drive cycle (many t_eval breakpoints).
+
+        Verifies that:
+          1. The reduced solution has fewer points than the baseline.
+          2. All derivatives are finite (no NaN from LS solve).
+          3. The Hermite spline error (integral L2 WRMS) stays below 1.0.
+        """
+        model = pybamm.lithium_ion.SPM()
+        param = model.default_parameter_values
+        data_loader = pybamm.DataLoader()
+        drive_cycle = pd.read_csv(
+            pybamm.get_parameters_filepath(data_loader.get_data("US06.csv")),
+            comment="#",
+            skip_blank_lines=True,
+            header=None,
+        ).to_numpy()
+        current_interpolant = pybamm.Interpolant(
+            drive_cycle[:, 0], drive_cycle[:, 1], pybamm.t
+        )
+        param["Current function [A]"] = current_interpolant
+
+        rtol = 1e-4
+        atol = 1e-6
+        hermite_reduction_factor = 2.0
+
+        # Baseline: no knot reduction
+        solver_base = pybamm.IDAKLUSolver(rtol=rtol, atol=atol)
+        sim_base = pybamm.Simulation(model, parameter_values=param, solver=solver_base)
+        sol_base = sim_base.solve()
+
+        # Reduced: with knot reduction (and optionally LS refinement)
+        solver_red = pybamm.IDAKLUSolver(
+            rtol=rtol,
+            atol=atol,
+            options={"hermite_reduction_factor": hermite_reduction_factor},
+        )
+        sim_red = pybamm.Simulation(model, parameter_values=param, solver=solver_red)
+        sol_red = sim_red.solve()
+
+        # 1. Fewer points
+        n_base = sum(len(s) for s in sol_base.all_ts)
+        n_red = sum(len(s) for s in sol_red.all_ts)
+        assert n_red < n_base, (
+            f"Knot reduction should reduce points: {n_red} >= {n_base}"
+        )
+
+        # 2. All derivatives must be finite (no NaN from LS)
+        for seg in range(len(sol_red.all_ts)):
+            yp = np.asarray(sol_red.all_yps[seg])
+            assert np.all(np.isfinite(yp)), f"Non-finite derivatives in segment {seg}"
+
+        # 3. Integral L2 WRMS error must be bounded
+        for seg, wrms in _hermite_wrms(sol_base, sol_red, atol, rtol):
+            assert wrms < 1.0, f"Segment {seg} integral L2 WRMS too large: {wrms:.4e}"
+
+    def test_reduce_solution_errors(self):
+        """Test that reduce_solution raises on invalid inputs."""
+        model = pybamm.lithium_ion.SPM()
+        solver_base = pybamm.IDAKLUSolver(rtol=1e-4, atol=1e-6)
+        sim = pybamm.Simulation(model, solver=solver_base)
+        sol = sim.solve([0, 3600])
+
+        # No Hermite data: disable all_yps
+        sol_no_hermite = sol.copy()
+        sol_no_hermite._all_yps = None
+        with pytest.raises(pybamm.SolverError, match="Hermite interpolation data"):
+            solver_base.reduce_solution(sol_no_hermite)
+
+        # Solver had reduction active
+        solver_active = pybamm.IDAKLUSolver(
+            rtol=1e-4,
+            atol=1e-6,
+            options={"hermite_reduction_factor": 2.0},
+        )
+        with pytest.raises(pybamm.SolverError, match=r"hermite_reduction_factor = 1.0"):
+            solver_active.reduce_solution(sol)
+
+    def test_reduce_solution_basic(self):
+        """Test basic post-hoc reduce_solution: fewer points, finite yps, bounded error."""
+        model = pybamm.lithium_ion.SPM()
+        rtol = 1e-4
+        atol = 1e-6
+        solver = pybamm.IDAKLUSolver(rtol=rtol, atol=atol)
+        sim = pybamm.Simulation(model, solver=solver)
+        sol = sim.solve([0, 3600])
+
+        reduced = solver.reduce_solution(sol, hermite_reduction_factor=2.0)
+
+        # 1. Fewer points
+        n_orig = sum(len(s) for s in sol.all_ts)
+        n_red = sum(len(s) for s in reduced.all_ts)
+        assert n_red < n_orig, (
+            f"reduce_solution should reduce points: {n_red} >= {n_orig}"
+        )
+
+        # 2. All derivatives finite
+        for seg in range(len(reduced.all_ts)):
+            yp = np.asarray(reduced.all_yps[seg])
+            assert np.all(np.isfinite(yp)), f"Non-finite derivatives in segment {seg}"
+
+        # 3. Bounded WRMS error
+        for seg, wrms in _hermite_wrms(sol, reduced, atol, rtol):
+            assert wrms < 1.0, f"Segment {seg} integral L2 WRMS too large: {wrms:.4e}"
+
+    def test_reduce_solution_metadata(self):
+        """Test that reduce_solution preserves metadata from the original solution."""
+        model = pybamm.lithium_ion.SPM()
+        solver = pybamm.IDAKLUSolver(rtol=1e-4, atol=1e-6)
+        sim = pybamm.Simulation(model, solver=solver)
+        sol = sim.solve([0, 3600])
+
+        reduced = solver.reduce_solution(sol, hermite_reduction_factor=2.0)
+
+        assert reduced.termination == sol.termination
+        assert reduced.all_inputs == sol.all_inputs
+        assert len(reduced.all_models) == len(sol.all_models)
+        for rm, sm in zip(reduced.all_models, sol.all_models, strict=True):
+            assert rm is sm
+        if sol.t_event is not None:
+            np.testing.assert_array_equal(reduced.t_event, sol.t_event)
+        if sol.y_event is not None:
+            np.testing.assert_array_equal(reduced.y_event, sol.y_event)
+        # all_t_evals preserved
+        assert len(reduced.all_t_evals) == len(sol.all_t_evals)
+        for rte, ste in zip(reduced.all_t_evals, sol.all_t_evals, strict=True):
+            np.testing.assert_array_equal(rte, ste)
+
+    def test_reduce_solution_vs_online(self):
+        """Compare post-hoc reduce_solution with online knot reduction on a drive cycle.
+
+        Verifies that:
+          1. Post-hoc reduction produces similar point counts to online reduction.
+          2. Both have finite derivatives.
+          3. Both have bounded WRMS error vs the uncompressed baseline.
+        """
+        model = pybamm.lithium_ion.SPM()
+        param = model.default_parameter_values
+
+        time = np.arange(100)
+        np.random.seed(0)
+        current = 1 + 0.1 * np.random.rand(time.size)
+        current_interpolant = pybamm.Interpolant(time, current, pybamm.t)
+        param["Current function [A]"] = current_interpolant
+
+        rtol = 1e-4
+        atol = 1e-6
+        hermite_reduction_factor = 2.0
+
+        # Baseline: no reduction
+        solver_base = pybamm.IDAKLUSolver(rtol=rtol, atol=atol)
+        sim_base = pybamm.Simulation(model, parameter_values=param, solver=solver_base)
+        sol_base = sim_base.solve()
+
+        # Online reduction
+        solver_online = pybamm.IDAKLUSolver(
+            rtol=rtol,
+            atol=atol,
+            options={"hermite_reduction_factor": hermite_reduction_factor},
+        )
+        sim_online = pybamm.Simulation(
+            model, parameter_values=param, solver=solver_online
+        )
+        sol_online = sim_online.solve()
+
+        # Post-hoc reduction
+        sol_posthoc = solver_base.reduce_solution(
+            sol_base, hermite_reduction_factor=hermite_reduction_factor
+        )
+
+        n_base = sum(len(s) for s in sol_base.all_ts)
+        n_online = sum(len(s) for s in sol_online.all_ts)
+        n_posthoc = sum(len(s) for s in sol_posthoc.all_ts)
+
+        # Point counts should be equal
+        assert n_posthoc == n_online
+
+        # Time arrays should be equal
+        np.testing.assert_array_equal(sol_posthoc.t, sol_online.t)
+
+        # Both should reduce points
+        assert n_online < n_base
+
+        sols = {
+            "online": sol_online,
+            "posthoc": sol_posthoc,
+        }
+
+        for label, sol_r in sols.items():
+            # Both must have finite derivatives
+            for seg in range(len(sol_r.all_ts)):
+                yp = np.asarray(sol_r.all_yps[seg])
+                assert np.all(np.isfinite(yp)), (
+                    f"{label}: non-finite derivatives in segment {seg}"
+                )
+
+            # WRMS error bounded for both
+            for seg, wrms in _hermite_wrms(sol_base, sol_r, atol, rtol):
+                assert wrms < 1.0, (
+                    f"{label} segment {seg} integral L2 WRMS too large: {wrms:.4e}"
+                )

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -822,11 +822,14 @@ class TestIDAKLUSolver:
         for option in options_success:
             options = {option: options_success[option]}
             solver = pybamm.IDAKLUSolver(rtol=1e-6, atol=1e-6, options=options)
-            soln = solver.solve(model, t_eval, t_interp=t_interp)
+            soln = solver.solve(model, t_eval)
+            # Hermite upsample y
+            itp = CubicHermiteSpline(soln.t, soln.y, soln.yp, axis=1)
+            y_upsampled = itp(t_interp)
 
             # Asserts
             assert all(v == solver.options[k] for k, v in options.items())
-            np.testing.assert_allclose(soln.y, soln_base.y, rtol=1e-5, atol=1e-4)
+            np.testing.assert_allclose(y_upsampled, soln_base.y, rtol=1e-5, atol=1e-4)
 
         options_fail = {
             "max_order_bdf": -1,
@@ -842,9 +845,8 @@ class TestIDAKLUSolver:
         # test that the solver throws a warning
         for option in options_fail:
             options = {option: options_fail[option]}
-            solver = pybamm.IDAKLUSolver(options=options)
-
-            with pytest.raises((pybamm.SolverError, ValueError)):
+            with pytest.raises(pybamm.SolverError):
+                solver = pybamm.IDAKLUSolver(options=options)
                 solver.solve(model, t_eval)
 
     def test_with_output_variables(self):
@@ -1561,6 +1563,33 @@ class TestIDAKLUSolver:
         )
         with pytest.raises(pybamm.SolverError, match=r"hermite_reduction_factor = 1.0"):
             solver_active.reduce_solution(sol)
+
+    def test_hermite_reduction_factor_incompatible(self):
+        """Test errors/warnings when hermite_reduction_factor conflicts with other options."""
+        # Error at construction: hermite_reduction_factor + output_variables
+        with pytest.raises(pybamm.SolverError, match="output_variables"):
+            pybamm.IDAKLUSolver(
+                options={"hermite_reduction_factor": 2.0},
+                output_variables=["Voltage [V]"],
+            )
+
+        # Error at construction: hermite_reduction_factor + hermite_interpolation disabled
+        with pytest.raises(pybamm.SolverError, match="hermite_interpolation"):
+            pybamm.IDAKLUSolver(
+                options={
+                    "hermite_reduction_factor": 2.0,
+                    "hermite_interpolation": False,
+                },
+            )
+
+        # Warning at solve: hermite_reduction_factor + sensitivities
+        model_sens = pybamm.lithium_ion.SPM()
+        param = model_sens.default_parameter_values
+        param["Current function [A]"] = pybamm.InputParameter("I")
+        solver = pybamm.IDAKLUSolver(options={"hermite_reduction_factor": 2.0})
+        sim = pybamm.Simulation(model_sens, parameter_values=param, solver=solver)
+        with pytest.warns(pybamm.SolverWarning, match="not currently supported"):
+            sim.solve([0, 1], inputs={"I": 1.0}, calculate_sensitivities=True)
 
     def test_reduce_solution_basic(self):
         """Test basic post-hoc reduce_solution: fewer points, finite yps, bounded error."""


### PR DESCRIPTION
# Description

Companion PR to https://github.com/pybamm-team/pybammsolvers/pull/90

Adds an option to the `IDAKLUSolver` that dynamically reduces the size of the solution by removing points in the Hermite interpolant. Setting `hermite_reduction_factor > 1.0` compresses the solution size by introducing a small amount of error to the Hermite spline interpolant. A value of `2.0` roughly corresponds to a maximum 2x increase in error (practically the error is much smaller), while reducing the number of saved states by around 5-6x.

Example: DFN CC-CV charge showing the power. A value of `hermite_reduction_factor = 2` reduces the number of points by 5.4x, and introduces at most 0.9 mW of error compared to the original Hermite interpolant with a max error of ~5 mW near the CC-CV peak

<img width="731" height="521" alt="image" src="https://github.com/user-attachments/assets/1a199ff0-9a48-43f3-9ce4-eabbdc1cf05f" />


## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
