### PR TITLE
Fix initial conditions not updating when inputs change at same SOC

### DIFF
--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -149,6 +149,7 @@ class Simulation:
         self._disc = None
         self._solution = None
         self.quick_plot = None
+        self._needs_ic_rebuild = False
 
         # ignore runtime warnings in notebooks
         if is_notebook():  # pragma: no cover
@@ -430,15 +431,13 @@ class Simulation:
             if fingerprint == self._esoh_fingerprint:
                 return
         else:
-            fingerprint = None
+            normalized = self._normalize_inputs(inputs) if inputs else ()
+            fingerprint = (initial_soc, direction, normalized)
+            if fingerprint == self._esoh_fingerprint:
+                return
 
-        if self._built_initial_soc != initial_soc:
-            # reset
-            self._model_with_set_params = None
-            self._built_model = None
-            self._built_nominal_capacity = None
-            self.steps_to_built_models = None
-            self.steps_to_built_solvers = None
+        if fingerprint != self._esoh_fingerprint:
+            self._needs_ic_rebuild = True
 
         param = self._model.param
         options = self._model.options
@@ -479,6 +478,58 @@ class Simulation:
             initial_soc=initial_soc, direction=direction, inputs=inputs
         )
 
+    def _recompute_initial_conditions(self):
+        """Recompute initial conditions on built model(s) without full rebuild."""
+        if self._built_model is not None:
+            self._update_model_ics(self._built_model)
+        if self.steps_to_built_models is not None:
+            for built_model in self.steps_to_built_models.values():
+                self._update_model_ics(built_model)
+        # Clear solver setup so it re-processes the new ICs
+        self._solver._model_set_up = {}
+        self._needs_ic_rebuild = False
+
+    def _update_model_ics(self, built_model):
+        """Update initial conditions on a single built model."""
+        # Map unprocessed IC expressions by variable name
+        unprocessed_ics = {
+            var.name: expr
+            for var, expr in (
+                self._unprocessed_model.initial_conditions.items()
+            )
+        }
+
+        # Re-parameterise ICs using the built model's Variable objects.
+        # Only update ICs that exist in the unprocessed model; experiment
+        # models may add extra variables (e.g. "Current variable [A]")
+        # that should be left unchanged.
+        new_param_ics = {}
+        for var, existing_expr in built_model.initial_conditions.items():
+            if var.name in unprocessed_ics:
+                new_param_ics[var] = (
+                    self._parameter_values.process_symbol(
+                        unprocessed_ics[var.name]
+                    )
+                )
+            else:
+                new_param_ics[var] = existing_expr
+
+        # Temporarily set disc y_slices to match this model's
+        saved_y_slices = self._disc.y_slices
+        self._disc.y_slices = dict(built_model.y_slices)
+        try:
+            processed_ics = self._disc.process_dict(
+                new_param_ics, ics=True
+            )
+            concat_ics = self._disc._concatenate_in_order(
+                processed_ics, check_complete=True
+            )
+        finally:
+            self._disc.y_slices = saved_y_slices
+
+        built_model.initial_conditions = processed_ics
+        built_model.concatenated_initial_conditions = concat_ics
+
     def build(self, initial_soc=None, direction=None, inputs=None):
         """
         A method to build the model into a system of matrices and vectors suitable for
@@ -500,6 +551,8 @@ class Simulation:
             self.set_initial_state(initial_soc, direction=direction, inputs=inputs)
 
         if self._built_model:
+            if self._needs_ic_rebuild:
+                self._recompute_initial_conditions()
             return
         if self._model.is_discretised:
             self._model_with_set_params = self._model
@@ -517,6 +570,7 @@ class Simulation:
             )
             # rebuilt model so clear solver setup
             self._solver._model_set_up = {}
+        self._needs_ic_rebuild = False
 
     def build_for_experiment(
         self, initial_soc=None, direction=None, inputs=None, solve_kwargs=None
@@ -529,6 +583,8 @@ class Simulation:
             self.set_initial_state(initial_soc, direction=direction, inputs=inputs)
 
         if self.steps_to_built_models:
+            if self._needs_ic_rebuild:
+                self._recompute_initial_conditions()
             # Check if we need to update the models due to capacity change
             self._update_experiment_models_for_capacity(inputs, solve_kwargs)
             return
@@ -567,6 +623,7 @@ class Simulation:
             self._built_nominal_capacity = self._parameter_values.get(
                 "Nominal cell capacity [A.h]", None
             )
+            self._needs_ic_rebuild = False
 
     def _build_experiment_state_mappers(self, inputs: dict):
         self.model_state_mappers = {}

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -494,9 +494,7 @@ class Simulation:
         # Map unprocessed IC expressions by variable name
         unprocessed_ics = {
             var.name: expr
-            for var, expr in (
-                self._unprocessed_model.initial_conditions.items()
-            )
+            for var, expr in (self._unprocessed_model.initial_conditions.items())
         }
 
         # Re-parameterise ICs using the built model's Variable objects.
@@ -506,10 +504,8 @@ class Simulation:
         new_param_ics = {}
         for var, existing_expr in built_model.initial_conditions.items():
             if var.name in unprocessed_ics:
-                new_param_ics[var] = (
-                    self._parameter_values.process_symbol(
-                        unprocessed_ics[var.name]
-                    )
+                new_param_ics[var] = self._parameter_values.process_symbol(
+                    unprocessed_ics[var.name]
                 )
             else:
                 new_param_ics[var] = existing_expr
@@ -518,9 +514,7 @@ class Simulation:
         saved_y_slices = self._disc.y_slices
         self._disc.y_slices = dict(built_model.y_slices)
         try:
-            processed_ics = self._disc.process_dict(
-                new_param_ics, ics=True
-            )
+            processed_ics = self._disc.process_dict(new_param_ics, ics=True)
             concat_ics = self._disc._concatenate_in_order(
                 processed_ics, check_complete=True
             )

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -385,7 +385,7 @@ class Simulation:
 
         return (initial_soc, direction, pv_fp, evals)
 
-    def _create_esoh_solver(self, direction):
+    def _create_esoh_solver(self, direction, initial_soc):
         """Create the appropriate eSOH solver/sim for this model type."""
         options = self._model.options
         pv = self._unprocessed_parameter_values
@@ -410,10 +410,14 @@ class Simulation:
             )
             return pybamm.Simulation(model, parameter_values=pv)
         else:
+            if isinstance(initial_soc, str) and initial_soc.strip().endswith("V"):
+                initialization_method = "voltage"
+            else:
+                initialization_method = "SOC"
             model = pybamm.lithium_ion.ElectrodeSOHComposite(
                 options,
                 direction,
-                initialization_method="SOC",
+                initialization_method=initialization_method,
             )
             from .models.full_battery_models.lithium_ion.electrode_soh import (
                 get_esoh_default_solver,
@@ -436,15 +440,16 @@ class Simulation:
             if fingerprint == self._esoh_fingerprint:
                 return
 
-        if fingerprint != self._esoh_fingerprint:
-            self._needs_ic_rebuild = True
+        self._needs_ic_rebuild = True
 
         param = self._model.param
         options = self._model.options
 
         if self._cache_esoh:
             if self._initial_soc_solver is None:
-                self._initial_soc_solver = self._create_esoh_solver(direction)
+                self._initial_soc_solver = self._create_esoh_solver(
+                    direction, initial_soc
+                )
             self._parameter_values = pybamm.lithium_ion.set_initial_state(
                 initial_soc,
                 self._unprocessed_parameter_values,
@@ -480,49 +485,39 @@ class Simulation:
 
     def _recompute_initial_conditions(self):
         """Recompute initial conditions on built model(s) without full rebuild."""
-        if self._built_model is not None:
-            self._update_model_ics(self._built_model)
-        if self.steps_to_built_models is not None:
-            for built_model in self.steps_to_built_models.values():
-                self._update_model_ics(built_model)
-        # Clear solver setup so it re-processes the new ICs
-        self._solver._model_set_up = {}
-        self._needs_ic_rebuild = False
-
-    def _update_model_ics(self, built_model):
-        """Update initial conditions on a single built model."""
-        # Map unprocessed IC expressions by variable name
-        unprocessed_ics = {
+        unprocessed_by_name = {
             var.name: expr
-            for var, expr in (self._unprocessed_model.initial_conditions.items())
+            for var, expr in self._unprocessed_model.initial_conditions.items()
         }
 
-        # Re-parameterise ICs using the built model's Variable objects.
-        # Only update ICs that exist in the unprocessed model; experiment
-        # models may add extra variables (e.g. "Current variable [A]")
-        # that should be left unchanged.
-        new_param_ics = {}
-        for var, existing_expr in built_model.initial_conditions.items():
-            if var.name in unprocessed_ics:
-                new_param_ics[var] = self._parameter_values.process_symbol(
-                    unprocessed_ics[var.name]
-                )
-            else:
-                new_param_ics[var] = existing_expr
+        models = []
+        if self._built_model is not None:
+            models.append(self._built_model)
+        if self.steps_to_built_models is not None:
+            models.extend(self.steps_to_built_models.values())
 
-        # Temporarily set disc y_slices to match this model's
-        saved_y_slices = self._disc.y_slices
-        self._disc.y_slices = dict(built_model.y_slices)
-        try:
+        for built_model in models:
+            new_param_ics = {}
+            for var, existing in built_model.initial_conditions.items():
+                if var.name in unprocessed_by_name:
+                    new_param_ics[var] = self._parameter_values.process_symbol(
+                        unprocessed_by_name[var.name]
+                    )
+                else:
+                    new_param_ics[var] = existing
+
             processed_ics = self._disc.process_dict(new_param_ics, ics=True)
-            concat_ics = self._disc._concatenate_in_order(
-                processed_ics, check_complete=True
-            )
-        finally:
-            self._disc.y_slices = saved_y_slices
+            slices = [built_model.y_slices[var][0] for var in processed_ics]
+            sorted_eqs = [
+                eq for _, eq in sorted(zip(slices, processed_ics.values(), strict=True))
+            ]
+            concat_ics = pybamm.numpy_concatenation(*sorted_eqs)
 
-        built_model.initial_conditions = processed_ics
-        built_model.concatenated_initial_conditions = concat_ics
+            built_model.initial_conditions = processed_ics
+            built_model.concatenated_initial_conditions = concat_ics
+
+        self._solver._model_set_up = {}
+        self._needs_ic_rebuild = False
 
     def build(self, initial_soc=None, direction=None, inputs=None):
         """

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1185,22 +1185,14 @@ class TestSimulationExperiment:
         param["Negative electrode active material volume fraction"] = (
             pybamm.InputParameter("eps_s_n")
         )
