### PR TITLE
Fix MSMR exchange current density regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 ## Bug fixes
 
+- Fixed a bug in the exchange current density calculation for MSMR models. ([#5404](https://github.com/pybamm-team/PyBaMM/pull/5404))
 
 ## Breaking changes
 

--- a/src/pybamm/parameters/lithium_ion_parameters.py
+++ b/src/pybamm/parameters/lithium_ion_parameters.py
@@ -856,9 +856,9 @@ class ParticleLithiumIonParameters(BaseParameters):
         # approaches X_j
         j0_j = (
             j0_ref_j
-            * pybamm.reg_power(xj, wj)
+            * xj**wj
             * pybamm.exp(f * (1 - aj) * (U - self.U0_j(T, index)))
-            * pybamm.reg_power(c_e / c_e_ref, 1 - aj)
+            * (c_e / c_e_ref) ** (1 - aj)
         )
         return j0_j
 

--- a/src/pybamm/parameters/lithium_ion_parameters.py
+++ b/src/pybamm/parameters/lithium_ion_parameters.py
@@ -858,7 +858,7 @@ class ParticleLithiumIonParameters(BaseParameters):
             j0_ref_j
             * xj**wj
             * pybamm.exp(f * (1 - aj) * (U - self.U0_j(T, index)))
-            * (c_e / c_e_ref) ** (1 - aj)
+            * pybamm.reg_power(c_e / c_e_ref, 1 - aj)
         )
         return j0_j
 


### PR DESCRIPTION
# Description

See https://github.com/pybamm-team/PyBaMM/pull/5371#issuecomment-3991168734

Now getting the same answer as pre-#5371. I believe the first potential difference figure has a different end condition, so the second figure is not 1:1

<img width="960" height="720" alt="msmr_results" src="https://github.com/user-attachments/assets/5c4a8743-3aef-4b1f-8431-37beea034b95" />

<img width="960" height="720" alt="msmr_results_phi" src="https://github.com/user-attachments/assets/c5799506-3704-4549-a4e0-d106635e867a" />

cc @DrSOKane 

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
