### PR TITLE
fix: removes overly-aggressive removal of solver step caches

### DIFF
--- a/src/pybamm/simulation/base_simulation.py
+++ b/src/pybamm/simulation/base_simulation.py
@@ -374,7 +374,6 @@ class BaseSimulation:
             built_model.initial_conditions = processed_ics
             built_model.concatenated_initial_conditions = concat_ics
 
-        self._solver._model_set_up = {}
         self._needs_ic_rebuild = False
 
     def build(self, initial_soc=None, direction=None, inputs=None):

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -549,15 +549,6 @@ class Simulation(BaseSimulation):
             models.extend(self.steps_to_built_models.values())
         return models
 
-    def _recompute_initial_conditions(self):
-        super()._recompute_initial_conditions()
-        # Also clear per-step solver caches so they re-process the updated models
-        if self.steps_to_built_solvers is not None:
-            for solver in self.steps_to_built_solvers.values():
-                solver._model_set_up = {}
-        if self._built_experiment_solver is not None:
-            self._built_experiment_solver._model_set_up = {}
-
     def _build_experiment_state_mappers(self, inputs: dict):
         self.model_state_mappers = {}
         self._compiled_model_state_mappers = {}

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -2057,3 +2057,23 @@ class TestSimulationExperiment:
 
         # ICs must differ when inputs change at same SOC
         assert ic1 != ic2
+
+    @pytest.mark.parametrize("experiment_model_mode", ["legacy", "unified"])
+    def test_repeated_solves_refresh_initial_soc(self, experiment_model_mode):
+        model = pybamm.lithium_ion.SPM()
+        experiment = pybamm.Experiment(["Rest for 10 minutes", "Rest for 10 minutes"])
+        sim = pybamm.Simulation(
+            model,
+            parameter_values=pybamm.ParameterValues("Chen2020"),
+            experiment=experiment,
+            experiment_model_mode=experiment_model_mode,
+        )
+
+        sol1 = sim.solve(calc_esoh=False, initial_soc=0.2)
+        ic1 = sol1["X-averaged negative particle surface concentration"].data[0]
+
+        sol2 = sim.solve(calc_esoh=False, initial_soc=0.8)
+        ic2 = sol2["X-averaged negative particle surface concentration"].data[0]
+
+        # Reusing the same Simulation must refresh experiment ICs when SOC changes.
+        assert ic1 != ic2


### PR DESCRIPTION
# Description

Solvers handle IC's directly, this is an artefact from before that functionality. This restores experiment-based simulation performance to `v26.3.1` levels, and adds ~3x performance improvement for non-experiment simulations. 

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
