### PR TITLE
Remove mass matrix inverse and dense matrix temporaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Eliminated the mass matrix inverse and temporary dense matrix objects when building the simulation. ([#5391](https://github.com/pybamm-team/PyBaMM/pull/5391))
 - Added support for Python 3.14. ([#5374](https://github.com/pybamm-team/PyBaMM/pull/5374))
 - Added regularisation to the kinetics and OCPs so they are more numerically stable. ([#5371](https://github.com/pybamm-team/PyBaMM/pull/5371))
 - Improve the performance of matrix multiplication with CasADi expressions. ([#5351](https://github.com/pybamm-team/PyBaMM/pull/5351))
@@ -13,6 +14,7 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 ## Breaking changes
 
+- The mass matrix inverse is no longer computed during discretisation. Solvers instead use sparse linear solves. ([#5391](https://github.com/pybamm-team/PyBaMM/pull/5391))
 - Dropped JAX support on macOS with Intel (x86_64) processors. JAX dropped macOS Intel wheels in version 0.5.0, and the minimum JAX version has been bumped to >=0.7.0 for Python 3.14 compatibility. macOS users require Apple Silicon (M-series) for JAX features. ([#5374](https://github.com/pybamm-team/PyBaMM/pull/5374))
 - Added a small regularisation term to the exchange current density which slightly modifies the functional form of the kinetics as stoichiometry approaches 0 or 1. ([#5371](https://github.com/pybamm-team/PyBaMM/pull/5371))
 - The default OCP barrier as stoichiometry approaches 0 or 1 is now smooth instead of asymptotically approaching infinity. This may change the behavior of ESOH solvers in extreme stoichiometry limits. ([#5371](https://github.com/pybamm-team/PyBaMM/pull/5371))

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import casadi
 import numpy as np
 from scipy import interpolate, special
+from scipy.sparse import issparse
 
 import pybamm
 
@@ -346,10 +347,11 @@ def try_repeated_row_matmul(
     if m < 2:
         return None
 
-    # Convert to dense array for comparison
-    dense = entries.toarray() if hasattr(entries, "toarray") else np.asarray(entries)
+    if issparse(entries):
+        opt = _check_identical_rows_sparse(entries.tocsr())
+    else:
+        opt = _check_identical_rows_dense(np.asarray(entries))
 
-    opt = check_identical_rows(dense)
     if opt:
         return opt.apply(converted_right)
 
@@ -388,23 +390,77 @@ class MatMulBoundaryDiffers:
         return casadi.vertcat(first_result, interior_result, last_result)
 
 
-def check_identical_rows(
+def _csr_rows_equal(indptr, indices, data, i, j):
+    """Check if rows i and j of a CSR matrix are identical."""
+    si, ei = indptr[i], indptr[i + 1]
+    sj, ej = indptr[j], indptr[j + 1]
+    if ei - si != ej - sj:
+        return False
+    return np.array_equal(indices[si:ei], indices[sj:ej]) and np.array_equal(
+        data[si:ei], data[sj:ej]
+    )
+
+
+def _csr_row_to_dense(csr, i, n):
+    """Extract a single row from CSR as a dense 1D array."""
+    row = np.zeros(n)
+    s, e = csr.indptr[i], csr.indptr[i + 1]
+    row[csr.indices[s:e]] = csr.data[s:e]
+    return row
+
+
+def _check_identical_rows_sparse(
+    csr,
+) -> MatMulIdenticalRows | MatMulBoundaryDiffers | None:
+    """Check if interior rows are identical, operating directly on CSR data."""
+    m, n = csr.shape
+    indptr, indices, data = csr.indptr, csr.indices, csr.data
+
+    row_nnz = np.diff(indptr)
+    interior_nnz = row_nnz[1]
+
+    # All interior rows must have the same nnz to be candidates
+    if not (row_nnz[1:-1] == interior_nnz).all():
+        return None
+
+    if m == 2:
+        if _csr_rows_equal(indptr, indices, data, 0, 1):
+            return MatMulIdenticalRows(row=_csr_row_to_dense(csr, 0, n), m=m)
+        return None
+
+    for i in range(2, m - 1):
+        if not _csr_rows_equal(indptr, indices, data, 1, i):
+            return None
+
+    first_same = _csr_rows_equal(indptr, indices, data, 0, 1)
+    last_same = _csr_rows_equal(indptr, indices, data, m - 1, 1)
+
+    interior_row = _csr_row_to_dense(csr, 1, n)
+    if first_same and last_same:
+        return MatMulIdenticalRows(row=interior_row, m=m)
+    else:
+        return MatMulBoundaryDiffers(
+            interior_row=interior_row,
+            first_row=None if first_same else _csr_row_to_dense(csr, 0, n),
+            last_row=None if last_same else _csr_row_to_dense(csr, m - 1, n),
+            m=m,
+        )
+
+
+def _check_identical_rows_dense(
     dense: np.ndarray,
 ) -> MatMulIdenticalRows | MatMulBoundaryDiffers | None:
     """Check if interior rows are identical, with optional boundary differences."""
     first_row = dense[0, :]
     m = dense.shape[0]
 
-    # For m=2: just check if both rows are identical
     if m == 2:
         if np.array_equal(dense[1, :], first_row):
             return MatMulIdenticalRows(row=first_row, m=m)
         return None
 
-    # For m >= 3: check interior rows, then boundaries
     interior_row = dense[1, :]
 
-    # Check interior rows are all identical (start at row 2 since row 1 is the template)
     if not (dense[2:-1] == interior_row).all():
         return None
 

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -188,7 +188,6 @@ class Serialise:
             ),
             "events": [self._SymbolEncoder().default(event) for event in model.events],
             "mass_matrix": self._SymbolEncoder().default(model.mass_matrix),
-            "mass_matrix_inv": self._SymbolEncoder().default(model.mass_matrix_inv),
             "_solution_observable": model._solution_observable.name,
         }
 
@@ -296,9 +295,6 @@ class Serialise:
                 for event in model_data["events"]
             ],
             "mass_matrix": self._reconstruct_expression_tree(model_data["mass_matrix"]),
-            "mass_matrix_inv": self._reconstruct_expression_tree(
-                model_data["mass_matrix_inv"]
-            ),
         }
 
         recon_model_dict["geometry"] = (

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -149,7 +149,6 @@ class BaseModel:
         instance.bounds = properties["bounds"]
         instance.events = properties["events"]
         instance.mass_matrix = properties["mass_matrix"]
-        instance.mass_matrix_inv = properties["mass_matrix_inv"]
         instance._variables_processed = dict(properties.get("_variables_processed", {}))
 
         def assign_meshes_to_variables(variables_dict, mesh):
@@ -885,15 +884,18 @@ class BaseModel:
         M = [2I 0
              0 0]
         """
-        if self.mass_matrix is None or self.mass_matrix_inv is None:
+        if self.mass_matrix is None:
             return False
-        # Check that the mass matrix inverse is an identity matrix
-        mass_matrix_inv = self.mass_matrix_inv.entries
-        if scipy.sparse.issparse(mass_matrix_inv):
-            identity = scipy.sparse.identity(mass_matrix_inv.shape[0])
-            return (mass_matrix_inv - identity).nnz == 0
+        n_rhs = self.len_rhs
+        if n_rhs == 0:
+            return False
+        mass = self.mass_matrix.entries
+        M_ode = mass[:n_rhs, :n_rhs]
+        if scipy.sparse.issparse(M_ode):
+            identity = scipy.sparse.identity(n_rhs, format="csr")
+            return (M_ode - identity).nnz == 0
         else:
-            return np.allclose(mass_matrix_inv, np.eye(mass_matrix_inv.shape[0]))
+            return np.allclose(M_ode, np.eye(n_rhs))
 
     def _format_table_row(
         self, param_name, param_type, max_name_length, max_type_length

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -498,15 +498,6 @@ class BaseModel:
         self._mass_matrix = mass_matrix
 
     @property
-    def mass_matrix_inv(self):
-        """Returns the inverse of the mass matrix for the differential equations after discretisation."""
-        return self._mass_matrix_inv
-
-    @mass_matrix_inv.setter
-    def mass_matrix_inv(self, mass_matrix_inv):
-        self._mass_matrix_inv = mass_matrix_inv
-
-    @property
     def jacobian(self):
         """Returns the Jacobian matrix for the model, computed automatically if `use_jacobian` is True."""
         return self._jacobian

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -6,6 +6,7 @@ import warnings
 import casadi
 import numpy as np
 import pybammsolvers.idaklu as idaklu
+from scipy.sparse.linalg import spsolve
 
 import pybamm
 
@@ -870,7 +871,8 @@ class IDAKLUSolver(pybamm.BaseSolver):
             ydot0[: model.len_rhs] = rhs0
         else:
             # M^-1 is not the identity matrix, so we need to use the mass matrix
-            ydot0[: model.len_rhs] = model.mass_matrix_inv.entries @ rhs0
+            M_ode = model.mass_matrix.entries[: model.len_rhs, : model.len_rhs]
+            ydot0[: model.len_rhs] = spsolve(M_ode, rhs0)
 
         return ydot0
 

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from scipy.sparse import eye
 
 import pybamm
 from tests import get_discretisation_for_testing, get_mesh_for_testing
@@ -513,11 +512,6 @@ class TestCasadiSolver:
         # zeros
         mass_matrix = 10 * model.mass_matrix.entries
         model.mass_matrix = pybamm.Matrix(mass_matrix)
-
-        # Note that mass_matrix_inv is just the inverse of the ode block of the
-        # mass matrix
-        mass_matrix_inv = 0.1 * eye(int(mass_matrix.shape[0] / 2))
-        model.mass_matrix_inv = pybamm.Matrix(mass_matrix_inv)
 
         assert not model.is_standard_form_dae
 

--- a/tests/unit/test_solvers/test_idaklu_solver.py
+++ b/tests/unit/test_solvers/test_idaklu_solver.py
@@ -4,7 +4,6 @@ from contextlib import redirect_stdout
 
 import numpy as np
 import pytest
-from scipy.sparse import eye
 
 import pybamm
 from tests import get_discretisation_for_testing
@@ -1159,11 +1158,6 @@ class TestIDAKLUSolver:
         # zeros
         mass_matrix = 10 * model.mass_matrix.entries
         model.mass_matrix = pybamm.Matrix(mass_matrix)
-
-        # Note that mass_matrix_inv is just the inverse of the ode block of the
-        # mass matrix
-        mass_matrix_inv = 0.1 * eye(mass_matrix.shape[0] // 2)
-        model.mass_matrix_inv = pybamm.Matrix(mass_matrix_inv)
 
         assert not model.is_standard_form_dae
 


### PR DESCRIPTION
# Description

These caused a memory bottleneck for large models

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
