### PR TITLE
Fix PotentialPair1plus1D/2plus1D normalisation for parallel electrodes (#5467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- Fixed `PotentialPair1plus1D` and `PotentialPair2plus1D` current collector models so that the positive-tab Neumann boundary condition uses the per-electrode current rather than the total cell current. Previously, configurations with `"Number of electrodes connected in parallel to make a cell"` greater than 1 hit voltage cutoffs prematurely and reported reduced discharge capacity. ([#5467](https://github.com/pybamm-team/PyBaMM/issues/5467))
+
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 
 ## Bug fixes

--- a/src/pybamm/models/submodels/current_collector/potential_pair.py
+++ b/src/pybamm/models/submodels/current_collector/potential_pair.py
@@ -77,13 +77,20 @@ class PotentialPair1plus1D(BasePotentialPair):
         phi_s_cp = variables["Positive current collector potential [V]"]
 
         applied_current_density = variables["Total current density [A.m-2]"]
-        total_current = applied_current_density * self.param.A_cc
+        # The 1+1D model represents a single electrode pair, so the current entering
+        # the modelled stack is the total cell current divided by the number of
+        # electrodes connected in parallel.
+        current_per_electrode_pair = (
+            applied_current_density * self.param.A_cc / self.param.n_electrodes_parallel
+        )
 
         # In the 1+1D model, the behaviour is averaged over the y-direction, so the
         # effective tab area is the cell width multiplied by the current collector
         # thickness
         positive_tab_area = self.param.L_y * self.param.p.L_cc
-        pos_tab_bc = -total_current / (self.param.p.sigma_cc * positive_tab_area)
+        pos_tab_bc = -current_per_electrode_pair / (
+            self.param.p.sigma_cc * positive_tab_area
+        )
 
         # Boundary condition needs to be on the variables that go into the Laplacian,
         # even though phi_s_cp isn't a pybamm.Variable object
@@ -110,7 +117,12 @@ class PotentialPair2plus1D(BasePotentialPair):
         phi_s_cp = variables["Positive current collector potential [V]"]
 
         applied_current_density = variables["Total current density [A.m-2]"]
-        total_current = applied_current_density * self.param.A_cc
+        # The 2+1D model represents a single electrode pair, so the current entering
+        # the modelled stack is the total cell current divided by the number of
+        # electrodes connected in parallel.
+        current_per_electrode_pair = (
+            applied_current_density * self.param.A_cc / self.param.n_electrodes_parallel
+        )
 
         # Note: we divide by the *numerical* tab area so that the correct total
         # current is applied. That is, numerically integrating the current density
@@ -121,7 +133,9 @@ class PotentialPair2plus1D(BasePotentialPair):
         )
 
         # cc_area appears here due to choice of non-dimensionalisation
-        pos_tab_bc = -total_current / (self.param.p.sigma_cc * positive_tab_area)
+        pos_tab_bc = -current_per_electrode_pair / (
+            self.param.p.sigma_cc * positive_tab_area
+        )
 
         # Boundary condition needs to be on the variables that go into the Laplacian,
         # even though phi_s_cp isn't a pybamm.Variable object

--- a/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
+++ b/tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py
@@ -60,6 +60,53 @@ class TestDFN(BaseIntegrationTestLithiumIon):
 
         assert sol.termination == "final time"
 
+    def test_potential_pair_1plus1D_parallel_electrodes(self):
+        # Regression test for #5467: the 1+1D potential-pair current collector
+        # model represents a single electrode pair, so its boundary condition
+        # must use the per-electrode current. With multiple parallel electrodes,
+        # the cell discharge capacity should match that of a single wide electrode
+        # with the same total current-collector area.
+        model = pybamm.lithium_ion.DFN(
+            options={"current collector": "potential pair", "dimensionality": 1}
+        )
+        params = model.default_parameter_values
+        L_z = params["Electrode height [m]"]
+        L_y = params["Electrode width [m]"]
+        Q = params["Nominal cell capacity [A.h]"]
+
+        params_wide = params.copy()
+        params_wide.update(
+            {
+                "Electrode width [m]": L_y * 2,
+                "Number of electrodes connected in parallel to make a cell": 1,
+                "Nominal cell capacity [A.h]": Q * 2,
+                "Negative tab centre z-coordinate [m]": 0,
+                "Positive tab centre z-coordinate [m]": L_z,
+            }
+        )
+        params_parallel = params.copy()
+        params_parallel.update(
+            {
+                "Electrode width [m]": L_y,
+                "Number of electrodes connected in parallel to make a cell": 2,
+                "Nominal cell capacity [A.h]": Q * 2,
+                "Negative tab centre z-coordinate [m]": 0,
+                "Positive tab centre z-coordinate [m]": L_z,
+            }
+        )
+
+        capacities = []
+        for p in (params_wide, params_parallel):
+            sim = pybamm.Simulation(
+                model,
+                parameter_values=p,
+                experiment=pybamm.Experiment(["Discharge at 0.1C until 3.0 V"]),
+            )
+            sim.solve()
+            capacities.append(sim.solution["Discharge capacity [A.h]"].entries[-1])
+
+        np.testing.assert_allclose(capacities[0], capacities[1], rtol=1e-3)
+
 
 class TestDFNWithSizeDistribution:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- The 1+1D and 2+1D `PotentialPair` current-collector submodels apply a Neumann BC at the positive tab of a single modelled electrode pair, but the boundary condition was computed from the **total cell current** (`applied_current_density * A_cc`) rather than the **per-electrode-pair current**. Because `A_cc` already includes `n_electrodes_parallel`, the gradient of `phi_s_cp` at the tab was overstated by that factor whenever more than one electrode pair was connected in parallel — voltage drops in the current collector were inflated, the lower voltage cutoff was hit prematurely, and the reported discharge capacity was approximately `1 / n_electrodes_parallel` of the correct value.
- Fix: divide by `n_electrodes_parallel` so the BC uses the current per modelled electrode pair. No effect for the default `n=1` case.
- Added an integration regression test that compares discharge capacity between an equivalent wide single-electrode configuration and a two-parallel-electrode configuration with the same total current-collector area; capacities now match.

Fixes #5467

## Test plan
- [x] Reproduction script from the issue: parallel config now reports **40.84 A·h** (matches wide single-electrode case) instead of 22.36 A·h.
- [x] `pytest tests/integration/test_models/test_full_battery_models/test_lithium_ion/test_dfn.py::TestDFN::test_potential_pair_1plus1D_parallel_electrodes` (passes; verified to fail on pre-fix code)
- [x] `pytest tests/unit/test_models/test_full_battery_models/test_lithium_ion -k "1plus1D or 2plus1D or potential_pair"` — 50 passed
- [x] `pre-commit run --files <changed files>` — all hooks pass (ruff-check, ruff-format, blacken-docs, file-checks, sp-repo-review)