### PR TITLE
Fix load_custom_model when base class package is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- Fixed `load_custom_model` raising `ImportError` when the saved base class lives in a package not installed in the loading environment. The loader now falls back to `pybamm.BaseModel` with a warning. ([#5441](https://github.com/pybamm-team/PyBaMM/pull/5441))
 - Fixed serialisation bug in 2D finite volume discretisation. ([#5434](https://github.com/pybamm-team/PyBaMM/pull/5434))
 
 ## Breaking changes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1362,21 +1362,29 @@ class Serialise:
         if missing:
             raise KeyError(f"Missing required model sections: {missing}")
 
-        battery_model = model_data.get("base_class")
-        if not battery_model or battery_model.strip() == "pybamm.BaseModel":
+        battery_model = (model_data.get("base_class") or "").strip()
+        # Sentinels meaning "no specific subclass" — treat as BaseModel directly.
+        if battery_model in ("", "pybamm.BaseModel", "builtins.object"):
             base_cls = pybamm.BaseModel
         else:
+            # Opportunistically re-import the original class so subclass-specific
+            # Python behaviour survives a round-trip when the defining package is
+            # available. If it isn't (e.g. a third-party package isn't installed
+            # in the loading environment), fall back to BaseModel: the model is
+            # stored fully symbolically, so BaseModel is a sufficient container.
             module_name, class_name = battery_model.rsplit(".", 1)
             try:
                 module = importlib.import_module(module_name)
                 base_cls = getattr(module, class_name)
             except (ModuleNotFoundError, AttributeError) as e:
-                if battery_model == "builtins.object":
-                    base_cls = pybamm.BaseModel
-                else:
-                    raise ImportError(
-                        f"Could not import base class '{battery_model}': {e}"
-                    ) from e
+                warnings.warn(
+                    f"Could not import base class '{battery_model}': {e}. "
+                    "Falling back to pybamm.BaseModel; the loaded model will "
+                    "contain the symbolic equations but not any subclass-specific "
+                    "Python behaviour.",
+                    stacklevel=2,
+                )
+                base_cls = pybamm.BaseModel
 
         model = base_cls()
         model.name = model_data["name"]

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1363,15 +1363,9 @@ class Serialise:
             raise KeyError(f"Missing required model sections: {missing}")
 
         battery_model = (model_data.get("base_class") or "").strip()
-        # Sentinels meaning "no specific subclass" — treat as BaseModel directly.
         if battery_model in ("", "pybamm.BaseModel", "builtins.object"):
             base_cls = pybamm.BaseModel
         else:
-            # Opportunistically re-import the original class so subclass-specific
-            # Python behaviour survives a round-trip when the defining package is
-            # available. If it isn't (e.g. a third-party package isn't installed
-            # in the loading environment), fall back to BaseModel: the model is
-            # stored fully symbolically, so BaseModel is a sufficient container.
             module_name, class_name = battery_model.rsplit(".", 1)
             try:
                 module = importlib.import_module(module_name)

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -915,10 +915,6 @@ class TestSerialise:
         }
 
     def test_import_base_class_non_builtin_object(self, tmp_path):
-        # When the recorded base class lives in a package that isn't installed
-        # in the loading environment, load_custom_model should fall back to
-        # pybamm.BaseModel (with a warning) rather than raising ImportError,
-        # since the model is stored fully symbolically.
         model = pybamm.BaseModel(name="DummyModel")
         a = pybamm.Variable("a")
         model.rhs = {a: a}
@@ -928,7 +924,6 @@ class TestSerialise:
         file_path = tmp_path / "model.json"
         Serialise.save_custom_model(model, filename=str(file_path))
 
-        # Rewrite the saved base_class to a module that can't be imported.
         with open(file_path) as f:
             data = json.load(f)
         data["model"]["base_class"] = "nonexistent_module.DummyModel"
@@ -941,18 +936,12 @@ class TestSerialise:
         ):
             loaded_model = Serialise.load_custom_model(str(file_path))
 
-        # Falls back to plain BaseModel but preserves symbolic content
         assert type(loaded_model) is pybamm.BaseModel
         assert loaded_model.name == "DummyModel"
         assert len(loaded_model.rhs) == 1
         assert next(iter(loaded_model.rhs.keys())).name == "a"
 
     def test_custom_model_roundtrip_preserves_lithium_ion_base(self, tmp_path):
-        # Custom models authored as subclasses of li-ion BaseModel (or
-        # reparented to it before serialising) should round-trip with their
-        # base class and options intact, so that the loaded model's
-        # default_geometry / default_spatial_methods cover the particle
-        # domains without the caller passing them explicitly.
         from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
             BaseModel as LiIonBaseModel,
         )
@@ -978,11 +967,8 @@ class TestSerialise:
         Serialise.save_custom_model(model, filename=str(file_path))
         loaded = Serialise.load_custom_model(str(file_path))
 
-        # Base class is re-imported, not the BaseModel fallback.
         assert isinstance(loaded, LiIonBaseModel)
         assert loaded.options["working electrode"] == "positive"
-        # The li-ion defaults driven by the options are available on load,
-        # so Simulation can discretise without any extra dicts.
         assert "positive particle" in loaded.default_geometry
         assert "positive particle" in loaded.default_spatial_methods
 

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -915,32 +915,37 @@ class TestSerialise:
         }
 
     def test_import_base_class_non_builtin_object(self, tmp_path):