-        experiment = pybamm.Experiment(
-            ["Rest for 10 minutes", "Rest for 10 minutes"]
-        )
-        sim = pybamm.Simulation(
-            model, parameter_values=param, experiment=experiment
-        )
+        experiment = pybamm.Experiment(["Rest for 10 minutes", "Rest for 10 minutes"])
+        sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
 
         sol1 = sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
-        ic1 = sol1[
-            "X-averaged negative particle surface concentration"
-        ].data[0]
+        ic1 = sol1["X-averaged negative particle surface concentration"].data[0]
 
         sol2 = sim.solve(inputs={"eps_s_n": 0.9}, initial_soc=0.5)
-        ic2 = sol2[
-            "X-averaged negative particle surface concentration"
-        ].data[0]
+        ic2 = sol2["X-averaged negative particle surface concentration"].data[0]
 
         # ICs must differ when inputs change at same SOC
         assert ic1 != ic2

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1178,3 +1178,29 @@ class TestSimulationExperiment:
         finally:
             # Restore original logging level
             pybamm.logger.setLevel(original_log_level)
+
+    def test_inputs_with_initial_soc(self):
+        model = pybamm.lithium_ion.SPM()
+        param = pybamm.ParameterValues("Chen2020")
+        param["Negative electrode active material volume fraction"] = (
+            pybamm.InputParameter("eps_s_n")
+        )
+        experiment = pybamm.Experiment(
+            ["Rest for 10 minutes", "Rest for 10 minutes"]
+        )
+        sim = pybamm.Simulation(
+            model, parameter_values=param, experiment=experiment
+        )
+
+        sol1 = sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
+        ic1 = sol1[
+            "X-averaged negative particle surface concentration"
+        ].data[0]
+
+        sol2 = sim.solve(inputs={"eps_s_n": 0.9}, initial_soc=0.5)
+        ic2 = sol2[
+            "X-averaged negative particle surface concentration"
+        ].data[0]
+
+        # ICs must differ when inputs change at same SOC
+        assert ic1 != ic2

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1097,3 +1097,60 @@ class TestSimulation:
         assert fp1 is fp2
 
         sim._model.param = original_param
