### PR TITLE
Fix termination hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## Bug fixes
 
+- Fixed termination hashes causing duplicate experiment steps to be built. ([#5453](https://github.com/pybamm-team/PyBaMM/pull/5453))
 - Fixed a regression causing inaccurate initial guesses at experiment step transitions. ([#5452](https://github.com/pybamm-team/PyBaMM/pull/5452))
 
 ## Breaking changes

--- a/src/pybamm/experiment/step/step_termination.py
+++ b/src/pybamm/experiment/step/step_termination.py
@@ -46,12 +46,17 @@ class BaseTermination:
             return None
         return pybamm.Event(self.get_event_name(step), expression)
 
-    def __eq__(self, other):
-        # objects are equal if they have the same type and value
-        if isinstance(other, self.__class__):
-            return self.value == other.value
-        else:
+    def __repr__(self) -> str:
+        op = "" if self.operator is None else f" {self.operator}"
+        return f"{type(self).__name__}({self.value}{op})"
+
+    def __eq__(self, other) -> bool:
+        if type(self) is not type(other):
             return False
+        return self.value == other.value and self.operator == other.operator
+
+    def __hash__(self) -> int:
+        return hash((type(self).__name__, self.value, self.operator))
 
 
 class CRateTermination(BaseTermination):
@@ -202,6 +207,17 @@ class CustomTermination(BaseTermination):
 
     def get_event_expression(self, variables, step):
         return self.event_function(variables)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.name})"
+
+    def __eq__(self, other) -> bool:
+        if type(self) is not type(other):
+            return False
+        return self.name == other.name and self.event_function is other.event_function
+
+    def __hash__(self) -> int:
+        return hash((type(self).__name__, self.name, id(self.event_function)))
 
 
 def _read_termination(termination, operator=None):

--- a/tests/unit/test_experiments/test_experiment_step_termination.py
+++ b/tests/unit/test_experiments/test_experiment_step_termination.py
@@ -2,6 +2,8 @@
 # Test the experiment step termination classes
 #
 
+import copy
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -87,3 +89,119 @@ class TestExperimentStepTermination:
         assert current == pybamm.step.CurrentTermination(2.0, operator=">")
         assert voltage == pybamm.step.VoltageTermination(3.0, operator="<")
         assert crate == pybamm.step.CRateTermination(0.5, operator=">")
+
+    def test_base_termination_repr_value_based(self):
+        t1 = pybamm.step.VoltageTermination(4.2)
+        t2 = pybamm.step.VoltageTermination(4.2)
+        assert repr(t1) == repr(t2) == "VoltageTermination(4.2)"
+        assert re.search(r"0x[0-9a-f]+", repr(t1)) is None
+
+        t_gt = pybamm.step.VoltageTermination(4.2, operator=">")
+        t_lt = pybamm.step.VoltageTermination(4.2, operator="<")
+        assert repr(t_gt) == "VoltageTermination(4.2 >)"
+        assert repr(t_lt) == "VoltageTermination(4.2 <)"
+
+        assert repr(pybamm.step.CRateTermination(0.01)) == "CRateTermination(0.01)"
+        assert (
+            repr(pybamm.step.CurrentTermination(0.5, operator=">"))
+            == "CurrentTermination(0.5 >)"
+        )
+
+    def test_base_termination_hash(self):
+        t1 = pybamm.step.VoltageTermination(4.2, operator="<")
+        t2 = pybamm.step.VoltageTermination(4.2, operator="<")
+        t3 = pybamm.step.VoltageTermination(4.2, operator=">")
+        t4 = pybamm.step.VoltageTermination(2.5, operator="<")
+        t5 = pybamm.step.CurrentTermination(4.2, operator="<")
+
+        assert hash(t1) == hash(t2)
+        assert hash(t1) != hash(t3)
+        assert hash(t1) != hash(t4)
+        assert hash(t1) != hash(t5)
+        assert {t1, t2, t3, t4, t5} == {t1, t3, t4, t5}
+
+    def test_base_termination_eq_strict_type_and_operator(self):
+        base = pybamm.step.BaseTermination(1.0)
+        current = pybamm.step.CurrentTermination(1.0)
+        voltage = pybamm.step.VoltageTermination(1.0)
+        assert base != current
+        assert current != voltage
+        assert pybamm.step.VoltageTermination(
+            4.2, operator="<"
+        ) != pybamm.step.VoltageTermination(4.2, operator=">")
+        assert pybamm.step.VoltageTermination(
+            4.2, operator="<"
+        ) != pybamm.step.VoltageTermination(4.2)
+        assert pybamm.step.VoltageTermination(
+            4.2, operator="<"
+        ) == pybamm.step.VoltageTermination(4.2, operator="<")
+
+    def test_custom_termination_repr_eq_hash(self):
+        def evt(variables):
+            return variables["x"] - 1.0
+
+        def evt2(variables):
+            return variables["x"] - 2.0
+
+        t1 = pybamm.step.CustomTermination(name="cut-off", event_function=evt)
+        t2 = pybamm.step.CustomTermination(name="cut-off", event_function=evt)
+        t3 = pybamm.step.CustomTermination(name="other", event_function=evt)
+        t4 = pybamm.step.CustomTermination(name="cut-off", event_function=evt2)
+
+        assert repr(t1) == "CustomTermination(cut-off [experiment])"
+        assert re.search(r"0x[0-9a-f]+", repr(t1)) is None
+        assert t1 == t2
+        assert hash(t1) == hash(t2)
+        assert t1 != t3
+        assert t1 != t4
+        assert t1 != pybamm.step.VoltageTermination(1.0)
+        assert {t1, t2, t3, t4} == {t1, t3, t4}
+
+        t_copy = copy.deepcopy(t1)
+        assert t_copy == t1
+        assert hash(t_copy) == hash(t1)
+        assert repr(t_copy) == repr(t1)
+
+    def test_deepcopied_termination_is_value_equal(self):
+        t = pybamm.step.VoltageTermination(2.5, operator="<")
+        t_copy = copy.deepcopy(t)
+        assert t_copy is not t
+        assert t_copy == t
+        assert hash(t_copy) == hash(t)
+        assert repr(t_copy) == repr(t)
+
+    def test_unique_steps_independent_of_cycle_count(self):
+        # unique_steps must equal template length regardless of n_cycles
+        cycle_template = [
+            {
+                "type": "c-rate",
+                "value": 1.0,
+                "duration": 3600.0,
+                "terminations": [{"type": "voltage", "value": 2.5}],
+            },
+            {
+                "type": "c-rate",
+                "value": -0.3,
+                "duration": 24000.0,
+                "terminations": [{"type": "voltage", "value": 4.2}],
+            },
+            {
+                "type": "voltage",
+                "value": 4.2,
+                "duration": 86400.0,
+                "terminations": [{"type": "c-rate", "value": 0.01}],
+            },
+        ]
+        n_unique = len(cycle_template)
+
+        for n_cycles in (1, 2, 5, 10):
+            config = {
+                "cycles": [copy.deepcopy(cycle_template) for _ in range(n_cycles)]
+            }
+            exp = pybamm.Experiment.from_config(config)
+
+            assert len(exp.steps) == n_cycles * n_unique
+            assert len(exp.unique_steps) == n_unique, (
+                f"unique_steps={len(exp.unique_steps)} for n_cycles={n_cycles}, "
+                f"expected {n_unique} (steps must scale with template, not cycles)"
+            )

--- a/tests/unit/test_experiments/test_experiment_steps.py
+++ b/tests/unit/test_experiments/test_experiment_steps.py
@@ -362,11 +362,11 @@ class TestExperimentSteps:
         # operator overloading
         termination_lt_0_05_oo = pybamm.step.step_termination.Current() < 0.05
         termination_gt_0_05_oo = pybamm.step.step_termination.Current() > 0.05
-        assert termination_lt_0_05_oo == termination_gt_0_05
+        assert termination_lt_0_05_oo == termination_lt_0_05
         assert termination_gt_0_05_oo == termination_gt_0_05
         termination_lt_4_1_oo = pybamm.step.step_termination.Voltage() < 4.1
         termination_gt_4_1_oo = pybamm.step.step_termination.Voltage() > 4.1
-        assert termination_lt_4_1_oo == termination_gt_4_1
+        assert termination_lt_4_1_oo == termination_lt_4_1
         assert termination_gt_4_1_oo == termination_gt_4_1
 
     def test_symbolic_termination_expression_helpers(self):

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 from datetime import datetime
@@ -308,6 +309,70 @@ class TestSimulationExperiment:
                 assert (model_0, model_1) in sim.model_state_mappers
             else:
                 assert len(sim.model_state_mappers.values()) == 0
+
+    def test_built_models_and_state_mappers_independent_of_cycle_count(self):
+        cycle_template = [
+            {
+                "type": "c-rate",
+                "value": 1.0,
+                "duration": 3600.0,
+                "terminations": [{"type": "voltage", "value": 2.5}],
+            },
+            {
+                "type": "c-rate",
+                "value": -0.3,
+                "duration": 24000.0,
+                "terminations": [{"type": "voltage", "value": 4.2}],
+            },
+            {
+                "type": "voltage",
+                "value": 4.2,
+                "duration": 86400.0,
+                "terminations": [{"type": "c-rate", "value": 0.01}],
+            },
+        ]
+
+        n_unique = len(cycle_template)
+        # n_cycles >= 2 so the cycle-wrap transition (last->first) is realized
+        # and mapper count plateaus.
+        counts = []
+        for n_cycles in (2, 4, 8):
+            config = {
+                "cycles": [copy.deepcopy(cycle_template) for _ in range(n_cycles)]
+            }
+            experiment = pybamm.Experiment.from_config(config)
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode="legacy",
+            )
+            sim.build_for_experiment()
+
+            counts.append(
+                (
+                    n_cycles,
+                    len(sim.steps_to_built_models),
+                    len(set(sim.steps_to_built_models.values())),
+                    len(sim.steps_to_built_solvers),
+                    len(sim.model_state_mappers),
+                )
+            )
+
+        for n_cycles, n_step_models, n_unique_models, n_solvers, n_mappers in counts:
+            assert n_step_models == n_unique
+            assert n_unique_models == n_unique
+            assert n_solvers == n_unique
+            assert n_mappers <= n_unique * n_unique, (
+                f"model_state_mappers={n_mappers} for n_cycles={n_cycles}, "
+                f"must be bounded by template transitions, not cycles"
+            )
+
+        first = counts[0][1:]
+        for c in counts[1:]:
+            assert c[1:] == first, (
+                f"build counts grow with n_cycles instead of staying flat: {counts}"
+            )
 
     def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
         experiment = pybamm.Experiment(


### PR DESCRIPTION
# Description

This was causing a cache miss in the step mappers, causing the number of solvers/models to grow unbounded with increasing experiment sizes

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
