### PR TITLE
Fix Solution.get_data_dict() Step length mismatch with starting_solution (#4990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- Fixed `Solution.get_data_dict` returning a `"Step"` array one element longer than `"Cycle"` and `"Time [s]"` after solving with a `starting_solution`. The mismatch came from `EmptySolution` placeholder steps (created when an event triggers at the cycle's initial conditions) whose phantom timestamp is absent from `cycle.t`; they are now skipped when building `"Step"`. ([#4990](https://github.com/pybamm-team/PyBaMM/issues/4990))
+
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 
 ## Bug fixes

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -956,6 +956,12 @@ class Solution(SolutionBase):
                     [data_short_names["Cycle"], i * np.ones_like(cycle.t)]
                 )
                 for j, step in enumerate(cycle.steps):
+                    # EmptySolution steps carry a placeholder timestamp that is
+                    # not present in cycle.t (see Solution.__add__), so they
+                    # would otherwise inflate the Step array length relative to
+                    # cycle.t / Time [s].
+                    if isinstance(step, EmptySolution):
+                        continue
                     data_short_names["Step"] = np.concatenate(
                         [data_short_names["Step"], j * np.ones_like(step.t)]
                     )

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -689,6 +689,35 @@ class TestSolution:
             data["Step"], np.concatenate([np.zeros(50), np.ones(50)])
         )
 
+    def test_get_data_cycles_steps_skips_empty_step(self):
+        # Regression test for #4990: a step that returns an EmptySolution (e.g.
+        # because an event triggered at the cycle's initial conditions when
+        # resuming from a starting solution) carries a placeholder timestamp
+        # that is not present in cycle.t. It must be skipped in get_data_dict
+        # so that "Step" stays the same length as "Time [s]" and "Cycle".
+        model = pybamm.BaseModel()
+        c = pybamm.Variable("c")
+        model.rhs = {c: -c}
+        model.initial_conditions = {c: 1}
+        model.variables["c"] = c
+
+        # Use disjoint time arrays so Solution.__add__ does not deduplicate
+        # the boundary; this isolates the bug to the EmptySolution placeholder.
+        solver = pybamm.ScipySolver()
+        sol1 = solver.solve(model, np.array([0.0, 0.5, 1.0]))
+        sol2 = solver.solve(model, np.array([2.0, 3.0, 4.0]))
+        empty = pybamm.EmptySolution(termination="event", t=99.0)
+
+        cycle = sol1 + sol2
+        cycle.cycles = [cycle]
+        cycle.cycles[0].steps = [empty, sol1, sol2]
+
+        data = cycle.get_data_dict("c")
+        assert len(data["Step"]) == len(data["Cycle"]) == len(data["c"])
+        np.testing.assert_array_equal(
+            data["Step"], np.concatenate([np.ones(3), 2 * np.ones(3)])
+        )
+
     def test_solution_evals_with_inputs(self):
         model = pybamm.lithium_ion.SPM()
         geometry = model.default_geometry


### PR DESCRIPTION
## Summary
- When a `Simulation` is resumed via `starting_solution` and the very first experiment step's event triggers at the cycle's initial conditions, the simulation loop appends a `pybamm.EmptySolution` placeholder (with a single time equal to `start_time`) to that cycle's step list. `Solution.__add__` deduplicates that boundary timestamp against the carried-over `last_state`, so the placeholder time is **not** present in `cycle.t`.
- `Solution.get_data_dict` previously concatenated `np.ones_like(step.t)` for every entry in `cycle.steps` including the `EmptySolution`, which inflated `data["Step"]` by exactly one element per such cycle relative to `data["Cycle"]` and `data["Time [s]"]`.
- Skip `EmptySolution` entries when building `"Step"` so its length stays consistent with `cycle.t`.

Fixes #4990

## Test plan
- [x] Reproduction script from the issue: `Step`, `Cycle`, and `Time [s]` are all 1763 (previously 1764 / 1763 / 1763).
- [x] New regression test `tests/unit/test_solvers/test_solution.py::TestSolution::test_get_data_cycles_steps_skips_empty_step` — verified to fail on pre-fix code (`Step=7` vs `Cycle=6`) and pass with the fix.
- [x] Existing `test_get_data_cycles_steps` still passes.
- [x] `pytest tests/unit/test_solvers/test_solution.py` — 55 passed (1 pre-existing skipped: `test_plot` requires optional `matplotlib`).
- [x] `pre-commit run --files <changed files>` — all hooks pass.