+
+    def test_initial_conditions_update_with_changed_inputs(self):
+        model = pybamm.lithium_ion.SPM()
+        param = pybamm.ParameterValues("Chen2020")
+        param["Negative electrode active material volume fraction"] = (
+            pybamm.InputParameter("eps_s_n")
+        )
+        experiment = pybamm.Experiment(["Rest for 1 hour"])
+        sim = pybamm.Simulation(
+            model, parameter_values=param, experiment=experiment
+        )
+
+        sol1 = sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
+        ic1 = sol1[
+            "X-averaged negative particle surface concentration"
+        ].data[0]
+
+        sol2 = sim.solve(inputs={"eps_s_n": 0.9}, initial_soc=0.5)
+        ic2 = sol2[
+            "X-averaged negative particle surface concentration"
+        ].data[0]
+
+        # ICs must differ when inputs differ, even at the same SOC
+        assert ic1 != ic2
+
+        # Verify against reference: override parameter directly
+        param_ref = pybamm.ParameterValues("Chen2020")
+        param_ref[
+            "Negative electrode active material volume fraction"
+        ] = 0.6
+        sim_ref = pybamm.Simulation(
+            model, parameter_values=param_ref, experiment=experiment
+        )
+        sol_ref = sim_ref.solve(initial_soc=0.5)
+        ic_ref = sol_ref[
+            "X-averaged negative particle surface concentration"
+        ].data[0]
+        np.testing.assert_allclose(ic1, ic_ref, rtol=1e-10)
+
+    def test_initial_conditions_update_same_soc_same_inputs(self):
+        model = pybamm.lithium_ion.SPM()
+        param = pybamm.ParameterValues("Chen2020")
+        param["Negative electrode active material volume fraction"] = (
+            pybamm.InputParameter("eps_s_n")
+        )
+        experiment = pybamm.Experiment(["Rest for 1 hour"])
+        sim = pybamm.Simulation(
+            model, parameter_values=param, experiment=experiment
+        )
+
+        sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
+        # After first solve, IC rebuild flag should be cleared
+        assert sim._needs_ic_rebuild is False
+
+        # Solving again with same inputs+SOC should not trigger rebuild
+        sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
+        assert sim._needs_ic_rebuild is False

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1105,35 +1105,25 @@ class TestSimulation:
             pybamm.InputParameter("eps_s_n")
         )
         experiment = pybamm.Experiment(["Rest for 1 hour"])
