### PR TITLE
Single model for experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Added a unified experiment-model path that reuses a single built model and solver across compatible experiment steps, with automatic fallback to the legacy per-step build for unsupported cases. ([#5422](https://github.com/pybamm-team/PyBaMM/pull/5422))
 - Improved the performance of processed variables by replacing `casadi.vertcat` input stacking with numpy vectors. ([#5413](https://github.com/pybamm-team/PyBaMM/pull/5413))
 - Preserve custom variables and events in built-in model to_config ([#5411](https://github.com/pybamm-team/PyBaMM/pull/5411))
 - Allow out of bounds initial state of charge to enable initialising a simulation at a voltage outside the voltage limits. ([#5386](https://github.com/pybamm-team/PyBaMM/pull/5386))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Added a unified experiment-model path that reuses a single built model and solver across compatible experiment steps, with automatic fallback to the legacy per-step build for unsupported cases. ([#5422](https://github.com/pybamm-team/PyBaMM/pull/5422))
+- Added a unified experiment-model path that reuses a single built model and solver across compatible experiment steps. ([#5422](https://github.com/pybamm-team/PyBaMM/pull/5422))
 
 ## Bug fixes
 

--- a/docs/source/examples/notebooks/simulations_and_experiments/simulating-long-experiments.ipynb
+++ b/docs/source/examples/notebooks/simulations_and_experiments/simulating-long-experiments.ipynb
@@ -148,7 +148,7 @@
     "            \"Hold at 4.2V until C/50\",\n",
     "        )\n",
     "    ]\n",
-    "    * 500,\n",
+    "    * 100,\n",
     "    termination=\"80% capacity\",\n",
     ")\n",
     "sim = pybamm.Simulation(spm, experiment=experiment, parameter_values=parameter_values)\n",

--- a/scripts/benchmark_unified_experiment.py
+++ b/scripts/benchmark_unified_experiment.py
@@ -23,6 +23,7 @@ class Scenario:
     description: str
     experiment_factory: callable
     solve_kwargs: dict
+    solve_inputs_list: tuple[dict, ...] = ({}, {}, {})
 
 
 def make_event_driven_cccv_experiment():
@@ -62,6 +63,24 @@ def make_start_time_padding_experiment():
     )
 
 
+def make_input_parameter_repeat_experiment():
+    s = pybamm.step.string
+    return pybamm.Experiment(
+        [
+            (
+                pybamm.step.current(
+                    pybamm.InputParameter("I_app"),
+                    duration=20 * 60,
+                ),
+                s("Charge at 1 A for 10 minutes"),
+                s("Hold at 4.1 V for 10 minutes"),
+                "Discharge at 2 W for 10 minutes",
+                "Discharge at 4 Ohm for 10 minutes",
+            )
+        ]
+    )
+
+
 SCENARIOS = [
     Scenario(
         name="event_driven_cccv",
@@ -81,10 +100,25 @@ SCENARIOS = [
         experiment_factory=make_start_time_padding_experiment,
         solve_kwargs={"calc_esoh": False},
     ),
+    Scenario(
+        name="input_parameter_repeated_solves",
+        description=(
+            "Mixed-control cycle repeated on one built simulation with varying "
+            "input current in the first step"
+        ),
+        experiment_factory=make_input_parameter_repeat_experiment,
+        solve_kwargs={"calc_esoh": False},
+        solve_inputs_list=(
+            {"I_app": 0.5},
+            {"I_app": 1.0},
+            {"I_app": 1.5},
+        ),
+    ),
 ]
 
 MODEL_FACTORIES = {
     "SPM": pybamm.lithium_ion.SPM,
+    "SPMe": pybamm.lithium_ion.SPMe,
     "DFN": pybamm.lithium_ion.DFN,
 }
 
@@ -167,16 +201,27 @@ def run_case(model_name, scenario, mode):
     t0 = time.perf_counter()
     sim.build_for_experiment()
     t1 = time.perf_counter()
-    solution = sim.solve(**scenario.solve_kwargs)
+    solutions = []
+    solve_step_s = []
+    for solve_inputs in scenario.solve_inputs_list:
+        solve_kwargs = dict(scenario.solve_kwargs)
+        if solve_inputs:
+            solve_kwargs["inputs"] = solve_inputs
+        solve_t0 = time.perf_counter()
+        solutions.append(sim.solve(**solve_kwargs))
+        solve_step_s.append(time.perf_counter() - solve_t0)
     t2 = time.perf_counter()
+    solution = solutions[-1]
 
     return {
         "build_s": t1 - t0,
-        "solve_s": t2 - t1,
+        "solve_s": sum(solve_step_s),
+        "solve_step_s": solve_step_s,
         "total_s": t2 - t0,
+        "solve_count": len(solutions),
         "termination": solution.termination,
         "uses_unified_model": getattr(sim, "_experiment_uses_unified_model", False),
-        "solution": solution,
+        "solutions": solutions,
         "status": "ok",
     }
 
@@ -254,7 +299,15 @@ def assert_solutions_match(legacy_solution, unified_solution):
 def verify_scenario_pair(model_name, scenario):
     legacy_result = run_case(model_name, scenario, "legacy")
     unified_result = run_case(model_name, scenario, "unified")
-    assert_solutions_match(legacy_result["solution"], unified_result["solution"])
+    if len(legacy_result["solutions"]) != len(unified_result["solutions"]):
+        _raise_mismatch(
+            "number of repeated solves differs: "
+            f"{len(legacy_result['solutions'])} != {len(unified_result['solutions'])}"
+        )
+    for legacy_solution, unified_solution in zip(
+        legacy_result["solutions"], unified_result["solutions"], strict=True
+    ):
+        assert_solutions_match(legacy_solution, unified_solution)
     gc.collect()
 
 
@@ -266,7 +319,9 @@ def unsupported_result(model_name, scenario, mode, reason):
         "mode": mode,
         "build_s": None,
         "solve_s": None,
+        "solve_step_s": [None] * len(scenario.solve_inputs_list),
         "total_s": None,
+        "solve_count": len(scenario.solve_inputs_list),
         "termination": "n/a",
         "uses_unified_model": False,
         "status": reason,
@@ -278,6 +333,7 @@ def main():
     scenarios = [scenario for scenario in SCENARIOS if scenario.name in args.scenarios]
     results = []
     supported_modes = [mode for mode in MODES if mode_is_supported(mode)]
+    max_solve_count = max(len(scenario.solve_inputs_list) for scenario in scenarios)
 
     print(
         f"Running {len(scenarios)} scenario(s) across {len(args.models)} model(s), "
@@ -320,7 +376,17 @@ def main():
                         "mode": mode,
                         "build_s": median([sample["build_s"] for sample in samples]),
                         "solve_s": median([sample["solve_s"] for sample in samples]),
+                        "solve_step_s": [
+                            median(
+                                [
+                                    sample["solve_step_s"][solve_index]
+                                    for sample in samples
+                                ]
+                            )
+                            for solve_index in range(samples[-1]["solve_count"])
+                        ],
                         "total_s": median([sample["total_s"] for sample in samples]),
+                        "solve_count": samples[-1]["solve_count"],
                         "termination": samples[-1]["termination"],
                         "uses_unified_model": samples[-1]["uses_unified_model"],
                         "status": "ok",
@@ -332,15 +398,35 @@ def main():
             json.dump(results, handle, indent=2)
 
     print("\n## Raw Results")
-    print(
-        "| Model | Scenario | Mode | Build (s) | Solve (s) | Total (s) | Termination |"
+    solve_headers = " | ".join(
+        f"Solve {solve_index} (s)" for solve_index in range(1, max_solve_count + 1)
     )
-    print("| --- | --- | --- | ---: | ---: | ---: | --- |")
+    print(
+        "| Model | Scenario | Mode | Solves | Build (s) | "
+        f"{solve_headers} | Solve Total (s) | Total (s) | Termination |"
+    )
+    print(
+        "| --- | --- | --- | ---: | ---: | "
+        + " | ".join(["---:"] * max_solve_count)
+        + " | ---: | ---: | --- |"
+    )
     for row in results:
+        solve_step_displays = [
+            (
+                format_seconds(row["solve_step_s"][solve_index])
+                if solve_index < len(row["solve_step_s"])
+                and row["solve_step_s"][solve_index] is not None
+                else "n/a"
+            )
+            for solve_index in range(max_solve_count)
+        ]
         print(
             "| "
             f"{row['model']} | {row['scenario']} | {row['mode']} | "
+            f"{row['solve_count']} | "
             f"{format_seconds(row['build_s']) if row['build_s'] is not None else 'n/a'} | "
+            + " | ".join(solve_step_displays)
+            + " | "
             f"{format_seconds(row['solve_s']) if row['solve_s'] is not None else 'n/a'} | "
             f"{format_seconds(row['total_s']) if row['total_s'] is not None else 'n/a'} | "
             f"{row['termination'] if row['status'] == 'ok' else row['status']} |"

--- a/scripts/benchmark_unified_experiment.py
+++ b/scripts/benchmark_unified_experiment.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+
+import argparse
+import gc
+import inspect
+import json
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+
+import numpy as np
+
+import pybamm
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    description: str
+    experiment_factory: callable
+    solve_kwargs: dict
+
+
+def make_event_driven_cccv_experiment():
+    return pybamm.Experiment(
+        [("Charge at C/3 until 4.1 V", "Hold at 4.1 V until C/20")]
+    )
+
+
+def make_mixed_control_experiment():
+    s = pybamm.step.string
+    return pybamm.Experiment(
+        [
+            (
+                s("Discharge at C/20 for 20 minutes"),
+                s("Charge at 1 A for 10 minutes"),
+                s("Hold at 4.1 V for 10 minutes"),
+                "Discharge at 2 W for 10 minutes",
+                "Discharge at 4 Ohm for 10 minutes",
+            )
+        ]
+    )
+
+
+def make_start_time_padding_experiment():
+    return pybamm.Experiment(
+        [
+            pybamm.step.Current(
+                1,
+                duration=20 * 60,
+                start_time=datetime(2023, 1, 1, 8, 0, 0),
+            ),
+            pybamm.step.rest(
+                duration=20 * 60,
+                start_time=datetime(2023, 1, 1, 9, 0, 0),
+            ),
+        ]
+    )
+
+
+SCENARIOS = [
+    Scenario(
+        name="event_driven_cccv",
+        description="Charge to voltage cutoff, then hold until current cutoff",
+        experiment_factory=make_event_driven_cccv_experiment,
+        solve_kwargs={"initial_soc": 0.2, "calc_esoh": False},
+    ),
+    Scenario(
+        name="mixed_control",
+        description="Current, voltage, power, and resistance control in one cycle",
+        experiment_factory=make_mixed_control_experiment,
+        solve_kwargs={"calc_esoh": False},
+    ),
+    Scenario(
+        name="start_time_padding",
+        description="Timestamped steps with a gap that activates padding rest",
+        experiment_factory=make_start_time_padding_experiment,
+        solve_kwargs={"calc_esoh": False},
+    ),
+]
+
+MODEL_FACTORIES = {
+    "SPM": pybamm.lithium_ion.SPM,
+    "DFN": pybamm.lithium_ion.DFN,
+}
+
+MODES = ("legacy", "unified")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark legacy vs unified experiment model paths for representative "
+            "experiment setups."
+        )
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of timed repetitions for each model/scenario/mode pair.",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="Number of untimed warmup repetitions for each pair.",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=tuple(MODEL_FACTORIES),
+        default=list(MODEL_FACTORIES),
+        help="Base models to benchmark.",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        choices=[scenario.name for scenario in SCENARIOS],
+        default=[scenario.name for scenario in SCENARIOS],
+        help="Benchmark scenarios to run.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        help="Optional path to write the raw benchmark results as JSON.",
+    )
+    return parser.parse_args()
+
+
+def simulation_supports_experiment_model_mode():
+    return (
+        "experiment_model_mode"
+        in inspect.signature(pybamm.Simulation.__init__).parameters
+    )
+
+
+def mode_is_supported(mode):
+    if mode == "legacy":
+        return True
+    return simulation_supports_experiment_model_mode()
+
+
+def run_case(model_name, scenario, mode):
+    model = MODEL_FACTORIES[model_name]()
+    solver = pybamm.IDAKLUSolver()
+    experiment = scenario.experiment_factory()
+    simulation_kwargs = {
+        "experiment": experiment,
+        "solver": solver,
+    }
+    if simulation_supports_experiment_model_mode():
+        simulation_kwargs["experiment_model_mode"] = mode
+    elif mode != "legacy":
+        raise NotImplementedError(
+            "This PyBaMM version does not support experiment_model_mode="
+            f"{mode!r}. Run this script on the unified-experiment branch to "
+            "benchmark that mode."
+        )
+
+    sim = pybamm.Simulation(model, **simulation_kwargs)
+
+    t0 = time.perf_counter()
+    sim.build_for_experiment()
+    t1 = time.perf_counter()
+    solution = sim.solve(**scenario.solve_kwargs)
+    t2 = time.perf_counter()
+
+    return {
+        "build_s": t1 - t0,
+        "solve_s": t2 - t1,
+        "total_s": t2 - t0,
+        "termination": solution.termination,
+        "uses_unified_model": getattr(sim, "_experiment_uses_unified_model", False),
+        "solution": solution,
+        "status": "ok",
+    }
+
+
+def median(values):
+    return statistics.median(values)
+
+
+def format_seconds(value):
+    return f"{value:.3f}"
+
+
+def format_ratio(unified_value, legacy_value):
+    return f"{unified_value / legacy_value:.2f}x"
+
+
+def _raise_mismatch(message):
+    raise RuntimeError(f"Legacy/unified benchmark mismatch: {message}")
+
+
+def assert_solutions_match(legacy_solution, unified_solution):
+    if legacy_solution.termination != unified_solution.termination:
+        _raise_mismatch(
+            "top-level termination differs: "
+            f"{legacy_solution.termination!r} != {unified_solution.termination!r}"
+        )
+    np.testing.assert_allclose(
+        legacy_solution.t[-1], unified_solution.t[-1], rtol=5e-5, atol=5e-4
+    )
+    np.testing.assert_allclose(
+        legacy_solution["Discharge capacity [A.h]"].data[-1],
+        unified_solution["Discharge capacity [A.h]"].data[-1],
+        rtol=5e-5,
+        atol=5e-5,
+    )
+
+    if len(legacy_solution.cycles) != len(unified_solution.cycles):
+        _raise_mismatch(
+            "number of cycles differs: "
+            f"{len(legacy_solution.cycles)} != {len(unified_solution.cycles)}"
+        )
+    for legacy_cycle, unified_cycle in zip(
+        legacy_solution.cycles, unified_solution.cycles, strict=True
+    ):
+        if len(legacy_cycle.steps) != len(unified_cycle.steps):
+            _raise_mismatch(
+                "number of steps in a cycle differs: "
+                f"{len(legacy_cycle.steps)} != {len(unified_cycle.steps)}"
+            )
+        for legacy_step, unified_step in zip(
+            legacy_cycle.steps, unified_cycle.steps, strict=True
+        ):
+            if legacy_step.termination != unified_step.termination:
+                _raise_mismatch(
+                    "step termination differs: "
+                    f"{legacy_step.termination!r} != {unified_step.termination!r}"
+                )
+            np.testing.assert_allclose(
+                legacy_step.t[-1], unified_step.t[-1], rtol=5e-5, atol=5e-4
+            )
+            np.testing.assert_allclose(
+                legacy_step["Voltage [V]"].data[-1],
+                unified_step["Voltage [V]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+            np.testing.assert_allclose(
+                legacy_step["Current [A]"].data[-1],
+                unified_step["Current [A]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+
+
+def verify_scenario_pair(model_name, scenario):
+    legacy_result = run_case(model_name, scenario, "legacy")
+    unified_result = run_case(model_name, scenario, "unified")
+    assert_solutions_match(legacy_result["solution"], unified_result["solution"])
+    gc.collect()
+
+
+def unsupported_result(model_name, scenario, mode, reason):
+    return {
+        "model": model_name,
+        "scenario": scenario.name,
+        "description": scenario.description,
+        "mode": mode,
+        "build_s": None,
+        "solve_s": None,
+        "total_s": None,
+        "termination": "n/a",
+        "uses_unified_model": False,
+        "status": reason,
+    }
+
+
+def main():
+    args = parse_args()
+    scenarios = [scenario for scenario in SCENARIOS if scenario.name in args.scenarios]
+    results = []
+    supported_modes = [mode for mode in MODES if mode_is_supported(mode)]
+
+    print(
+        f"Running {len(scenarios)} scenario(s) across {len(args.models)} model(s), "
+        f"{len(supported_modes)} supported mode(s), warmup={args.warmup}, "
+        f"repeats={args.repeats}"
+    )
+
+    for model_name in args.models:
+        for scenario in scenarios:
+            if mode_is_supported("unified"):
+                print(f"* verifying {model_name} / {scenario.name} legacy vs unified")
+                verify_scenario_pair(model_name, scenario)
+            for mode in MODES:
+                if not mode_is_supported(mode):
+                    print(f"- {model_name} / {scenario.name} / {mode} (unsupported)")
+                    results.append(
+                        unsupported_result(
+                            model_name,
+                            scenario,
+                            mode,
+                            "unsupported on this PyBaMM version",
+                        )
+                    )
+                    continue
+                print(f"- {model_name} / {scenario.name} / {mode}")
+                for _ in range(args.warmup):
+                    run_case(model_name, scenario, mode)
+                    gc.collect()
+
+                samples = [
+                    run_case(model_name, scenario, mode) for _ in range(args.repeats)
+                ]
+                gc.collect()
+
+                results.append(
+                    {
+                        "model": model_name,
+                        "scenario": scenario.name,
+                        "description": scenario.description,
+                        "mode": mode,
+                        "build_s": median([sample["build_s"] for sample in samples]),
+                        "solve_s": median([sample["solve_s"] for sample in samples]),
+                        "total_s": median([sample["total_s"] for sample in samples]),
+                        "termination": samples[-1]["termination"],
+                        "uses_unified_model": samples[-1]["uses_unified_model"],
+                        "status": "ok",
+                    }
+                )
+
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as handle:
+            json.dump(results, handle, indent=2)
+
+    print("\n## Raw Results")
+    print(
+        "| Model | Scenario | Mode | Build (s) | Solve (s) | Total (s) | Termination |"
+    )
+    print("| --- | --- | --- | ---: | ---: | ---: | --- |")
+    for row in results:
+        print(
+            "| "
+            f"{row['model']} | {row['scenario']} | {row['mode']} | "
+            f"{format_seconds(row['build_s']) if row['build_s'] is not None else 'n/a'} | "
+            f"{format_seconds(row['solve_s']) if row['solve_s'] is not None else 'n/a'} | "
+            f"{format_seconds(row['total_s']) if row['total_s'] is not None else 'n/a'} | "
+            f"{row['termination'] if row['status'] == 'ok' else row['status']} |"
+        )
+
+    print("\n## Unified vs Legacy Comparison")
+    print(
+        "| Model | Scenario | Legacy Total (s) | Unified Total (s) | Unified / Legacy |"
+    )
+    print("| --- | --- | ---: | ---: | ---: |")
+    for model_name in args.models:
+        for scenario in scenarios:
+            legacy_row = next(
+                row
+                for row in results
+                if row["model"] == model_name
+                and row["scenario"] == scenario.name
+                and row["mode"] == "legacy"
+            )
+            unified_row = next(
+                row
+                for row in results
+                if row["model"] == model_name
+                and row["scenario"] == scenario.name
+                and row["mode"] == "unified"
+            )
+            if legacy_row["status"] != "ok" or unified_row["status"] != "ok":
+                unified_display = (
+                    format_seconds(unified_row["total_s"])
+                    if unified_row["total_s"] is not None
+                    else "n/a"
+                )
+                ratio_display = (
+                    format_ratio(unified_row["total_s"], legacy_row["total_s"])
+                    if unified_row["total_s"] is not None
+                    and legacy_row["total_s"] is not None
+                    else "n/a"
+                )
+            else:
+                unified_display = format_seconds(unified_row["total_s"])
+                ratio_display = format_ratio(
+                    unified_row["total_s"], legacy_row["total_s"]
+                )
+            print(
+                "| "
+                f"{model_name} | {scenario.name} | "
+                f"{format_seconds(legacy_row['total_s'])} | "
+                f"{unified_display} | "
+                f"{ratio_display} |"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -31,6 +31,7 @@ from .expression_tree.averages import *
 from .expression_tree.averages import _BaseAverage
 from .expression_tree.broadcasts import *
 from .expression_tree.functions import *
+from .expression_tree.conditional import Conditional
 from .expression_tree.interpolant import Interpolant
 from .expression_tree.discrete_time_sum import *
 from .expression_tree.input_parameter import InputParameter

--- a/src/pybamm/discretisations/discretisation.py
+++ b/src/pybamm/discretisations/discretisation.py
@@ -1112,7 +1112,7 @@ class Discretisation:
                 else:
                     return symbol.create_copy(new_children=[disc_child])
 
-        elif isinstance(symbol, pybamm.Function):
+        elif isinstance(symbol, (pybamm.Function, pybamm.Conditional)):
             disc_children = [self.process_symbol(child) for child in symbol.children]
             return symbol.create_copy(disc_children)
 

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -427,11 +427,22 @@ class BaseStep:
     def update_voltage_safety_events(new_model):
         # Keep the min and max voltages as safeguards but add some tolerances
         # so that they are not triggered before the voltage limits in the
-        # experiment
+        # experiment. For the CasADi "fast with events" DAE path we also move
+        # the voltage switch events away from the experiment cutoffs, otherwise
+        # the switch can freeze the dynamics before the experiment termination
+        # event itself crosses zero.
         for i, event in enumerate(new_model.events):
             if event.name in ["Minimum voltage [V]", "Maximum voltage [V]"]:
                 new_model.events[i] = pybamm.Event(
                     event.name, event.expression + 1, event.event_type
+                )
+            elif event.name == "Minimum voltage switch [V]":
+                new_model.events[i] = pybamm.Event(
+                    event.name, event.expression + 1, event.event_type
+                )
+            elif event.name == "Maximum voltage switch [V]":
+                new_model.events[i] = pybamm.Event(
+                    event.name, event.expression - 1, event.event_type
                 )
 
     def update_model_events(self, new_model):

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -206,6 +206,10 @@ class BaseStep:
         self.next_start_time = None
         self.end_time = None
 
+    @staticmethod
+    def is_implicit() -> bool:
+        return False
+
     def copy(self):
         """
         Return a copy of the step.
@@ -524,6 +528,10 @@ class BaseStepExplicit(BaseStep):
 class BaseStepImplicit(BaseStep):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def is_implicit():
+        return True
 
     def get_parameter_values(self, variables):
         return {}

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -414,9 +414,13 @@ class BaseStep:
         if not events:
             return pybamm.Scalar(1)
 
-        expression = pybamm.Scalar(1)
-        for event in events:
-            expression *= event.expression
+        # A step terminates when any of its termination expressions crosses zero, so the
+        # step-local aggregate should become non-positive as soon as the first child
+        # event does. Using a nested minimum also preserves infeasible-initial-condition
+        # detection when more than one termination is already violated.
+        expression = events[0].expression
+        for event in events[1:]:
+            expression = pybamm.minimum(expression, event.expression)
         return expression
 
     @staticmethod

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -401,12 +401,26 @@ class BaseStep:
             delayed_variable_processing=delayed_variable_processing,
         )
 
-    def update_model_events(self, new_model):
+    def get_termination_events(self, variables):
+        events = []
         for term in self.termination:
-            event = term.get_event(new_model.variables, self)
+            event = term.get_event(variables, self)
             if event is not None:
-                new_model.events.append(event)
+                events.append(event)
+        return events
 
+    def get_combined_termination_expression(self, variables):
+        events = self.get_termination_events(variables)
+        if not events:
+            return pybamm.Scalar(1)
+
+        expression = pybamm.Scalar(1)
+        for event in events:
+            expression *= event.expression
+        return expression
+
+    @staticmethod
+    def update_voltage_safety_events(new_model):
         # Keep the min and max voltages as safeguards but add some tolerances
         # so that they are not triggered before the voltage limits in the
         # experiment
@@ -415,6 +429,10 @@ class BaseStep:
                 new_model.events[i] = pybamm.Event(
                     event.name, event.expression + 1, event.event_type
                 )
+
+    def update_model_events(self, new_model):
+        new_model.events.extend(self.get_termination_events(new_model.variables))
+        self.update_voltage_safety_events(new_model)
 
     def value_based_charge_or_discharge(self):
         """
@@ -478,6 +496,9 @@ class BaseStepExplicit(BaseStep):
     def current_value(self, variables):
         raise NotImplementedError
 
+    def get_control_residual(self, variables):
+        return variables["Current [A]"] - self.current_value(variables)
+
     def set_up(self, new_model, new_parameter_values):
         new_parameter_values["Current function [A]"] = self.current_value(
             new_model.variables
@@ -495,15 +516,11 @@ class BaseStepImplicit(BaseStep):
     def get_submodel(self, model):
         raise NotImplementedError
 
-    def set_up(self, new_model, new_parameter_values):
-        # Create a new model where the current density is now a variable
-        # To do so, we replace all instances of the current density in the
-        # model with a current density variable, which is obtained from the
-        # FunctionControl submodel
-        # check which kind of external circuit model we need (differential
-        # or algebraic)
-        # Build the new submodel and update the model with it
-        submodel = self.get_submodel(new_model)
+    def get_control_residual(self, variables):
+        raise NotImplementedError
+
+    @staticmethod
+    def add_control_submodel(new_model, submodel, new_parameter_values=None):
         variables = new_model.variables
         submodel.variables = submodel.get_fundamental_variables()
         variables.update(submodel.variables)
@@ -516,13 +533,23 @@ class BaseStepImplicit(BaseStep):
         new_model.algebraic.update(submodel.algebraic)
         new_model.initial_conditions.update(submodel.initial_conditions)
 
-        # Set the "current function" to be the variable defined in the submodel
-        new_parameter_values["Current function [A]"] = submodel.variables["Current [A]"]
-        # Update any other parameters as necessary
-        new_parameter_values.update(
-            self.get_parameter_values(variables),
-        )
+        if new_parameter_values is not None:
+            new_parameter_values["Current function [A]"] = submodel.variables[
+                "Current [A]"
+            ]
 
+        return new_model, variables
+
+    def set_up(self, new_model, new_parameter_values):
+        # Create a new model where the current density is now a variable
+        # To do so, we replace all instances of the current density in the
+        # model with a current density variable, which is obtained from the
+        # FunctionControl submodel
+        submodel = self.get_submodel(new_model)
+        new_model, variables = self.add_control_submodel(
+            new_model, submodel, new_parameter_values
+        )
+        new_parameter_values.update(self.get_parameter_values(variables))
         return new_model, new_parameter_values
 
 

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -509,7 +509,7 @@ class BaseStepExplicit(BaseStep):
         super().__init__(*args, **kwargs)
 
     def current_value(self, variables):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def get_control_residual(self, variables):
         return variables["Current [A]"] - self.current_value(variables)
@@ -529,10 +529,10 @@ class BaseStepImplicit(BaseStep):
         return {}
 
     def get_submodel(self, model):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def get_control_residual(self, variables):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     @staticmethod
     def add_control_submodel(new_model, submodel, new_parameter_values=None):

--- a/src/pybamm/experiment/step/step_termination.py
+++ b/src/pybamm/experiment/step/step_termination.py
@@ -23,7 +23,7 @@ class BaseTermination:
         self.operator = operator
 
     def get_event_name(self, step):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def get_event_expression(self, variables, step):
         """
@@ -38,7 +38,7 @@ class BaseTermination:
             Step for which this is a termination event, to be used in some
             cases to determine the sign of the event.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def get_event(self, variables, step):
         expression = self.get_event_expression(variables, step)

--- a/src/pybamm/experiment/step/step_termination.py
+++ b/src/pybamm/experiment/step/step_termination.py
@@ -6,8 +6,8 @@ import pybamm
 class BaseTermination:
     """
     Base class for a termination event for an experiment step. To create a custom
-    termination, a class must implement `get_event` to return a :class:`pybamm.Event`
-    corresponding to the desired termination. In most cases the class
+    termination, a class must implement `get_event_expression` to return the symbolic
+    expression for the event. In most cases the class
     :class:`pybamm.step.CustomTermination` can be used to assist with this.
 
     Parameters
@@ -22,9 +22,12 @@ class BaseTermination:
             raise ValueError(f"Invalid operator: {operator}")
         self.operator = operator
 
-    def get_event(self, variables, step):
+    def get_event_name(self, step):
+        raise NotImplementedError
+
+    def get_event_expression(self, variables, step):
         """
-        Return a :class:`pybamm.Event` object corresponding to the termination event
+        Return the symbolic expression corresponding to the termination event.
 
         Parameters
         ----------
@@ -36,6 +39,12 @@ class BaseTermination:
             cases to determine the sign of the event.
         """
         raise NotImplementedError
+
+    def get_event(self, variables, step):
+        expression = self.get_event_expression(variables, step)
+        if expression is None:
+            return None
+        return pybamm.Event(self.get_event_name(step), expression)
 
     def __eq__(self, other):
         # objects are equal if they have the same type and value
@@ -51,15 +60,11 @@ class CRateTermination(BaseTermination):
     (e.g. "C/10") is provided
     """
 
-    def get_event(self, variables, step):
-        """
-        See :meth:`BaseTermination.get_event`
-        """
-        event = pybamm.Event(
-            "C-rate cut-off [experiment]",
-            abs(variables["C-rate"]) - self.value,
-        )
-        return event
+    def get_event_name(self, step):
+        return "C-rate cut-off [experiment]"
+
+    def get_event_expression(self, variables, step):
+        return abs(variables["C-rate"]) - self.value
 
 
 class CrateTermination(CRateTermination):
@@ -82,25 +87,23 @@ class CurrentTermination(BaseTermination):
     (e.g. "1A") is provided
     """
 
-    def get_event(self, variables, step):
-        """
-        See :meth:`BaseTermination.get_event`
-        """
+    def get_event_name(self, step):
         operator = self.operator
         if operator == ">":
-            expr = self.value - variables["Current [A]"]
-            event_string = f"Current [A] > {self.value} [A] [experiment]"
+            return f"Current [A] > {self.value} [A] [experiment]"
         elif operator == "<":
-            expr = variables["Current [A]"] - self.value
-            event_string = f"Current [A] < {self.value} [A] [experiment]"
+            return f"Current [A] < {self.value} [A] [experiment]"
         else:
-            expr = abs(variables["Current [A]"]) - self.value
-            event_string = f"abs(Current [A]) < {self.value} [A] [experiment]"
-        event = pybamm.Event(
-            event_string,
-            expr,
-        )
-        return event
+            return f"abs(Current [A]) < {self.value} [A] [experiment]"
+
+    def get_event_expression(self, variables, step):
+        operator = self.operator
+        if operator == ">":
+            return self.value - variables["Current [A]"]
+        elif operator == "<":
+            return variables["Current [A]"] - self.value
+        else:
+            return abs(variables["Current [A]"]) - self.value
 
 
 class VoltageTermination(BaseTermination):
@@ -109,15 +112,7 @@ class VoltageTermination(BaseTermination):
     (e.g. "4.2V") is provided
     """
 
-    def get_event(self, variables, step):
-        """
-        See :meth:`BaseTermination.get_event`
-        """
-        # The voltage event should be positive at the start of charge/
-        # discharge. We use the sign of the current or power input to
-        # figure out whether the voltage event is greater than the starting
-        # voltage (charge) or less (discharge) and set the sign of the
-        # event accordingly
+    def _get_operator(self, step):
         operator = self.operator
         if operator is None:
             direction = step.direction
@@ -126,22 +121,31 @@ class VoltageTermination(BaseTermination):
             elif direction == "discharge":
                 operator = "<"
             else:
-                # No event for rest steps
                 return None
+        return operator
+
+    def get_event_name(self, step):
+        operator = self._get_operator(step)
+        if operator is None:
+            return None
+        return f"Voltage {operator} {self.value} [V] [experiment]"
+
+    def get_event_expression(self, variables, step):
+        # The voltage event should be positive at the start of charge/
+        # discharge. We use the sign of the current or power input to
+        # figure out whether the voltage event is greater than the starting
+        # voltage (charge) or less (discharge) and set the sign of the
+        # event accordingly
+        operator = self._get_operator(step)
+        if operator is None:
+            return None
 
         if operator == ">":
             sign = -1
         else:
-            # operator can only be "<" or ">"
             sign = 1
 
-        # Event should be positive at initial conditions for both
-        # charge and discharge
-        event = pybamm.Event(
-            f"Voltage {operator} {self.value} [V] [experiment]",
-            sign * (variables["Battery voltage [V]"] - self.value),
-        )
-        return event
+        return sign * (variables["Battery voltage [V]"] - self.value)
 
 
 class Voltage:
@@ -193,11 +197,11 @@ class CustomTermination(BaseTermination):
         self.name = name
         self.event_function = event_function
 
-    def get_event(self, variables, step):
-        """
-        See :meth:`BaseTermination.get_event`
-        """
-        return pybamm.Event(self.name, self.event_function(variables))
+    def get_event_name(self, step):
+        return self.name
+
+    def get_event_expression(self, variables, step):
+        return self.event_function(variables)
 
 
 def _read_termination(termination, operator=None):

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -179,6 +179,9 @@ class Voltage(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Voltage function [V]": self.value}
 
+    def get_control_residual(self, variables):
+        return variables["Voltage [V]"] - self.value
+
     def get_submodel(self, model):
         return pybamm.external_circuit.VoltageFunctionControl(
             model.param, model.options
@@ -212,6 +215,9 @@ class Power(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Power function [W]": self.value}
 
+    def get_control_residual(self, variables):
+        return variables["Power [W]"] - self.value
+
     def get_submodel(self, model):
         return pybamm.external_circuit.PowerFunctionControl(model.param, model.options)
 
@@ -242,6 +248,9 @@ class Resistance(BaseStepImplicit):
 
     def get_parameter_values(self, variables):
         return {"Resistance function [Ohm]": self.value}
+
+    def get_control_residual(self, variables):
+        return variables["Resistance [Ohm]"] - self.value
 
     def get_submodel(self, model):
         return pybamm.external_circuit.ResistanceFunctionControl(
@@ -409,6 +418,13 @@ class CustomStepImplicit(BaseStepImplicit):
             raise ValueError("control must be either 'algebraic' or 'differential'")
         self.control = control
         self.kwargs = kwargs
+
+    def get_control_residual(self, variables):
+        if self.control != "algebraic":
+            raise NotImplementedError(
+                "Unified experiment control only supports algebraic implicit custom steps"
+            )
+        return self.current_rhs_function(variables)
 
     def get_submodel(self, model):
         return pybamm.external_circuit.FunctionControl(

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -77,7 +77,7 @@ def string(text, **kwargs):
 
     # read remaining instruction
     if text.startswith("Rest"):
-        step_class = Current
+        step_class = Rest
         value = 0
     elif text.startswith("Run"):
         raise ValueError(
@@ -142,6 +142,21 @@ def current(value, **kwargs):
     Current-controlled step, see :class:`pybamm.step.Current`.
     """
     return Current(value, **kwargs)
+
+
+class Rest(Current):
+    """
+    Rest step, implemented as a zero-current explicit step.
+    """
+
+    def __init__(self, value=0, **kwargs):
+        if value != 0:
+            raise ValueError("Rest steps must have a current value of 0")
+        super().__init__(0, **kwargs)
+
+    @staticmethod
+    def padding_weight_input_name():
+        return "Experiment step weight padding rest"
 
 
 class CRate(BaseStepExplicit):
@@ -267,10 +282,9 @@ def resistance(value, **kwargs):
 
 def rest(duration=None, **kwargs):
     """
-    Create a rest step, equivalent to a constant current step with value 0
-    (see :meth:`pybamm.step.current`).
+    Create a rest step (see :class:`pybamm.step.Rest`).
     """
-    return Current(0, duration=duration, **kwargs)
+    return Rest(duration=duration, **kwargs)
 
 
 class CustomStepExplicit(BaseStepExplicit):

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -154,10 +154,6 @@ class Rest(Current):
             raise ValueError("Rest steps must have a current value of 0")
         super().__init__(0, **kwargs)
 
-    @staticmethod
-    def padding_weight_input_name():
-        return "Experiment step weight padding rest"
-
 
 class CRate(BaseStepExplicit):
     """

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -250,7 +250,7 @@ class Resistance(BaseStepImplicit):
         return {"Resistance function [Ohm]": self.value}
 
     def get_control_residual(self, variables):
-        return variables["Resistance [Ohm]"] - self.value
+        return variables["Voltage [V]"] - self.value * variables["Current [A]"]
 
     def get_submodel(self, model):
         return pybamm.external_circuit.ResistanceFunctionControl(

--- a/src/pybamm/expression_tree/__init__.py
+++ b/src/pybamm/expression_tree/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['array', 'averages', 'binary_operators', 'broadcasts',
-           'concatenations', 'exceptions', 'functions', 'independent_variable',
+           'concatenations', 'conditional', 'exceptions', 'functions', 'independent_variable',
            'input_parameter', 'interpolant', 'matrix', 'operations',
            'parameter', 'printing', 'scalar', 'state_vector', 'symbol',
            'unary_operators', 'variable', 'vector', 'discrete_time_sum', 'vector_field', 'magnitude' ]

--- a/src/pybamm/expression_tree/conditional.py
+++ b/src/pybamm/expression_tree/conditional.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import numbers
+
+import numpy as np
+import numpy.typing as npt
+import scipy.sparse
+import sympy
+
+import pybamm
+
+
+class Conditional(pybamm.Symbol):
+    """
+    A node in the expression tree representing a branch selection on a scalar selector.
+
+    The first child is the selector ``s``. Branch ``i`` is active when
+    ``i - 0.5 < s < i + 0.5`` using 1-based indexing. If no branch matches, the
+    expression evaluates to zero with the same shape as the branch children.
+    """
+
+    def __init__(self, selector: pybamm.Symbol, *branches: pybamm.Symbol):
+        selector = pybamm.convert_to_symbol(selector)
+        branches = [pybamm.convert_to_symbol(branch) for branch in branches]
+        if not branches:
+            raise ValueError("Conditional requires at least one branch child")
+        if selector.shape_for_testing != ():
+            raise ValueError("Conditional selector must evaluate to a scalar")
+
+        domains = self.get_children_domains(branches)
+        first_shape = branches[0].shape_for_testing
+        first_size = branches[0].size_for_testing
+        returns_scalar = first_size == 1
+        for branch in branches[1:]:
+            compatible_shape = (
+                branch.size_for_testing == 1
+                if returns_scalar
+                else branch.shape_for_testing == first_shape
+            )
+            if not compatible_shape:
+                raise ValueError(
+                    "Conditional branches must all have the same shape, not "
+                    f"{first_shape} and {branch.shape_for_testing}"
+                )
+
+        self._returns_scalar = returns_scalar
+        super().__init__("conditional", children=[selector, *branches], domains=domains)
+
+    @classmethod
+    def _from_json(cls, snippet: dict):
+        return cls(*snippet["children"])
+
+    @property
+    def selector(self):
+        return self.children[0]
+
+    @property
+    def branches(self):
+        return self.children[1:]
+
+    def __str__(self):
+        children = ", ".join(str(child) for child in self.children)
+        return f"conditional({children})"
+
+    def create_copy(
+        self,
+        new_children: list[pybamm.Symbol] | None = None,
+        perform_simplifications: bool = True,
+    ):
+        children = self._children_for_copying(new_children)
+        if len(children) < 2:
+            raise ValueError("Conditional must have a selector and at least one branch")
+        return self.__class__(*children)
+
+    @staticmethod
+    def _coerce_selector_value(value):
+        if isinstance(value, numbers.Number):
+            return float(value)
+
+        value = np.asarray(value)
+        if value.size != 1:
+            raise ValueError("Conditional selector must evaluate to a scalar")
+        return float(value.reshape(-1)[0])
+
+    def _active_branch_index(
+        self,
+        t: float | None = None,
+        y: npt.NDArray[np.float64] | None = None,
+        y_dot: npt.NDArray[np.float64] | None = None,
+        inputs: dict | str | None = None,
+    ):
+        selector_value = self._coerce_selector_value(
+            self.selector.evaluate(t, y, y_dot, inputs)
+        )
+        for branch_index, _branch in enumerate(self.branches, start=1):
+            if branch_index - 0.5 < selector_value < branch_index + 0.5:
+                return branch_index - 1
+        return None
+
+    @staticmethod
+    def _zero_like(template):
+        if isinstance(template, numbers.Number):
+            return 0
+        if scipy.sparse.issparse(template):
+            return scipy.sparse.csr_matrix(template.shape)
+        return np.zeros_like(template)
+
+    def evaluate(
+        self,
+        t: float | None = None,
+        y: npt.NDArray[np.float64] | None = None,
+        y_dot: npt.NDArray[np.float64] | None = None,
+        inputs: dict | str | None = None,
+    ):
+        branch_index = self._active_branch_index(t, y, y_dot, inputs)
+        if branch_index is None:
+            if self._returns_scalar:
+                return 0
+            return self._zero_like(self.branches[0].evaluate_for_shape())
+        value = self.branches[branch_index].evaluate(t, y, y_dot, inputs)
+        if self._returns_scalar and not isinstance(value, numbers.Number):
+            return self._coerce_selector_value(value)
+        return value
+
+    def _evaluate_for_shape(self):
+        if self._returns_scalar:
+            return np.nan
+        return self.branches[0].evaluate_for_shape()
+
+    def _evaluates_on_edges(self, dimension: str) -> bool:
+        return any(branch.evaluates_on_edges(dimension) for branch in self.branches)
+
+    def is_constant(self):
+        return all(child.is_constant() for child in self.children)
+
+    def _diff(self, variable):
+        return Conditional(
+            self.selector,
+            *[branch.diff(variable) for branch in self.branches],
+        )
+
+    def _jac(self, variable):
+        return Conditional(
+            self.selector,
+            *[branch.jac(variable) for branch in self.branches],
+        )
+
+    def to_equation(self):
+        if self.print_name is not None:
+            return sympy.Symbol(self.print_name)
+        return sympy.Function("Conditional")(
+            *[child.to_equation() for child in self.children]
+        )

--- a/src/pybamm/expression_tree/operations/convert_to_casadi.py
+++ b/src/pybamm/expression_tree/operations/convert_to_casadi.py
@@ -77,6 +77,24 @@ class CasadiConverter:
                 raise ValueError("Must provide a 'y_dot' for converting state vectors")
             return casadi.vertcat(*[y_dot[y_slice] for y_slice in symbol.y_slices])
 
+        elif isinstance(symbol, pybamm.Conditional):
+            converted_selector = self.convert(symbol.selector, t, y, y_dot, inputs)
+            first_branch = self.convert(symbol.branches[0], t, y, y_dot, inputs)
+            result = casadi.MX.zeros(*first_branch.shape)
+            for branch_index in range(len(symbol.branches), 0, -1):
+                if branch_index == 1:
+                    converted_branch = first_branch
+                else:
+                    converted_branch = self.convert(
+                        symbol.branches[branch_index - 1], t, y, y_dot, inputs
+                    )
+                condition = casadi.logic_and(
+                    converted_selector > (branch_index - 0.5),
+                    converted_selector < (branch_index + 0.5),
+                )
+                result = casadi.if_else(condition, converted_branch, result)
+            return result
+
         elif isinstance(symbol, pybamm.BinaryOperator):
             left, right = symbol.children
             # process children

--- a/src/pybamm/expression_tree/operations/evaluate_python.py
+++ b/src/pybamm/expression_tree/operations/evaluate_python.py
@@ -204,7 +204,17 @@ def find_symbols(
         else:
             children_vars.append(id_to_python_variable(child.id, False))
 
-    if isinstance(symbol, pybamm.BinaryOperator):
+    if isinstance(symbol, pybamm.Conditional):
+        selector_var = children_vars[0]
+        symbol_str = "0"
+        for branch_index, branch_var in reversed(
+            list(enumerate(children_vars[1:], start=1))
+        ):
+            lower = branch_index - 0.5
+            upper = branch_index + 0.5
+            symbol_str = f"({branch_var} if ({lower} < {selector_var} < {upper}) else {symbol_str})"
+
+    elif isinstance(symbol, pybamm.BinaryOperator):
         # Multiplication and Division need special handling for scipy sparse matrices
         # TODO: we can pass through a dummy y and t to get the type and then hardcode
         # the right line, avoiding these checks

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1754,6 +1754,7 @@ class Serialise:
         """
         step_type_map = {
             "Current": "current",
+            "Rest": "rest",
             "Voltage": "voltage",
             "Power": "power",
             "CRate": "c-rate",
@@ -1836,7 +1837,7 @@ class Serialise:
             "voltage": pybamm.step.voltage,
             "power": pybamm.step.power,
             "c-rate": pybamm.step.c_rate,
-            "rest": pybamm.step.current,
+            "rest": pybamm.step.rest,
         }
         term_class_map = {
             "voltage": pybamm.step.VoltageTermination,
@@ -1888,6 +1889,8 @@ class Serialise:
                     _parse_termination(t) for t in step_dict["terminations"]
                 ]
 
+            if step_type == "rest":
+                return step_func(duration=duration, termination=terminations)
             return step_func(value, duration=duration, termination=terminations)
 
         if "cycles" in data and data["cycles"] is not None:

--- a/src/pybamm/models/submodels/external_circuit/__init__.py
+++ b/src/pybamm/models/submodels/external_circuit/__init__.py
@@ -10,6 +10,7 @@ from .function_control_external_circuit import (
     VoltageFunctionControl,
     PowerFunctionControl,
     ResistanceFunctionControl,
+    ExperimentFunctionControl,
     CCCVFunctionControl,
 )
 

--- a/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
@@ -141,22 +141,24 @@ class ResistanceFunctionControl(FunctionControl):
 
 
 class ExperimentFunctionControl(FunctionControl):
-    """External circuit with one weighted control residual shared across steps."""
+    """External circuit with one conditional control residual shared across steps."""
 
-    def __init__(self, param, options, step_control_builders):
+    def __init__(self, param, options, step_index_input_name, step_control_builders):
+        self.step_index_input_name = step_index_input_name
         self.step_control_builders = step_control_builders
         super().__init__(
             param,
-            self.weighted_control_residual,
+            self.conditional_control_residual,
             options,
             control="algebraic",
         )
 
-    def weighted_control_residual(self, variables):
-        expression = pybamm.Scalar(0)
-        for weight_name, builder in self.step_control_builders:
-            expression += pybamm.InputParameter(weight_name) * builder(variables)
-        return expression
+    def conditional_control_residual(self, variables):
+        selector = pybamm.InputParameter(self.step_index_input_name)
+        return pybamm.Conditional(
+            selector,
+            *[builder(variables) for builder in self.step_control_builders],
+        )
 
 
 class CCCVFunctionControl(FunctionControl):

--- a/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
@@ -141,6 +141,25 @@ class ResistanceFunctionControl(FunctionControl):
             return -K_R * (R - R_applied)
 
 
+class ExperimentFunctionControl(FunctionControl):
+    """External circuit with one weighted control residual shared across steps."""
+
+    def __init__(self, param, options, step_control_builders):
+        self.step_control_builders = step_control_builders
+        super().__init__(
+            param,
+            self.weighted_control_residual,
+            options,
+            control="algebraic",
+        )
+
+    def weighted_control_residual(self, variables):
+        expression = pybamm.Scalar(0)
+        for weight_name, builder in self.step_control_builders:
+            expression += pybamm.InputParameter(weight_name) * builder(variables)
+        return expression
+
+
 class CCCVFunctionControl(FunctionControl):
     """
     External circuit with constant-current constant-voltage control, as implemented in

--- a/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
@@ -129,16 +129,15 @@ class ResistanceFunctionControl(FunctionControl):
     def constant_resistance(self, variables):
         I = variables["Current [A]"]
         V = variables["Voltage [V]"]
-        R = V / I
         R_applied = pybamm.FunctionParameter(
             "Resistance function [Ohm]", {"Time [s]": pybamm.t}
         )
         if self.control == "algebraic":
-            return R - R_applied
+            return V - R_applied * I
         else:
             # Multiply by the time scale so that the overshoot only lasts a few seconds
             K_R = 0.01
-            return -K_R * (R - R_applied)
+            return -K_R * (V - R_applied * I)
 
 
 class ExperimentFunctionControl(FunctionControl):

--- a/src/pybamm/parameters/parameter_substitutor.py
+++ b/src/pybamm/parameters/parameter_substitutor.py
@@ -251,6 +251,7 @@ class ParameterSubstitutor:
             isinstance(symbol, pybamm.Function)
             or isinstance(symbol, pybamm.Concatenation)
             or isinstance(symbol, pybamm.BinaryOperator)
+            or isinstance(symbol, pybamm.Conditional)
         ):
             new_children = [self.process_symbol(child) for child in symbol.children]
             return symbol.create_copy(new_children)

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -276,6 +276,18 @@ class Simulation:
         return f"Experiment step weight {step_index}"
 
     @staticmethod
+    def _experiment_time_stop_termination():
+        return "experiment time limit reached"
+
+    @staticmethod
+    def _experiment_voltage_stop_termination():
+        return "experiment voltage limit reached"
+
+    @staticmethod
+    def _experiment_capacity_stop_termination():
+        return "experiment capacity limit reached"
+
+    @staticmethod
     def _normalise_experiment_model_mode(mode):
         aliases = {
             "auto": "auto",
@@ -1190,6 +1202,8 @@ class Simulation:
             idx = 0
             num_cycles = len(self.experiment.cycle_lengths)
             feasible = True  # simulation will stop if experiment is infeasible
+            stop_experiment = False
+            experiment_termination = None
 
             # Add initial padding rest if current time is earlier than first start time
             # This could be the case when using a starting solution
@@ -1301,6 +1315,12 @@ class Simulation:
                     # if dt + starttime is larger than time_stop, set dt to time_stop - starttime
                     if time_stop is not None:
                         dt = min(dt, time_stop - start_time)
+                        if dt <= 0:
+                            experiment_termination = (
+                                self._experiment_time_stop_termination()
+                            )
+                            stop_experiment = True
+                            break
 
                     step_str = str(step)
                     model = self.steps_to_built_models[step.basic_repr()]
@@ -1439,13 +1459,19 @@ class Simulation:
 
                     elif time_stop is not None and logs["experiment time"] >= time_stop:
                         # reached the time limit of the experiment
+                        experiment_termination = (
+                            self._experiment_time_stop_termination()
+                        )
+                        stop_experiment = True
                         break
 
                     else:
                         # Increment index for next iteration, then continue
                         idx += 1
 
-                if save_this_cycle or feasible is False:
+                if cycle_solution is not None and (
+                    save_this_cycle or feasible is False or stop_experiment
+                ):
                     self._solution = self._solution + cycle_solution
 
                 # At the final step of the inner loop we save the cycle
@@ -1541,19 +1567,33 @@ class Simulation:
                 if capacity_stop is not None:
                     capacity_now = cycle_sum_vars["Capacity [A.h]"]
                     if not np.isnan(capacity_now) and capacity_now <= capacity_stop:
+                        experiment_termination = (
+                            self._experiment_capacity_stop_termination()
+                        )
+                        stop_experiment = True
                         break
 
                 if voltage_stop is not None:
                     if min_voltage <= voltage_stop[0]:
+                        experiment_termination = (
+                            self._experiment_voltage_stop_termination()
+                        )
+                        stop_experiment = True
                         break
 
                 if not feasible:
+                    break
+
+                if stop_experiment:
                     break
 
             if self._solution is not None and len(all_cycle_solutions) > 0:
                 self._solution.cycles = all_cycle_solutions
                 self._solution.update_summary_variables(all_summary_variables)
                 self._solution.all_first_states = all_first_states
+
+            if self._solution is not None and experiment_termination is not None:
+                self._solution.termination = experiment_termination
 
             callbacks.on_experiment_end(logs)
 

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -436,6 +436,67 @@ class Simulation:
         for step in self.experiment.unique_steps:
             self.experiment_unique_steps_to_model[step.basic_repr()] = processed_model
 
+    def _build_unified_experiment_state_mapper(self, built_model):
+        """
+        Build the symbolic self-mapper used between unified experiment steps.
+
+        The unified experiment path reuses one built model for every compatible step,
+        so step-to-step reinitialisation is a same-model state mapping. This mapper
+        leaves the full state vector unchanged except for the scalar
+        ``"Current variable [A]"`` entry, which is replaced by a one-hot-selected
+        initial guess for the newly active step. Explicit controlled steps contribute
+        their prescribed current, while implicit steps keep the incoming current state.
+        """
+        current_variable = next(
+            (
+                variable
+                for variable in built_model.y_slices
+                if variable.name == "Current variable [A]"
+            ),
+            None,
+        )
+        if current_variable is None:
+            return built_model.build_initial_state_mapper(built_model)
+        current_slice = built_model.y_slices[current_variable][0]
+        if current_slice.stop - current_slice.start != 1:
+            raise pybamm.ModelError(
+                "Unified experiment self-mapper expects a scalar current-control state."
+            )
+
+        current_guess = pybamm.Scalar(0)
+        current_state = built_model.process_symbol(built_model.variables["Current [A]"])
+        for weight_name, step in zip(
+            self._experiment_step_weight_input_names,
+            self.experiment.steps,
+            strict=True,
+        ):
+            if isinstance(step, pybamm.step.BaseStepExplicit):
+                step_guess = built_model.process_symbol(
+                    step.current_value(built_model.variables)
+                )
+            else:
+                step_guess = current_state
+            current_guess += pybamm.InputParameter(weight_name) * step_guess
+
+        if self._experiment_includes_padding_rest:
+            current_guess += pybamm.InputParameter(
+                self._experiment_padding_rest_weight_name()
+            ) * pybamm.Scalar(0)
+
+        equations = []
+        if current_slice.start > 0:
+            equations.append(pybamm.StateVector(slice(0, current_slice.start)))
+        equations.append(
+            (current_guess - current_variable.reference) / current_variable.scale
+        )
+        if current_slice.stop < built_model.len_rhs_and_alg:
+            equations.append(
+                pybamm.StateVector(
+                    slice(current_slice.stop, built_model.len_rhs_and_alg)
+                )
+            )
+        return pybamm.NumpyConcatenation(*equations)
+
     def _build_unified_experiment_inputs(
         self, user_inputs, active_weight_name, start_time, temperature
     ):
@@ -991,41 +1052,48 @@ class Simulation:
         if not self.experiment or not self.steps_to_built_models:
             return
         if self._experiment_uses_unified_model:
-            return
+            built_model = self._built_experiment_model
+            if built_model is not None:
+                self.model_state_mappers[(built_model, built_model)] = (
+                    self._build_unified_experiment_state_mapper(built_model)
+                )
+        else:
+            ordered_steps = self.experiment.steps
+            previous_model = None
+            for step in ordered_steps:
+                model = self.steps_to_built_models[step.basic_repr()]
+                if previous_model is not None and previous_model is not model:
+                    key = (previous_model, model)
+                    if key not in self.model_state_mappers:
+                        self.model_state_mappers[key] = (
+                            model.build_initial_state_mapper(previous_model)
+                        )
+                previous_model = model
 
-        ordered_steps = self.experiment.steps
-        previous_model = None
-        for step in ordered_steps:
-            model = self.steps_to_built_models[step.basic_repr()]
-            if previous_model is not None and previous_model is not model:
-                key = (previous_model, model)
-                if key not in self.model_state_mappers:
-                    self.model_state_mappers[key] = model.build_initial_state_mapper(
-                        previous_model
-                    )
-            previous_model = model
+            rest_model = self.steps_to_built_models.get("Rest for padding")
+            if rest_model is not None:
+                unique_models = set(self.steps_to_built_models.values())
+                for model in unique_models:
+                    if model is rest_model:
+                        continue
+                    to_rest_key = (model, rest_model)
+                    if to_rest_key not in self.model_state_mappers:
+                        self.model_state_mappers[to_rest_key] = (
+                            rest_model.build_initial_state_mapper(model)
+                        )
+                    from_rest_key = (rest_model, model)
+                    if from_rest_key not in self.model_state_mappers:
+                        self.model_state_mappers[from_rest_key] = (
+                            model.build_initial_state_mapper(rest_model)
+                        )
 
-        rest_model = self.steps_to_built_models.get("Rest for padding")
-        if rest_model is not None:
-            unique_models = set(self.steps_to_built_models.values())
-            for model in unique_models:
-                if model is rest_model:
-                    continue
-                to_rest_key = (model, rest_model)
-                if to_rest_key not in self.model_state_mappers:
-                    self.model_state_mappers[to_rest_key] = (
-                        rest_model.build_initial_state_mapper(model)
-                    )
-                from_rest_key = (rest_model, model)
-                if from_rest_key not in self.model_state_mappers:
-                    self.model_state_mappers[from_rest_key] = (
-                        model.build_initial_state_mapper(rest_model)
-                    )
-
-        # compile all the mappers
         for (previous_model, next_model), mapper in self.model_state_mappers.items():
+            ordered_compile_inputs = {
+                name: inputs.get(name, 0)
+                for name in sorted(ip.name for ip in previous_model.input_parameters)
+            }
             vars_for_processing = pybamm.BaseSolver._get_vars_for_processing(
-                previous_model, inputs
+                previous_model, ordered_compile_inputs
             )
             if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
@@ -1044,9 +1112,12 @@ class Simulation:
         if not solution.all_models:
             return None
         from_model = solution.all_models[-1]
+        mapper = self._compiled_model_state_mappers.get((from_model, model))
+        if mapper is not None:
+            return mapper
         if from_model is model:
             return None
-        return self._compiled_model_state_mappers.get((from_model, model))
+        return None
 
     def solve(
         self,

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -956,6 +956,8 @@ class Simulation:
         self._compiled_model_state_mappers = {}
         if not self.experiment or not self.steps_to_built_models:
             return
+        if self._experiment_uses_unified_model:
+            return
 
         ordered_steps = self.experiment.steps
         previous_model = None
@@ -988,23 +990,16 @@ class Simulation:
 
         # compile all the mappers
         for (previous_model, next_model), mapper in self.model_state_mappers.items():
-            input_names = tuple(ip.name for ip in previous_model.input_parameters)
-            mapper_inputs = {
-                name: inputs.get(name, np.array([np.nan])) for name in input_names
-            }
             vars_for_processing = pybamm.BaseSolver._get_vars_for_processing(
-                previous_model, mapper_inputs
+                previous_model, inputs
             )
             if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
             f, jac, jacp, _jac_action = process(mapper, "mapper", vars_for_processing)
-            # Store both the compiled mapper and the input keys used
-            # we don't need jac and jacp yet, but should use them for sensitivity calculations in the future
             self._compiled_model_state_mappers[(previous_model, next_model)] = (
                 f,
                 jac,
                 jacp,
-                input_names,
             )
 
     def _get_state_mapper_for_solution(self, solution, model):

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -164,6 +164,7 @@ class Simulation:
         self._experiment_uses_unified_model = False
         self._experiment_unified_model_key = "Unified experiment"
         self._experiment_step_weight_input_names = []
+        self._experiment_includes_padding_rest = False
         self._combined_step_termination_event_name = "Combined termination [experiment]"
 
         # ignore runtime warnings in notebooks
@@ -205,6 +206,8 @@ class Simulation:
             self._experiment_unified_model_key = "Unified experiment"
         if "_experiment_step_weight_input_names" not in self.__dict__:
             self._experiment_step_weight_input_names = []
+        if "_experiment_includes_padding_rest" not in self.__dict__:
+            self._experiment_includes_padding_rest = False
         if "_combined_step_termination_event_name" not in self.__dict__:
             self._combined_step_termination_event_name = (
                 "Combined termination [experiment]"
@@ -272,8 +275,13 @@ class Simulation:
         self._build_experiment_state_mappers(inputs)
         self._built_nominal_capacity = current_capacity
 
-    def _experiment_step_weight_input_name(self, step_index):
+    @staticmethod
+    def _experiment_step_weight_input_name(step_index):
         return f"Experiment step weight {step_index}"
+
+    @staticmethod
+    def _experiment_padding_rest_weight_name():
+        return "Experiment step weight padding rest"
 
     @staticmethod
     def _experiment_time_stop_termination():
@@ -306,8 +314,6 @@ class Simulation:
     def _get_unified_experiment_model_blockers(self):
         if self.experiment is None:
             return ["no experiment is attached to the simulation"]
-        if self.experiment.initial_start_time:
-            return ["experiments with start-time padding still use per-step models"]
 
         has_implicit_step = False
         for step in self.experiment.steps:
@@ -342,6 +348,9 @@ class Simulation:
             self._experiment_step_weight_input_name(i)
             for i, _step in enumerate(self.experiment.steps)
         ]
+        self._experiment_includes_padding_rest = bool(
+            self.experiment.initial_start_time
+        )
 
         new_model = self._model.new_copy()
         new_parameter_values = parameter_values.copy()
@@ -359,6 +368,13 @@ class Simulation:
                 strict=True,
             )
         ]
+        if self._experiment_includes_padding_rest:
+            step_control_builders.append(
+                (
+                    self._experiment_padding_rest_weight_name(),
+                    lambda variables: variables["Current [A]"],
+                )
+            )
         submodel = pybamm.external_circuit.ExperimentFunctionControl(
             new_model.param,
             new_model.options,
@@ -383,6 +399,10 @@ class Simulation:
             combined_termination_expression += pybamm.InputParameter(
                 weight_name
             ) * step.get_combined_termination_expression(variables)
+        if self._experiment_includes_padding_rest:
+            combined_termination_expression += pybamm.InputParameter(
+                self._experiment_padding_rest_weight_name()
+            )
         new_model.events.append(
             pybamm.Event(
                 self._combined_step_termination_event_name,
@@ -405,17 +425,20 @@ class Simulation:
             self.experiment_unique_steps_to_model[step.basic_repr()] = processed_model
 
     def _build_unified_experiment_inputs(
-        self, user_inputs, step_index, step, start_time
+        self, user_inputs, active_weight_name, start_time, temperature
     ):
         inputs = {
             **user_inputs,
-            "Ambient temperature [K]": (
-                step.temperature or self._parameter_values["Ambient temperature [K]"]
-            ),
+            "Ambient temperature [K]": temperature,
             "start time": start_time,
         }
-        for i, weight_name in enumerate(self._experiment_step_weight_input_names):
-            inputs[weight_name] = 1 if i == step_index else 0
+        for weight_name in self._experiment_step_weight_input_names:
+            inputs[weight_name] = 1 if weight_name == active_weight_name else 0
+        if self._experiment_includes_padding_rest:
+            padding_weight_name = self._experiment_padding_rest_weight_name()
+            inputs[padding_weight_name] = (
+                1 if padding_weight_name == active_weight_name else 0
+            )
         return inputs
 
     @staticmethod
@@ -587,6 +610,7 @@ class Simulation:
 
         self._experiment_uses_unified_model = False
         self._experiment_step_weight_input_names = []
+        self._experiment_includes_padding_rest = False
 
         # Process each step
         self.experiment_unique_steps_to_model = {}
@@ -964,8 +988,12 @@ class Simulation:
 
         # compile all the mappers
         for (previous_model, next_model), mapper in self.model_state_mappers.items():
+            input_names = tuple(ip.name for ip in previous_model.input_parameters)
+            mapper_inputs = {
+                name: inputs.get(name, np.array([np.nan])) for name in input_names
+            }
             vars_for_processing = pybamm.BaseSolver._get_vars_for_processing(
-                previous_model, inputs
+                previous_model, mapper_inputs
             )
             if not hasattr(previous_model, "calculate_sensitivities"):
                 previous_model.calculate_sensitivities = []
@@ -976,6 +1004,7 @@ class Simulation:
                 f,
                 jac,
                 jacp,
+                input_names,
             )
 
     def _get_state_mapper_for_solution(self, solution, model):
@@ -1269,14 +1298,23 @@ class Simulation:
                         # logs["step operating conditions"] = "Initial rest for padding"
                         # callbacks.on_step_start(logs)
 
-                        inputs = {
-                            **user_inputs,
-                            "Ambient temperature [K]": (
-                                step.temperature
-                                or self._parameter_values["Ambient temperature [K]"]
-                            ),
-                            "start time": current_solution.t[-1],
-                        }
+                        temperature = (
+                            step.temperature
+                            or self._parameter_values["Ambient temperature [K]"]
+                        )
+                        if self._experiment_uses_unified_model:
+                            inputs = self._build_unified_experiment_inputs(
+                                user_inputs,
+                                self._experiment_padding_rest_weight_name(),
+                                current_solution.t[-1],
+                                temperature,
+                            )
+                        else:
+                            inputs = {
+                                **user_inputs,
+                                "Ambient temperature [K]": temperature,
+                                "start time": current_solution.t[-1],
+                            }
                         steps = current_solution.cycles[-1].steps
                         step_solution = current_solution.cycles[-1].steps[-1]
 
@@ -1380,8 +1418,15 @@ class Simulation:
                     callbacks.on_step_start(logs)
 
                     if self._experiment_uses_unified_model:
+                        temperature = (
+                            step.temperature
+                            or self._parameter_values["Ambient temperature [K]"]
+                        )
                         inputs = self._build_unified_experiment_inputs(
-                            user_inputs, idx, step, start_time
+                            user_inputs,
+                            self._experiment_step_weight_input_names[idx],
+                            start_time,
+                            temperature,
                         )
                     else:
                         inputs = {
@@ -1449,14 +1494,23 @@ class Simulation:
                             logs["step operating conditions"] = "Rest for padding"
                             callbacks.on_step_start(logs)
 
-                            inputs = {
-                                **user_inputs,
-                                "Ambient temperature [K]": (
-                                    step.temperature
-                                    or self._parameter_values["Ambient temperature [K]"]
-                                ),
-                                "start time": step_solution.t[-1],
-                            }
+                            temperature = (
+                                step.temperature
+                                or self._parameter_values["Ambient temperature [K]"]
+                            )
+                            if self._experiment_uses_unified_model:
+                                inputs = self._build_unified_experiment_inputs(
+                                    user_inputs,
+                                    self._experiment_padding_rest_weight_name(),
+                                    step_solution.t[-1],
+                                    temperature,
+                                )
+                            else:
+                                inputs = {
+                                    **user_inputs,
+                                    "Ambient temperature [K]": temperature,
+                                    "start time": step_solution.t[-1],
+                                }
 
                             step_solution_with_rest = self.run_padding_rest(
                                 kwargs, rest_time, step_solution, inputs=inputs
@@ -1651,8 +1705,13 @@ class Simulation:
         return self._solution
 
     def run_padding_rest(self, kwargs, rest_time, step_solution, inputs):
-        model = self.steps_to_built_models["Rest for padding"]
-        solver = self.steps_to_built_solvers["Rest for padding"]
+        if self._experiment_uses_unified_model:
+            first_step = self.experiment.steps[0]
+            model = self.steps_to_built_models[first_step.basic_repr()]
+            solver = self.steps_to_built_solvers[first_step.basic_repr()]
+        else:
+            model = self.steps_to_built_models["Rest for padding"]
+            solver = self.steps_to_built_solvers["Rest for padding"]
         state_mapper = self._get_state_mapper_for_solution(step_solution, model)
 
         # Make sure we take at least 2 timesteps. The period is hardcoded to 10

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -68,11 +68,8 @@ class Simulation:
         See :class:`pybamm.Discretisation` for details.
     experiment_model_mode : str, optional
         How to construct experiment models. Options are:
-        ``"auto"`` (default), which uses the unified experiment model when
-        compatible and otherwise falls back to one model per step;
-        ``"unified"``, which requires the shared experiment model path; and
-        ``"legacy"``, which always uses one model per step. ``"per-step"`` is
-        accepted as an alias for ``"legacy"``.
+        ``"legacy"`` (default), which always uses one model per step; and
+        ``"unified"``, which requires the shared experiment model path.
     """
 
     def __init__(
@@ -89,7 +86,7 @@ class Simulation:
         C_rate=None,
         discretisation_kwargs=None,
         cache_esoh=True,
-        experiment_model_mode="auto",
+        experiment_model_mode="legacy",
     ):
         self._parameter_values = parameter_values or model.default_parameter_values
         self._unprocessed_parameter_values = self._parameter_values
@@ -223,8 +220,9 @@ class Simulation:
             self._combined_step_termination_event_name = (
                 "Combined termination [experiment]"
             )
-        if "_experiment_model_mode" not in self.__dict__:
-            self._experiment_model_mode = "auto"
+        self._experiment_model_mode = self._normalise_experiment_model_mode(
+            self.__dict__.get("_experiment_model_mode", "legacy")
+        )
 
     def set_up_and_parameterise_experiment(self, solve_kwargs=None):
         msg = "pybamm.simulation.set_up_and_parameterise_experiment is deprecated and not meant to be accessed by users."
@@ -309,17 +307,14 @@ class Simulation:
     @staticmethod
     def _normalise_experiment_model_mode(mode):
         aliases = {
-            "auto": "auto",
             "unified": "unified",
             "legacy": "legacy",
-            "per-step": "legacy",
         }
         try:
             return aliases[mode]
         except KeyError as err:
             raise ValueError(
-                "experiment_model_mode must be one of 'auto', 'unified', "
-                "'legacy', or 'per-step'"
+                "experiment_model_mode must be one of 'unified' or 'legacy'"
             ) from err
 
     def _get_unified_experiment_model_blockers(self):
@@ -423,66 +418,6 @@ class Simulation:
         # processed model instance.
         for step in self.experiment.unique_steps:
             self.experiment_unique_steps_to_model[step.basic_repr()] = processed_model
-
-    def _build_unified_experiment_state_mapper(self, built_model):
-        """
-        Build the symbolic self-mapper used between unified experiment steps.
-
-        The unified experiment path reuses one built model for every compatible step,
-        so step-to-step reinitialisation is a same-model state mapping. This mapper
-        leaves the full state vector unchanged except for the scalar
-        ``"Current variable [A]"`` entry, which is replaced by a step-index-selected
-        initial guess for the newly active step. Explicit controlled steps contribute
-        their prescribed current, while implicit steps keep the incoming current state.
-        """
-        current_variable = next(
-            (
-                variable
-                for variable in built_model.y_slices
-                if variable.name == "Current variable [A]"
-            ),
-            None,
-        )
-        if current_variable is None:
-            return built_model.build_initial_state_mapper(built_model)
-        current_slice = built_model.y_slices[current_variable][0]
-        if current_slice.stop - current_slice.start != 1:
-            raise pybamm.ModelError(
-                "Unified experiment self-mapper expects a scalar current-control state."
-            )
-
-        current_guess_branches = []
-        current_state = built_model.process_symbol(built_model.variables["Current [A]"])
-        for step in self.experiment.steps:
-            if isinstance(step, pybamm.step.BaseStepExplicit):
-                step_guess = built_model.process_symbol(
-                    step.current_value(built_model.variables)
-                )
-            else:
-                step_guess = current_state
-            current_guess_branches.append(step_guess)
-
-        if self._experiment_includes_padding_rest:
-            current_guess_branches.append(pybamm.Scalar(0))
-
-        current_guess = pybamm.Conditional(
-            pybamm.InputParameter(self._experiment_step_index_input_name()),
-            *current_guess_branches,
-        )
-
-        equations = []
-        if current_slice.start > 0:
-            equations.append(pybamm.StateVector(slice(0, current_slice.start)))
-        equations.append(
-            (current_guess - current_variable.reference) / current_variable.scale
-        )
-        if current_slice.stop < built_model.len_rhs_and_alg:
-            equations.append(
-                pybamm.StateVector(
-                    slice(current_slice.stop, built_model.len_rhs_and_alg)
-                )
-            )
-        return pybamm.NumpyConcatenation(*equations)
 
     def _build_experiment_step_inputs(
         self,
@@ -684,29 +619,15 @@ class Simulation:
             parameter_values["Initial temperature [K]"] = init_temp
 
         blockers = self._get_unified_experiment_model_blockers()
-        raise_model_error = blockers and self._experiment_model_mode == "unified"
-        use_unified = not blockers and self._experiment_model_mode in {
-            "auto",
-            "unified",
-        }
-        fallback_to_per_step = blockers and self._experiment_model_mode == "auto"
-
-        if raise_model_error:
-            raise pybamm.ModelError(
-                "Cannot build a unified experiment model: "
-                + "; ".join(blockers)
-                + ". Use 'legacy'/'per-step' mode or a compatible solver/experiment."
-            )
-
-        if use_unified:
+        if self._experiment_model_mode == "unified":
+            if blockers:
+                raise pybamm.ModelError(
+                    "Cannot build a unified experiment model: "
+                    + "; ".join(blockers)
+                    + ". Use 'legacy' mode or a compatible solver/experiment."
+                )
             self._set_up_unified_experiment_model(parameter_values)
             return
-
-        if fallback_to_per_step:
-            pybamm.logger.debug(
-                "Falling back to per-step experiment models: %s",
-                "; ".join(blockers),
-            )
 
         self._experiment_uses_unified_model = False
         self._built_experiment_model = None
@@ -1063,15 +984,11 @@ class Simulation:
     def _build_experiment_state_mappers(self, inputs: dict):
         self.model_state_mappers = {}
         self._compiled_model_state_mappers = {}
+
         if not self.experiment or not self.steps_to_built_models:
             return
-        if self._experiment_uses_unified_model:
-            built_model = self._built_experiment_model
-            if built_model is not None:
-                self.model_state_mappers[(built_model, built_model)] = (
-                    self._build_unified_experiment_state_mapper(built_model)
-                )
-        else:
+
+        if not self._experiment_uses_unified_model:
             ordered_steps = self.experiment.steps
             previous_model = None
             for step in ordered_steps:

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -165,7 +165,8 @@ class Simulation:
         )
         self._experiment_uses_unified_model = False
         self._experiment_unified_model_key = "Unified experiment"
-        self._experiment_step_weight_input_names = []
+        self._experiment_step_indices = []
+        self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
         self._combined_step_termination_event_name = "Combined termination [experiment]"
 
@@ -212,8 +213,10 @@ class Simulation:
             self._experiment_uses_unified_model = False
         if "_experiment_unified_model_key" not in self.__dict__:
             self._experiment_unified_model_key = "Unified experiment"
-        if "_experiment_step_weight_input_names" not in self.__dict__:
-            self._experiment_step_weight_input_names = []
+        if "_experiment_step_indices" not in self.__dict__:
+            self._experiment_step_indices = []
+        if "_experiment_padding_rest_index" not in self.__dict__:
+            self._experiment_padding_rest_index = None
         if "_experiment_includes_padding_rest" not in self.__dict__:
             self._experiment_includes_padding_rest = False
         if "_combined_step_termination_event_name" not in self.__dict__:
@@ -288,8 +291,8 @@ class Simulation:
         self._built_nominal_capacity = current_capacity
 
     @staticmethod
-    def _experiment_step_weight_input_name(step_index):
-        return f"Experiment step weight {step_index}"
+    def _experiment_step_index_input_name():
+        return "Experiment step index"
 
     @staticmethod
     def _experiment_time_stop_termination():
@@ -350,12 +353,14 @@ class Simulation:
 
     def _set_up_unified_experiment_model(self, parameter_values):
         self._experiment_uses_unified_model = True
-        self._experiment_step_weight_input_names = [
-            self._experiment_step_weight_input_name(i)
-            for i, _step in enumerate(self.experiment.steps)
-        ]
+        self._experiment_step_indices = list(range(1, len(self.experiment.steps) + 1))
         self._experiment_includes_padding_rest = bool(
             self.experiment.initial_start_time
+        )
+        self._experiment_padding_rest_index = (
+            len(self.experiment.steps) + 1
+            if self._experiment_includes_padding_rest
+            else None
         )
 
         new_model = self._model.new_copy()
@@ -364,27 +369,18 @@ class Simulation:
         # ambient temperature from step-level inputs instead of baking in one value.
         new_parameter_values["Ambient temperature [K]"] = "[input]"
 
-        # Build one weighted control residual that selects the active step's control
-        # law via one-hot input weights.
+        # Build one conditional control residual that selects the active step's
+        # control law via the experiment step index input.
         step_control_builders = [
-            (weight_name, step.get_control_residual)
-            for weight_name, step in zip(
-                self._experiment_step_weight_input_names,
-                self.experiment.steps,
-                strict=True,
-            )
+            step.get_control_residual for step in self.experiment.steps
         ]
         if self._experiment_includes_padding_rest:
             padding_rest_step = pybamm.step.Rest(duration=1)
-            step_control_builders.append(
-                (
-                    pybamm.step.Rest.padding_weight_input_name(),
-                    padding_rest_step.get_control_residual,
-                )
-            )
+            step_control_builders.append(padding_rest_step.get_control_residual)
         submodel = pybamm.external_circuit.ExperimentFunctionControl(
             new_model.param,
             new_model.options,
+            self._experiment_step_index_input_name(),
             step_control_builders,
         )
         # Reuse the implicit-step wiring so the experiment-wide controller owns the
@@ -396,20 +392,17 @@ class Simulation:
         )
 
         # Combine each step's local termination expression into one experiment event,
-        # again selecting the active branch with the one-hot step weights.
-        combined_termination_expression = pybamm.Scalar(0)
-        for weight_name, step in zip(
-            self._experiment_step_weight_input_names,
-            self.experiment.steps,
-            strict=True,
-        ):
-            combined_termination_expression += pybamm.InputParameter(
-                weight_name
-            ) * step.get_combined_termination_expression(variables)
+        # selecting the active branch with the step index input.
+        termination_branches = [
+            step.get_combined_termination_expression(variables)
+            for step in self.experiment.steps
+        ]
         if self._experiment_includes_padding_rest:
-            combined_termination_expression += pybamm.InputParameter(
-                pybamm.step.Rest.padding_weight_input_name()
-            )
+            termination_branches.append(pybamm.Scalar(1))
+        combined_termination_expression = pybamm.Conditional(
+            pybamm.InputParameter(self._experiment_step_index_input_name()),
+            *termination_branches,
+        )
         new_model.events.append(
             pybamm.Event(
                 self._combined_step_termination_event_name,
@@ -438,7 +431,7 @@ class Simulation:
         The unified experiment path reuses one built model for every compatible step,
         so step-to-step reinitialisation is a same-model state mapping. This mapper
         leaves the full state vector unchanged except for the scalar
-        ``"Current variable [A]"`` entry, which is replaced by a one-hot-selected
+        ``"Current variable [A]"`` entry, which is replaced by a step-index-selected
         initial guess for the newly active step. Explicit controlled steps contribute
         their prescribed current, while implicit steps keep the incoming current state.
         """
@@ -458,25 +451,24 @@ class Simulation:
                 "Unified experiment self-mapper expects a scalar current-control state."
             )
 
-        current_guess = pybamm.Scalar(0)
+        current_guess_branches = []
         current_state = built_model.process_symbol(built_model.variables["Current [A]"])
-        for weight_name, step in zip(
-            self._experiment_step_weight_input_names,
-            self.experiment.steps,
-            strict=True,
-        ):
+        for step in self.experiment.steps:
             if isinstance(step, pybamm.step.BaseStepExplicit):
                 step_guess = built_model.process_symbol(
                     step.current_value(built_model.variables)
                 )
             else:
                 step_guess = current_state
-            current_guess += pybamm.InputParameter(weight_name) * step_guess
+            current_guess_branches.append(step_guess)
 
         if self._experiment_includes_padding_rest:
-            current_guess += pybamm.InputParameter(
-                pybamm.step.Rest.padding_weight_input_name()
-            ) * pybamm.Scalar(0)
+            current_guess_branches.append(pybamm.Scalar(0))
+
+        current_guess = pybamm.Conditional(
+            pybamm.InputParameter(self._experiment_step_index_input_name()),
+            *current_guess_branches,
+        )
 
         equations = []
         if current_slice.start > 0:
@@ -497,7 +489,7 @@ class Simulation:
         user_inputs,
         step,
         start_time,
-        active_weight_name=None,
+        active_step_index=None,
         include_temperature=True,
     ):
         temperature = (
@@ -506,7 +498,7 @@ class Simulation:
         if self._experiment_uses_unified_model:
             return self._build_unified_experiment_inputs(
                 user_inputs,
-                active_weight_name,
+                active_step_index,
                 start_time,
                 temperature,
             )
@@ -519,20 +511,14 @@ class Simulation:
         return inputs
 
     def _build_unified_experiment_inputs(
-        self, user_inputs, active_weight_name, start_time, temperature
+        self, user_inputs, active_step_index, start_time, temperature
     ):
         inputs = {
             **user_inputs,
             "Ambient temperature [K]": temperature,
             "start time": start_time,
+            self._experiment_step_index_input_name(): active_step_index,
         }
-        for weight_name in self._experiment_step_weight_input_names:
-            inputs[weight_name] = 1 if weight_name == active_weight_name else 0
-        if self._experiment_includes_padding_rest:
-            padding_weight_name = pybamm.step.Rest.padding_weight_input_name()
-            inputs[padding_weight_name] = (
-                1 if padding_weight_name == active_weight_name else 0
-            )
         return inputs
 
     @staticmethod
@@ -725,7 +711,8 @@ class Simulation:
         self._experiment_uses_unified_model = False
         self._built_experiment_model = None
         self._built_experiment_solver = None
-        self._experiment_step_weight_input_names = []
+        self._experiment_step_indices = []
+        self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
 
         # Process each step
@@ -1429,7 +1416,7 @@ class Simulation:
                             user_inputs,
                             step,
                             current_solution.t[-1],
-                            pybamm.step.Rest.padding_weight_input_name(),
+                            self._experiment_padding_rest_index,
                         )
 
                         steps = current_solution.cycles[-1].steps
@@ -1534,16 +1521,14 @@ class Simulation:
                     logs["step duration"] = step.duration
                     callbacks.on_step_start(logs)
 
-                    active_weight_name = None
+                    active_step_index = None
                     if self._experiment_uses_unified_model:
-                        active_weight_name = self._experiment_step_weight_input_names[
-                            idx
-                        ]
+                        active_step_index = self._experiment_step_indices[idx]
                     inputs = self._build_experiment_step_inputs(
                         user_inputs,
                         step,
                         start_time,
-                        active_weight_name,
+                        active_step_index,
                         include_temperature=self._experiment_uses_unified_model,
                     )
 
@@ -1612,7 +1597,7 @@ class Simulation:
                                 user_inputs,
                                 step,
                                 step_solution.t[-1],
-                                pybamm.step.Rest.padding_weight_input_name(),
+                                self._experiment_padding_rest_index,
                             )
 
                             step_solution_with_rest = self.run_padding_rest(

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -327,6 +327,14 @@ class Simulation:
         for step in self.experiment.steps:
             if step.is_drive_cycle:
                 return ["drive-cycle experiment steps are not yet supported"]
+            if isinstance(step, pybamm.step.BaseStep) and not isinstance(
+                step,
+                (
+                    pybamm.step.BaseStepExplicit,
+                    pybamm.step.BaseStepImplicit,
+                ),
+            ):
+                return [f"unsupported experiment step type '{type(step).__name__}'"]
             if (
                 isinstance(step, pybamm.step.CustomStepImplicit)
                 and step.control != "algebraic"
@@ -490,6 +498,32 @@ class Simulation:
                 )
             )
         return pybamm.NumpyConcatenation(*equations)
+
+    def _build_experiment_step_inputs(
+        self,
+        user_inputs,
+        step,
+        start_time,
+        active_weight_name=None,
+        include_temperature=True,
+    ):
+        temperature = (
+            step.temperature or self._parameter_values["Ambient temperature [K]"]
+        )
+        if self._experiment_uses_unified_model:
+            return self._build_unified_experiment_inputs(
+                user_inputs,
+                active_weight_name,
+                start_time,
+                temperature,
+            )
+        inputs = {
+            **user_inputs,
+            "start time": start_time,
+        }
+        if include_temperature:
+            inputs["Ambient temperature [K]"] = temperature
+        return inputs
 
     def _build_unified_experiment_inputs(
         self, user_inputs, active_weight_name, start_time, temperature
@@ -1392,23 +1426,13 @@ class Simulation:
                         # logs["step operating conditions"] = "Initial rest for padding"
                         # callbacks.on_step_start(logs)
 
-                        temperature = (
-                            step.temperature
-                            or self._parameter_values["Ambient temperature [K]"]
+                        inputs = self._build_experiment_step_inputs(
+                            user_inputs,
+                            step,
+                            current_solution.t[-1],
+                            pybamm.step.Rest.padding_weight_input_name(),
                         )
-                        if self._experiment_uses_unified_model:
-                            inputs = self._build_unified_experiment_inputs(
-                                user_inputs,
-                                pybamm.step.Rest.padding_weight_input_name(),
-                                current_solution.t[-1],
-                                temperature,
-                            )
-                        else:
-                            inputs = {
-                                **user_inputs,
-                                "Ambient temperature [K]": temperature,
-                                "start time": current_solution.t[-1],
-                            }
+
                         steps = current_solution.cycles[-1].steps
                         step_solution = current_solution.cycles[-1].steps[-1]
 
@@ -1511,22 +1535,19 @@ class Simulation:
                     logs["step duration"] = step.duration
                     callbacks.on_step_start(logs)
 
+                    active_weight_name = None
                     if self._experiment_uses_unified_model:
-                        temperature = (
-                            step.temperature
-                            or self._parameter_values["Ambient temperature [K]"]
-                        )
-                        inputs = self._build_unified_experiment_inputs(
-                            user_inputs,
-                            self._experiment_step_weight_input_names[idx],
-                            start_time,
-                            temperature,
-                        )
-                    else:
-                        inputs = {
-                            **user_inputs,
-                            "start time": start_time,
-                        }
+                        active_weight_name = self._experiment_step_weight_input_names[
+                            idx
+                        ]
+                    inputs = self._build_experiment_step_inputs(
+                        user_inputs,
+                        step,
+                        start_time,
+                        active_weight_name,
+                        include_temperature=self._experiment_uses_unified_model,
+                    )
+
                     # Make sure we take at least 2 timesteps
                     t_eval, t_interp_processed = step.setup_timestepping(
                         solver, dt, t_interp
@@ -1588,23 +1609,12 @@ class Simulation:
                             logs["step operating conditions"] = "Rest for padding"
                             callbacks.on_step_start(logs)
 
-                            temperature = (
-                                step.temperature
-                                or self._parameter_values["Ambient temperature [K]"]
+                            inputs = self._build_experiment_step_inputs(
+                                user_inputs,
+                                step,
+                                step_solution.t[-1],
+                                pybamm.step.Rest.padding_weight_input_name(),
                             )
-                            if self._experiment_uses_unified_model:
-                                inputs = self._build_unified_experiment_inputs(
-                                    user_inputs,
-                                    pybamm.step.Rest.padding_weight_input_name(),
-                                    step_solution.t[-1],
-                                    temperature,
-                                )
-                            else:
-                                inputs = {
-                                    **user_inputs,
-                                    "Ambient temperature [K]": temperature,
-                                    "start time": step_solution.t[-1],
-                                }
 
                             step_solution_with_rest = self.run_padding_rest(
                                 kwargs, rest_time, step_solution, inputs=inputs

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -146,6 +146,8 @@ class Simulation:
         self._built_model = None
         self._built_initial_soc = None
         self._built_nominal_capacity = None
+        self._built_experiment_model = None
+        self._built_experiment_solver = None
         self.steps_to_built_models = None
         self.steps_to_built_solvers = None
         self._cache_esoh = cache_esoh
@@ -183,6 +185,8 @@ class Simulation:
         result["get_esoh_solver"] = None  # Exclude LRU cache
         result["model_state_mappers"] = {}
         result["_compiled_model_state_mappers"] = {}
+        result["_built_experiment_model"] = None
+        result["_built_experiment_solver"] = None
         result["steps_to_built_models"] = None
         result["steps_to_built_solvers"] = None
         result["experiment_unique_steps_to_model"] = None
@@ -198,6 +202,10 @@ class Simulation:
             self.model_state_mappers = {}
         if "_compiled_model_state_mappers" not in self.__dict__:
             self._compiled_model_state_mappers = {}
+        if "_built_experiment_model" not in self.__dict__:
+            self._built_experiment_model = None
+        if "_built_experiment_solver" not in self.__dict__:
+            self._built_experiment_solver = None
         if "experiment_unique_steps_to_model" not in self.__dict__:
             self.experiment_unique_steps_to_model = None
         if "_experiment_uses_unified_model" not in self.__dict__:
@@ -243,6 +251,8 @@ class Simulation:
         self._set_up_and_parameterise_experiment(solve_kwargs)
 
         # Re-discretise the models
+        self._built_experiment_model = None
+        self._built_experiment_solver = None
         self.steps_to_built_models = {}
         self.steps_to_built_solvers = {}
         if self._experiment_uses_unified_model:
@@ -255,6 +265,8 @@ class Simulation:
                 delayed_variable_processing=True,
             )
             solver = self._solver.copy()
+            self._built_experiment_model = built_model
+            self._built_experiment_solver = solver
             for step in self.experiment.unique_steps:
                 self.steps_to_built_models[step.basic_repr()] = built_model
                 self.steps_to_built_solvers[step.basic_repr()] = solver
@@ -455,6 +467,20 @@ class Simulation:
 
         return float(value)
 
+    def _get_built_experiment_model(self, step_or_key):
+        if self._experiment_uses_unified_model:
+            return self._built_experiment_model
+        if isinstance(step_or_key, str):
+            return self.steps_to_built_models[step_or_key]
+        return self.steps_to_built_models[step_or_key.basic_repr()]
+
+    def _get_built_experiment_solver(self, step_or_key):
+        if self._experiment_uses_unified_model:
+            return self._built_experiment_solver
+        if isinstance(step_or_key, str):
+            return self.steps_to_built_solvers[step_or_key]
+        return self.steps_to_built_solvers[step_or_key.basic_repr()]
+
     def _evaluate_step_termination_expression_from_solution(
         self, term, step_solution, step
     ):
@@ -609,6 +635,8 @@ class Simulation:
             )
 
         self._experiment_uses_unified_model = False
+        self._built_experiment_model = None
+        self._built_experiment_solver = None
         self._experiment_step_weight_input_names = []
         self._experiment_includes_padding_rest = False
 
@@ -816,7 +844,9 @@ class Simulation:
         models = []
         if self._built_model is not None:
             models.append(self._built_model)
-        if self.steps_to_built_models is not None:
+        if self._built_experiment_model is not None:
+            models.append(self._built_experiment_model)
+        elif self.steps_to_built_models is not None:
             models.extend(self.steps_to_built_models.values())
 
         for built_model in models:
@@ -894,7 +924,7 @@ class Simulation:
         if initial_soc is not None:
             self.set_initial_state(initial_soc, direction=direction, inputs=inputs)
 
-        if self.steps_to_built_models:
+        if self._built_experiment_model is not None or self.steps_to_built_models:
             if self._needs_ic_rebuild:
                 self._recompute_initial_conditions()
             # Check if we need to update the models due to capacity change
@@ -912,6 +942,8 @@ class Simulation:
                 self._mesh, self._spatial_methods, **self._discretisation_kwargs
             )
             # Process all the different models
+            self._built_experiment_model = None
+            self._built_experiment_solver = None
             self.steps_to_built_models = {}
             self.steps_to_built_solvers = {}
             if self._experiment_uses_unified_model:
@@ -924,6 +956,8 @@ class Simulation:
                     delayed_variable_processing=True,
                 )
                 solver = self._solver.copy()
+                self._built_experiment_model = built_model
+                self._built_experiment_solver = solver
                 for step in self.experiment.unique_steps:
                     self.steps_to_built_models[step.basic_repr()] = built_model
                     self.steps_to_built_solvers[step.basic_repr()] = solver
@@ -1404,8 +1438,8 @@ class Simulation:
                             break
 
                     step_str = str(step)
-                    model = self.steps_to_built_models[step.basic_repr()]
-                    solver = self.steps_to_built_solvers[step.basic_repr()]
+                    model = self._get_built_experiment_model(step)
+                    solver = self._get_built_experiment_solver(step)
 
                     logs["step number"] = (step_num, cycle_length)
                     logs["step operating conditions"] = step_str
@@ -1700,13 +1734,8 @@ class Simulation:
         return self._solution
 
     def run_padding_rest(self, kwargs, rest_time, step_solution, inputs):
-        if self._experiment_uses_unified_model:
-            first_step = self.experiment.steps[0]
-            model = self.steps_to_built_models[first_step.basic_repr()]
-            solver = self.steps_to_built_solvers[first_step.basic_repr()]
-        else:
-            model = self.steps_to_built_models["Rest for padding"]
-            solver = self.steps_to_built_solvers["Rest for padding"]
+        model = self._get_built_experiment_model("Rest for padding")
+        solver = self._get_built_experiment_solver("Rest for padding")
         state_mapper = self._get_state_mapper_for_solution(step_solution, model)
 
         # Make sure we take at least 2 timesteps. The period is hardcoded to 10
@@ -1928,6 +1957,11 @@ class Simulation:
                     and solver.integrator_specs != {}
                 ):
                     solver.integrator_specs = {}
+        if (
+            isinstance(self._built_experiment_solver, pybamm.CasadiSolver)
+            and self._built_experiment_solver.integrator_specs != {}
+        ):
+            self._built_experiment_solver.integrator_specs = {}
 
         with open(filename, "wb") as f:
             pickle.dump(self, f, pickle.HIGHEST_PROTOCOL)

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -292,10 +292,6 @@ class Simulation:
         return f"Experiment step weight {step_index}"
 
     @staticmethod
-    def _experiment_padding_rest_weight_name():
-        return "Experiment step weight padding rest"
-
-    @staticmethod
     def _experiment_time_stop_termination():
         return "experiment time limit reached"
 
@@ -329,21 +325,18 @@ class Simulation:
 
         has_implicit_step = False
         for step in self.experiment.steps:
-            if getattr(step, "is_drive_cycle", False):
+            if step.is_drive_cycle:
                 return ["drive-cycle experiment steps are not yet supported"]
             if (
                 isinstance(step, pybamm.step.CustomStepImplicit)
                 and step.control != "algebraic"
             ):
                 return ["CustomStepImplicit with differential control is not supported"]
-            if issubclass(step.__class__, pybamm.experiment.step.BaseStepImplicit):
-                has_implicit_step = True
-            elif not issubclass(
-                step.__class__, pybamm.experiment.step.BaseStepExplicit
-            ):
-                return [f"unsupported experiment step type '{step.__class__.__name__}'"]
 
-        if not has_implicit_step and getattr(self._solver, "ode_solver", False):
+            if step.is_implicit():
+                has_implicit_step = True
+
+        if not has_implicit_step and self._solver.ode_solver:
             return [
                 "all-explicit experiments require a DAE-capable solver when using "
                 "the unified experiment model"
@@ -381,10 +374,11 @@ class Simulation:
             )
         ]
         if self._experiment_includes_padding_rest:
+            padding_rest_step = pybamm.step.Rest(duration=1)
             step_control_builders.append(
                 (
-                    self._experiment_padding_rest_weight_name(),
-                    lambda variables: variables["Current [A]"],
+                    pybamm.step.Rest.padding_weight_input_name(),
+                    padding_rest_step.get_control_residual,
                 )
             )
         submodel = pybamm.external_circuit.ExperimentFunctionControl(
@@ -413,7 +407,7 @@ class Simulation:
             ) * step.get_combined_termination_expression(variables)
         if self._experiment_includes_padding_rest:
             combined_termination_expression += pybamm.InputParameter(
-                self._experiment_padding_rest_weight_name()
+                pybamm.step.Rest.padding_weight_input_name()
             )
         new_model.events.append(
             pybamm.Event(
@@ -480,7 +474,7 @@ class Simulation:
 
         if self._experiment_includes_padding_rest:
             current_guess += pybamm.InputParameter(
-                self._experiment_padding_rest_weight_name()
+                pybamm.step.Rest.padding_weight_input_name()
             ) * pybamm.Scalar(0)
 
         equations = []
@@ -508,7 +502,7 @@ class Simulation:
         for weight_name in self._experiment_step_weight_input_names:
             inputs[weight_name] = 1 if weight_name == active_weight_name else 0
         if self._experiment_includes_padding_rest:
-            padding_weight_name = self._experiment_padding_rest_weight_name()
+            padding_weight_name = pybamm.step.Rest.padding_weight_input_name()
             inputs[padding_weight_name] = (
                 1 if padding_weight_name == active_weight_name else 0
             )
@@ -714,7 +708,7 @@ class Simulation:
         # Set up rest model if experiment has start times
         if self.experiment.initial_start_time:
             # duration doesn't matter, we just need the model
-            rest_step = pybamm.step.rest(duration=1)
+            rest_step = pybamm.step.Rest(duration=1)
             # Change ambient temperature to be an input, which will be changed at
             # solve time
             parameter_values["Ambient temperature [K]"] = "[input]"
@@ -1405,7 +1399,7 @@ class Simulation:
                         if self._experiment_uses_unified_model:
                             inputs = self._build_unified_experiment_inputs(
                                 user_inputs,
-                                self._experiment_padding_rest_weight_name(),
+                                pybamm.step.Rest.padding_weight_input_name(),
                                 current_solution.t[-1],
                                 temperature,
                             )
@@ -1601,7 +1595,7 @@ class Simulation:
                             if self._experiment_uses_unified_model:
                                 inputs = self._build_unified_experiment_inputs(
                                     user_inputs,
-                                    self._experiment_padding_rest_weight_name(),
+                                    pybamm.step.Rest.padding_weight_input_name(),
                                     step_solution.t[-1],
                                     temperature,
                                 )

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -456,20 +456,6 @@ class Simulation:
         }
         return inputs
 
-    @staticmethod
-    def _coerce_termination_value(value):
-        if isinstance(value, np.ndarray):
-            value = value.reshape(-1)[0]
-        elif hasattr(value, "full"):
-            value = value.full().reshape(-1)[0]
-        elif hasattr(value, "item") and not np.isscalar(value):
-            value = value.item()
-
-        if isinstance(value, np.ndarray):
-            value = value.item()
-
-        return float(value)
-
     def _get_built_experiment_model(self, step_or_key):
         if self._experiment_uses_unified_model:
             return self._built_experiment_model
@@ -507,7 +493,7 @@ class Simulation:
         except (KeyError, NotImplementedError):  # pragma: no cover
             return None
 
-        return self._coerce_termination_value(value)
+        return value
 
     def _decode_combined_step_termination(self, step_solution, step, model, inputs):
         if (
@@ -536,9 +522,7 @@ class Simulation:
                 else step_solution.y[:, -1]
             )
             try:
-                value = self._coerce_termination_value(
-                    event.expression.evaluate(t=t, y=y, inputs=inputs)
-                )
+                value = event.expression.evaluate(t=t, y=y, inputs=inputs)
             except NotImplementedError:  # pragma: no cover
                 value = None
 

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -150,6 +150,10 @@ class Simulation:
         self._solution = None
         self.quick_plot = None
         self._needs_ic_rebuild = False
+        self._experiment_uses_unified_model = False
+        self._experiment_unified_model_key = "Unified experiment"
+        self._experiment_step_weight_input_names = []
+        self._combined_step_termination_event_name = "Combined termination [experiment]"
 
         # ignore runtime warnings in notebooks
         if is_notebook():  # pragma: no cover
@@ -184,6 +188,16 @@ class Simulation:
             self._compiled_model_state_mappers = {}
         if "experiment_unique_steps_to_model" not in self.__dict__:
             self.experiment_unique_steps_to_model = None
+        if "_experiment_uses_unified_model" not in self.__dict__:
+            self._experiment_uses_unified_model = False
+        if "_experiment_unified_model_key" not in self.__dict__:
+            self._experiment_unified_model_key = "Unified experiment"
+        if "_experiment_step_weight_input_names" not in self.__dict__:
+            self._experiment_step_weight_input_names = []
+        if "_combined_step_termination_event_name" not in self.__dict__:
+            self._combined_step_termination_event_name = (
+                "Combined termination [experiment]"
+            )
 
     def set_up_and_parameterise_experiment(self, solve_kwargs=None):
         msg = "pybamm.simulation.set_up_and_parameterise_experiment is deprecated and not meant to be accessed by users."
@@ -215,21 +229,184 @@ class Simulation:
         # Re-discretise the models
         self.steps_to_built_models = {}
         self.steps_to_built_solvers = {}
-        for (
-            step,
-            model_with_set_params,
-        ) in self.experiment_unique_steps_to_model.items():
+        if self._experiment_uses_unified_model:
+            model_with_set_params = self.experiment_unique_steps_to_model[
+                self._experiment_unified_model_key
+            ]
             built_model = self._disc.process_model(
                 model_with_set_params,
                 inplace=True,
                 delayed_variable_processing=True,
             )
             solver = self._solver.copy()
-            self.steps_to_built_solvers[step] = solver
-            self.steps_to_built_models[step] = built_model
+            for step in self.experiment.unique_steps:
+                self.steps_to_built_models[step.basic_repr()] = built_model
+                self.steps_to_built_solvers[step.basic_repr()] = solver
+        else:
+            for (
+                step,
+                model_with_set_params,
+            ) in self.experiment_unique_steps_to_model.items():
+                built_model = self._disc.process_model(
+                    model_with_set_params,
+                    inplace=True,
+                    delayed_variable_processing=True,
+                )
+                solver = self._solver.copy()
+                self.steps_to_built_solvers[step] = solver
+                self.steps_to_built_models[step] = built_model
 
         self._build_experiment_state_mappers(inputs)
         self._built_nominal_capacity = current_capacity
+
+    def _experiment_step_weight_input_name(self, step_index):
+        return f"Experiment step weight {step_index}"
+
+    def _experiment_can_use_unified_model(self):
+        if self.experiment is None or self.experiment.initial_start_time:
+            return False
+
+        has_implicit_step = False
+        for step in self.experiment.steps:
+            if getattr(step, "is_drive_cycle", False):
+                return False
+            if (
+                isinstance(step, pybamm.step.CustomStepImplicit)
+                and step.control != "algebraic"
+            ):
+                return False
+            if issubclass(step.__class__, pybamm.experiment.step.BaseStepImplicit):
+                has_implicit_step = True
+            elif not issubclass(
+                step.__class__, pybamm.experiment.step.BaseStepExplicit
+            ):
+                return False
+
+        return has_implicit_step
+
+    def _set_up_unified_experiment_model(self, parameter_values):
+        self._experiment_uses_unified_model = True
+        self._experiment_step_weight_input_names = [
+            self._experiment_step_weight_input_name(i)
+            for i, _step in enumerate(self.experiment.steps)
+        ]
+
+        new_model = self._model.new_copy()
+        new_parameter_values = parameter_values.copy()
+        # Temperatures may change between steps, so the unified model must read the
+        # ambient temperature from step-level inputs instead of baking in one value.
+        new_parameter_values["Ambient temperature [K]"] = "[input]"
+
+        # Build one weighted control residual that selects the active step's control
+        # law via one-hot input weights.
+        step_control_builders = [
+            (weight_name, step.get_control_residual)
+            for weight_name, step in zip(
+                self._experiment_step_weight_input_names,
+                self.experiment.steps,
+                strict=True,
+            )
+        ]
+        submodel = pybamm.external_circuit.ExperimentFunctionControl(
+            new_model.param,
+            new_model.options,
+            step_control_builders,
+        )
+        # Reuse the implicit-step wiring so the experiment-wide controller owns the
+        # current variable in the same way as voltage/power/resistance steps do today.
+        new_model, variables = pybamm.step.BaseStepImplicit.add_control_submodel(
+            new_model,
+            submodel,
+            new_parameter_values,
+        )
+
+        # Combine each step's local termination expression into one experiment event,
+        # again selecting the active branch with the one-hot step weights.
+        combined_termination_expression = pybamm.Scalar(0)
+        for weight_name, step in zip(
+            self._experiment_step_weight_input_names,
+            self.experiment.steps,
+            strict=True,
+        ):
+            combined_termination_expression += pybamm.InputParameter(
+                weight_name
+            ) * step.get_combined_termination_expression(variables)
+        new_model.events.append(
+            pybamm.Event(
+                self._combined_step_termination_event_name,
+                combined_termination_expression,
+            )
+        )
+        pybamm.step.BaseStep.update_voltage_safety_events(new_model)
+
+        processed_model = new_parameter_values.process_model(
+            new_model,
+            inplace=False,
+            delayed_variable_processing=True,
+        )
+        self.experiment_unique_steps_to_model = {
+            self._experiment_unified_model_key: processed_model,
+        }
+        # Keep the legacy lookup keys alive even though compatible steps now share one
+        # processed model instance.
+        for step in self.experiment.unique_steps:
+            self.experiment_unique_steps_to_model[step.basic_repr()] = processed_model
+
+    def _build_unified_experiment_inputs(
+        self, user_inputs, step_index, step, start_time
+    ):
+        inputs = {
+            **user_inputs,
+            "Ambient temperature [K]": (
+                step.temperature or self._parameter_values["Ambient temperature [K]"]
+            ),
+            "start time": start_time,
+        }
+        for i, weight_name in enumerate(self._experiment_step_weight_input_names):
+            inputs[weight_name] = 1 if i == step_index else 0
+        return inputs
+
+    def _decode_combined_step_termination(self, step_solution, step, model, inputs):
+        if (
+            step_solution.termination
+            != f"event: {self._combined_step_termination_event_name}"
+        ):
+            return step_solution.termination
+
+        final_event_values = {}
+        for term in step.termination:
+            event = term.get_event(model.variables, step)
+            if event is None:
+                continue
+
+            value = None
+            if isinstance(term, pybamm.step.CurrentTermination):
+                current = step_solution["Current [A]"].data[-1]
+                if term.operator == ">":
+                    value = term.value - current
+                elif term.operator == "<":
+                    value = current - term.value
+                else:
+                    value = abs(current) - term.value
+            elif isinstance(term, pybamm.step.CRateTermination):
+                crate = step_solution["C-rate"].data[-1]
+                value = abs(crate) - term.value
+            elif isinstance(term, pybamm.step.VoltageTermination):
+                operator = term._get_operator(step)
+                if operator is not None:
+                    voltage = step_solution["Battery voltage [V]"].data[-1]
+                    sign = -1 if operator == ">" else 1
+                    value = sign * (voltage - term.value)
+
+            if value is not None:
+                final_event_values[event.name] = value
+
+        if not final_event_values:
+            return step_solution.termination
+
+        termination_event = min(final_event_values, key=final_event_values.get)
+        step_solution.termination = f"event: {termination_event}"
+        return step_solution.termination
 
     def _set_up_and_parameterise_experiment(self, solve_kwargs=None):
         """
@@ -288,6 +465,13 @@ class Simulation:
         init_temp = self.experiment.steps[0].temperature
         if init_temp is not None:
             parameter_values["Initial temperature [K]"] = init_temp
+
+        if self._experiment_can_use_unified_model():
+            self._set_up_unified_experiment_model(parameter_values)
+            return
+
+        self._experiment_uses_unified_model = False
+        self._experiment_step_weight_input_names = []
 
         # Process each step
         self.experiment_unique_steps_to_model = {}
@@ -591,20 +775,34 @@ class Simulation:
             # Process all the different models
             self.steps_to_built_models = {}
             self.steps_to_built_solvers = {}
-            for (
-                step,
-                model_with_set_params,
-            ) in self.experiment_unique_steps_to_model.items():
-                # It's ok to modify the model with set parameters in place as it's
-                # not returned anywhere
+            if self._experiment_uses_unified_model:
+                model_with_set_params = self.experiment_unique_steps_to_model[
+                    self._experiment_unified_model_key
+                ]
                 built_model = self._disc.process_model(
                     model_with_set_params,
                     inplace=True,
                     delayed_variable_processing=True,
                 )
                 solver = self._solver.copy()
-                self.steps_to_built_solvers[step] = solver
-                self.steps_to_built_models[step] = built_model
+                for step in self.experiment.unique_steps:
+                    self.steps_to_built_models[step.basic_repr()] = built_model
+                    self.steps_to_built_solvers[step.basic_repr()] = solver
+            else:
+                for (
+                    step,
+                    model_with_set_params,
+                ) in self.experiment_unique_steps_to_model.items():
+                    # It's ok to modify the model with set parameters in place as it's
+                    # not returned anywhere
+                    built_model = self._disc.process_model(
+                        model_with_set_params,
+                        inplace=True,
+                        delayed_variable_processing=True,
+                    )
+                    solver = self._solver.copy()
+                    self.steps_to_built_solvers[step] = solver
+                    self.steps_to_built_models[step] = built_model
 
             if inputs is None:
                 inputs = {}
@@ -1058,10 +1256,15 @@ class Simulation:
                     logs["step duration"] = step.duration
                     callbacks.on_step_start(logs)
 
-                    inputs = {
-                        **user_inputs,
-                        "start time": start_time,
-                    }
+                    if self._experiment_uses_unified_model:
+                        inputs = self._build_unified_experiment_inputs(
+                            user_inputs, idx, step, start_time
+                        )
+                    else:
+                        inputs = {
+                            **user_inputs,
+                            "start time": start_time,
+                        }
                     # Make sure we take at least 2 timesteps
                     t_eval, t_interp_processed = step.setup_timestepping(
                         solver, dt, t_interp
@@ -1102,7 +1305,12 @@ class Simulation:
                             # Otherwise, just stop this cycle
                             break
 
-                    step_termination = step_solution.termination
+                    if self._experiment_uses_unified_model:
+                        step_termination = self._decode_combined_step_termination(
+                            step_solution, step, model, inputs
+                        )
+                    else:
+                        step_termination = step_solution.termination
 
                     # Add a padding rest step if necessary
                     if step.next_start_time is not None:

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -323,7 +323,6 @@ class Simulation:
         if self.experiment is None:
             return ["no experiment is attached to the simulation"]
 
-        has_implicit_step = False
         for step in self.experiment.steps:
             if step.is_drive_cycle:
                 return ["drive-cycle experiment steps are not yet supported"]
@@ -341,14 +340,8 @@ class Simulation:
             ):
                 return ["CustomStepImplicit with differential control is not supported"]
 
-            if step.is_implicit():
-                has_implicit_step = True
-
-        if not has_implicit_step and self._solver.ode_solver:
-            return [
-                "all-explicit experiments require a DAE-capable solver when using "
-                "the unified experiment model"
-            ]
+        if self._solver.ode_solver:
+            return ["unified experiment model requires a DAE-capable solver"]
 
         return []
 
@@ -427,7 +420,7 @@ class Simulation:
 
         processed_model = new_parameter_values.process_model(
             new_model,
-            inplace=False,
+            inplace=True,
             delayed_variable_processing=True,
         )
         self.experiment_unique_steps_to_model = {
@@ -659,9 +652,9 @@ class Simulation:
         # input parameters
         restrict_list = {"Initial temperature [K]", "Ambient temperature [K]"}
         for step in self.experiment.steps:
-            if issubclass(step.__class__, pybamm.experiment.step.BaseStepImplicit):
+            if step.is_implicit():
                 restrict_list.update(step.get_parameter_values([]).keys())
-            elif issubclass(step.__class__, pybamm.experiment.step.BaseStepExplicit):
+            else:
                 restrict_list.update(["Current function [A]"])
         for key in restrict_list:
             if key in parameter_values.keys() and isinstance(
@@ -705,19 +698,25 @@ class Simulation:
             parameter_values["Initial temperature [K]"] = init_temp
 
         blockers = self._get_unified_experiment_model_blockers()
-        if self._experiment_model_mode == "unified":
-            if blockers:
-                raise pybamm.ModelError(
-                    "Cannot build a unified experiment model: "
-                    + "; ".join(blockers)
-                    + ". Use 'legacy'/'per-step' mode or a compatible solver/experiment."
-                )
+        raise_model_error = blockers and self._experiment_model_mode == "unified"
+        use_unified = not blockers and self._experiment_model_mode in {
+            "auto",
+            "unified",
+        }
+        fallback_to_per_step = blockers and self._experiment_model_mode == "auto"
+
+        if raise_model_error:
+            raise pybamm.ModelError(
+                "Cannot build a unified experiment model: "
+                + "; ".join(blockers)
+                + ". Use 'legacy'/'per-step' mode or a compatible solver/experiment."
+            )
+
+        if use_unified:
             self._set_up_unified_experiment_model(parameter_values)
             return
-        if self._experiment_model_mode == "auto" and not blockers:
-            self._set_up_unified_experiment_model(parameter_values)
-            return
-        if self._experiment_model_mode == "auto" and blockers:
+
+        if fallback_to_per_step:
             pybamm.logger.debug(
                 "Falling back to per-step experiment models: %s",
                 "; ".join(blockers),

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -418,6 +418,45 @@ class Simulation:
             inputs[weight_name] = 1 if i == step_index else 0
         return inputs
 
+    @staticmethod
+    def _coerce_termination_value(value):
+        if isinstance(value, np.ndarray):
+            value = value.reshape(-1)[0]
+        elif hasattr(value, "full"):
+            value = value.full().reshape(-1)[0]
+        elif hasattr(value, "item") and not np.isscalar(value):
+            value = value.item()
+
+        if isinstance(value, np.ndarray):
+            value = value.item()
+
+        return float(value)
+
+    def _evaluate_step_termination_expression_from_solution(
+        self, term, step_solution, step
+    ):
+        # Some custom terminations reference symbols that are not directly evaluable
+        # from the raw event expression, but are available as processed solution
+        # variables. Rebuild a minimal variables dict from the solved step state and
+        # re-run the termination expression against that view of the solution.
+        if step_solution.t_event is not None:
+            t = float(np.asarray(step_solution.t_event).reshape(-1)[0])
+        else:
+            t = float(step_solution.t[-1])
+
+        class SolutionVariables(dict):
+            def __missing__(self, key):
+                value = step_solution[key](t)
+                self[key] = value
+                return value
+
+        try:
+            value = term.get_event_expression(SolutionVariables(), step)
+        except (KeyError, NotImplementedError):  # pragma: no cover
+            return None
+
+        return self._coerce_termination_value(value)
+
     def _decode_combined_step_termination(self, step_solution, step, model, inputs):
         if (
             step_solution.termination
@@ -432,23 +471,32 @@ class Simulation:
                 continue
 
             value = None
-            if isinstance(term, pybamm.step.CurrentTermination):
-                current = step_solution["Current [A]"].data[-1]
-                if term.operator == ">":
-                    value = term.value - current
-                elif term.operator == "<":
-                    value = current - term.value
-                else:
-                    value = abs(current) - term.value
-            elif isinstance(term, pybamm.step.CRateTermination):
-                crate = step_solution["C-rate"].data[-1]
-                value = abs(crate) - term.value
-            elif isinstance(term, pybamm.step.VoltageTermination):
-                operator = term._get_operator(step)
-                if operator is not None:
-                    voltage = step_solution["Battery voltage [V]"].data[-1]
-                    sign = -1 if operator == ">" else 1
-                    value = sign * (voltage - term.value)
+            # First try the exact symbolic event expression that the unified model used.
+            # This is the closest match to what the solver just triggered.
+            t = (
+                step_solution.t_event
+                if step_solution.t_event is not None
+                else step_solution.t[-1]
+            )
+            y = (
+                step_solution.y_event
+                if step_solution.y_event is not None
+                else step_solution.y[:, -1]
+            )
+            try:
+                value = self._coerce_termination_value(
+                    event.expression.evaluate(t=t, y=y, inputs=inputs)
+                )
+            except NotImplementedError:  # pragma: no cover
+                value = None
+
+            # If the raw expression still contains unevaluated symbols, fall back to
+            # the processed variables on the solved step. This is slower, but it works
+            # for custom terminations built from model outputs.
+            if value is None:
+                value = self._evaluate_step_termination_expression_from_solution(
+                    term, step_solution, step
+                )
 
             if value is not None:
                 final_event_values[event.name] = value

--- a/src/pybamm/simulation.py
+++ b/src/pybamm/simulation.py
@@ -66,6 +66,13 @@ class Simulation:
     discretisation_kwargs: dict (optional)
         Any keyword arguments to pass to the Discretisation class.
         See :class:`pybamm.Discretisation` for details.
+    experiment_model_mode : str, optional
+        How to construct experiment models. Options are:
+        ``"auto"`` (default), which uses the unified experiment model when
+        compatible and otherwise falls back to one model per step;
+        ``"unified"``, which requires the shared experiment model path; and
+        ``"legacy"``, which always uses one model per step. ``"per-step"`` is
+        accepted as an alias for ``"legacy"``.
     """
 
     def __init__(
@@ -82,6 +89,7 @@ class Simulation:
         C_rate=None,
         discretisation_kwargs=None,
         cache_esoh=True,
+        experiment_model_mode="auto",
     ):
         self._parameter_values = parameter_values or model.default_parameter_values
         self._unprocessed_parameter_values = self._parameter_values
@@ -150,6 +158,9 @@ class Simulation:
         self._solution = None
         self.quick_plot = None
         self._needs_ic_rebuild = False
+        self._experiment_model_mode = self._normalise_experiment_model_mode(
+            experiment_model_mode
+        )
         self._experiment_uses_unified_model = False
         self._experiment_unified_model_key = "Unified experiment"
         self._experiment_step_weight_input_names = []
@@ -198,6 +209,8 @@ class Simulation:
             self._combined_step_termination_event_name = (
                 "Combined termination [experiment]"
             )
+        if "_experiment_model_mode" not in self.__dict__:
+            self._experiment_model_mode = "auto"
 
     def set_up_and_parameterise_experiment(self, solve_kwargs=None):
         msg = "pybamm.simulation.set_up_and_parameterise_experiment is deprecated and not meant to be accessed by users."
@@ -262,27 +275,54 @@ class Simulation:
     def _experiment_step_weight_input_name(self, step_index):
         return f"Experiment step weight {step_index}"
 
-    def _experiment_can_use_unified_model(self):
-        if self.experiment is None or self.experiment.initial_start_time:
-            return False
+    @staticmethod
+    def _normalise_experiment_model_mode(mode):
+        aliases = {
+            "auto": "auto",
+            "unified": "unified",
+            "legacy": "legacy",
+            "per-step": "legacy",
+        }
+        try:
+            return aliases[mode]
+        except KeyError as err:
+            raise ValueError(
+                "experiment_model_mode must be one of 'auto', 'unified', "
+                "'legacy', or 'per-step'"
+            ) from err
+
+    def _get_unified_experiment_model_blockers(self):
+        if self.experiment is None:
+            return ["no experiment is attached to the simulation"]
+        if self.experiment.initial_start_time:
+            return ["experiments with start-time padding still use per-step models"]
 
         has_implicit_step = False
         for step in self.experiment.steps:
             if getattr(step, "is_drive_cycle", False):
-                return False
+                return ["drive-cycle experiment steps are not yet supported"]
             if (
                 isinstance(step, pybamm.step.CustomStepImplicit)
                 and step.control != "algebraic"
             ):
-                return False
+                return ["CustomStepImplicit with differential control is not supported"]
             if issubclass(step.__class__, pybamm.experiment.step.BaseStepImplicit):
                 has_implicit_step = True
             elif not issubclass(
                 step.__class__, pybamm.experiment.step.BaseStepExplicit
             ):
-                return False
+                return [f"unsupported experiment step type '{step.__class__.__name__}'"]
 
-        return has_implicit_step
+        if not has_implicit_step and getattr(self._solver, "ode_solver", False):
+            return [
+                "all-explicit experiments require a DAE-capable solver when using "
+                "the unified experiment model"
+            ]
+
+        return []
+
+    def _experiment_can_use_unified_model(self):
+        return not self._get_unified_experiment_model_blockers()
 
     def _set_up_unified_experiment_model(self, parameter_values):
         self._experiment_uses_unified_model = True
@@ -466,9 +506,24 @@ class Simulation:
         if init_temp is not None:
             parameter_values["Initial temperature [K]"] = init_temp
 
-        if self._experiment_can_use_unified_model():
+        blockers = self._get_unified_experiment_model_blockers()
+        if self._experiment_model_mode == "unified":
+            if blockers:
+                raise pybamm.ModelError(
+                    "Cannot build a unified experiment model: "
+                    + "; ".join(blockers)
+                    + ". Use 'legacy'/'per-step' mode or a compatible solver/experiment."
+                )
             self._set_up_unified_experiment_model(parameter_values)
             return
+        if self._experiment_model_mode == "auto" and not blockers:
+            self._set_up_unified_experiment_model(parameter_values)
+            return
+        if self._experiment_model_mode == "auto" and blockers:
+            pybamm.logger.debug(
+                "Falling back to per-step experiment models: %s",
+                "; ".join(blockers),
+            )
 
         self._experiment_uses_unified_model = False
         self._experiment_step_weight_input_names = []

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1409,7 +1409,19 @@ class BaseSolver:
                 self.set_up(model, model_inputs, ics_only=True)
         elif old_solution.all_models[-1] == model:
             last_state = old_solution.last_state
-            model.y0_list = [last_state.all_ys[0]]
+            if state_mapper is not None:
+                y_from = last_state.all_ys[0]
+                mapper_func, _mapper_jac, _mapper_jacp = state_mapper
+                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
+                model.y0_list = [
+                    mapper_func(
+                        t_start_shifted,
+                        y_from,
+                        p_casadi_stacked,
+                    )
+                ]
+            else:
+                model.y0_list = [last_state.all_ys[0]]
             if using_sensitivities:
                 full_sens = last_state._all_sensitivities["all"][0]
                 model.y0S_list = [

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1420,8 +1420,22 @@ class BaseSolver:
             if state_mapper is not None:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
-                mapper_func, _mapper_jac, _mapper_jacp = state_mapper
-                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
+                if len(state_mapper) == 4:
+                    mapper_func, _mapper_jac, _mapper_jacp, mapper_input_names = (
+                        state_mapper
+                    )
+                    mapper_inputs = [
+                        old_solution.all_inputs[-1].get(
+                            name, DUMMY_INPUT_PARAMETER_VALUE
+                        )
+                        for name in mapper_input_names
+                    ]
+                    p_casadi_stacked = casadi.vertcat(*mapper_inputs)
+                else:
+                    mapper_func, _mapper_jac, _mapper_jacp = state_mapper
+                    p_casadi_stacked = casadi.vertcat(
+                        *[p for p in model_inputs.values()]
+                    )
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1420,22 +1420,8 @@ class BaseSolver:
             if state_mapper is not None:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
-                if len(state_mapper) == 4:
-                    mapper_func, _mapper_jac, _mapper_jacp, mapper_input_names = (
-                        state_mapper
-                    )
-                    mapper_inputs = [
-                        old_solution.all_inputs[-1].get(
-                            name, DUMMY_INPUT_PARAMETER_VALUE
-                        )
-                        for name in mapper_input_names
-                    ]
-                    p_casadi_stacked = casadi.vertcat(*mapper_inputs)
-                else:
-                    mapper_func, _mapper_jac, _mapper_jacp = state_mapper
-                    p_casadi_stacked = casadi.vertcat(
-                        *[p for p in model_inputs.values()]
-                    )
+                mapper_func, _mapper_jac, _mapper_jacp = state_mapper
+                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1419,19 +1419,7 @@ class BaseSolver:
                 self.set_up(model, model_inputs, ics_only=True)
         elif old_solution.all_models[-1] == model:
             last_state = old_solution.last_state
-            if state_mapper is not None:
-                y_from = last_state.all_ys[0]
-                mapper_func, _mapper_jac, _mapper_jacp = state_mapper
-                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
-                model.y0_list = [
-                    mapper_func(
-                        t_start_shifted,
-                        y_from,
-                        p_casadi_stacked,
-                    )
-                ]
-            else:
-                model.y0_list = [last_state.all_ys[0]]
+            model.y0_list = [last_state.all_ys[0]]
             if using_sensitivities:
                 full_sens = last_state._all_sensitivities["all"][0]
                 model.y0S_list = [

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -713,14 +713,24 @@ class BaseSolver:
     def _solve_process_calculate_sensitivities_arg(
         inputs: dict, model: pybamm.BaseModel, calculate_sensitivities: list[str] | bool
     ):
+        excluded_sensitivity_inputs = {
+            pybamm.Simulation._experiment_step_index_input_name()
+        }
+
         # get a list-only version of calculate_sensitivities
         if isinstance(calculate_sensitivities, bool):
             if calculate_sensitivities:
-                calculate_sensitivities_list = [p for p in inputs.keys()]
+                calculate_sensitivities_list = [
+                    p for p in inputs.keys() if p not in excluded_sensitivity_inputs
+                ]
             else:
                 calculate_sensitivities_list = []
         else:
-            calculate_sensitivities_list = calculate_sensitivities
+            calculate_sensitivities_list = [
+                p
+                for p in calculate_sensitivities
+                if p not in excluded_sensitivity_inputs
+            ]
 
         calculate_sensitivities_list.sort()
         if not hasattr(model, "calculate_sensitivities"):

--- a/src/pybamm/solvers/idaklu_solver.py
+++ b/src/pybamm/solvers/idaklu_solver.py
@@ -748,7 +748,7 @@ class IDAKLUSolver(pybamm.BaseSolver):
         number_of_samples = sol.y.shape[0] // number_of_timesteps
         sol.y = sol.y.reshape((number_of_timesteps, number_of_samples))
         sensitivity_params = (
-            list(inputs_dict.keys()) if model.calculate_sensitivities else []
+            model.calculate_sensitivities if model.calculate_sensitivities else []
         )
 
         start_idx = 0

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -53,6 +53,9 @@ class ProcessedVariable(BaseProcessedVariable):
         self.all_yps = solution.all_yps
         self.all_inputs = solution.all_inputs
         self.all_inputs_stacked = solution.all_inputs_stacked
+        self.sensitivity_names = [
+            name for name in solution._all_sensitivities.keys() if name != "all"
+        ]
 
         self.mesh = base_variables[0].mesh
         self.domain = base_variables[0].domain
@@ -419,21 +422,27 @@ class ProcessedVariable(BaseProcessedVariable):
         "Set up the sensitivity dictionary"
 
         all_S_var = []
-        for ts, ys, inputs_stacked, inputs, base_variable, dy_dp in zip(
+        for ts, ys, inputs, base_variable, dy_dp in zip(
             self.all_ts,
             self.all_ys,
-            self.all_inputs_stacked,
             self.all_inputs,
             self.base_variables,
             self.all_solution_sensitivities["all"],
             strict=True,
         ):
+            sensitivity_inputs = {
+                name: inputs[name] for name in self.sensitivity_names if name in inputs
+            }
+            sensitivity_inputs_stacked = casadi.vertcat(
+                *[sensitivity_inputs[name] for name in self.sensitivity_names]
+            )
+
             # Set up symbolic variables
             t_casadi = casadi.MX.sym("t")
             y_casadi = casadi.MX.sym("y", ys.shape[0])
             p_casadi = {
                 name: casadi.MX.sym(name, value.shape[0])
-                for name, value in inputs.items()
+                for name, value in sensitivity_inputs.items()
             }
 
             p_casadi_stacked = casadi.vertcat(*[p for p in p_casadi.values()])
@@ -452,13 +461,13 @@ class ProcessedVariable(BaseProcessedVariable):
             )
             dvar_dy_eval = casadi.diagcat(
                 *[
-                    dvar_dy_func(t, ys[:, idx], inputs_stacked)
+                    dvar_dy_func(t, ys[:, idx], sensitivity_inputs_stacked)
                     for idx, t in enumerate(ts)
                 ]
             )
             dvar_dp_eval = casadi.vertcat(
                 *[
-                    dvar_dp_func(t, ys[:, idx], inputs_stacked)
+                    dvar_dp_func(t, ys[:, idx], sensitivity_inputs_stacked)
                     for idx, t in enumerate(ts)
                 ]
             )
@@ -477,7 +486,7 @@ class ProcessedVariable(BaseProcessedVariable):
         sensitivities = {"all": S_var}
 
         # Add the individual sensitivity
-        for i, name in enumerate(self.all_inputs[0].keys()):
+        for i, name in enumerate(self.sensitivity_names):
             sensitivities[name] = S_var[:, i : i + 1].reshape(-1)
 
         # Save attribute

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -499,6 +499,9 @@ class ProcessedVariable(BaseProcessedVariable):
         use together, e.g. when using a last state solution with a new simulation running
         with output variables in the solver.
         """
+        sensitivities = self._sensitivities
+        if sensitivities is None and self.all_solution_sensitivities:
+            sensitivities = self.sensitivities
 
         def _stub_solution(self):
             """
@@ -523,7 +526,7 @@ class ProcessedVariable(BaseProcessedVariable):
                 self.all_ys,
                 self.all_inputs,
                 self.all_inputs_stacked,
-                self.sensitivities,
+                sensitivities or {},
                 self.t_pts,
             )
 
@@ -541,9 +544,9 @@ class ProcessedVariable(BaseProcessedVariable):
         )
 
         # add sensitivities if they exist
-        if self.sensitivities:
+        if sensitivities:
             # TODO: test once #5058 is fixed
-            cpv._sensitivities = self.sensitivities  # pragma: no cover
+            cpv._sensitivities = sensitivities  # pragma: no cover
 
         return cpv
 

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -545,8 +545,7 @@ class ProcessedVariable(BaseProcessedVariable):
 
         # add sensitivities if they exist
         if sensitivities:
-            # TODO: test once #5058 is fixed
-            cpv._sensitivities = sensitivities  # pragma: no cover
+            cpv._sensitivities = sensitivities
 
         return cpv
 

--- a/src/pybamm/solvers/processed_variable_computed.py
+++ b/src/pybamm/solvers/processed_variable_computed.py
@@ -721,9 +721,12 @@ class ProcessedVariableComputed(BaseProcessedVariable):
 
         new_var = self.__class__(bv, bvc, bvd, new_sol)
 
-        new_var._sensitivities = {
-            k: np.concatenate((self.sensitivities[k], other.sensitivities[k]))
-            for k in self.sensitivities.keys()
-        }
+        self_sensitivities = self.sensitivities or {}
+        other_sensitivities = other.sensitivities or {}
+        if self_sensitivities or other_sensitivities:
+            new_var._sensitivities = {
+                k: np.concatenate((self_sensitivities[k], other_sensitivities[k]))
+                for k in self_sensitivities.keys()
+            }
 
         return new_var

--- a/tests/unit/test_experiments/test_base_step.py
+++ b/tests/unit/test_experiments/test_base_step.py
@@ -1,6 +1,15 @@
+import numpy as np
 import pytest
 
 import pybamm
+
+
+class DummySolver:
+    supports_interp = True
+
+    @staticmethod
+    def process_t_interp(t_interp):
+        return t_interp
 
 
 @pytest.mark.parametrize(
@@ -16,3 +25,22 @@ import pybamm
 )
 def test_read_units(test_string, unit_string):
     assert unit_string == pybamm.experiment.step.base_step.get_unit_from(test_string)
+
+
+def test_drive_cycle_default_time_vector_uses_smallest_sample_spacing():
+    drive_cycle = np.array([[0.0, 0.0], [2.0, 1.0], [5.0, -1.0]])
+    step = pybamm.step.current(drive_cycle, duration=4)
+
+    time_vector = step.default_time_vector(DummySolver(), tf=4)
+
+    np.testing.assert_array_equal(time_vector, np.array([0.0, 2.0, 4.0]))
+
+
+def test_drive_cycle_setup_timestepping_truncates_and_appends_final_time():
+    drive_cycle = np.array([[0.0, 0.0], [2.0, 1.0], [5.0, -1.0]])
+    step = pybamm.step.current(drive_cycle, duration=4)
+
+    t_eval, t_interp = step.setup_timestepping(DummySolver(), tf=4)
+
+    np.testing.assert_array_equal(t_eval, np.array([0.0, 2.0, 4.0]))
+    assert t_interp is None

--- a/tests/unit/test_experiments/test_base_step.py
+++ b/tests/unit/test_experiments/test_base_step.py
@@ -44,3 +44,90 @@ def test_drive_cycle_setup_timestepping_truncates_and_appends_final_time():
 
     np.testing.assert_array_equal(t_eval, np.array([0.0, 2.0, 4.0]))
     assert t_interp is None
+
+
+def test_base_step_validates_direction_tags_and_start_time():
+    with pytest.raises(ValueError, match="Invalid direction"):
+        pybamm.step.current(1, duration=10, direction="sideways")
+
+    step = pybamm.step.current(1, duration=10, tags="tag")
+    assert step.tags == ["tag"]
+
+    with pytest.raises(TypeError, match=r"datetime\.datetime"):
+        pybamm.step.current(1, duration=10, start_time=0)
+
+
+def test_drive_cycle_validation_and_looping():
+    with pytest.raises(ValueError, match="2-column array"):
+        pybamm.step.current(np.array([0.0, 1.0]), duration=1)
+
+    with pytest.raises(ValueError, match="start at t=0"):
+        pybamm.step.current(np.array([[1.0, 0.0], [2.0, 1.0]]), duration=2)
+
+    step = pybamm.step.current(np.array([[0.0, 0.0], [2.0, 1.0]]), duration=5)
+
+    np.testing.assert_array_equal(
+        step.value.x[0], np.array([0.0, 2.0, 4.0, 6.0, 8.0, 10.0])
+    )
+    np.testing.assert_array_equal(
+        step.value.y, np.array([0.0, 1.0, 0.0, 1.0, 0.0, 1.0])
+    )
+
+
+def test_default_time_vector_uses_drive_cycle_period_only_when_supported():
+    step = pybamm.step.current(
+        np.array([[0.0, 0.0], [2.0, 1.0], [5.0, -1.0]]), duration=5
+    )
+
+    class SolverWithoutInterp:
+        supports_interp = False
+
+    time_vector = step.default_time_vector(SolverWithoutInterp(), tf=5)
+
+    np.testing.assert_array_equal(time_vector, np.array([0.0, 5.0]))
+
+
+def test_value_based_charge_or_discharge_with_input_parameter():
+    step = pybamm.step.current(pybamm.InputParameter("I_app"), termination="> 2A")
+
+    assert step.direction is None
+    assert step.termination[0] == pybamm.step.CurrentTermination(2.0, operator=">")
+
+
+@pytest.mark.parametrize(
+    "helper,input_value,match",
+    [
+        (
+            pybamm.experiment.step.base_step._convert_time_to_seconds,
+            0,
+            "time must be positive",
+        ),
+        (
+            pybamm.experiment.step.base_step._convert_time_to_seconds,
+            "1 day",
+            "time units must be 'seconds', 'minutes' or 'hours'",
+        ),
+        (
+            pybamm.experiment.step.base_step._convert_temperature_to_kelvin,
+            "20 F",
+            "temperature units must be 'K' or 'oC'",
+        ),
+        (
+            pybamm.experiment.step.base_step._convert_electric,
+            "1 B",
+            "units must be 'A', 'V', 'W', 'Ohm', or 'C'",
+        ),
+    ],
+)
+def test_base_step_conversion_helpers_raise_for_invalid_inputs(
+    helper, input_value, match
+):
+    with pytest.raises(ValueError, match=match):
+        helper(input_value)
+
+
+def test_parse_termination_requires_operator_for_input_parameter():
+    with pytest.raises(ValueError, match="Termination must include an operator"):
+        pybamm.experiment.step.base_step._parse_termination(
+            "2A", pybamm.InputParameter("I_app")
+        )

--- a/tests/unit/test_experiments/test_experiment_step_termination.py
+++ b/tests/unit/test_experiments/test_experiment_step_termination.py
@@ -19,6 +19,10 @@ class TestExperimentStepTermination:
         assert term != pybamm.step.BaseTermination(2)
         assert term != pybamm.step.CurrentTermination(1)
 
+    def test_base_termination_invalid_operator(self):
+        with pytest.raises(ValueError, match="Invalid operator"):
+            pybamm.step.BaseTermination(1, operator="=")
+
     def test_c_rate_termination(self):
         term = pybamm.step.CRateTermination(0.02)
         assert term.value == 0.02
@@ -32,6 +36,40 @@ class TestExperimentStepTermination:
                 == term_old.get_event(variables, None).evaluate()
             )
 
+    def test_current_and_voltage_termination_operator_branches(self):
+        variables = {
+            "Current [A]": pybamm.Scalar(0.5),
+            "Battery voltage [V]": pybamm.Scalar(4.2),
+        }
+        rest_step = SimpleNamespace(direction="rest")
+
+        current_gt = pybamm.step.CurrentTermination(0.4, operator=">")
+        current_lt = pybamm.step.CurrentTermination(0.6, operator="<")
+        assert current_gt.get_event_name(None) == "Current [A] > 0.4 [A] [experiment]"
+        assert current_lt.get_event_name(None) == "Current [A] < 0.6 [A] [experiment]"
+        assert current_gt.get_event_expression(
+            variables, None
+        ).evaluate() == pytest.approx(-0.1)
+        assert current_lt.get_event_expression(
+            variables, None
+        ).evaluate() == pytest.approx(-0.1)
+
+        voltage_gt = pybamm.step.VoltageTermination(4.1, operator=">")
+        voltage_lt = pybamm.step.VoltageTermination(4.3, operator="<")
+        assert voltage_gt.get_event_name(rest_step) == "Voltage > 4.1 [V] [experiment]"
+        assert voltage_lt.get_event_name(rest_step) == "Voltage < 4.3 [V] [experiment]"
+        assert voltage_gt.get_event_expression(
+            variables, rest_step
+        ).evaluate() == pytest.approx(-0.1)
+        assert voltage_lt.get_event_expression(
+            variables, rest_step
+        ).evaluate() == pytest.approx(-0.1)
+
+        assert (pybamm.step.step_termination.Current() > 0.4) == current_gt
+        assert (pybamm.step.step_termination.Current() < 0.6) == current_lt
+        assert (pybamm.step.step_termination.Voltage() > 4.1) == voltage_gt
+        assert (pybamm.step.step_termination.Voltage() < 4.3) == voltage_lt
+
     def test_voltage_termination_returns_none_without_charge_or_discharge(self):
         term = pybamm.step.VoltageTermination(4.2)
         step = SimpleNamespace(direction="rest")
@@ -40,3 +78,12 @@ class TestExperimentStepTermination:
         assert term.get_event_name(step) is None
         assert term.get_event_expression(variables, step) is None
         assert term.get_event(variables, step) is None
+
+    def test_read_termination_tuple(self):
+        current = pybamm.step.step_termination._read_termination((">", "current", 2.0))
+        voltage = pybamm.step.step_termination._read_termination(("<", "voltage", 3.0))
+        crate = pybamm.step.step_termination._read_termination((">", "C-rate", 0.5))
+
+        assert current == pybamm.step.CurrentTermination(2.0, operator=">")
+        assert voltage == pybamm.step.VoltageTermination(3.0, operator="<")
+        assert crate == pybamm.step.CRateTermination(0.5, operator=">")

--- a/tests/unit/test_experiments/test_experiment_step_termination.py
+++ b/tests/unit/test_experiments/test_experiment_step_termination.py
@@ -2,6 +2,8 @@
 # Test the experiment step termination classes
 #
 
+from types import SimpleNamespace
+
 import pytest
 
 import pybamm
@@ -29,3 +31,12 @@ class TestExperimentStepTermination:
                 term.get_event(variables, None).evaluate()
                 == term_old.get_event(variables, None).evaluate()
             )
+
+    def test_voltage_termination_returns_none_without_charge_or_discharge(self):
+        term = pybamm.step.VoltageTermination(4.2)
+        step = SimpleNamespace(direction="rest")
+        variables = {"Battery voltage [V]": pybamm.Scalar(4.2)}
+
+        assert term.get_event_name(step) is None
+        assert term.get_event_expression(variables, step) is None
+        assert term.get_event(variables, step) is None

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -364,6 +364,21 @@ class TestExperimentSteps:
         assert termination_gt_4_1_oo == termination_gt_4_1
 
     def test_symbolic_termination_expression_helpers(self):
+        single_termination_step = pybamm.step.current(
+            1, duration=3600, termination="2.5V"
+        )
+        single_termination_variables = {
+            "Battery voltage [V]": 3.0,
+            "Current [A]": 0.2,
+            "C-rate": 0.1,
+        }
+        np.testing.assert_allclose(
+            single_termination_step.get_combined_termination_expression(
+                single_termination_variables
+            ),
+            3.0 - 2.5,
+        )
+
         step = pybamm.step.current(1, duration=3600, termination=["2.5V", "0.05A"])
         variables = {
             "Battery voltage [V]": 3.0,

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -378,7 +378,15 @@ class TestExperimentSteps:
         ]
         np.testing.assert_allclose(
             step.get_combined_termination_expression(variables).evaluate(),
-            (3.0 - 2.5) * (0.2 - 0.05),
+            min(3.0 - 2.5, 0.2 - 0.05),
+        )
+
+        no_termination_step = pybamm.step.current(1, duration=3600)
+        np.testing.assert_allclose(
+            no_termination_step.get_combined_termination_expression(
+                variables
+            ).evaluate(),
+            1,
         )
 
     def test_symbolic_control_residual_helpers(self):

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -76,6 +76,12 @@ class TestExperimentSteps:
         assert isinstance(resistance, pybamm.step.Resistance)
         assert resistance.value == 1
 
+    def test_rest_step_requires_zero_current(self):
+        with pytest.raises(
+            ValueError, match=r"Rest steps must have a current value of 0"
+        ):
+            pybamm.step.Rest(1)
+
     def test_step_string(self):
         steps = [
             "Discharge at 1C for 0.5 hours",

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -65,7 +65,7 @@ class TestExperimentSteps:
         assert voltage.value == 1
 
         rest = pybamm.step.rest()
-        assert isinstance(rest, pybamm.step.Current)
+        assert isinstance(rest, pybamm.step.Rest)
         assert rest.value == 0
 
         power = pybamm.step.power(1)
@@ -139,7 +139,7 @@ class TestExperimentSteps:
             },
             {
                 "value": 0,
-                "type": "Current",
+                "type": "Rest",
                 "duration": 600.0,
                 "termination": [],
             },

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -362,3 +362,71 @@ class TestExperimentSteps:
         termination_gt_4_1_oo = pybamm.step.step_termination.Voltage() > 4.1
         assert termination_lt_4_1_oo == termination_gt_4_1
         assert termination_gt_4_1_oo == termination_gt_4_1
+
+    def test_symbolic_termination_expression_helpers(self):
+        step = pybamm.step.current(1, duration=3600, termination=["2.5V", "0.05A"])
+        variables = {
+            "Battery voltage [V]": 3.0,
+            "Current [A]": 0.2,
+            "C-rate": 0.1,
+        }
+
+        events = step.get_termination_events(variables)
+        assert [event.name for event in events] == [
+            "Voltage < 2.5 [V] [experiment]",
+            "abs(Current [A]) < 0.05 [A] [experiment]",
+        ]
+        np.testing.assert_allclose(
+            step.get_combined_termination_expression(variables).evaluate(),
+            (3.0 - 2.5) * (0.2 - 0.05),
+        )
+
+    def test_symbolic_control_residual_helpers(self):
+        current_step = pybamm.step.current(1, duration=10)
+        np.testing.assert_allclose(
+            current_step.get_control_residual({"Current [A]": 1.2}),
+            0.2,
+        )
+
+        voltage_step = pybamm.step.voltage(4.1, duration=10)
+        np.testing.assert_allclose(
+            voltage_step.get_control_residual({"Voltage [V]": 4.2}),
+            0.1,
+        )
+
+        power_step = pybamm.step.power(2, duration=10)
+        np.testing.assert_allclose(
+            power_step.get_control_residual({"Power [W]": 2.4}),
+            0.4,
+        )
+
+        resistance_step = pybamm.step.resistance(4, duration=10)
+        np.testing.assert_allclose(
+            resistance_step.get_control_residual({"Resistance [Ohm]": 4.3}),
+            0.3,
+        )
+
+        custom_explicit = pybamm.step.CustomStepExplicit(
+            lambda variables: 0.5, duration=1
+        )
+        np.testing.assert_allclose(
+            custom_explicit.get_control_residual({"Current [A]": 0.7}),
+            0.2,
+        )
+
+        custom_algebraic = pybamm.step.CustomStepImplicit(
+            lambda variables: variables["Voltage [V]"] - 4.2,
+            duration=1,
+        )
+        np.testing.assert_allclose(
+            custom_algebraic.get_control_residual({"Voltage [V]": 4.3}),
+            0.1,
+        )
+
+        custom_differential = pybamm.step.CustomStepImplicit(
+            lambda variables: variables["Voltage [V]"] - 4.2,
+            control="differential",
+            duration=1,
+        )
+        with pytest.raises(NotImplementedError):
+            custom_differential.get_control_residual({"Voltage [V]": 4.3})

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -410,7 +410,9 @@ class TestExperimentSteps:
 
         resistance_step = pybamm.step.resistance(4, duration=10)
         np.testing.assert_allclose(
-            resistance_step.get_control_residual({"Resistance [Ohm]": 4.3}),
+            resistance_step.get_control_residual(
+                {"Voltage [V]": 4.3, "Current [A]": 1}
+            ),
             0.3,
         )
 

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1183,8 +1183,13 @@ class TestSimulationExperiment:
         experiment = pybamm.Experiment(
             [pybamm.step.c_rate(1, termination=neg_stoich_termination)]
         )
-        sim = pybamm.Simulation(model, experiment=experiment)
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            experiment_model_mode="unified",
+        )
         sol = sim.solve(calc_esoh=False)
+        assert sim._experiment_uses_unified_model
         assert (
             sol.cycles[0].steps[0].termination
             == "event: Negative stoichiometry cut-off [experiment]"

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -183,6 +183,30 @@ class TestSimulationExperiment:
         with pytest.raises(TypeError, match=r"experiment must be"):
             pybamm.Simulation(pybamm.lithium_ion.SPM(), experiment=0)
 
+    def test_unified_model_mode_validation_and_blockers(self):
+        with pytest.raises(ValueError, match="experiment_model_mode must be one of"):
+            pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment_model_mode="invalid",
+            )
+
+        sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
+        sim.experiment = None
+        assert sim._get_unified_experiment_model_blockers() == [
+            "no experiment is attached to the simulation"
+        ]
+        assert sim._experiment_can_use_unified_model() is False
+
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment([pybamm.step.BaseStep(1, duration=1)]),
+            solver=pybamm.IDAKLUSolver(),
+        )
+        assert sim._get_unified_experiment_model_blockers() == [
+            "unsupported experiment step type 'BaseStep'"
+        ]
+        assert sim._experiment_can_use_unified_model() is False
+
     def test_set_up_unified_preserves_voltage_safety_events(self):
         experiment = pybamm.Experiment(
             [
@@ -1329,6 +1353,20 @@ class TestSimulationExperiment:
         np.testing.assert_array_less(np.max(sol.cycles[0]["Time [s]"].data), 1800)
         np.testing.assert_array_equal(np.max(sol.cycles[1]["Time [s]"].data), 1800)
         assert len(sol.cycles) == 2
+
+    def test_run_experiment_termination_time_with_starting_solution_at_limit(self):
+        experiment = pybamm.Experiment(
+            [pybamm.step.string("Discharge at 0.5C for 10 seconds")],
+            termination="10 s",
+        )
+        sim = pybamm.Simulation(pybamm.lithium_ion.SPM(), experiment=experiment)
+
+        solution = sim.solve(calc_esoh=False)
+        resumed_solution = sim.solve(calc_esoh=False, starting_solution=solution.copy())
+
+        assert solution.termination == "experiment time limit reached"
+        assert resumed_solution.termination == "experiment time limit reached"
+        assert resumed_solution["Time [s]"].entries[-1] == pytest.approx(10)
 
     def test_save_at_cycles(self):
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -970,16 +970,9 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sim.build_for_experiment()
-        assert "Rest for padding" in sim.experiment_unique_steps_to_model.keys()
-        # Check at least there is an input parameter (temperature)
-        assert (
-            len(sim.experiment_unique_steps_to_model["Rest for padding"].parameters) > 0
-        )
-        # Check the model is the same
-        assert isinstance(
-            sim.experiment_unique_steps_to_model["Rest for padding"],
-            pybamm.lithium_ion.SPM,
-        )
+        assert sim._experiment_uses_unified_model
+        assert "Rest for padding" not in sim.experiment_unique_steps_to_model.keys()
+        assert sim._experiment_includes_padding_rest
 
     def test_run_start_time_experiment(self):
         model = pybamm.lithium_ion.SPM()
@@ -998,6 +991,7 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sol = sim.solve(calc_esoh=False)
+        assert sim._experiment_uses_unified_model
         assert sol["Time [s]"].entries[-1] == 5400
 
         # Test padding rest is added if time stamp is late
@@ -1014,6 +1008,33 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sol = sim.solve(calc_esoh=False)
+        assert sim._experiment_uses_unified_model
+        assert sol["Time [s]"].entries[-1] == 10800
+
+    def test_run_start_time_experiment_forced_unified(self):
+        model = pybamm.lithium_ion.SPM()
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.string(
+                    "Discharge at 0.5C for 1 hour",
+                    start_time=datetime(2023, 1, 1, 8, 0, 0),
+                ),
+                pybamm.step.string(
+                    "Rest for 1 hour", start_time=datetime(2023, 1, 1, 10, 0, 0)
+                ),
+            ]
+        )
+
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            experiment_model_mode="unified",
+        )
+        sol = sim.solve(calc_esoh=False)
+
+        assert sim._experiment_uses_unified_model
+        assert "Rest for padding" not in sim.steps_to_built_models
+        assert sim._experiment_includes_padding_rest
         assert sol["Time [s]"].entries[-1] == 10800
 
     def test_starting_solution(self):
@@ -1134,8 +1155,13 @@ class TestSimulationExperiment:
         # Check that there are only 2 unique steps
         assert len(sim.experiment.unique_steps) == 2
 
-        # Check that there are only 3 built models (unique steps + padding rest)
-        assert len(sim.steps_to_built_models) == 3
+        if sim._experiment_uses_unified_model:
+            assert len(sim.steps_to_built_models) == 2
+            assert len(set(sim.steps_to_built_models.values())) == 1
+            assert "Rest for padding" not in sim.steps_to_built_models
+        else:
+            # Check that there are only 3 built models (unique steps + padding rest)
+            assert len(sim.steps_to_built_models) == 3
 
     def test_experiment_custom_steps(self, subtests):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -16,6 +16,24 @@ class ShortDurationCRate(pybamm.step.CRate):
 
 
 class TestSimulationExperiment:
+    @staticmethod
+    def _make_differential_custom_step_simulation(**simulation_kwargs):
+        def custom_step_voltage(variables):
+            return 100 * (variables["Voltage [V]"] - 4.2)
+
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.CustomStepImplicit(
+                    custom_step_voltage, control="differential", duration=100, period=10
+                )
+            ]
+        )
+        return pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            **simulation_kwargs,
+        )
+
     def test_set_up(self):
         experiment = pybamm.Experiment(
             [
@@ -158,6 +176,25 @@ class TestSimulationExperiment:
         )
 
         with pytest.raises(pybamm.ModelError, match="DAE-capable solver"):
+            sim.build_for_experiment()
+
+    def test_set_up_differential_custom_step_falls_back_to_legacy(self):
+        sim = self._make_differential_custom_step_simulation(
+            solver=pybamm.IDAKLUSolver()
+        )
+        sim.build_for_experiment()
+
+        assert not sim._experiment_uses_unified_model
+
+    def test_set_up_unified_mode_rejects_differential_custom_step(self):
+        sim = self._make_differential_custom_step_simulation(
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        with pytest.raises(
+            pybamm.ModelError, match="differential control is not supported"
+        ):
             sim.build_for_experiment()
 
     def test_experiment_state_mappers_built(self):
@@ -310,6 +347,158 @@ class TestSimulationExperiment:
         )
         np.testing.assert_array_equal(
             sol.cycles[0].steps[2]["Ambient temperature [C]"].data[0], -14
+        )
+
+    def test_run_mixed_control_experiment_unified_single_model(self):
+        s = pybamm.step.string
+        experiment = pybamm.Experiment(
+            [
+                (
+                    s("Discharge at C/20 for 20 minutes"),
+                    s("Charge at 1 A for 10 minutes"),
+                    s("Hold at 4.1 V for 10 minutes"),
+                    "Discharge at 2 W for 10 minutes",
+                    "Discharge at 4 Ohm for 10 minutes",
+                )
+            ]
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8),
+            experiment_model_mode="unified",
+        )
+
+        sim.build_for_experiment()
+        assert sim._experiment_uses_unified_model
+        assert len(set(sim.steps_to_built_models.values())) == 1
+
+        sol = sim.solve(calc_esoh=False)
+
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[0]["C-rate"].data, 1 / 20, rtol=1e-7, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[1]["Current [A]"].data, -1, rtol=1e-7, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[2]["Voltage [V]"].data, 4.1, rtol=1e-6, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[3]["Power [W]"].data, 2, rtol=3e-4, atol=3e-4
+        )
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[4]["Resistance [Ohm]"].data, 4, rtol=2e-4, atol=6e-4
+        )
+
+    def test_run_mixed_control_experiment_unified_matches_legacy(self):
+        s = pybamm.step.string
+        experiment = pybamm.Experiment(
+            [
+                (
+                    s("Discharge at C/20 for 20 minutes"),
+                    s("Charge at 1 A for 10 minutes"),
+                    s("Hold at 4.1 V for 10 minutes"),
+                    "Discharge at 2 W for 10 minutes",
+                    "Discharge at 4 Ohm for 10 minutes",
+                )
+            ]
+        )
+
+        legacy_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+        unified_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        legacy_sol = legacy_sim.solve(calc_esoh=False)
+        unified_sol = unified_sim.solve(calc_esoh=False)
+
+        assert not legacy_sim._experiment_uses_unified_model
+        assert unified_sim._experiment_uses_unified_model
+
+        legacy_steps = legacy_sol.cycles[0].steps
+        unified_steps = unified_sol.cycles[0].steps
+        assert len(legacy_steps) == len(unified_steps)
+
+        for legacy_step, unified_step in zip(legacy_steps, unified_steps, strict=True):
+            assert legacy_step.termination == unified_step.termination
+            np.testing.assert_allclose(
+                legacy_step.t[-1], unified_step.t[-1], rtol=1e-8, atol=1e-8
+            )
+            np.testing.assert_allclose(
+                legacy_step["Voltage [V]"].data[-1],
+                unified_step["Voltage [V]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+            np.testing.assert_allclose(
+                legacy_step["Current [A]"].data[-1],
+                unified_step["Current [A]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+
+        np.testing.assert_allclose(
+            legacy_sol["Discharge capacity [A.h]"].data[-1],
+            unified_sol["Discharge capacity [A.h]"].data[-1],
+            rtol=5e-5,
+            atol=5e-5,
+        )
+
+    def test_run_event_driven_experiment_unified_matches_legacy(self):
+        experiment = pybamm.Experiment(
+            [("Charge at C/3 until 4.1 V", "Hold at 4.1 V until C/20")]
+        )
+
+        legacy_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+        unified_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        legacy_sol = legacy_sim.solve(calc_esoh=False, initial_soc=0.2)
+        unified_sol = unified_sim.solve(calc_esoh=False, initial_soc=0.2)
+
+        legacy_steps = legacy_sol.cycles[0].steps
+        unified_steps = unified_sol.cycles[0].steps
+        assert len(legacy_steps) == len(unified_steps) == 2
+
+        for legacy_step, unified_step in zip(legacy_steps, unified_steps, strict=True):
+            assert legacy_step.termination == unified_step.termination
+            np.testing.assert_allclose(
+                legacy_step.t[-1], unified_step.t[-1], rtol=5e-5, atol=5e-4
+            )
+            np.testing.assert_allclose(
+                legacy_step["Voltage [V]"].data[-1],
+                unified_step["Voltage [V]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+            np.testing.assert_allclose(
+                legacy_step["Current [A]"].data[-1],
+                unified_step["Current [A]"].data[-1],
+                rtol=5e-5,
+                atol=5e-5,
+            )
+
+        np.testing.assert_allclose(
+            legacy_sol.t[-1], unified_sol.t[-1], rtol=5e-5, atol=5e-4
         )
 
     def test_skip_ok(self):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -35,160 +35,21 @@ class TestSimulationExperiment:
             **simulation_kwargs,
         )
 
-    @staticmethod
-    def _make_composite_plating_parameter_values():
-        parameter_values = pybamm.ParameterValues("Chen2020_composite")
-
-        def graphite_plating_exchange_current_density(c_e, c_Li, T):
-            del c_Li, T
-            k_plating = pybamm.Parameter(
-                "Primary: Lithium plating kinetic rate constant [m.s-1]"
-            )
-            return pybamm.constants.F * k_plating * c_e
-
-        def graphite_stripping_exchange_current_density(c_e, c_Li, T):
-            del c_e, T
-            k_plating = pybamm.Parameter(
-                "Primary: Lithium plating kinetic rate constant [m.s-1]"
-            )
-            return pybamm.constants.F * k_plating * c_Li
-
-        def graphite_sei_limited_dead_lithium(L_sei):
-            gamma_0 = pybamm.Parameter("Primary: Dead lithium decay constant [s-1]")
-            L_inner_0 = pybamm.Parameter("Primary: Initial inner SEI thickness [m]")
-            L_outer_0 = pybamm.Parameter("Primary: Initial outer SEI thickness [m]")
-            return gamma_0 * (L_inner_0 + L_outer_0) / L_sei
-
-        def silicon_plating_exchange_current_density(c_e, c_Li, T):
-            del c_Li, T
-            k_plating = pybamm.Parameter(
-                "Secondary: Lithium plating kinetic rate constant [m.s-1]"
-            )
-            return pybamm.constants.F * k_plating * c_e
-
-        def silicon_stripping_exchange_current_density(c_e, c_Li, T):
-            del c_e, T
-            k_plating = pybamm.Parameter(
-                "Secondary: Lithium plating kinetic rate constant [m.s-1]"
-            )
-            return pybamm.constants.F * k_plating * c_Li
-
-        def silicon_sei_limited_dead_lithium(L_sei):
-            gamma_0 = pybamm.Parameter("Secondary: Dead lithium decay constant [s-1]")
-            L_inner_0 = pybamm.Parameter("Secondary: Initial inner SEI thickness [m]")
-            L_outer_0 = pybamm.Parameter("Secondary: Initial outer SEI thickness [m]")
-            return gamma_0 * (L_inner_0 + L_outer_0) / L_sei
-
-        parameter_values.update(
-            {
-                "Lithium metal partial molar volume [m3.mol-1]": 1.3e-05,
-                "Primary: Lithium plating kinetic rate constant [m.s-1]": 1e-09,
-                "Primary: Exchange-current density for plating [A.m-2]": (
-                    graphite_plating_exchange_current_density
-                ),
-                "Primary: Exchange-current density for stripping [A.m-2]": (
-                    graphite_stripping_exchange_current_density
-                ),
-                "Primary: Initial plated lithium concentration [mol.m-3]": 0.0,
-                "Primary: Typical plated lithium concentration [mol.m-3]": 1000.0,
-                "Primary: Lithium plating transfer coefficient": 0.65,
-                "Primary: Dead lithium decay constant [s-1]": 1e-06,
-                "Primary: Dead lithium decay rate [s-1]": (
-                    graphite_sei_limited_dead_lithium
-                ),
-                "Secondary: Lithium plating kinetic rate constant [m.s-1]": 1e-09,
-                "Secondary: Exchange-current density for plating [A.m-2]": (
-                    silicon_plating_exchange_current_density
-                ),
-                "Secondary: Exchange-current density for stripping [A.m-2]": (
-                    silicon_stripping_exchange_current_density
-                ),
-                "Secondary: Initial plated lithium concentration [mol.m-3]": 0.0,
-                "Secondary: Typical plated lithium concentration [mol.m-3]": 1000.0,
-                "Secondary: Lithium plating transfer coefficient": 0.65,
-                "Secondary: Dead lithium decay constant [s-1]": 1e-06,
-                "Secondary: Dead lithium decay rate [s-1]": (
-                    silicon_sei_limited_dead_lithium
-                ),
-                "Ambient temperature [K]": 268.15,
-                "Upper voltage cut-off [V]": 4.21,
-                "Lithium plating transfer coefficient": 0.5,
-                "Dead lithium decay constant [s-1]": 1e-4,
-                "Primary: Initial inner SEI thickness [m]": 5e-09,
-                "Primary: Initial outer SEI thickness [m]": 5e-09,
-                "Secondary: Initial inner SEI thickness [m]": 5e-09,
-                "Secondary: Initial outer SEI thickness [m]": 5e-09,
-            }
-        )
-        return parameter_values
-
-    @staticmethod
-    def _make_composite_plating_model():
-        return pybamm.lithium_ion.DFN(
-            {
-                "particle phases": ("2", "1"),
-                "open-circuit potential": (("single", "current sigmoid"), "single"),
-                "lithium plating": "reversible",
-            },
-            name="reversible",
-        )
-
-    def test_set_up(self):
-        experiment = pybamm.Experiment(
-            [
-                "Discharge at C/20 for 1 hour",
-                "Charge at 1 A until 4.1 V",
-                "Hold at 4.1 V until 50 mA",
-                "Discharge at 2 W until 3.5 V",
-            ]
-        )
-        for experiment_model_mode in ["legacy", "unified"]:
-            sim = pybamm.Simulation(
-                pybamm.lithium_ion.SPM(),
-                experiment=experiment,
-                solver=pybamm.IDAKLUSolver(),
-                experiment_model_mode=experiment_model_mode,
-            )
-            sim.build_for_experiment()
-
-            assert sim.experiment.args == experiment.args
-            steps = sim.experiment.steps
-
-            if experiment_model_mode == "legacy":
-                assert sim._built_experiment_model is None
-                assert sim._built_experiment_solver is None
-                model_I = sim.experiment_unique_steps_to_model[
-                    steps[1].basic_repr()
-                ]  # CC charge
-                model_V = sim.experiment_unique_steps_to_model[
-                    steps[2].basic_repr()
-                ]  # CV hold
-                assert "abs(Current [A]) < 0.05 [A] [experiment]" in [
-                    event.name for event in model_V.events
-                ]
-                assert "Voltage > 4.1 [V] [experiment]" in [
-                    event.name for event in model_I.events
-                ]
-            else:
-                assert sim._built_experiment_model is not None
-                assert sim._built_experiment_solver is not None
-                unified_model = sim.experiment_unique_steps_to_model[
-                    sim._experiment_unified_model_key
-                ]
-                assert sim._combined_step_termination_event_name in [
-                    event.name for event in unified_model.events
-                ]
-                assert len(set(sim.steps_to_built_models.values())) == 1
-
-        # fails if trying to set up with something that isn't an experiment
-        with pytest.raises(TypeError, match=r"experiment must be"):
-            pybamm.Simulation(pybamm.lithium_ion.SPM(), experiment=0)
-
     def test_unified_model_mode_validation_and_blockers(self):
         with pytest.raises(ValueError, match="experiment_model_mode must be one of"):
             pybamm.Simulation(
                 pybamm.lithium_ion.SPM(),
                 experiment_model_mode="invalid",
+            )
+        with pytest.raises(ValueError, match="experiment_model_mode must be one of"):
+            pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment_model_mode="auto",
+            )
+        with pytest.raises(ValueError, match="experiment_model_mode must be one of"):
+            pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment_model_mode="per-step",
             )
 
         sim = pybamm.Simulation(pybamm.lithium_ion.SPM())
@@ -300,6 +161,7 @@ class TestSimulationExperiment:
             model,
             experiment=experiment,
             solver=pybamm.CasadiSolver(),
+            experiment_model_mode="unified",
         )
         sim.build_for_experiment()
 
@@ -311,7 +173,7 @@ class TestSimulationExperiment:
         ]
         assert "Current variable [A]" in unified_model.variables
 
-    def test_set_up_all_explicit_falls_back_for_ode_solver(self):
+    def test_set_up_all_explicit_defaults_to_legacy_model(self):
         experiment = pybamm.Experiment(
             [
                 "Discharge at C/20 for 1 hour",
@@ -323,7 +185,7 @@ class TestSimulationExperiment:
         sim = pybamm.Simulation(
             model,
             experiment=experiment,
-            solver=pybamm.ScipySolver(),
+            solver=pybamm.CasadiSolver(),
         )
         sim.build_for_experiment()
 
@@ -426,44 +288,6 @@ class TestSimulationExperiment:
         ):
             sim.build_for_experiment()
 
-    def test_run_composite_plating_experiment_unified_keeps_rest_step(self):
-        parameter_values = self._make_composite_plating_parameter_values()
-        model = self._make_composite_plating_model()
-        discharge_experiment = pybamm.Experiment(
-            [("Discharge at C/20 until 2.5 V", "Rest for 1 hour")]
-        )
-        sim_discharge = pybamm.Simulation(
-            model,
-            parameter_values=parameter_values,
-            experiment=discharge_experiment,
-            solver=pybamm.IDAKLUSolver(),
-            experiment_model_mode="unified",
-        )
-        sol_discharge = sim_discharge.solve(calc_esoh=False)
-        model.set_initial_conditions_from(sol_discharge, inplace=True)
-
-        experiment = pybamm.Experiment(
-            [
-                (
-                    "Charge at 1C until 4.2 V",
-                    "Hold at 4.2 V until C/20",
-                    "Rest for 1 hour",
-                )
-            ]
-        )
-        sim = pybamm.Simulation(
-            model,
-            parameter_values=parameter_values,
-            experiment=experiment,
-            solver=pybamm.IDAKLUSolver(),
-            experiment_model_mode="unified",
-        )
-        sol = sim.solve(calc_esoh=False)
-
-        assert sim._experiment_uses_unified_model
-        assert len(sol.cycles[0].steps) == 3
-        assert sol.cycles[0].steps[-1].termination == "final time"
-
     def test_experiment_state_mappers_built(self):
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
@@ -484,15 +308,14 @@ class TestSimulationExperiment:
             if experiment_model_mode == "legacy":
                 assert (model_0, model_1) in sim.model_state_mappers
             else:
-                assert model_0 is model_1
-                assert (model_0, model_1) in sim.model_state_mappers
+                assert len(sim.model_state_mappers.values()) == 0
 
     def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
         )
         var_pts = {"x_n": 6, "x_s": 6, "x_p": 6, "r_n": 6, "r_p": 6, "y": 6, "z": 6}
-        for experiment_model_mode in ["legacy", "unified"]:
+        for experiment_model_mode in ["legacy"]:
             sim = pybamm.Simulation(
                 pybamm.lithium_ion.DFN(
                     {"current collector": "potential pair", "dimensionality": 2}
@@ -513,102 +336,6 @@ class TestSimulationExperiment:
                 assert model_0 is model_1
                 mapper = sim.model_state_mappers[(model_0, model_1)]
             assert mapper.shape[0] == model_1.len_rhs_and_alg
-
-    def test_unified_state_mapper_selects_control_initial_guess_with_step_index(
-        self,
-    ):
-        experiment = pybamm.Experiment(
-            [
-                pybamm.step.current(1.0, duration=600),
-                pybamm.step.voltage(4.1, duration=600),
-                pybamm.step.current(-2.0, duration=600),
-            ]
-        )
-        sim = pybamm.Simulation(
-            pybamm.lithium_ion.SPM(),
-            experiment=experiment,
-            solver=pybamm.CasadiSolver(),
-            experiment_model_mode="unified",
-        )
-        sim.build_for_experiment()
-
-        built_model = sim._built_experiment_model
-        mapper = sim._compiled_model_state_mappers[(built_model, built_model)][0]
-        current_variable = next(
-            variable
-            for variable in built_model.y_slices
-            if variable.name == "Current variable [A]"
-        )
-        current_slice = built_model.y_slices[current_variable][0]
-        current_scale = float(current_variable.scale.evaluate())
-        current_reference = float(current_variable.reference.evaluate())
-        y_from = np.zeros(built_model.len_rhs_and_alg)
-        y_from[current_slice] = (0.3 - current_reference) / current_scale
-
-        def mapped_current(active_step_index):
-            inputs = sim._build_unified_experiment_inputs(
-                {},
-                active_step_index,
-                start_time=0.0,
-                temperature=sim._parameter_values["Ambient temperature [K]"],
-            )
-            ordered_inputs = pybamm.BaseSolver._set_up_model_inputs(built_model, inputs)
-            p_stacked = casadi.vertcat(*ordered_inputs.values())
-            mapped = mapper(0.0, y_from, p_stacked)
-            mapped_state = float(mapped[current_slice].full().reshape(-1)[0])
-            return current_reference + current_scale * mapped_state
-
-        np.testing.assert_allclose(mapped_current(sim._experiment_step_indices[0]), 1.0)
-        np.testing.assert_allclose(mapped_current(sim._experiment_step_indices[1]), 0.3)
-        np.testing.assert_allclose(
-            mapped_current(sim._experiment_step_indices[2]), -2.0
-        )
-        assert sim._experiment_padding_rest_index is None
-
-    def test_unified_state_mapper_uses_zero_current_for_padding_rest(self):
-        start = datetime(2024, 1, 1, 12)
-        experiment = pybamm.Experiment(
-            [
-                (
-                    pybamm.step.current(1.0, duration=600, start_time=start),
-                    pybamm.step.voltage(4.1, duration=600),
-                )
-            ]
-        )
-        sim = pybamm.Simulation(
-            pybamm.lithium_ion.SPM(),
-            experiment=experiment,
-            solver=pybamm.CasadiSolver(),
-            experiment_model_mode="unified",
-        )
-        sim.build_for_experiment()
-
-        built_model = sim._built_experiment_model
-        mapper = sim._compiled_model_state_mappers[(built_model, built_model)][0]
-        current_variable = next(
-            variable
-            for variable in built_model.y_slices
-            if variable.name == "Current variable [A]"
-        )
-        current_slice = built_model.y_slices[current_variable][0]
-        current_scale = float(current_variable.scale.evaluate())
-        current_reference = float(current_variable.reference.evaluate())
-        y_from = np.zeros(built_model.len_rhs_and_alg)
-        y_from[current_slice] = (0.3 - current_reference) / current_scale
-
-        inputs = sim._build_unified_experiment_inputs(
-            {},
-            sim._experiment_padding_rest_index,
-            start_time=0.0,
-            temperature=sim._parameter_values["Ambient temperature [K]"],
-        )
-        ordered_inputs = pybamm.BaseSolver._set_up_model_inputs(built_model, inputs)
-        p_stacked = casadi.vertcat(*ordered_inputs.values())
-        mapped = mapper(0.0, y_from, p_stacked)
-        mapped_state = float(mapped[current_slice].full().reshape(-1)[0])
-        mapped_current = current_reference + current_scale * mapped_state
-
-        np.testing.assert_allclose(mapped_current, 0.0)
 
     def test_run_experiment(self):
         s = pybamm.step.string
@@ -715,6 +442,7 @@ class TestSimulationExperiment:
             model,
             experiment=experiment,
             solver=pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8),
+            experiment_model_mode="unified",
         )
         sol = sim.solve(calc_esoh=False)
 
@@ -1694,9 +1422,9 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sim.build_for_experiment()
-        assert sim._experiment_uses_unified_model
-        assert "Rest for padding" not in sim.experiment_unique_steps_to_model.keys()
-        assert sim._experiment_includes_padding_rest
+        assert not sim._experiment_uses_unified_model
+        assert "Rest for padding" in sim.experiment_unique_steps_to_model.keys()
+        assert not sim._experiment_includes_padding_rest
 
     def test_run_start_time_experiment(self):
         model = pybamm.lithium_ion.SPM()
@@ -1715,7 +1443,7 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sol = sim.solve(calc_esoh=False)
-        assert sim._experiment_uses_unified_model
+        assert not sim._experiment_uses_unified_model
         assert sol["Time [s]"].entries[-1] == 5400
 
         # Test padding rest is added if time stamp is late
@@ -1732,7 +1460,7 @@ class TestSimulationExperiment:
         )
         sim = pybamm.Simulation(model, experiment=experiment)
         sol = sim.solve(calc_esoh=False)
-        assert sim._experiment_uses_unified_model
+        assert not sim._experiment_uses_unified_model
         assert sol["Time [s]"].entries[-1] == 10800
 
     def test_run_start_time_experiment_forced_unified(self):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -281,6 +281,37 @@ class TestSimulationExperiment:
         assert len(sol3.cycles) == 2
         os.remove("test_experiment.sav")
 
+    def test_run_experiment_temperature_switching_unified(self):
+        s = pybamm.step.string
+        experiment = pybamm.Experiment(
+            [
+                (
+                    s("Discharge at C/20 for 10 minutes", temperature="30.5oC"),
+                    s("Charge at 1 A for 5 minutes", temperature="24oC"),
+                    "Rest for 5 minutes",
+                )
+            ],
+            temperature="-14oC",
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(atol=1e-8, rtol=1e-8),
+        )
+        sol = sim.solve(calc_esoh=False)
+
+        assert sim._experiment_uses_unified_model
+        np.testing.assert_array_equal(
+            sol.cycles[0].steps[0]["Ambient temperature [C]"].data[0], 30.5
+        )
+        np.testing.assert_array_equal(
+            sol.cycles[0].steps[1]["Ambient temperature [C]"].data[0], 24
+        )
+        np.testing.assert_array_equal(
+            sol.cycles[0].steps[2]["Ambient temperature [C]"].data[0], -14
+        )
+
     def test_skip_ok(self):
         model = pybamm.lithium_ion.SPMe()
         cc_charge_skip_ok = pybamm.step.Current(-5, termination="4.2 V")

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import datetime
+from types import SimpleNamespace
 
 import casadi
 import numpy as np
@@ -1684,6 +1685,124 @@ class TestSimulationExperiment:
         assert "Rest for padding" not in sim.steps_to_built_models
         assert sim._experiment_includes_padding_rest
         assert sol["Time [s]"].entries[-1] == 10800
+
+    def test_run_start_time_experiment_legacy_builds_padding_rest_mappers(self):
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.string(
+                    "Discharge at 0.5C for 1 hour",
+                    start_time=datetime(2023, 1, 1, 8, 0, 0),
+                ),
+                pybamm.step.string(
+                    "Rest for 1 hour", start_time=datetime(2023, 1, 1, 10, 0, 0)
+                ),
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+
+        sol = sim.solve(calc_esoh=False)
+
+        assert not sim._experiment_uses_unified_model
+        assert "Rest for padding" in sim.steps_to_built_models
+        assert sim._experiment_includes_padding_rest is False
+        assert sim.solution is sol
+        assert sol["Time [s]"].entries[-1] == 10800
+        assert sim.model_state_mappers
+        assert sim._compiled_model_state_mappers
+        rest_model = sim.steps_to_built_models["Rest for padding"]
+        step_models = [
+            sim.steps_to_built_models[step.basic_repr()]
+            for step in sim.experiment.steps
+        ]
+        assert any(
+            previous is rest_model or next_model is rest_model
+            for previous, next_model in sim.model_state_mappers
+        )
+        assert any(
+            (step_model, rest_model) in sim._compiled_model_state_mappers
+            or (rest_model, step_model) in sim._compiled_model_state_mappers
+            for step_model in step_models
+        )
+
+    def test_decode_combined_step_termination_handles_none_events_and_missing_t_event(
+        self,
+    ):
+        def neg_stoich_cutoff(variables):
+            return variables["Negative electrode stoichiometry"] - 0.5
+
+        custom_termination = pybamm.step.CustomTermination(
+            name="Negative stoichiometry cut-off", event_function=neg_stoich_cutoff
+        )
+        experiment = pybamm.Experiment(
+            [pybamm.step.c_rate(1, termination=custom_termination)]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            experiment_model_mode="unified",
+        )
+        sol = sim.solve(calc_esoh=False)
+
+        actual_step_solution = sol.cycles[0].steps[0]
+
+        class StepSolutionProxy:
+            def __init__(self, source):
+                self.source = source
+                self.termination = f"event: {sim._combined_step_termination_event_name}"
+                self.t_event = None
+                self.y_event = None
+                self.t = source.t
+                self.y = source.y
+                self.all_inputs = source.all_inputs
+
+            def __getitem__(self, key):
+                return self.source[key]
+
+        step_solution = StepSolutionProxy(actual_step_solution)
+
+        step = SimpleNamespace(
+            direction="rest",
+            termination=[pybamm.step.VoltageTermination(4.2), custom_termination],
+        )
+        decoded = sim._decode_combined_step_termination(
+            step_solution,
+            step,
+            sim._built_experiment_model,
+            step_solution.all_inputs[0],
+        )
+
+        assert decoded == "event: Negative stoichiometry cut-off [experiment]"
+
+    def test_decode_combined_step_termination_returns_original_when_no_events_match(
+        self,
+    ):
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(["Rest for 10 seconds"]),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        step_solution = pybamm.EmptySolution()
+        step_solution.termination = (
+            f"event: {sim._combined_step_termination_event_name}"
+        )
+        step = SimpleNamespace(
+            direction="rest", termination=[pybamm.step.VoltageTermination(4.2)]
+        )
+
+        decoded = sim._decode_combined_step_termination(
+            step_solution,
+            step,
+            sim._built_experiment_model,
+            {},
+        )
+
+        assert decoded == step_solution.termination
 
     def test_starting_solution(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -632,6 +632,7 @@ class TestSimulationExperiment:
         param["SEI kinetic rate constant [m.s-1]"] = 1e-14
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         sol = sim.solve()
+        assert sol.termination == "experiment capacity limit reached"
         C = sol.summary_variables["Capacity [A.h]"]
         np.testing.assert_array_less(np.diff(C), 0)
         # all but the last value should be above the termination condition
@@ -654,6 +655,7 @@ class TestSimulationExperiment:
         param["SEI kinetic rate constant [m.s-1]"] = 1e-14
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         sol = sim.solve()
+        assert sol.termination == "experiment capacity limit reached"
         C = sol.summary_variables["Capacity [A.h]"]
         # all but the last value should be above the termination condition
         np.testing.assert_array_less(5.04, C[:-1])
@@ -687,12 +689,13 @@ class TestSimulationExperiment:
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         # Test with calc_esoh=False here
         sol = sim.solve(calc_esoh=False)
+        assert sol.termination == "experiment voltage limit reached"
         # Only two cycles should be completed, only 2nd cycle should go below 4V
         np.testing.assert_array_less(4, np.min(sol.cycles[0]["Voltage [V]"].data))
         np.testing.assert_array_less(np.min(sol.cycles[1]["Voltage [V]"].data), 4)
         assert len(sol.cycles) == 2
 
-    def test_run_experiment_termination_time_min(self):
+    def test_run_experiment_termination_time_min(self, caplog):
         experiment = pybamm.Experiment(
             [
                 ("Discharge at 0.5C for 10 minutes", "Rest for 10 minutes"),
@@ -704,7 +707,10 @@ class TestSimulationExperiment:
         param = pybamm.ParameterValues("Chen2020")
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         # Test with calc_esoh=False here
-        sol = sim.solve(calc_esoh=False)
+        with caplog.at_level(logging.ERROR, logger="pybamm.logger"):
+            sol = sim.solve(calc_esoh=False)
+        assert sol.termination == "experiment time limit reached"
+        assert "Step time must be >0" not in caplog.text
         # Only two cycles should be completed, only 2nd cycle should go below 4V
         np.testing.assert_array_less(np.max(sol.cycles[0]["Time [s]"].data), 1500)
         np.testing.assert_array_equal(np.max(sol.cycles[1]["Time [s]"].data), 1500)
@@ -723,6 +729,7 @@ class TestSimulationExperiment:
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         # Test with calc_esoh=False here
         sol = sim.solve(calc_esoh=False)
+        assert sol.termination == "experiment time limit reached"
         # Only two cycles should be completed, only 2nd cycle should go below 4V
         np.testing.assert_array_less(np.max(sol.cycles[0]["Time [s]"].data), 1500)
         np.testing.assert_array_equal(np.max(sol.cycles[1]["Time [s]"].data), 1500)
@@ -741,6 +748,7 @@ class TestSimulationExperiment:
         sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         # Test with calc_esoh=False here
         sol = sim.solve(calc_esoh=False)
+        assert sol.termination == "experiment time limit reached"
         # Only two cycles should be completed, only 2nd cycle should go below 4V
         np.testing.assert_array_less(np.max(sol.cycles[0]["Time [s]"].data), 1800)
         np.testing.assert_array_equal(np.max(sol.cycles[1]["Time [s]"].data), 1800)

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -333,6 +333,35 @@ class TestSimulationExperiment:
         sol = sim.solve()
         assert sol.termination == "Event exceeded in initial conditions"
 
+    def test_skip_ok_with_multiple_infeasible_terminations_in_unified_model(self):
+        model = pybamm.lithium_ion.SPM()
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.Current(
+                    -5,
+                    termination=[(">", "current", -6), ("<", "current", -4)],
+                    skip_ok=True,
+                ),
+                pybamm.step.Voltage(4.2, termination="0.01 A", skip_ok=False),
+            ]
+        )
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.CasadiSolver(),
+            experiment_model_mode="unified",
+        )
+
+        sol = sim.solve(calc_esoh=False)
+
+        assert sim._experiment_uses_unified_model
+        assert len(sol.cycles) == 1
+        assert len(sol.cycles[0].steps) == 1
+        assert (
+            sol.cycles[0].steps[0].termination
+            == "event: abs(Current [A]) < 0.01 [A] [experiment]"
+        )
+
     def test_all_empty_solution_errors(self):
         model = pybamm.lithium_ion.SPM()
         parameter_values = pybamm.ParameterValues("Chen2020")

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -920,6 +920,48 @@ class TestSimulationExperiment:
             atol=2e-3,
         )
 
+    def test_solve_with_sensitivity_list_ignores_internal_experiment_input(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 10 seconds",
+                "Charge at 1 A for 10 seconds",
+            ]
+        )
+        input_param_name = "Negative electrode active material volume fraction"
+        model = pybamm.lithium_ion.SPM()
+        input_param_value = model.default_parameter_values[input_param_name]
+
+        def make_sim():
+            model = pybamm.lithium_ion.SPM()
+            param = model.default_parameter_values
+            param.update({input_param_name: "[input]"})
+            return pybamm.Simulation(
+                model,
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                parameter_values=param,
+                experiment_model_mode="unified",
+            )
+
+        baseline = make_sim().solve(inputs={input_param_name: input_param_value})
+
+        internal_keys = set(baseline.all_inputs[0]) - {
+            input_param_name,
+            "Ambient temperature [K]",
+            "start time",
+        }
+        assert len(internal_keys) == 1
+        experiment_input_name = internal_keys.pop()
+
+        sol = make_sim().solve(
+            inputs={input_param_name: input_param_value},
+            calculate_sensitivities=[input_param_name, experiment_input_name],
+        )
+
+        sensitivity_keys = set(sol.sensitivities)
+        assert input_param_name in sensitivity_keys
+        assert experiment_input_name not in sensitivity_keys
+
     def test_run_experiment_drive_cycle(self):
         drive_cycle = np.array([np.arange(10), np.arange(10)]).T
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -266,17 +266,17 @@ class TestSimulationExperiment:
         assert step_inputs["start time"] == 123.0
         assert step_inputs["Experiment step weight 0"] == 0
         assert step_inputs["Experiment step weight 1"] == 1
-        assert step_inputs[sim._experiment_padding_rest_weight_name()] == 0
+        assert step_inputs[pybamm.step.Rest.padding_weight_input_name()] == 0
 
         padding_inputs = sim._build_unified_experiment_inputs(
             {},
-            sim._experiment_padding_rest_weight_name(),
+            pybamm.step.Rest.padding_weight_input_name(),
             start_time=0.0,
             temperature=300.0,
         )
         assert padding_inputs["Experiment step weight 0"] == 0
         assert padding_inputs["Experiment step weight 1"] == 0
-        assert padding_inputs[sim._experiment_padding_rest_weight_name()] == 1
+        assert padding_inputs[pybamm.step.Rest.padding_weight_input_name()] == 1
 
     def test_setup_experiment_string_or_list(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -72,6 +72,94 @@ class TestSimulationExperiment:
         sim.build_for_experiment()
         assert len(sim.experiment.steps) == 2
 
+    def test_set_up_all_explicit_uses_unified_model_with_dae_solver(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Rest for 10 minutes",
+                "Charge at 1 A for 20 minutes",
+            ]
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.CasadiSolver(),
+        )
+        sim.build_for_experiment()
+
+        assert sim._experiment_uses_unified_model
+        assert len(set(sim.steps_to_built_models.values())) == 1
+
+        unified_model = sim.experiment_unique_steps_to_model[
+            sim._experiment_unified_model_key
+        ]
+        assert "Current variable [A]" in unified_model.variables
+
+    def test_set_up_all_explicit_falls_back_for_ode_solver(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Rest for 10 minutes",
+                "Charge at 1 A for 20 minutes",
+            ]
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.ScipySolver(),
+        )
+        sim.build_for_experiment()
+
+        assert not sim._experiment_uses_unified_model
+        assert len(set(sim.steps_to_built_models.values())) == len(
+            sim.experiment.unique_steps
+        )
+
+    def test_set_up_can_force_legacy_experiment_models(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Charge at 1 A until 4.1 V",
+                "Hold at 4.1 V until 50 mA",
+            ]
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.CasadiSolver(),
+            experiment_model_mode="legacy",
+        )
+        sim.build_for_experiment()
+
+        assert not sim._experiment_uses_unified_model
+        model_I = sim.experiment_unique_steps_to_model[
+            sim.experiment.steps[1].basic_repr()
+        ]
+        assert "Voltage > 4.1 [V] [experiment]" in [
+            event.name for event in model_I.events
+        ]
+
+    def test_set_up_unified_mode_rejects_all_explicit_ode_solver(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Rest for 10 minutes",
+            ]
+        )
+        model = pybamm.lithium_ion.SPM()
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            solver=pybamm.ScipySolver(),
+            experiment_model_mode="unified",
+        )
+
+        with pytest.raises(pybamm.ModelError, match="DAE-capable solver"):
+            sim.build_for_experiment()
+
     def test_experiment_state_mappers_built(self):
         model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -231,7 +231,7 @@ class TestSimulationExperiment:
         assert "Minimum voltage [V]" in event_names
         assert "Maximum voltage [V]" in event_names
 
-    def test_build_unified_experiment_inputs_uses_expected_one_hot_names(self):
+    def test_build_unified_experiment_inputs_uses_expected_step_index(self):
         start = datetime(2024, 1, 1, 12)
         experiment = pybamm.Experiment(
             [
@@ -249,34 +249,29 @@ class TestSimulationExperiment:
         )
         sim.build_for_experiment()
 
-        assert sim._experiment_step_weight_input_names == [
-            "Experiment step weight 0",
-            "Experiment step weight 1",
-        ]
+        assert sim._experiment_step_index_input_name() == "Experiment step index"
+        assert sim._experiment_step_indices == [1, 2]
+        assert sim._experiment_padding_rest_index == 3
         assert sim._experiment_includes_padding_rest
 
         step_inputs = sim._build_unified_experiment_inputs(
             {"user input": 7},
-            "Experiment step weight 1",
+            2,
             start_time=123.0,
             temperature=298.15,
         )
         assert step_inputs["user input"] == 7
         assert step_inputs["Ambient temperature [K]"] == 298.15
         assert step_inputs["start time"] == 123.0
-        assert step_inputs["Experiment step weight 0"] == 0
-        assert step_inputs["Experiment step weight 1"] == 1
-        assert step_inputs[pybamm.step.Rest.padding_weight_input_name()] == 0
+        assert step_inputs["Experiment step index"] == 2
 
         padding_inputs = sim._build_unified_experiment_inputs(
             {},
-            pybamm.step.Rest.padding_weight_input_name(),
+            sim._experiment_padding_rest_index,
             start_time=0.0,
             temperature=300.0,
         )
-        assert padding_inputs["Experiment step weight 0"] == 0
-        assert padding_inputs["Experiment step weight 1"] == 0
-        assert padding_inputs[pybamm.step.Rest.padding_weight_input_name()] == 1
+        assert padding_inputs["Experiment step index"] == 3
 
     def test_setup_experiment_string_or_list(self):
         model = pybamm.lithium_ion.SPM()
@@ -519,7 +514,7 @@ class TestSimulationExperiment:
                 mapper = sim.model_state_mappers[(model_0, model_1)]
             assert mapper.shape[0] == model_1.len_rhs_and_alg
 
-    def test_unified_state_mapper_selects_control_initial_guess_with_one_hot_weights(
+    def test_unified_state_mapper_selects_control_initial_guess_with_step_index(
         self,
     ):
         experiment = pybamm.Experiment(
@@ -550,10 +545,10 @@ class TestSimulationExperiment:
         y_from = np.zeros(built_model.len_rhs_and_alg)
         y_from[current_slice] = (0.3 - current_reference) / current_scale
 
-        def mapped_current(active_weight_name):
+        def mapped_current(active_step_index):
             inputs = sim._build_unified_experiment_inputs(
                 {},
-                active_weight_name,
+                active_step_index,
                 start_time=0.0,
                 temperature=sim._parameter_values["Ambient temperature [K]"],
             )
@@ -563,15 +558,57 @@ class TestSimulationExperiment:
             mapped_state = float(mapped[current_slice].full().reshape(-1)[0])
             return current_reference + current_scale * mapped_state
 
+        np.testing.assert_allclose(mapped_current(sim._experiment_step_indices[0]), 1.0)
+        np.testing.assert_allclose(mapped_current(sim._experiment_step_indices[1]), 0.3)
         np.testing.assert_allclose(
-            mapped_current(sim._experiment_step_weight_input_names[0]), 1.0
+            mapped_current(sim._experiment_step_indices[2]), -2.0
         )
-        np.testing.assert_allclose(
-            mapped_current(sim._experiment_step_weight_input_names[1]), 0.3
+        assert sim._experiment_padding_rest_index is None
+
+    def test_unified_state_mapper_uses_zero_current_for_padding_rest(self):
+        start = datetime(2024, 1, 1, 12)
+        experiment = pybamm.Experiment(
+            [
+                (
+                    pybamm.step.current(1.0, duration=600, start_time=start),
+                    pybamm.step.voltage(4.1, duration=600),
+                )
+            ]
         )
-        np.testing.assert_allclose(
-            mapped_current(sim._experiment_step_weight_input_names[2]), -2.0
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.CasadiSolver(),
+            experiment_model_mode="unified",
         )
+        sim.build_for_experiment()
+
+        built_model = sim._built_experiment_model
+        mapper = sim._compiled_model_state_mappers[(built_model, built_model)][0]
+        current_variable = next(
+            variable
+            for variable in built_model.y_slices
+            if variable.name == "Current variable [A]"
+        )
+        current_slice = built_model.y_slices[current_variable][0]
+        current_scale = float(current_variable.scale.evaluate())
+        current_reference = float(current_variable.reference.evaluate())
+        y_from = np.zeros(built_model.len_rhs_and_alg)
+        y_from[current_slice] = (0.3 - current_reference) / current_scale
+
+        inputs = sim._build_unified_experiment_inputs(
+            {},
+            sim._experiment_padding_rest_index,
+            start_time=0.0,
+            temperature=sim._parameter_values["Ambient temperature [K]"],
+        )
+        ordered_inputs = pybamm.BaseSolver._set_up_model_inputs(built_model, inputs)
+        p_stacked = casadi.vertcat(*ordered_inputs.values())
+        mapped = mapper(0.0, y_from, p_stacked)
+        mapped_state = float(mapped[current_slice].full().reshape(-1)[0])
+        mapped_current = current_reference + current_scale * mapped_state
+
+        np.testing.assert_allclose(mapped_current, 0.0)
 
     def test_run_experiment(self):
         s = pybamm.step.string

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1168,6 +1168,12 @@ class TestSimulationExperiment:
             rtol=5e-2,
             equal_nan=True,
         )
+        sensitivity_keys = set(solutions[1]["Voltage [V]"].sensitivities)
+        assert input_param_name in sensitivity_keys
+        assert (
+            pybamm.Simulation._experiment_step_index_input_name()
+            not in sensitivity_keys
+        )
 
         # use finite difference to check sensitivities
         t = solutions[0].t

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -43,38 +43,43 @@ class TestSimulationExperiment:
                 "Discharge at 2 W until 3.5 V",
             ]
         )
-        model = pybamm.lithium_ion.SPM()
-        sim = pybamm.Simulation(model, experiment=experiment)
-        sim.build_for_experiment()
+        for experiment_model_mode in ["legacy", "unified"]:
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=experiment_model_mode,
+            )
+            sim.build_for_experiment()
 
-        assert sim.experiment.args == experiment.args
-        steps = sim.experiment.steps
+            assert sim.experiment.args == experiment.args
+            steps = sim.experiment.steps
 
-        if sim._experiment_uses_unified_model:
-            unified_model = sim.experiment_unique_steps_to_model[
-                sim._experiment_unified_model_key
-            ]
-            assert sim._combined_step_termination_event_name in [
-                event.name for event in unified_model.events
-            ]
-            assert len(set(sim.steps_to_built_models.values())) == 1
-        else:
-            model_I = sim.experiment_unique_steps_to_model[
-                steps[1].basic_repr()
-            ]  # CC charge
-            model_V = sim.experiment_unique_steps_to_model[
-                steps[2].basic_repr()
-            ]  # CV hold
-            assert "abs(Current [A]) < 0.05 [A] [experiment]" in [
-                event.name for event in model_V.events
-            ]
-            assert "Voltage > 4.1 [V] [experiment]" in [
-                event.name for event in model_I.events
-            ]
+            if experiment_model_mode == "legacy":
+                model_I = sim.experiment_unique_steps_to_model[
+                    steps[1].basic_repr()
+                ]  # CC charge
+                model_V = sim.experiment_unique_steps_to_model[
+                    steps[2].basic_repr()
+                ]  # CV hold
+                assert "abs(Current [A]) < 0.05 [A] [experiment]" in [
+                    event.name for event in model_V.events
+                ]
+                assert "Voltage > 4.1 [V] [experiment]" in [
+                    event.name for event in model_I.events
+                ]
+            else:
+                unified_model = sim.experiment_unique_steps_to_model[
+                    sim._experiment_unified_model_key
+                ]
+                assert sim._combined_step_termination_event_name in [
+                    event.name for event in unified_model.events
+                ]
+                assert len(set(sim.steps_to_built_models.values())) == 1
 
         # fails if trying to set up with something that isn't an experiment
         with pytest.raises(TypeError, match=r"experiment must be"):
-            pybamm.Simulation(model, experiment=0)
+            pybamm.Simulation(pybamm.lithium_ion.SPM(), experiment=0)
 
     def test_set_up_unified_preserves_voltage_safety_events(self):
         experiment = pybamm.Experiment(
@@ -98,6 +103,53 @@ class TestSimulationExperiment:
 
         assert "Minimum voltage [V]" in event_names
         assert "Maximum voltage [V]" in event_names
+
+    def test_build_unified_experiment_inputs_uses_expected_one_hot_names(self):
+        start = datetime(2024, 1, 1, 12)
+        experiment = pybamm.Experiment(
+            [
+                (
+                    pybamm.step.Current(1, duration=600, start_time=start),
+                    pybamm.step.Voltage(4.1, duration=300),
+                )
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+
+        assert sim._experiment_step_weight_input_names == [
+            "Experiment step weight 0",
+            "Experiment step weight 1",
+        ]
+        assert sim._experiment_includes_padding_rest
+
+        step_inputs = sim._build_unified_experiment_inputs(
+            {"user input": 7},
+            "Experiment step weight 1",
+            start_time=123.0,
+            temperature=298.15,
+        )
+        assert step_inputs["user input"] == 7
+        assert step_inputs["Ambient temperature [K]"] == 298.15
+        assert step_inputs["start time"] == 123.0
+        assert step_inputs["Experiment step weight 0"] == 0
+        assert step_inputs["Experiment step weight 1"] == 1
+        assert step_inputs[sim._experiment_padding_rest_weight_name()] == 0
+
+        padding_inputs = sim._build_unified_experiment_inputs(
+            {},
+            sim._experiment_padding_rest_weight_name(),
+            start_time=0.0,
+            temperature=300.0,
+        )
+        assert padding_inputs["Experiment step weight 0"] == 0
+        assert padding_inputs["Experiment step weight 1"] == 0
+        assert padding_inputs[sim._experiment_padding_rest_weight_name()] == 1
 
     def test_setup_experiment_string_or_list(self):
         model = pybamm.lithium_ion.SPM()
@@ -221,37 +273,54 @@ class TestSimulationExperiment:
             sim.build_for_experiment()
 
     def test_experiment_state_mappers_built(self):
-        model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
         )
-        sim = pybamm.Simulation(model, experiment=experiment)
-        sim.build_for_experiment()
+        for experiment_model_mode in ["legacy", "unified"]:
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=experiment_model_mode,
+            )
+            sim.build_for_experiment()
 
-        steps = sim.experiment.steps
-        model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
-        model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
+            steps = sim.experiment.steps
+            model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
+            model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
 
-        key = (model_0, model_1)
-        assert key in sim.model_state_mappers
+            if experiment_model_mode == "legacy":
+                assert (model_0, model_1) in sim.model_state_mappers
+            else:
+                assert model_0 is model_1
+                assert sim.model_state_mappers == {}
 
     def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
-        model = pybamm.lithium_ion.DFN(
-            {"current collector": "potential pair", "dimensionality": 2}
-        )
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
         )
         var_pts = {"x_n": 6, "x_s": 6, "x_p": 6, "r_n": 6, "r_p": 6, "y": 6, "z": 6}
-        sim = pybamm.Simulation(model, experiment=experiment, var_pts=var_pts)
-        sim.build_for_experiment()
+        for experiment_model_mode in ["legacy", "unified"]:
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.DFN(
+                    {"current collector": "potential pair", "dimensionality": 2}
+                ),
+                experiment=experiment,
+                var_pts=var_pts,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=experiment_model_mode,
+            )
+            sim.build_for_experiment()
 
-        steps = sim.experiment.steps
-        model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
-        model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
-        mapper = sim.model_state_mappers[(model_0, model_1)]
-
-        assert mapper.shape[0] == model_1.len_rhs_and_alg
+            steps = sim.experiment.steps
+            model_0 = sim.steps_to_built_models[steps[0].basic_repr()]
+            model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
+            if experiment_model_mode == "legacy":
+                mapper = sim.model_state_mappers[(model_0, model_1)]
+                assert mapper.shape[0] == model_1.len_rhs_and_alg
+            else:
+                assert model_0 is model_1
+                assert sim.model_state_mappers == {}
 
     def test_run_experiment(self):
         s = pybamm.step.string
@@ -522,6 +591,55 @@ class TestSimulationExperiment:
 
         np.testing.assert_allclose(
             legacy_sol.t[-1], unified_sol.t[-1], rtol=5e-5, atol=5e-4
+        )
+
+    def test_run_multi_termination_step_unified_matches_legacy(self):
+        experiment = pybamm.Experiment(
+            [
+                (
+                    "Charge at 1 A until 4.1 V",
+                    pybamm.step.Voltage(4.1, termination=["0.5 A", "0.1 A"]),
+                )
+            ]
+        )
+
+        legacy_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+        unified_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        legacy_sol = legacy_sim.solve(calc_esoh=False, initial_soc=0.2)
+        unified_sol = unified_sim.solve(calc_esoh=False, initial_soc=0.2)
+
+        legacy_hold = legacy_sol.cycles[0].steps[1]
+        unified_hold = unified_sol.cycles[0].steps[1]
+
+        assert (
+            legacy_hold.termination == "event: abs(Current [A]) < 0.5 [A] [experiment]"
+        )
+        assert legacy_hold.termination == unified_hold.termination
+        np.testing.assert_allclose(
+            legacy_hold.t[-1], unified_hold.t[-1], rtol=5e-5, atol=5e-4
+        )
+        np.testing.assert_allclose(
+            legacy_hold["Current [A]"].data[-1],
+            unified_hold["Current [A]"].data[-1],
+            rtol=5e-5,
+            atol=5e-5,
+        )
+        np.testing.assert_allclose(
+            legacy_hold["Voltage [V]"].data[-1],
+            unified_hold["Voltage [V]"].data[-1],
+            rtol=5e-5,
+            atol=5e-5,
         )
 
     def test_run_unified_resistance_branch_is_safe_when_inactive_at_zero_current(self):
@@ -1179,7 +1297,6 @@ class TestSimulationExperiment:
             )
 
     def test_skipped_step_continuous(self):
-        model = pybamm.lithium_ion.SPM({"SEI": "solvent-diffusion limited"})
         experiment = pybamm.Experiment(
             [
                 ("Rest for 24 hours (1 hour period)",),
@@ -1190,14 +1307,49 @@ class TestSimulationExperiment:
                 ),
             ]
         )
-        sim = pybamm.Simulation(model, experiment=experiment)
-        sim.solve(initial_soc=1)
-        np.testing.assert_allclose(
-            sim.solution.cycles[0].last_state.y,
-            sim.solution.cycles[1].steps[-1].first_state.y,
-            atol=1e-15,
-            rtol=1e-15,
-        )
+        for experiment_model_mode in ["legacy", "unified"]:
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM({"SEI": "solvent-diffusion limited"}),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=experiment_model_mode,
+            )
+            sim.solve(initial_soc=1)
+            previous_state = sim.solution.cycles[0].last_state.y
+            next_state = sim.solution.cycles[1].steps[-1].first_state.y
+
+            if experiment_model_mode == "legacy":
+                np.testing.assert_allclose(
+                    previous_state,
+                    next_state,
+                    atol=1e-15,
+                    rtol=1e-15,
+                )
+            else:
+                # The unified path carries control-only algebraic states such as the
+                # current controller variable. Those can change when the active step
+                # changes, so here we only enforce continuity of the physical state.
+                built_model = sim.steps_to_built_models[
+                    sim.experiment.steps[0].basic_repr()
+                ]
+                control_state_indices = []
+                for variable in built_model.algebraic:
+                    if variable.name in {"Current variable [A]", "Voltage [V]"}:
+                        for state_slice in built_model.y_slices[variable]:
+                            control_state_indices.extend(
+                                range(state_slice.start, state_slice.stop)
+                            )
+                keep_indices = [
+                    i
+                    for i in range(previous_state.shape[0])
+                    if i not in control_state_indices
+                ]
+                np.testing.assert_allclose(
+                    previous_state[keep_indices],
+                    next_state[keep_indices],
+                    atol=1e-14,
+                    rtol=1e-14,
+                )
 
     def test_run_experiment_half_cell(self):
         experiment = pybamm.Experiment(
@@ -1393,8 +1545,6 @@ class TestSimulationExperiment:
     def test_experiment_start_time_identical_steps(self):
         # Test that if we have the same step twice, with different start times,
         # they get processed only once
-        model = pybamm.lithium_ion.SPM()
-
         experiment = pybamm.Experiment(
             [
                 pybamm.step.string(
@@ -1410,22 +1560,25 @@ class TestSimulationExperiment:
             ]
         )
 
-        sim = pybamm.Simulation(model, experiment=experiment)
-        sim.solve(calc_esoh=False)
-
-        # Check that there are 4 steps
         assert len(experiment.steps) == 4
 
-        # Check that there are only 2 unique steps
-        assert len(sim.experiment.unique_steps) == 2
+        for experiment_model_mode in ["legacy", "unified"]:
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=experiment_model_mode,
+            )
+            sim.solve(calc_esoh=False)
 
-        if sim._experiment_uses_unified_model:
-            assert len(sim.steps_to_built_models) == 2
-            assert len(set(sim.steps_to_built_models.values())) == 1
-            assert "Rest for padding" not in sim.steps_to_built_models
-        else:
-            # Check that there are only 3 built models (unique steps + padding rest)
-            assert len(sim.steps_to_built_models) == 3
+            assert len(sim.experiment.unique_steps) == 2
+
+            if experiment_model_mode == "legacy":
+                assert len(sim.steps_to_built_models) == 3
+            else:
+                assert len(sim.steps_to_built_models) == 2
+                assert len(set(sim.steps_to_built_models.values())) == 1
+                assert "Rest for padding" not in sim.steps_to_built_models
 
     def test_experiment_custom_steps(self, subtests):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -56,6 +56,8 @@ class TestSimulationExperiment:
             steps = sim.experiment.steps
 
             if experiment_model_mode == "legacy":
+                assert sim._built_experiment_model is None
+                assert sim._built_experiment_solver is None
                 model_I = sim.experiment_unique_steps_to_model[
                     steps[1].basic_repr()
                 ]  # CC charge
@@ -69,6 +71,8 @@ class TestSimulationExperiment:
                     event.name for event in model_I.events
                 ]
             else:
+                assert sim._built_experiment_model is not None
+                assert sim._built_experiment_solver is not None
                 unified_model = sim.experiment_unique_steps_to_model[
                     sim._experiment_unified_model_key
                 ]

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -34,6 +34,104 @@ class TestSimulationExperiment:
             **simulation_kwargs,
         )
 
+    @staticmethod
+    def _make_composite_plating_parameter_values():
+        parameter_values = pybamm.ParameterValues("Chen2020_composite")
+
+        def graphite_plating_exchange_current_density(c_e, c_Li, T):
+            del c_Li, T
+            k_plating = pybamm.Parameter(
+                "Primary: Lithium plating kinetic rate constant [m.s-1]"
+            )
+            return pybamm.constants.F * k_plating * c_e
+
+        def graphite_stripping_exchange_current_density(c_e, c_Li, T):
+            del c_e, T
+            k_plating = pybamm.Parameter(
+                "Primary: Lithium plating kinetic rate constant [m.s-1]"
+            )
+            return pybamm.constants.F * k_plating * c_Li
+
+        def graphite_sei_limited_dead_lithium(L_sei):
+            gamma_0 = pybamm.Parameter("Primary: Dead lithium decay constant [s-1]")
+            L_inner_0 = pybamm.Parameter("Primary: Initial inner SEI thickness [m]")
+            L_outer_0 = pybamm.Parameter("Primary: Initial outer SEI thickness [m]")
+            return gamma_0 * (L_inner_0 + L_outer_0) / L_sei
+
+        def silicon_plating_exchange_current_density(c_e, c_Li, T):
+            del c_Li, T
+            k_plating = pybamm.Parameter(
+                "Secondary: Lithium plating kinetic rate constant [m.s-1]"
+            )
+            return pybamm.constants.F * k_plating * c_e
+
+        def silicon_stripping_exchange_current_density(c_e, c_Li, T):
+            del c_e, T
+            k_plating = pybamm.Parameter(
+                "Secondary: Lithium plating kinetic rate constant [m.s-1]"
+            )
+            return pybamm.constants.F * k_plating * c_Li
+
+        def silicon_sei_limited_dead_lithium(L_sei):
+            gamma_0 = pybamm.Parameter("Secondary: Dead lithium decay constant [s-1]")
+            L_inner_0 = pybamm.Parameter("Secondary: Initial inner SEI thickness [m]")
+            L_outer_0 = pybamm.Parameter("Secondary: Initial outer SEI thickness [m]")
+            return gamma_0 * (L_inner_0 + L_outer_0) / L_sei
+
+        parameter_values.update(
+            {
+                "Lithium metal partial molar volume [m3.mol-1]": 1.3e-05,
+                "Primary: Lithium plating kinetic rate constant [m.s-1]": 1e-09,
+                "Primary: Exchange-current density for plating [A.m-2]": (
+                    graphite_plating_exchange_current_density
+                ),
+                "Primary: Exchange-current density for stripping [A.m-2]": (
+                    graphite_stripping_exchange_current_density
+                ),
+                "Primary: Initial plated lithium concentration [mol.m-3]": 0.0,
+                "Primary: Typical plated lithium concentration [mol.m-3]": 1000.0,
+                "Primary: Lithium plating transfer coefficient": 0.65,
+                "Primary: Dead lithium decay constant [s-1]": 1e-06,
+                "Primary: Dead lithium decay rate [s-1]": (
+                    graphite_sei_limited_dead_lithium
+                ),
+                "Secondary: Lithium plating kinetic rate constant [m.s-1]": 1e-09,
+                "Secondary: Exchange-current density for plating [A.m-2]": (
+                    silicon_plating_exchange_current_density
+                ),
+                "Secondary: Exchange-current density for stripping [A.m-2]": (
+                    silicon_stripping_exchange_current_density
+                ),
+                "Secondary: Initial plated lithium concentration [mol.m-3]": 0.0,
+                "Secondary: Typical plated lithium concentration [mol.m-3]": 1000.0,
+                "Secondary: Lithium plating transfer coefficient": 0.65,
+                "Secondary: Dead lithium decay constant [s-1]": 1e-06,
+                "Secondary: Dead lithium decay rate [s-1]": (
+                    silicon_sei_limited_dead_lithium
+                ),
+                "Ambient temperature [K]": 268.15,
+                "Upper voltage cut-off [V]": 4.21,
+                "Lithium plating transfer coefficient": 0.5,
+                "Dead lithium decay constant [s-1]": 1e-4,
+                "Primary: Initial inner SEI thickness [m]": 5e-09,
+                "Primary: Initial outer SEI thickness [m]": 5e-09,
+                "Secondary: Initial inner SEI thickness [m]": 5e-09,
+                "Secondary: Initial outer SEI thickness [m]": 5e-09,
+            }
+        )
+        return parameter_values
+
+    @staticmethod
+    def _make_composite_plating_model():
+        return pybamm.lithium_ion.DFN(
+            {
+                "particle phases": ("2", "1"),
+                "open-circuit potential": (("single", "current sigmoid"), "single"),
+                "lithium plating": "reversible",
+            },
+            name="reversible",
+        )
+
     def test_set_up(self):
         experiment = pybamm.Experiment(
             [
@@ -276,6 +374,44 @@ class TestSimulationExperiment:
         ):
             sim.build_for_experiment()
 
+    def test_run_composite_plating_experiment_unified_keeps_rest_step(self):
+        parameter_values = self._make_composite_plating_parameter_values()
+        model = self._make_composite_plating_model()
+        discharge_experiment = pybamm.Experiment(
+            [("Discharge at C/20 until 2.5 V", "Rest for 1 hour")]
+        )
+        sim_discharge = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            experiment=discharge_experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sol_discharge = sim_discharge.solve(calc_esoh=False)
+        model.set_initial_conditions_from(sol_discharge, inplace=True)
+
+        experiment = pybamm.Experiment(
+            [
+                (
+                    "Charge at 1C until 4.2 V",
+                    "Hold at 4.2 V until C/20",
+                    "Rest for 1 hour",
+                )
+            ]
+        )
+        sim = pybamm.Simulation(
+            model,
+            parameter_values=parameter_values,
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sol = sim.solve(calc_esoh=False)
+
+        assert sim._experiment_uses_unified_model
+        assert len(sol.cycles[0].steps) == 3
+        assert sol.cycles[0].steps[-1].termination == "final time"
+
     def test_experiment_state_mappers_built(self):
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]
@@ -297,7 +433,7 @@ class TestSimulationExperiment:
                 assert (model_0, model_1) in sim.model_state_mappers
             else:
                 assert model_0 is model_1
-                assert sim.model_state_mappers == {}
+                assert (model_0, model_1) in sim.model_state_mappers
 
     def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
         experiment = pybamm.Experiment(
@@ -321,10 +457,64 @@ class TestSimulationExperiment:
             model_1 = sim.steps_to_built_models[steps[1].basic_repr()]
             if experiment_model_mode == "legacy":
                 mapper = sim.model_state_mappers[(model_0, model_1)]
-                assert mapper.shape[0] == model_1.len_rhs_and_alg
             else:
                 assert model_0 is model_1
-                assert sim.model_state_mappers == {}
+                mapper = sim.model_state_mappers[(model_0, model_1)]
+            assert mapper.shape[0] == model_1.len_rhs_and_alg
+
+    def test_unified_state_mapper_selects_control_initial_guess_with_one_hot_weights(
+        self,
+    ):
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.current(1.0, duration=600),
+                pybamm.step.voltage(4.1, duration=600),
+                pybamm.step.current(-2.0, duration=600),
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.CasadiSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+
+        built_model = sim._built_experiment_model
+        mapper = sim._compiled_model_state_mappers[(built_model, built_model)][0]
+        current_variable = next(
+            variable
+            for variable in built_model.y_slices
+            if variable.name == "Current variable [A]"
+        )
+        current_slice = built_model.y_slices[current_variable][0]
+        current_scale = float(current_variable.scale.evaluate())
+        current_reference = float(current_variable.reference.evaluate())
+        y_from = np.zeros(built_model.len_rhs_and_alg)
+        y_from[current_slice] = (0.3 - current_reference) / current_scale
+
+        def mapped_current(active_weight_name):
+            inputs = sim._build_unified_experiment_inputs(
+                {},
+                active_weight_name,
+                start_time=0.0,
+                temperature=sim._parameter_values["Ambient temperature [K]"],
+            )
+            ordered_inputs = pybamm.BaseSolver._set_up_model_inputs(built_model, inputs)
+            p_stacked = casadi.vertcat(*ordered_inputs.values())
+            mapped = mapper(0.0, y_from, p_stacked)
+            mapped_state = float(mapped[current_slice].full().reshape(-1)[0])
+            return current_reference + current_scale * mapped_state
+
+        np.testing.assert_allclose(
+            mapped_current(sim._experiment_step_weight_input_names[0]), 1.0
+        )
+        np.testing.assert_allclose(
+            mapped_current(sim._experiment_step_weight_input_names[1]), 0.3
+        )
+        np.testing.assert_allclose(
+            mapped_current(sim._experiment_step_weight_input_names[2]), -2.0
+        )
 
     def test_run_experiment(self):
         s = pybamm.step.string

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -2024,7 +2024,8 @@ class TestSimulationExperiment:
         neg_stoich = sol["Negative electrode stoichiometry"].data
         assert neg_stoich[-1] == pytest.approx(0.5, abs=0.0001)
 
-    def test_simulation_changing_capacity_crate_steps(self):
+    @pytest.mark.parametrize("experiment_model_mode", ["legacy", "unified"])
+    def test_simulation_changing_capacity_crate_steps(self, experiment_model_mode):
         """Test that C-rate steps are correctly updated when capacity changes"""
         model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment(
@@ -2037,7 +2038,12 @@ class TestSimulationExperiment:
             ]
         )
         param = pybamm.ParameterValues("Chen2020")
-        sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            parameter_values=param,
+            experiment_model_mode=experiment_model_mode,
+        )
 
         # First solve
         sol1 = sim.solve(calc_esoh=False)
@@ -2073,14 +2079,22 @@ class TestSimulationExperiment:
         np.testing.assert_allclose(I_C2_2 / I_C2_1, 0.9, rtol=1e-2)
         np.testing.assert_allclose(I_1C_2 / I_1C_1, 0.9, rtol=1e-2)
 
-    def test_simulation_multiple_cycles_with_capacity_change(self):
+    @pytest.mark.parametrize("experiment_model_mode", ["legacy", "unified"])
+    def test_simulation_multiple_cycles_with_capacity_change(
+        self, experiment_model_mode
+    ):
         """Test capacity changes across multiple experiment cycles"""
         model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment(
             [("Discharge at 1C for 5 minutes", "Charge at 1C for 5 minutes")] * 2
         )
         param = pybamm.ParameterValues("Chen2020")
-        sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            parameter_values=param,
+            experiment_model_mode=experiment_model_mode,
+        )
 
         # First solve
         sol1 = sim.solve(calc_esoh=False)
@@ -2112,12 +2126,20 @@ class TestSimulationExperiment:
         np.testing.assert_allclose(I_discharge_cycle1_new, new_capacity, rtol=1e-2)
         np.testing.assert_allclose(I_discharge_cycle2_new, new_capacity, rtol=1e-2)
 
-    def test_simulation_logging_with_capacity_change(self, caplog):
+    @pytest.mark.parametrize("experiment_model_mode", ["legacy", "unified"])
+    def test_simulation_logging_with_capacity_change(
+        self, caplog, experiment_model_mode
+    ):
         """Test that capacity changes are logged appropriately"""
         model = pybamm.lithium_ion.SPM()
         experiment = pybamm.Experiment([("Discharge at 1C for 10 minutes",)])
         param = pybamm.ParameterValues("Chen2020")
-        sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            parameter_values=param,
+            experiment_model_mode=experiment_model_mode,
+        )
 
         # First solve
         sim.solve(calc_esoh=False)

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -32,16 +32,27 @@ class TestSimulationExperiment:
         assert sim.experiment.args == experiment.args
         steps = sim.experiment.steps
 
-        model_I = sim.experiment_unique_steps_to_model[
-            steps[1].basic_repr()
-        ]  # CC charge
-        model_V = sim.experiment_unique_steps_to_model[steps[2].basic_repr()]  # CV hold
-        assert "abs(Current [A]) < 0.05 [A] [experiment]" in [
-            event.name for event in model_V.events
-        ]
-        assert "Voltage > 4.1 [V] [experiment]" in [
-            event.name for event in model_I.events
-        ]
+        if sim._experiment_uses_unified_model:
+            unified_model = sim.experiment_unique_steps_to_model[
+                sim._experiment_unified_model_key
+            ]
+            assert sim._combined_step_termination_event_name in [
+                event.name for event in unified_model.events
+            ]
+            assert len(set(sim.steps_to_built_models.values())) == 1
+        else:
+            model_I = sim.experiment_unique_steps_to_model[
+                steps[1].basic_repr()
+            ]  # CC charge
+            model_V = sim.experiment_unique_steps_to_model[
+                steps[2].basic_repr()
+            ]  # CV hold
+            assert "abs(Current [A]) < 0.05 [A] [experiment]" in [
+                event.name for event in model_V.events
+            ]
+            assert "Voltage > 4.1 [V] [experiment]" in [
+                event.name for event in model_I.events
+            ]
 
         # fails if trying to set up with something that isn't an experiment
         with pytest.raises(TypeError, match=r"experiment must be"):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -76,6 +76,29 @@ class TestSimulationExperiment:
         with pytest.raises(TypeError, match=r"experiment must be"):
             pybamm.Simulation(model, experiment=0)
 
+    def test_set_up_unified_preserves_voltage_safety_events(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Charge at 1 A until 4.1 V",
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+
+        unified_model = sim.experiment_unique_steps_to_model[
+            sim._experiment_unified_model_key
+        ]
+        event_names = [event.name for event in unified_model.events]
+
+        assert "Minimum voltage [V]" in event_names
+        assert "Maximum voltage [V]" in event_names
+
     def test_setup_experiment_string_or_list(self):
         model = pybamm.lithium_ion.SPM()
 
@@ -499,6 +522,27 @@ class TestSimulationExperiment:
 
         np.testing.assert_allclose(
             legacy_sol.t[-1], unified_sol.t[-1], rtol=5e-5, atol=5e-4
+        )
+
+    def test_run_unified_resistance_branch_is_safe_when_inactive_at_zero_current(self):
+        experiment = pybamm.Experiment(
+            [("Rest for 5 minutes", "Discharge at 4 Ohm for 5 minutes")]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        sol = sim.solve(calc_esoh=False)
+
+        assert sim._experiment_uses_unified_model
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[0]["Current [A]"].data, 0, atol=1e-10
+        )
+        np.testing.assert_allclose(
+            sol.cycles[0].steps[1]["Resistance [Ohm]"].data, 4, rtol=2e-4, atol=6e-4
         )
 
     def test_skip_ok(self):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -362,6 +362,38 @@ class TestSimulationExperiment:
             event.name for event in model_I.events
         ]
 
+    def test_build_for_experiment_legacy_processes_each_unique_step(self):
+        experiment = pybamm.Experiment(
+            [
+                "Discharge at C/20 for 1 hour",
+                "Charge at 1 A for 10 seconds",
+                "Discharge at C/20 for 1 hour",
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+
+        sim.build_for_experiment()
+
+        assert not sim._experiment_uses_unified_model
+        assert set(sim.steps_to_built_models) == set(
+            sim.experiment_unique_steps_to_model
+        )
+        assert set(sim.steps_to_built_solvers) == set(
+            sim.experiment_unique_steps_to_model
+        )
+        assert all(model.is_discretised for model in sim.steps_to_built_models.values())
+        assert all(
+            solver is not sim.solver for solver in sim.steps_to_built_solvers.values()
+        )
+        assert len(
+            {id(solver) for solver in sim.steps_to_built_solvers.values()}
+        ) == len(sim.steps_to_built_solvers)
+
     def test_set_up_unified_mode_rejects_all_explicit_ode_solver(self):
         experiment = pybamm.Experiment(
             [

--- a/tests/unit/test_expression_tree/test_conditional.py
+++ b/tests/unit/test_expression_tree/test_conditional.py
@@ -1,6 +1,7 @@
 import casadi
 import numpy as np
 import pytest
+import scipy.sparse
 
 import pybamm
 from pybamm.expression_tree.operations.serialise import (
@@ -101,6 +102,61 @@ class TestConditional:
         rebuilt = convert_symbol_from_json(json_data)
         assert isinstance(rebuilt, pybamm.Conditional)
         assert rebuilt.evaluate(inputs={"selector": 2}) == 2
+
+    def test_from_json_and_str(self):
+        selector = pybamm.InputParameter("selector")
+        expr = pybamm.Conditional._from_json(
+            {"children": [selector, pybamm.Scalar(1), pybamm.Scalar(2)]}
+        )
+
+        assert isinstance(expr, pybamm.Conditional)
+        assert str(expr) == "conditional(selector, 1.0, 2.0)"
+
+    def test_create_copy_validation_and_selector_must_be_scalar(self):
+        expr = pybamm.Conditional(
+            pybamm.InputParameter("selector"),
+            pybamm.Scalar(3),
+            pybamm.Scalar(4),
+        )
+
+        with pytest.raises(
+            ValueError, match="Conditional must have a selector and at least one branch"
+        ):
+            expr.create_copy([pybamm.Scalar(1)])
+
+        with pytest.raises(
+            ValueError, match="Conditional selector must evaluate to a scalar"
+        ):
+            expr._coerce_selector_value(np.array([1, 2]))
+
+    def test_zero_like_numeric_and_sparse_branch_shape(self):
+        assert pybamm.Conditional._zero_like(5) == 0
+
+        selector = pybamm.InputParameter("selector")
+        sparse_branch = pybamm.Matrix(scipy.sparse.csr_matrix([[1, 0], [0, 1]]))
+        expr = pybamm.Conditional(selector, sparse_branch)
+
+        shape = expr.evaluate_for_shape()
+        assert scipy.sparse.issparse(shape)
+        assert shape.shape == (2, 2)
+
+        out = expr.evaluate(inputs={"selector": 0})
+        assert scipy.sparse.issparse(out)
+        assert out.shape == (2, 2)
+        assert out.nnz == 0
+
+    def test_evaluates_on_edges(self):
+        expr_on_edges = pybamm.Conditional(
+            pybamm.Scalar(1),
+            pybamm.PrimaryBroadcastToEdges(pybamm.Scalar(1), ["negative electrode"]),
+        )
+        assert expr_on_edges.evaluates_on_edges("primary")
+
+        expr_not_on_edges = pybamm.Conditional(
+            pybamm.Scalar(1),
+            pybamm.PrimaryBroadcast(pybamm.Scalar(1), ["negative electrode"]),
+        )
+        assert not expr_not_on_edges.evaluates_on_edges("primary")
 
     def test_evaluator_python(self):
         selector = pybamm.InputParameter("selector")

--- a/tests/unit/test_expression_tree/test_conditional.py
+++ b/tests/unit/test_expression_tree/test_conditional.py
@@ -1,0 +1,135 @@
+import casadi
+import numpy as np
+import pytest
+
+import pybamm
+from pybamm.expression_tree.operations.serialise import (
+    convert_symbol_from_json,
+    convert_symbol_to_json,
+)
+
+
+class TestConditional:
+    def test_evaluate_scalar_branches(self):
+        selector = pybamm.InputParameter("selector")
+        expr = pybamm.Conditional(selector, pybamm.Scalar(3), pybamm.Scalar(7))
+
+        assert expr.evaluate(inputs={"selector": 1}) == 3
+        assert expr.evaluate(inputs={"selector": 2}) == 7
+        assert expr.evaluate(inputs={"selector": 0}) == 0
+        assert expr.evaluate(inputs={"selector": 0.5}) == 0
+        assert expr.evaluate(inputs={"selector": 1.5}) == 0
+
+    def test_evaluate_vector_branches_and_shape(self):
+        selector = pybamm.InputParameter("selector")
+        expr = pybamm.Conditional(
+            selector,
+            pybamm.Vector(np.array([1, 2])),
+            pybamm.Vector(np.array([3, 4])),
+        )
+
+        np.testing.assert_array_equal(
+            expr.evaluate(inputs={"selector": 2}),
+            np.array([[3], [4]]),
+        )
+        np.testing.assert_array_equal(
+            expr.evaluate(inputs={"selector": -1}),
+            np.zeros((2, 1)),
+        )
+        assert expr.shape == (2, 1)
+
+    def test_validation(self):
+        with pytest.raises(ValueError, match="at least one branch"):
+            pybamm.Conditional(pybamm.Scalar(1))
+
+        with pytest.raises(ValueError, match="selector must evaluate to a scalar"):
+            pybamm.Conditional(
+                pybamm.Vector(np.array([1, 2])),
+                pybamm.Scalar(1),
+            )
+
+        with pytest.raises(ValueError, match="must all have the same shape"):
+            pybamm.Conditional(
+                pybamm.Scalar(1),
+                pybamm.Scalar(1),
+                pybamm.Vector(np.array([1, 2])),
+            )
+
+        with pytest.raises(
+            pybamm.DomainError, match="children must have same or empty"
+        ):
+            pybamm.Conditional(
+                pybamm.Scalar(1),
+                pybamm.Variable("a", domain=["negative electrode"]),
+                pybamm.Variable("b", domain=["positive electrode"]),
+            )
+
+    def test_diff_and_jacobian(self):
+        x = pybamm.StateVector(slice(0, 1))
+        selector = pybamm.InputParameter("selector")
+        expr = pybamm.Conditional(selector, x**2, x**3)
+        deriv = expr.diff(x)
+
+        np.testing.assert_allclose(
+            deriv.evaluate(inputs={"selector": 1}, y=np.array([2.0])),
+            np.array([[4.0]]),
+        )
+        np.testing.assert_allclose(
+            deriv.evaluate(inputs={"selector": 2}, y=np.array([2.0])),
+            np.array([[12.0]]),
+        )
+
+        jac_expr = pybamm.Conditional(selector, x**2, x**3).jac(x)
+        np.testing.assert_allclose(
+            jac_expr.evaluate(inputs={"selector": 1}, y=np.array([2.0])),
+            np.array([[4.0]]),
+        )
+        np.testing.assert_allclose(
+            jac_expr.evaluate(inputs={"selector": 2}, y=np.array([2.0])),
+            np.array([[12.0]]),
+        )
+
+    def test_copy_equation_and_serialisation(self):
+        selector = pybamm.InputParameter("selector")
+        expr = pybamm.Conditional(selector, pybamm.Scalar(1), pybamm.Scalar(2))
+
+        copied = expr.create_copy()
+        assert copied == expr
+        assert str(expr.to_equation()) == "Conditional(selector, 1.0, 2.0)"
+
+        json_data = convert_symbol_to_json(expr)
+        rebuilt = convert_symbol_from_json(json_data)
+        assert isinstance(rebuilt, pybamm.Conditional)
+        assert rebuilt.evaluate(inputs={"selector": 2}) == 2
+
+    def test_evaluator_python(self):
+        selector = pybamm.InputParameter("selector")
+        a = pybamm.StateVector(slice(0, 1))
+        b = pybamm.StateVector(slice(1, 2))
+        expr = pybamm.Conditional(selector, a + b, a - b)
+
+        evaluator = pybamm.EvaluatorPython(expr)
+        y = np.array([5.0, 2.0])
+        np.testing.assert_allclose(
+            evaluator(y=y, inputs={"selector": 1}), np.array([[7.0]])
+        )
+        np.testing.assert_allclose(
+            evaluator(y=y, inputs={"selector": 2}), np.array([[3.0]])
+        )
+        np.testing.assert_allclose(evaluator(y=y, inputs={"selector": 0}), 0)
+
+    def test_to_casadi(self):
+        selector = pybamm.InputParameter("selector")
+        y = pybamm.StateVector(slice(0, 1))
+        expr = pybamm.Conditional(selector, 2 * y, 3 * y)
+
+        casadi_y = casadi.MX.sym("y", 1)
+        casadi_selector = casadi.MX.sym("selector")
+        casadi_expr = expr.to_casadi(y=casadi_y, inputs={"selector": casadi_selector})
+        f = casadi.Function("f", [casadi_y, casadi_selector], [casadi_expr])
+
+        np.testing.assert_allclose(np.array(f([4.0], 1.0)).reshape(-1), np.array([8.0]))
+        np.testing.assert_allclose(
+            np.array(f([4.0], 2.0)).reshape(-1), np.array([12.0])
+        )
+        np.testing.assert_allclose(np.array(f([4.0], 0.5)).reshape(-1), np.array([0.0]))

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -2814,6 +2814,7 @@ class TestExperimentSerialization:
         assert config["cycles"][0][0]["type"] == "rest"
         assert "value" not in config["cycles"][0][0]
         exp2 = pybamm.Experiment.from_config(config)
+        assert isinstance(exp2.steps[0], pybamm.step.Rest)
         assert exp2.steps[0].duration == 1800
 
     def test_multi_cycle_round_trip(self):

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -118,6 +118,89 @@ class TestSimulation:
         sim.solve([0, 600])
         sim.set_parameters()
 
+    def test_setstate_restores_unified_experiment_defaults(self):
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(["Discharge at 1C for 10 seconds"]),
+        )
+        state = sim.__dict__.copy()
+        for key in [
+            "model_state_mappers",
+            "_compiled_model_state_mappers",
+            "_built_experiment_model",
+            "_built_experiment_solver",
+            "experiment_unique_steps_to_model",
+            "_experiment_uses_unified_model",
+            "_experiment_unified_model_key",
+            "_experiment_step_weight_input_names",
+            "_experiment_includes_padding_rest",
+            "_combined_step_termination_event_name",
+            "_experiment_model_mode",
+        ]:
+            state.pop(key, None)
+
+        restored = pybamm.Simulation.__new__(pybamm.Simulation)
+        restored.__setstate__(state)
+
+        assert callable(restored.get_esoh_solver)
+        assert restored.model_state_mappers == {}
+        assert restored._compiled_model_state_mappers == {}
+        assert restored._built_experiment_model is None
+        assert restored._built_experiment_solver is None
+        assert restored.experiment_unique_steps_to_model is None
+        assert restored._experiment_uses_unified_model is False
+        assert restored._experiment_unified_model_key == "Unified experiment"
+        assert restored._experiment_step_weight_input_names == []
+        assert restored._experiment_includes_padding_rest is False
+        assert (
+            restored._combined_step_termination_event_name
+            == "Combined termination [experiment]"
+        )
+        assert restored._experiment_model_mode == "auto"
+
+    def test_build_unified_experiment_state_mapper_edge_cases(self):
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(["Discharge at 1C for 10 seconds"]),
+        )
+
+        scalar_model = pybamm.BaseModel()
+        scalar_variable = pybamm.Variable("y")
+        scalar_model.rhs = {scalar_variable: scalar_variable}
+        scalar_model.initial_conditions = {scalar_variable: 1}
+        scalar_built_model = pybamm.Discretisation().process_model(
+            scalar_model, inplace=False
+        )
+
+        expected_mapper = scalar_built_model.build_initial_state_mapper(
+            scalar_built_model
+        )
+        actual_mapper = sim._build_unified_experiment_state_mapper(scalar_built_model)
+        np.testing.assert_allclose(
+            actual_mapper.evaluate(y=np.array([3.0])),
+            expected_mapper.evaluate(y=np.array([3.0])),
+        )
+
+        vector_model = pybamm.BaseModel()
+        current_variable = pybamm.Variable(
+            "Current variable [A]", domain="negative electrode"
+        )
+        vector_model.rhs = {current_variable: current_variable}
+        vector_model.initial_conditions = {current_variable: 1}
+        vector_built_model = pybamm.Discretisation(
+            pybamm.Mesh(
+                {"negative electrode": {"x_n": {"min": 0, "max": 1}}},
+                {"negative electrode": pybamm.Uniform1DSubMesh},
+                {"x_n": 2},
+            ),
+            {"negative electrode": pybamm.FiniteVolume()},
+        ).process_model(vector_model, inplace=False)
+
+        with pytest.raises(
+            pybamm.ModelError, match="expects a scalar current-control state"
+        ):
+            sim._build_unified_experiment_state_mapper(vector_built_model)
+
     def test_set_crate(self):
         model = pybamm.lithium_ion.SPM()
         current_1C = model.default_parameter_values["Current function [A]"]
@@ -773,6 +856,29 @@ class TestSimulation:
             while abs(sim.solution.t[i] - t) < 1e-6:
                 i += 1
                 assert i < len(sim.solution.t)
+
+    def test_drive_cycle_t_eval_warnings_for_missing_points_and_resolution(self):
+        model = pybamm.lithium_ion.SPM()
+        param = model.default_parameter_values
+        drive_cycle = np.array([[0.0, 0.0], [1.0, 0.5], [2.0, -0.5]])
+        param["Current function [A]"] = pybamm.Interpolant(
+            drive_cycle[:, 0], drive_cycle[:, 1], pybamm.t
+        )
+        sim = pybamm.Simulation(
+            model, parameter_values=param, solver=pybamm.ScipySolver()
+        )
+
+        with pytest.warns(pybamm.SolverWarning) as warnings_record:
+            sim.solve(t_eval=np.array([0.0, 2.0]))
+
+        warning_messages = [str(warning.message) for warning in warnings_record]
+        assert any(
+            "t_eval does not contain all of the time points in the data" in message
+            for message in warning_messages
+        )
+        assert any(
+            "largest timestep in t_eval" in message for message in warning_messages
+        )
 
     # Test with an ODE and DAE model
     @pytest.mark.parametrize(

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -132,7 +132,8 @@ class TestSimulation:
             "experiment_unique_steps_to_model",
             "_experiment_uses_unified_model",
             "_experiment_unified_model_key",
-            "_experiment_step_weight_input_names",
+            "_experiment_step_indices",
+            "_experiment_padding_rest_index",
             "_experiment_includes_padding_rest",
             "_combined_step_termination_event_name",
             "_experiment_model_mode",
@@ -150,7 +151,9 @@ class TestSimulation:
         assert restored.experiment_unique_steps_to_model is None
         assert restored._experiment_uses_unified_model is False
         assert restored._experiment_unified_model_key == "Unified experiment"
-        assert restored._experiment_step_weight_input_names == []
+        assert restored._experiment_step_index_input_name() == "Experiment step index"
+        assert restored._experiment_step_indices == []
+        assert restored._experiment_padding_rest_index is None
         assert restored._experiment_includes_padding_rest is False
         assert (
             restored._combined_step_termination_event_name

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -159,50 +159,7 @@ class TestSimulation:
             restored._combined_step_termination_event_name
             == "Combined termination [experiment]"
         )
-        assert restored._experiment_model_mode == "auto"
-
-    def test_build_unified_experiment_state_mapper_edge_cases(self):
-        sim = pybamm.Simulation(
-            pybamm.lithium_ion.SPM(),
-            experiment=pybamm.Experiment(["Discharge at 1C for 10 seconds"]),
-        )
-
-        scalar_model = pybamm.BaseModel()
-        scalar_variable = pybamm.Variable("y")
-        scalar_model.rhs = {scalar_variable: scalar_variable}
-        scalar_model.initial_conditions = {scalar_variable: 1}
-        scalar_built_model = pybamm.Discretisation().process_model(
-            scalar_model, inplace=False
-        )
-
-        expected_mapper = scalar_built_model.build_initial_state_mapper(
-            scalar_built_model
-        )
-        actual_mapper = sim._build_unified_experiment_state_mapper(scalar_built_model)
-        np.testing.assert_allclose(
-            actual_mapper.evaluate(y=np.array([3.0])),
-            expected_mapper.evaluate(y=np.array([3.0])),
-        )
-
-        vector_model = pybamm.BaseModel()
-        current_variable = pybamm.Variable(
-            "Current variable [A]", domain="negative electrode"
-        )
-        vector_model.rhs = {current_variable: current_variable}
-        vector_model.initial_conditions = {current_variable: 1}
-        vector_built_model = pybamm.Discretisation(
-            pybamm.Mesh(
-                {"negative electrode": {"x_n": {"min": 0, "max": 1}}},
-                {"negative electrode": pybamm.Uniform1DSubMesh},
-                {"x_n": 2},
-            ),
-            {"negative electrode": pybamm.FiniteVolume()},
-        ).process_model(vector_model, inplace=False)
-
-        with pytest.raises(
-            pybamm.ModelError, match="expects a scalar current-control state"
-        ):
-            sim._build_unified_experiment_state_mapper(vector_built_model)
+        assert restored._experiment_model_mode == "legacy"
 
     def test_set_crate(self):
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_solvers/test_processed_variable.py
+++ b/tests/unit/test_solvers/test_processed_variable.py
@@ -1595,6 +1595,30 @@ class TestProcessedVariable:
 
         np.testing.assert_array_equal(computed_var.entries, t_sol * y_sol[0])
 
+    def test_as_computed_with_sensitivities(self):
+        model = pybamm.BaseModel()
+        y = pybamm.Variable("y")
+        a = pybamm.InputParameter("a")
+        model.rhs = {y: 0 * y}
+        model.initial_conditions = {y: 1}
+        model.variables = {"a times y": a * y}
+
+        solution = pybamm.IDAKLUSolver().solve(
+            model,
+            [0, 1],
+            inputs={"a": 2.0},
+            calculate_sensitivities=True,
+            t_interp=np.array([0, 1]),
+        )
+        processed_var = solution["a times y"]
+
+        computed_var = processed_var.as_computed()
+
+        np.testing.assert_array_equal(computed_var.entries, np.array([2.0, 2.0]))
+        np.testing.assert_array_equal(
+            computed_var.sensitivities["a"], np.array([1.0, 1.0])
+        )
+
     def test_as_computed_1D(self):
         var = pybamm.Variable("var", domain=["negative electrode", "separator"])
         x = pybamm.SpatialVariable("x", domain=["negative electrode", "separator"])

--- a/tests/unit/test_solvers/test_processed_variable_computed.py
+++ b/tests/unit/test_solvers/test_processed_variable_computed.py
@@ -287,6 +287,43 @@ class TestProcessedVariableComputed:
         )
         np.testing.assert_array_equal(comb_var.entries, comb_var.data)
 
+    def test_processed_variable_0D_update_sensitivities(self):
+        def solve_processed_var(t_eval, calculate_sensitivities):
+            model = pybamm.BaseModel()
+            y = pybamm.Variable("y")
+            a = pybamm.InputParameter("a")
+            model.rhs = {y: 0 * y}
+            model.initial_conditions = {y: 1}
+            model.variables = {"a times y": a * y}
+
+            solver = pybamm.IDAKLUSolver(output_variables=["a times y"])
+            sol = solver.solve(
+                model,
+                t_eval,
+                inputs={"a": 2.0},
+                calculate_sensitivities=calculate_sensitivities,
+                t_interp=np.array(t_eval),
+            )
+            return sol, sol["a times y"]
+
+        _, processed_var_no_sens = solve_processed_var([0, 1], False)
+        assert processed_var_no_sens.sensitivities == {}
+
+        sol1, processed_var1 = solve_processed_var([0, 1], True)
+        sol2, processed_var2 = solve_processed_var([2, 3], True)
+
+        combined_sol = sol1 + sol2
+        combined_var = processed_var1.update(processed_var2, combined_sol)
+
+        np.testing.assert_array_equal(
+            combined_var.entries,
+            np.array([2.0, 2.0, 2.0, 2.0]),
+        )
+        np.testing.assert_array_equal(
+            combined_var.sensitivities["a"],
+            np.array([1.0, 1.0, 1.0, 1.0]),
+        )
+
     def test_processed_variable_2D_x_r(self):
         var = pybamm.Variable(
             "var",


### PR DESCRIPTION
# Description

fixes #5407

This PR adds a unified experiment-model path that reuses one processed model and one solver across compatible experiment steps, instead of building one model per step.

The unified path combines per-step control and termination behavior into shared experiment-wide expressions, and switches the active step through solve-time one-hot inputs.

For step weights $w_i$, step control residuals $g_i(x)$, and step-local termination aggregates $h_i(x)$, the unified model uses:

$$
\sum_i w_i g_i(x) = 0
$$

and

$$
\sum_i w_i h_i(x) = 0
$$

where exactly one $w_i$ is active for each solve step.
UPDATE: the sum over one-hot weights has been replaced by a conditional expression over a single "step index" input, see discussion below

Examples of the control residuals include:

$$
g_i(x) =
\begin{cases}
I - I_{\mathrm{set}} & \text{current step} \\
V - V_{\mathrm{set}} & \text{voltage step} \\
VI - P_{\mathrm{set}} & \text{power step} \\
V - R_{\mathrm{set}} I & \text{resistance step}
\end{cases}
$$

For steps with multiple terminations $f_{ij}(x)$, the step-local aggregate is formed as a nested minimum so that any active termination can stop the step:

$$
h_i(x) = \min_j f_{ij}(x)
$$

The legacy per-step build remains available, and `Simulation` now supports:
- `experiment_model_mode="unified"`
- `experiment_model_mode="legacy"` (default)

Unsupported cases raise clearly in `unified` mode.

## Benchmarks

Benchmark script:
- `scripts/benchmark_unified_experiment.py`

Scenarios:
- `event_driven_cccv`
  - `Charge at C/3 until 4.1 V`
  - `Hold at 4.1 V until C/20`
- `mixed_control`
  - `Discharge at C/20 for 20 minutes`
  - `Charge at 1 A for 10 minutes`
  - `Hold at 4.1 V for 10 minutes`
  - `Discharge at 2 W for 10 minutes`
  - `Discharge at 4 Ohm for 10 minutes`
- `start_time_padding`
  - `Current(1, duration=20 minutes, start_time=2023-01-01 08:00:00)`
  - `Rest(duration=20 minutes, start_time=2023-01-01 09:00:00)`

Models:
- `SPM`
- `DFN`

The script was run on both this branch and `main`. `main` legacy timings were effectively the same as this branch’s legacy timings, so the comparison is consistent.

### Current branch results

| Model | Scenario | Legacy Total (s) | Unified Total (s) | Unified / Legacy |
| --- | --- | ---: | ---: | ---: |
| SPM | event_driven_cccv | 0.335 | 0.314 | 0.94x |
| SPM | mixed_control | 0.481 | 0.155 | 0.32x |
| SPM | start_time_padding | 0.244 | 0.105 | 0.43x |
| DFN | event_driven_cccv | 0.616 | 0.438 | 0.71x |
| DFN | mixed_control | 1.165 | 0.320 | 0.27x |
| DFN | start_time_padding | 0.736 | 0.295 | 0.40x |

### `main` legacy comparison

| Model | Scenario | This branch legacy (s) | `main` legacy (s) |
| --- | --- | ---: | ---: |
| SPM | event_driven_cccv | 0.335 | 0.334 |
| SPM | mixed_control | 0.481 | 0.488 |
| SPM | start_time_padding | 0.244 | 0.241 |
| DFN | event_driven_cccv | 0.616 | 0.618 |
| DFN | mixed_control | 1.165 | 1.181 |
| DFN | start_time_padding | 0.736 | 0.738 |

On this machine, the unified path is faster in all benchmarked cases, with the largest gains in mixed-control and start-time experiments.