-        # Minimal model JSON with a non-existent base class
-        model_json = {
-            "schema_version": "1.1",
-            "pybamm_version": pybamm.__version__,
-            "model": {
-                "base_class": "nonexistent_module.DummyModel",
-                "name": "DummyModel",
-                "rhs": [],
-                "algebraic": [],
-                "initial_conditions": [],
-                "boundary_conditions": [],
-                "events": [],
-                "variables": {},
-            },
-        }
+        # When the recorded base class lives in a package that isn't installed
+        # in the loading environment, load_custom_model should fall back to
+        # pybamm.BaseModel (with a warning) rather than raising ImportError,
+        # since the model is stored fully symbolically.
+        model = pybamm.BaseModel(name="DummyModel")
+        a = pybamm.Variable("a")
+        model.rhs = {a: a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
 
         file_path = tmp_path / "model.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
 
+        # Rewrite the saved base_class to a module that can't be imported.
+        with open(file_path) as f:
+            data = json.load(f)
+        data["model"]["base_class"] = "nonexistent_module.DummyModel"
         with open(file_path, "w") as f:
-            json.dump(model_json, f)
+            json.dump(data, f)
 
-        with pytest.raises(
-            ImportError,
-            match=r"(?i)Could not import base class 'nonexistent_module\.DummyModel'",
+        with pytest.warns(
+            UserWarning,
+            match=r"Could not import base class 'nonexistent_module\.DummyModel'",
         ):
-            Serialise.load_custom_model(str(file_path))
+            loaded_model = Serialise.load_custom_model(str(file_path))
+
+        # Falls back to plain BaseModel but preserves symbolic content
+        assert type(loaded_model) is pybamm.BaseModel
+        assert loaded_model.name == "DummyModel"
+        assert len(loaded_model.rhs) == 1
+        assert next(iter(loaded_model.rhs.keys())).name == "a"
 
     def test_function_parameter_with_diff_variable_serialisation(self):
         x = pybamm.Variable("x")

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -947,6 +947,45 @@ class TestSerialise:
         assert len(loaded_model.rhs) == 1
         assert next(iter(loaded_model.rhs.keys())).name == "a"
 
+    def test_custom_model_roundtrip_preserves_lithium_ion_base(self, tmp_path):
+        # Custom models authored as subclasses of li-ion BaseModel (or
+        # reparented to it before serialising) should round-trip with their
+        # base class and options intact, so that the loaded model's
+        # default_geometry / default_spatial_methods cover the particle
+        # domains without the caller passing them explicitly.
+        from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
+            BaseModel as LiIonBaseModel,
+        )
+
+        model = LiIonBaseModel(options={"working electrode": "positive"})
+        model.name = "HalfCellGITTLike"
+        c = pybamm.Variable(
+            "X-averaged positive particle concentration [mol.m-3]",
+            domain="positive particle",
+            bounds=(0, 1),
+        )
+        model.rhs = {c: -pybamm.div(-pybamm.grad(c))}
+        model.initial_conditions = {c: pybamm.Scalar(0.5)}
+        model.boundary_conditions = {
+            c: {
+                "left": (pybamm.Scalar(0), "Neumann"),
+                "right": (pybamm.Scalar(0), "Neumann"),
+            }
+        }
+        model.variables = {c.name: c}
+
+        file_path = tmp_path / "halfcell.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+        loaded = Serialise.load_custom_model(str(file_path))
+
+        # Base class is re-imported, not the BaseModel fallback.
+        assert isinstance(loaded, LiIonBaseModel)
+        assert loaded.options["working electrode"] == "positive"
+        # The li-ion defaults driven by the options are available on load,
+        # so Simulation can discretise without any extra dicts.
+        assert "positive particle" in loaded.default_geometry
+        assert "positive particle" in loaded.default_spatial_methods
+
     def test_function_parameter_with_diff_variable_serialisation(self):
         x = pybamm.Variable("x")
         diff_var = pybamm.Variable("r")


### PR DESCRIPTION
## Summary
- `Serialise.load_custom_model` now falls back to `pybamm.BaseModel` (with a warning) when the recorded `base_class` can't be re-imported, instead of raising `ImportError`. This restores the pre-#5389 contract and makes models authored in third-party packages loadable by anyone, since the model content is stored fully symbolically.
- Consolidated the fallback logic: the `"builtins.object"` sentinel now lives in the top-level guard alongside `""` and `"pybamm.BaseModel"`, removing a dead branch inside the `except` clause (importing `builtins` never raises).
- Updated `test_import_base_class_non_builtin_object` to assert the new warn-and-fallback behaviour, and simplified its setup to round-trip through `save_custom_model` + a single JSON field edit rather than hand-rolling the model JSON.

## Context
Reported by a user loading a `HalfCellGITTModel` defined in package on a machine without that package installed.

Before #5389, `load_custom_model(filename, battery_model=None)` defaulted to `pybamm.BaseModel()` and never tried to import anything. #5389 started storing `f"{cls.__module__}.{cls.__name__}"` and `importlib.import_module`-ing it at load time, with no fallback for non-pybamm subclasses. This PR keeps the opportunistic re-import (so subclass behaviour still round-trips when the package *is* installed) but degrades gracefully when it isn't.

## Test plan
- [x] `pytest tests/unit/test_serialisation/test_serialisation.py -k "custom_model or base_class"` — 8 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)