-        sim = pybamm.Simulation(
-            model, parameter_values=param, experiment=experiment
-        )
+        sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
 
         sol1 = sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
-        ic1 = sol1[
-            "X-averaged negative particle surface concentration"
-        ].data[0]
+        ic1 = sol1["X-averaged negative particle surface concentration"].data[0]
 
         sol2 = sim.solve(inputs={"eps_s_n": 0.9}, initial_soc=0.5)
-        ic2 = sol2[
-            "X-averaged negative particle surface concentration"
-        ].data[0]
+        ic2 = sol2["X-averaged negative particle surface concentration"].data[0]
 
         # ICs must differ when inputs differ, even at the same SOC
         assert ic1 != ic2
 
         # Verify against reference: override parameter directly
         param_ref = pybamm.ParameterValues("Chen2020")
-        param_ref[
-            "Negative electrode active material volume fraction"
-        ] = 0.6
+        param_ref["Negative electrode active material volume fraction"] = 0.6
         sim_ref = pybamm.Simulation(
             model, parameter_values=param_ref, experiment=experiment
         )
         sol_ref = sim_ref.solve(initial_soc=0.5)
-        ic_ref = sol_ref[
-            "X-averaged negative particle surface concentration"
-        ].data[0]
+        ic_ref = sol_ref["X-averaged negative particle surface concentration"].data[0]
         np.testing.assert_allclose(ic1, ic_ref, rtol=1e-10)
 
     def test_initial_conditions_update_same_soc_same_inputs(self):
