### PR TITLE
Update changelog and citation for v26.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@
 
 ## Bug fixes
 
+## Breaking changes
+
+# [v26.3.1](https://github.com/pybamm-team/PyBaMM/tree/v26.3.1) - 2026-04-10
+
+## Bug fixes
+
 - Fixed `load_custom_model` raising `ImportError` when the saved base class lives in a package not installed in the loading environment. The loader now falls back to `pybamm.BaseModel` with a warning. ([#5441](https://github.com/pybamm-team/PyBaMM/pull/5441))
 - Fixed serialisation bug in 2D finite volume discretisation. ([#5434](https://github.com/pybamm-team/PyBaMM/pull/5434))
-
-## Breaking changes
 
 # [v26.3.0](https://github.com/pybamm-team/PyBaMM/tree/v26.3.0) - 2026-03-23
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.3.0"
+version: "26.3.1"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"


### PR DESCRIPTION
## Summary

- Moves the #5441 and #5434 bug fix entries from Unreleased into a new v26.3.1 section in CHANGELOG.md
- Updates CITATION.cff version to 26.3.1

This is the `main` changelog update for the v26.3.1 patch release, as per the [release workflow](/.github/release_workflow.md#creating-a-patch-release) (step 7). The release tag will be created separately from the `release/v26.3.1` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)