### PR TITLE
fix: stack state mapper p using previous model inputs in experiment steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- Fixed legacy experiment stepping: the precalculated state mapper is evaluated with the *previous* step model's input layout, not the next model's. Fixes CasADi mapper shape errors when transitioning from a scalar `Current` step to a piecewise (array) `Current` step with additional `InputParameter`s.
+
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 
 ## Bug fixes

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1466,17 +1466,13 @@ class BaseSolver:
                 # as an input parameter; match compile-time defaults from
                 # Simulation._build_experiment_state_mappers (inputs.get(name, 0)).
                 mapper_p_inputs = dict(inputs)
-                for name in sorted(
-                    ip.name for ip in previous_model.input_parameters
-                ):
+                for name in sorted(ip.name for ip in previous_model.input_parameters):
                     if name not in mapper_p_inputs or mapper_p_inputs[name] is None:
                         mapper_p_inputs[name] = inputs.get(name, 0)
                 mapper_inputs = BaseSolver._set_up_model_inputs(
                     previous_model, mapper_p_inputs
                 )
-                p_casadi_stacked = casadi.vertcat(
-                    *[p for p in mapper_inputs.values()]
-                )
+                p_casadi_stacked = casadi.vertcat(*[p for p in mapper_inputs.values()])
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1457,7 +1457,14 @@ class BaseSolver:
                 last_state = old_solution.last_state
                 y_from = last_state.all_ys[0]
                 mapper_func, _mapper_jac, _mapper_jacp = state_mapper
-                p_casadi_stacked = casadi.vertcat(*[p for p in model_inputs.values()])
+                # Mapper CasADi graph is compiled using previous_model.input_parameters
+                # (see Simulation._build_experiment_state_mappers); stack p in that
+                # layout, not the next model's model_inputs.
+                previous_model = old_solution.all_models[-1]
+                mapper_inputs = BaseSolver._set_up_model_inputs(previous_model, inputs)
+                p_casadi_stacked = casadi.vertcat(
+                    *[p for p in mapper_inputs.values()]
+                )
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1461,8 +1461,22 @@ class BaseSolver:
                 # (see Simulation._build_experiment_state_mappers); stack p in that
                 # layout, not the next model's model_inputs.
                 previous_model = old_solution.all_models[-1]
-                mapper_inputs = BaseSolver._set_up_model_inputs(previous_model, inputs)
-                p_casadi_stacked = casadi.vertcat(*[p for p in mapper_inputs.values()])
+                # Legacy experiment solves often omit temperature in `inputs`
+                # (include_temperature=False). Padding-rest models still list ambient
+                # as an input parameter; match compile-time defaults from
+                # Simulation._build_experiment_state_mappers (inputs.get(name, 0)).
+                mapper_p_inputs = dict(inputs)
+                for name in sorted(
+                    ip.name for ip in previous_model.input_parameters
+                ):
+                    if name not in mapper_p_inputs or mapper_p_inputs[name] is None:
+                        mapper_p_inputs[name] = inputs.get(name, 0)
+                mapper_inputs = BaseSolver._set_up_model_inputs(
+                    previous_model, mapper_p_inputs
+                )
+                p_casadi_stacked = casadi.vertcat(
+                    *[p for p in mapper_inputs.values()]
+                )
 
                 model.y0_list = [
                     mapper_func(

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1462,9 +1462,7 @@ class BaseSolver:
                 # layout, not the next model's model_inputs.
                 previous_model = old_solution.all_models[-1]
                 mapper_inputs = BaseSolver._set_up_model_inputs(previous_model, inputs)
-                p_casadi_stacked = casadi.vertcat(
-                    *[p for p in mapper_inputs.values()]
-                )
+                p_casadi_stacked = casadi.vertcat(*[p for p in mapper_inputs.values()])
 
                 model.y0_list = [
                     mapper_func(

--- a/tests/integration/test_simulations.py
+++ b/tests/integration/test_simulations.py
@@ -81,10 +81,9 @@ class TestSimulationConsistentState:
 
         cc_solution = sol.cycles[0].steps[0]
 
-        # Replay BaseSolver.step's mapper invocation exactly: pull the
-        # compiled (func, jac_y, jac_p) tuple, build the CV step's input
-        # vector through the same code path, and call the func on the CC
-        # step's last raw state vector.
+        # Compiled state mappers use the *previous* model's input layout; match
+        # BaseSolver.step by stacking p via that model and the upcoming step's
+        # inputs dict (see Simulation.solve / _build_experiment_step_inputs).
         mapper_func, _, _ = sim._compiled_model_state_mappers[(cc_model, cv_model)]
         cv_inputs_dict = sim._build_experiment_step_inputs(
             {},
@@ -93,9 +92,9 @@ class TestSimulationConsistentState:
             None,
             include_temperature=False,
         )
-        cv_solver = sim._get_built_experiment_solver(cv_step)
-        model_inputs = cv_solver._set_up_model_inputs(cv_model, cv_inputs_dict)
-        p_vec = casadi.vertcat(*model_inputs.values())
+        cc_solver = sim._get_built_experiment_solver(cc_step)
+        mapper_p = cc_solver._set_up_model_inputs(cc_model, cv_inputs_dict)
+        p_vec = casadi.vertcat(*mapper_p.values())
         y_from = cc_solution.last_state.all_ys[0]
         seed = np.asarray(mapper_func(float(cc_solution.t[-1]), y_from, p_vec)).ravel()
 
@@ -110,3 +109,34 @@ class TestSimulationConsistentState:
         )
 
         assert seed_current_phys == pytest.approx(-charge_current, rel=1e-9)
+
+    def test_state_mapper_previous_step_input_layout_scalar_then_array_current(self):
+        """Regression: experiment mapper CasADi `p` must match *previous* model inputs.
+
+        Array (piecewise) `Current` steps add a `start time` input; scalar
+        `Current` steps do not. Stacking `p` from the *next* model caused a
+        CasADi shape error at the step transition when another input parameter
+        (e.g. SEI diffusivity) was present on both models.
+        """
+        t = np.linspace(0.0, 30.0, 5)
+        current = np.full_like(t, -0.5)
+        arr = np.column_stack((t, current))
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.Current(0.2, duration=60.0),
+                pybamm.step.Current(arr, duration=float(t[-1])),
+            ]
+        )
+        model = pybamm.lithium_ion.SPM({"SEI": "solvent-diffusion limited"})
+        model.events = []
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        parameter_values["SEI solvent diffusivity [m2.s-1]"] = "[input]"
+        sim = pybamm.Simulation(
+            model,
+            experiment=experiment,
+            parameter_values=parameter_values,
+            solver=pybamm.ScipySolver(),
+        )
+        sol = sim.solve(inputs={"SEI solvent diffusivity [m2.s-1]": 1e-19})
+        assert sol is not None
+        assert sol.t[-1] > 0


### PR DESCRIPTION


Simulation._build_experiment_state_mappers compiles mappers from previous_model.input_parameters; BaseSolver.step must pass the same p layout when calling the compiled CasADi mapper.

Fixes CasADi shape errors when the next step model has more InputParameters than the previous (e.g. scalar Current then piecewise Current with start time).

- Regression test: SPM + SEI input, scalar then array Current
- Align CV initial-guess test with previous-model p stacking

Made-with: Cursor

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