@@ -1143,9 +1133,7 @@ class TestSimulation:
             pybamm.InputParameter("eps_s_n")
         )
         experiment = pybamm.Experiment(["Rest for 1 hour"])
-        sim = pybamm.Simulation(
-            model, parameter_values=param, experiment=experiment
-        )
+        sim = pybamm.Simulation(model, parameter_values=param, experiment=experiment)
 
         sim.solve(inputs={"eps_s_n": 0.6}, initial_soc=0.5)
         # After first solve, IC rebuild flag should be cleared

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1098,6 +1098,56 @@ class TestSimulation:
 
         sim._model.param = original_param
 
+    def test_initial_soc_regular_model(self):
+        model = pybamm.lithium_ion.SPM()
+        param = model.default_parameter_values
+        param["Current function [A]"] = 0.0
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc=0.5)
+        assert sim._built_initial_soc == 0.5
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc="4.0 V")
+        voltage = sol["Terminal voltage [V]"].entries
+        assert voltage[0] == pytest.approx(4.0, abs=1e-3)
+
+    def test_initial_soc_composite_model(self):
+        options = {"particle phases": ("2", "1")}
+        model = pybamm.lithium_ion.SPM(options=options)
+        param = pybamm.ParameterValues("Chen2020_composite")
+        param.update(
+            {
+                "Secondary: Initial concentration in negative electrode "
+                "[mol.m-3]": 2.3512e05
+            }
+        )
+        param["Current function [A]"] = 0.0
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc=0.5)
+        assert sim._built_initial_soc == 0.5
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc="3.8 V")
+        voltage = sol["Terminal voltage [V]"].entries
+        assert voltage[0] == pytest.approx(3.8, abs=1e-3)
+
+    def test_initial_soc_half_cell_model(self):
+        options = {"working electrode": "positive"}
+        model = pybamm.lithium_ion.SPM(options)
+        param = model.default_parameter_values
+        param["Current function [A]"] = 0.0
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc=0.5)
+        assert sim._built_initial_soc == 0.5
+
+        sim = pybamm.Simulation(model, parameter_values=param)
+        sol = sim.solve([0, 1], initial_soc="4.0 V")
+        voltage = sol["Terminal voltage [V]"].entries
+        assert voltage[0] == pytest.approx(4.0, abs=1e-3)
+
     def test_initial_conditions_update_with_changed_inputs(self):
         model = pybamm.lithium_ion.SPM()
         param = pybamm.ParameterValues("Chen2020")


### PR DESCRIPTION
## Summary
- When `sim.solve(inputs={...}, initial_soc=X)` was called multiple times with the **same SOC but different input values** affecting initial conditions (e.g. `eps_s_n`), the ICs were not recomputed
- Fixed the reset condition to use fingerprint-based comparison (not just SOC equality) for both `cache_esoh=True` and `False` paths
- Replaced full model rebuild with targeted IC-only recomputation via `_recompute_initial_conditions()`, avoiding unnecessary rebuilds of mesh, discretisation, and solver setup

## Test plan
- [x] `test_initial_conditions_update_with_changed_inputs` — verifies ICs change when inputs differ at same SOC, and match the reference (direct parameter override)
- [x] `test_initial_conditions_update_same_soc_same_inputs` — verifies no IC recomputation when same SOC and inputs
- [x] `test_inputs_with_initial_soc` (experiment test) — verifies ICs change in multi-step experiments
- [x] Full unit + integration test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)