### PR TITLE
Fix psd 2 phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 - Fixed a bug in the exchange current density calculation for MSMR models. ([#5404](https://github.com/pybamm-team/PyBaMM/pull/5404))
 - Fixed a bug where when converting `ExpressionFunctionParameter` to source code, `Interpolant` objects were being reduced to just their input variable names (e.g., sto) instead of preserving the full constructor call with data arrays. ([#5393](https://github.com/pybamm-team/PyBaMM/pull/5393))
+- - Fixed a bug when using 2 phases with particle size distribution the bounds of the particle size distribution were always taken from the primary phase. ([#5411](https://github.com/pybamm-team/PyBaMM/pull/5411))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 - Fixed a bug in the exchange current density calculation for MSMR models. ([#5404](https://github.com/pybamm-team/PyBaMM/pull/5404))
 - Fixed a bug where when converting `ExpressionFunctionParameter` to source code, `Interpolant` objects were being reduced to just their input variable names (e.g., sto) instead of preserving the full constructor call with data arrays. ([#5393](https://github.com/pybamm-team/PyBaMM/pull/5393))
-- - Fixed a bug when using 2 phases with particle size distribution the bounds of the particle size distribution were always taken from the primary phase. ([#5415](https://github.com/pybamm-team/PyBaMM/pull/5415))
+- Fixed a bug when using 2 phases with particle size distribution the bounds of the particle size distribution were always taken from the primary phase. ([#5415](https://github.com/pybamm-team/PyBaMM/pull/5415))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ as initial conditions. ([#5311](https://github.com/pybamm-team/PyBaMM/pull/5311)
 
 - Fixed a bug in the exchange current density calculation for MSMR models. ([#5404](https://github.com/pybamm-team/PyBaMM/pull/5404))
 - Fixed a bug where when converting `ExpressionFunctionParameter` to source code, `Interpolant` objects were being reduced to just their input variable names (e.g., sto) instead of preserving the full constructor call with data arrays. ([#5393](https://github.com/pybamm-team/PyBaMM/pull/5393))
-- - Fixed a bug when using 2 phases with particle size distribution the bounds of the particle size distribution were always taken from the primary phase. ([#5411](https://github.com/pybamm-team/PyBaMM/pull/5411))
+- - Fixed a bug when using 2 phases with particle size distribution the bounds of the particle size distribution were always taken from the primary phase. ([#5415](https://github.com/pybamm-team/PyBaMM/pull/5415))
 
 ## Breaking changes
 

--- a/src/pybamm/geometry/battery_geometry.py
+++ b/src/pybamm/geometry/battery_geometry.py
@@ -85,13 +85,15 @@ def battery_geometry(
         )
         phases = int(options.negative["particle phases"])
         if phases >= 2:
+            R_min_n_sec = geo.n.sec.R_min
+            R_max_n_sec = geo.n.sec.R_max
             geometry.update(
                 {
                     "negative primary particle size": {
                         "R_n_prim": {"min": R_min_n, "max": R_max_n}
                     },
                     "negative secondary particle size": {
-                        "R_n_sec": {"min": R_min_n, "max": R_max_n}
+                        "R_n_sec": {"min": R_min_n_sec, "max": R_max_n_sec}
                     },
                 }
             )
@@ -109,13 +111,15 @@ def battery_geometry(
         )
         phases = int(options.positive["particle phases"])
         if phases >= 2:
+            R_min_p_sec = geo.p.sec.R_min
+            R_max_p_sec = geo.p.sec.R_max
             geometry.update(
                 {
                     "positive primary particle size": {
                         "R_p_prim": {"min": R_min_p, "max": R_max_p}
                     },
                     "positive secondary particle size": {
-                        "R_p_sec": {"min": R_min_p, "max": R_max_p}
+                        "R_p_sec": {"min": R_min_p_sec, "max": R_max_p_sec}
                     },
                 }
             )


### PR DESCRIPTION
## Description

# Issue:
If 2 phases were selected the secondary particle size distribution bounds were not implemented. The program was using the primary particle size distribution bounds. 

# Fix:
Now if >2 phases == true, the PSD bounds of secondary phase are used instead.

- No style issues: `nox -s pre-commit` PASSED
- All tests pass: `nox -s tests` PASSED
- The documentation builds: `nox -s doctests` PASSED
