### PR TITLE
Release v26.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-# [Unreleased](https://github.com/pybamm-team/PyBaMM/)
-
-## Features
+# [v26.3.1](https://github.com/pybamm-team/PyBaMM/tree/v26.3.1) - 2026-04-10
 
 ## Bug fixes
 
-## Breaking changes
+- Fixed `load_custom_model` raising `ImportError` when the saved base class lives in a package not installed in the loading environment. The loader now falls back to `pybamm.BaseModel` with a warning. ([#5441](https://github.com/pybamm-team/PyBaMM/pull/5441))
+- Fixed serialisation bug in 2D finite volume discretisation. ([#5434](https://github.com/pybamm-team/PyBaMM/pull/5434))
 
 # [v26.3.0](https://github.com/pybamm-team/PyBaMM/tree/v26.3.0) - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [Unreleased](https://github.com/pybamm-team/PyBaMM/)
+
+## Features
+
+- Adds EIS support via `EISSimulation` class with a restructure to the `Solution` class to support `EISSolution`. Includes examples and citation, with a ~5x solve improvement over pybamm-eis. ([#5433](https://github.com/pybamm-team/PyBaMM/pull/5433))
+- Refactors `Simulation` class into an inherited class from a `BaseSimulation`. `BaseSimulation` is used for all non-experiment based simulations, with the `Simulation` class adding experiment support. Includes a small code cleanup. ([#5430](https://github.com/pybamm-team/PyBaMM/pull/5430))
+- Improved pchip interpolation performance. ([#5436](https://github.com/pybamm-team/PyBaMM/pull/5436))
+- Refactored CasADi codegen conversion to use OOP dispatch. ([#5436](https://github.com/pybamm-team/PyBaMM/pull/5436))
+- Added a unified experiment-model path that reuses a single built model and solver across compatible experiment steps. ([#5422](https://github.com/pybamm-team/PyBaMM/pull/5422))
+
+## Bug fixes
+
+## Breaking changes
+
 # [v26.3.1](https://github.com/pybamm-team/PyBaMM/tree/v26.3.1) - 2026-04-10
 
 ## Bug fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.3.0"
+version: "26.3.1"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1362,8 +1362,8 @@ class Serialise:
         if missing:
             raise KeyError(f"Missing required model sections: {missing}")
 
-        battery_model = model_data.get("base_class")
-        if not battery_model or battery_model.strip() == "pybamm.BaseModel":
+        battery_model = (model_data.get("base_class") or "").strip()
+        if battery_model in ("", "pybamm.BaseModel", "builtins.object"):
             base_cls = pybamm.BaseModel
         else:
             module_name, class_name = battery_model.rsplit(".", 1)
@@ -1371,12 +1371,14 @@ class Serialise:
                 module = importlib.import_module(module_name)
                 base_cls = getattr(module, class_name)
             except (ModuleNotFoundError, AttributeError) as e:
-                if battery_model == "builtins.object":
-                    base_cls = pybamm.BaseModel
-                else:
-                    raise ImportError(
-                        f"Could not import base class '{battery_model}': {e}"
-                    ) from e
+                warnings.warn(
+                    f"Could not import base class '{battery_model}': {e}. "
+                    "Falling back to pybamm.BaseModel; the loaded model will "
+                    "contain the symbolic equations but not any subclass-specific "
+                    "Python behaviour.",
+                    stacklevel=2,
+                )
+                base_cls = pybamm.BaseModel
 
         model = base_cls()
         model.name = model_data["name"]

--- a/src/pybamm/spatial_methods/finite_volume_2d.py
+++ b/src/pybamm/spatial_methods/finite_volume_2d.py
@@ -17,19 +17,26 @@ from scipy.sparse import (
 import pybamm
 
 
+class _EvaluatesOnEdgesOverride:
+    __slots__ = ("direction", "fallback")
+
+    def __init__(self, direction, fallback):
+        self.direction = direction
+        self.fallback = fallback
+
+    def __call__(self, dim):
+        if dim == "primary":
+            return self.direction
+        return self.fallback(dim)
+
+
 def _evaluates_on_edges_one_side(symbol, direction):
     if hasattr(symbol, "_evaluates_on_edges_original"):
         return symbol
-    if direction == "lr":
-        symbol._evaluates_on_edges_original = symbol._evaluates_on_edges
-        symbol._evaluates_on_edges = lambda dim: (
-            "lr" if dim == "primary" else symbol._evaluates_on_edges_original(dim)
-        )
-    elif direction == "tb":
-        symbol._evaluates_on_edges_original = symbol._evaluates_on_edges
-        symbol._evaluates_on_edges = lambda dim: (
-            "tb" if dim == "primary" else symbol._evaluates_on_edges_original(dim)
-        )
+    symbol._evaluates_on_edges_original = symbol._evaluates_on_edges
+    symbol._evaluates_on_edges = _EvaluatesOnEdgesOverride(
+        direction, symbol._evaluates_on_edges_original
+    )
     return symbol
 
 

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -915,32 +915,62 @@ class TestSerialise:
         }
 
     def test_import_base_class_non_builtin_object(self, tmp_path):
-        # Minimal model JSON with a non-existent base class
-        model_json = {
-            "schema_version": "1.1",
-            "pybamm_version": pybamm.__version__,
-            "model": {
-                "base_class": "nonexistent_module.DummyModel",
-                "name": "DummyModel",
-                "rhs": [],
-                "algebraic": [],
-                "initial_conditions": [],
-                "boundary_conditions": [],
-                "events": [],
-                "variables": {},
-            },
-        }
+        model = pybamm.BaseModel(name="DummyModel")
+        a = pybamm.Variable("a")
+        model.rhs = {a: a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
 
         file_path = tmp_path / "model.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
 
+        with open(file_path) as f:
+            data = json.load(f)
+        data["model"]["base_class"] = "nonexistent_module.DummyModel"
         with open(file_path, "w") as f:
-            json.dump(model_json, f)
+            json.dump(data, f)
 
-        with pytest.raises(
-            ImportError,
-            match=r"(?i)Could not import base class 'nonexistent_module\.DummyModel'",
+        with pytest.warns(
+            UserWarning,
+            match=r"Could not import base class 'nonexistent_module\.DummyModel'",
         ):
-            Serialise.load_custom_model(str(file_path))
+            loaded_model = Serialise.load_custom_model(str(file_path))
+
+        assert type(loaded_model) is pybamm.BaseModel
+        assert loaded_model.name == "DummyModel"
+        assert len(loaded_model.rhs) == 1
+        assert next(iter(loaded_model.rhs.keys())).name == "a"
+
+    def test_custom_model_roundtrip_preserves_lithium_ion_base(self, tmp_path):
+        from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
+            BaseModel as LiIonBaseModel,
+        )
+
+        model = LiIonBaseModel(options={"working electrode": "positive"})
+        model.name = "HalfCellGITTLike"
+        c = pybamm.Variable(
+            "X-averaged positive particle concentration [mol.m-3]",
+            domain="positive particle",
+            bounds=(0, 1),
+        )
+        model.rhs = {c: -pybamm.div(-pybamm.grad(c))}
+        model.initial_conditions = {c: pybamm.Scalar(0.5)}
+        model.boundary_conditions = {
+            c: {
+                "left": (pybamm.Scalar(0), "Neumann"),
+                "right": (pybamm.Scalar(0), "Neumann"),
+            }
+        }
+        model.variables = {c.name: c}
+
+        file_path = tmp_path / "halfcell.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+        loaded = Serialise.load_custom_model(str(file_path))
+
+        assert isinstance(loaded, LiIonBaseModel)
+        assert loaded.options["working electrode"] == "positive"
+        assert "positive particle" in loaded.default_geometry
+        assert "positive particle" in loaded.default_spatial_methods
 
     def test_function_parameter_with_diff_variable_serialisation(self):
         x = pybamm.Variable("x")

--- a/tests/unit/test_spatial_methods/test_finite_volume_2d/test_finite_volume_2d.py
+++ b/tests/unit/test_spatial_methods/test_finite_volume_2d/test_finite_volume_2d.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -1095,6 +1097,30 @@ class TestFiniteVolume2D:
         result_complex_neumann = eqn_disc_complex_neumann.evaluate(None, test_y)
         assert result_complex_neumann is not None
         assert result_complex_neumann.shape[0] == submesh.npts
+
+    def test_discretised_grad_is_picklable(self, mesh_2d):
+        whole_cell = ["negative electrode", "separator", "positive electrode"]
+        mesh = mesh_2d
+        disc = pybamm.Discretisation(mesh, {"macroscale": pybamm.FiniteVolume2D()})
+        submesh = mesh[whole_cell]
+
+        var = pybamm.Variable("var", domain=whole_cell)
+        disc.set_variable_slices([var])
+        disc.bcs = {
+            var: {
+                "left": (pybamm.Scalar(0), "Dirichlet"),
+                "right": (pybamm.Scalar(1), "Dirichlet"),
+                "top": (pybamm.Scalar(0), "Neumann"),
+                "bottom": (pybamm.Scalar(0), "Neumann"),
+            }
+        }
+        grad_disc = disc.process_symbol(pybamm.grad(var))
+
+        y = np.ones(submesh.npts)
+        expected = grad_disc.lr_field.evaluate(None, y)
+
+        roundtripped = pickle.loads(pickle.dumps(grad_disc))
+        np.testing.assert_array_equal(roundtripped.lr_field.evaluate(None, y), expected)
 
     def test_delta_function(self, mesh_2d):
         # Create discretisation


### PR DESCRIPTION
## Summary

Patch release v26.3.1 cherry-picked on top of v26.3.0 with two bug fixes:

- Fixed `load_custom_model` raising `ImportError` when the saved base class lives in a package not installed in the loading environment (#5441)
- Fixed serialisation bug in 2D finite volume discretisation (#5434)

## Release checklist

- [ ] Review cherry-picked changes
- [ ] Merge PR
- [ ] Create GitHub release with tag `v26.3.1` from `release/v26.3.1` branch (not `main`)
- [ ] Verify PyPI release: `pip install pybamm==26.3.1`
- [ ] Open separate PR to update changelog on `main` (do NOT merge release branch back)
- [ ] Delete `release/v26.3.1` branch after tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)