### PR TITLE
Add zizmor config to ignore secrets-outside-env findings

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository == 'pybamm-team/PyBaMM'
     name: Build image
     runs-on: ubuntu-latest
+    environment: dockerhub
     permissions:
       contents: read
 

--- a/.github/workflows/run_benchmarks_over_history.yml
+++ b/.github/workflows/run_benchmarks_over_history.yml
@@ -128,6 +128,7 @@ jobs:
     name: Push and publish results
     needs: benchmarks
     runs-on: ubuntu-latest
+    environment: benchmarks
     permissions:
       contents: write
     steps:

--- a/.github/workflows/validation_benchmarks.yml
+++ b/.github/workflows/validation_benchmarks.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'pybamm-team/PyBaMM'
     name: Dispatch to `pybamm-validation`
     runs-on: ubuntu-latest
+    environment: benchmarks
     permissions:
       contents: read
     steps:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,4 +1,6 @@
 rules:
+  # These workflows use repo-level secrets without GitHub Environments.
+  # Environments add unnecessary friction for these non-deployment workflows.
   secrets-outside-env:
     ignore:
       - docker.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  secrets-outside-env:
+    ignore:
+      - docker.yml
+      - periodic_benchmarks.yml
+      - run_benchmarks_over_history.yml
+      - run_periodic_tests.yml
+      - test_on_push.yml
+      - validation_benchmarks.yml

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,11 +1,8 @@
 rules:
   # These workflows use repo-level secrets without GitHub Environments.
-  # Environments add unnecessary friction for these non-deployment workflows.
+  # Environments add unnecessary noise for these high-frequency workflows.
   secrets-outside-env:
     ignore:
-      - docker.yml
       - periodic_benchmarks.yml
-      - run_benchmarks_over_history.yml
       - run_periodic_tests.yml
       - test_on_push.yml
-      - validation_benchmarks.yml


### PR DESCRIPTION
# Description

Suppresses secrets-outside-env warnings for workflows that use repo-level secrets without dedicated GitHub environments.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
