### PR TITLE
Fix Arcsinh2 in evaluate_python and JAX paths

### DIFF
--- a/src/pybamm/expression_tree/functions.py
+++ b/src/pybamm/expression_tree/functions.py
@@ -366,12 +366,22 @@ class Arcsinh2(Function):
 
     @staticmethod
     def _arcsinh2_evaluate(a, b, eps):
-        """Evaluate arcsinh2 using numpy.
+        """Evaluate arcsinh2.
 
         Computes arcsinh(a/b) with regularization to avoid division by zero.
         Uses arcsinh(a / b_eff) where b_eff = sign(b) * hypot(b, eps).
         This formula has the correct derivative 1/b_eff at a=0.
+
+        Works with both numpy arrays and JAX traced arrays.
         """
+        # Use jax.numpy when tracing JAX arrays, otherwise numpy
+        if pybamm.has_jax():
+            import jax.numpy as jnp
+
+            if isinstance(a, jnp.ndarray) or isinstance(b, jnp.ndarray):
+                sign_b = jnp.where(b >= 0, 1.0, -1.0)
+                b_eff = sign_b * jnp.sqrt(b**2 + eps**2)
+                return jnp.arcsinh(a / b_eff)
         # sign(b) but treat sign(0) as non-zero
         sign_b = np.where(b >= 0, 1.0, -1.0)
         b_eff = sign_b * np.hypot(b, eps)

--- a/src/pybamm/expression_tree/operations/evaluate_python.py
+++ b/src/pybamm/expression_tree/operations/evaluate_python.py
@@ -291,7 +291,13 @@ def find_symbols(
                 children_str = child_var
             else:
                 children_str += ", " + child_var
-        if isinstance(symbol.function, np.ufunc):
+        if isinstance(symbol, pybamm.Arcsinh2):
+            # Arcsinh2._arcsinh2_evaluate takes (a, b, eps) but only (a, b)
+            # are children, so we need to call _function_evaluate instead
+            constant_symbols[symbol.id] = symbol._function_evaluate
+            funct_var = id_to_python_variable(symbol.id, True)
+            symbol_str = f"{funct_var}([{children_str}])"
+        elif isinstance(symbol.function, np.ufunc):
             # write any numpy functions directly
             symbol_str = f"np.{symbol.function.__name__}({children_str})"
         else:

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
@@ -446,6 +446,15 @@ class TestEvaluate:
             result = evaluator(t=t, y=y)
             np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
 
+        # test Arcsinh2 (two-argument arcsinh with regularisation)
+        a = pybamm.StateVector(slice(0, 1))
+        b = pybamm.StateVector(slice(1, 2))
+        expr = pybamm.Arcsinh2(a, b)
+        evaluator = pybamm.EvaluatorPython(expr)
+        for y in y_tests:
+            result = evaluator(t=None, y=y)
+            np.testing.assert_allclose(result, expr.evaluate(t=None, y=y))
+
         # test RegPower without scale
         x = pybamm.StateVector(slice(0, 1))
         rp = pybamm.RegPower(x, 0.5)
@@ -569,6 +578,15 @@ class TestEvaluate:
         for t, y in zip(t_tests, y_tests, strict=False):
             result = evaluator(t=t, y=y)
             np.testing.assert_allclose(result, expr.evaluate(t=t, y=y))
+
+        # test Arcsinh2 (two-argument arcsinh with regularisation)
+        expr = pybamm.Arcsinh2(a, b)
+        evaluator = pybamm.EvaluatorJax(expr)
+        for y in y_tests:
+            result = evaluator(t=None, y=y)
+            np.testing.assert_allclose(
+                result, expr.evaluate(t=None, y=y), rtol=1e-6
+            )
 
         # test something with an index
         expr = pybamm.Index(A @ pybamm.StateVector(slice(0, 2)), 0)

--- a/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
+++ b/tests/unit/test_expression_tree/test_operations/test_evaluate_python.py
@@ -584,9 +584,7 @@ class TestEvaluate:
         evaluator = pybamm.EvaluatorJax(expr)
         for y in y_tests:
             result = evaluator(t=None, y=y)
-            np.testing.assert_allclose(
-                result, expr.evaluate(t=None, y=y), rtol=1e-6
-            )
+            np.testing.assert_allclose(result, expr.evaluate(t=None, y=y), rtol=1e-6)
 
         # test something with an index
         expr = pybamm.Index(A @ pybamm.StateVector(slice(0, 2)), 0)


### PR DESCRIPTION
## Summary

- Fix `Arcsinh2` in `evaluate_python.py`: the code generation stored `_arcsinh2_evaluate(a, b, eps)` as the function but called it with only `(a, b)`, missing `eps`. Fix by using `symbol._function_evaluate` (a bound method that correctly passes `eps`).
- Fix `Arcsinh2` JAX compatibility: `_arcsinh2_evaluate` used `np.where`/`np.hypot`/`np.arcsinh` which fail on JAX traced arrays. Detect JAX arrays at runtime and use `jnp` equivalents.
- Add unit tests for `Arcsinh2` through both `EvaluatorPython` and `EvaluatorJax` paths.

Cherry-picked from #5419 (expression tree changes only).

## Test plan

- [x] `test_evaluator_python` — verifies `Arcsinh2` evaluates correctly via `EvaluatorPython`
- [x] `test_evaluator_jax` — verifies `Arcsinh2` evaluates correctly via `EvaluatorJax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)