### PR TITLE
Fix load_custom_model to walk recorded MRO instead of dropping to BaseModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- `Serialise.load_custom_model` no longer silently drops to `pybamm.BaseModel` when the recorded `base_class` cannot be imported. `serialise_custom_model` now records the full ancestor chain in a new `base_class_mro` field, and the loader walks it to resolve to the closest importable ancestor (typically a pybamm-provided class such as the lithium-ion `BaseModel`). This preserves subclass defaults — including `default_spatial_methods` — so loaded models discretise correctly on machines that do not have the original subclass package installed. Falling back to `pybamm.BaseModel` is still the last resort if no MRO entry can be imported.
+
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-- `Serialise.load_custom_model` no longer silently drops to `pybamm.BaseModel` when the recorded `base_class` cannot be imported. `serialise_custom_model` now records the full ancestor chain in a new `base_class_mro` field, and the loader walks it to resolve to the closest importable ancestor (typically a pybamm-provided class such as the lithium-ion `BaseModel`). This preserves subclass defaults — including `default_spatial_methods` — so loaded models discretise correctly on machines that do not have the original subclass package installed. Falling back to `pybamm.BaseModel` is still the last resort if no MRO entry can be imported.
+- Fixed `Serialise.load_custom_model` silently dropping to `pybamm.BaseModel` when the recorded base class cannot be imported. The loader now walks the recorded MRO to resolve to the closest importable ancestor, preserving subclass defaults such as `default_spatial_methods`. ([#5485](https://github.com/pybamm-team/PyBaMM/pull/5485))
 
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -396,9 +396,7 @@ class Serialise:
             If ``dotted_path`` does not contain a module separator.
         """
         if "." not in dotted_path:
-            raise ValueError(
-                f"Expected 'module.ClassName' but got {dotted_path!r}"
-            )
+            raise ValueError(f"Expected 'module.ClassName' but got {dotted_path!r}")
         module_name, class_name = dotted_path.rsplit(".", 1)
         module = importlib.import_module(module_name)
         return getattr(module, class_name)

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -374,27 +374,7 @@ class Serialise:
 
     @staticmethod
     def _import_dotted_class(dotted_path: str):
-        """Import ``module.ClassName`` and return the class, or raise.
-
-        Parameters
-        ----------
-        dotted_path : str
-            Fully qualified ``module.ClassName`` reference.
-
-        Returns
-        -------
-        type
-            The imported class.
-
-        Raises
-        ------
-        ModuleNotFoundError
-            If the module cannot be imported.
-        AttributeError
-            If the module does not expose the named class.
-        ValueError
-            If ``dotted_path`` does not contain a module separator.
-        """
+        """Import ``module.ClassName`` and return the class."""
         if "." not in dotted_path:
             raise ValueError(f"Expected 'module.ClassName' but got {dotted_path!r}")
         module_name, class_name = dotted_path.rsplit(".", 1)
@@ -403,32 +383,13 @@ class Serialise:
 
     @staticmethod
     def _resolve_base_class(base_class: str, base_class_mro: list[str]):
-        """Resolve a serialised ``base_class`` to a Python class, walking the MRO.
+        """Resolve a serialised ``base_class`` to a Python class.
 
-        When a model is serialised on one machine and loaded on another, the
-        user's subclass package may not be installed on the loader's side.
-        Older payloads recorded only ``base_class`` and silently dropped to
-        ``pybamm.BaseModel`` on import failure, which loses subclass-specific
-        defaults (e.g. ``default_spatial_methods`` on lithium-ion models) and
-        produces models that fail mysteriously at discretisation time.
-
-        This resolver tries the recorded ``base_class`` first, then walks
-        ``base_class_mro`` to find the closest ancestor that *is* importable,
-        and only falls back to ``pybamm.BaseModel`` if nothing in the MRO is
-        importable.
-
-        Parameters
-        ----------
-        base_class : str
-            Fully qualified ``module.ClassName`` of the original model class.
-        base_class_mro : list of str
-            Fully qualified ancestor chain (including ``base_class`` at index
-            0) recorded at serialise time. May be empty for older payloads.
-
-        Returns
-        -------
-        type
-            A class to instantiate as the loaded model.
+        Tries ``base_class`` first, then each entry in ``base_class_mro`` (the
+        ancestor chain recorded at serialise time). Falls back to
+        ``pybamm.BaseModel`` only if nothing in the MRO is importable, so a
+        custom subclass loaded in an environment without its defining package
+        is still reconstructed against the closest pybamm-provided ancestor.
         """
         try:
             return Serialise._import_dotted_class(base_class)
@@ -438,7 +399,9 @@ class Serialise:
                     continue
                 try:
                     resolved = Serialise._import_dotted_class(ancestor)
-                except (ModuleNotFoundError, AttributeError, ValueError):
+                except (ModuleNotFoundError, AttributeError):
+                    # ValueError is left to propagate: MRO entries are produced
+                    # by ``serialise_custom_model`` and are always well-formed.
                     continue
                 warnings.warn(
                     f"Could not import base class '{base_class}': "
@@ -509,12 +472,6 @@ class Serialise:
         else:
             base_cls_str = f"{base_cls.__module__}.{base_cls.__name__}"
 
-        # Record the full ancestor chain so a loader running in an environment
-        # without the user's subclass package can fall back to the closest
-        # ancestor it can import (typically a pybamm-provided class) rather
-        # than silently dropping all the way to ``pybamm.BaseModel``. ``object``
-        # and other ``builtins`` entries are excluded as they are not useful
-        # fallbacks.
         base_class_mro = [
             f"{ancestor.__module__}.{ancestor.__name__}"
             for ancestor in base_cls.__mro__

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -373,6 +373,92 @@ class Serialise:
             raise TypeError(f"Object of type {type(obj)} is not JSON serializable.")
 
     @staticmethod
+    def _import_dotted_class(dotted_path: str):
+        """Import ``module.ClassName`` and return the class, or raise.
+
+        Parameters
+        ----------
+        dotted_path : str
+            Fully qualified ``module.ClassName`` reference.
+
+        Returns
+        -------
+        type
+            The imported class.
+
+        Raises
+        ------
+        ModuleNotFoundError
+            If the module cannot be imported.
+        AttributeError
+            If the module does not expose the named class.
+        ValueError
+            If ``dotted_path`` does not contain a module separator.
+        """
+        if "." not in dotted_path:
+            raise ValueError(
+                f"Expected 'module.ClassName' but got {dotted_path!r}"
+            )
+        module_name, class_name = dotted_path.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        return getattr(module, class_name)
+
+    @staticmethod
+    def _resolve_base_class(base_class: str, base_class_mro: list[str]):
+        """Resolve a serialised ``base_class`` to a Python class, walking the MRO.
+
+        When a model is serialised on one machine and loaded on another, the
+        user's subclass package may not be installed on the loader's side.
+        Older payloads recorded only ``base_class`` and silently dropped to
+        ``pybamm.BaseModel`` on import failure, which loses subclass-specific
+        defaults (e.g. ``default_spatial_methods`` on lithium-ion models) and
+        produces models that fail mysteriously at discretisation time.
+
+        This resolver tries the recorded ``base_class`` first, then walks
+        ``base_class_mro`` to find the closest ancestor that *is* importable,
+        and only falls back to ``pybamm.BaseModel`` if nothing in the MRO is
+        importable.
+
+        Parameters
+        ----------
+        base_class : str
+            Fully qualified ``module.ClassName`` of the original model class.
+        base_class_mro : list of str
+            Fully qualified ancestor chain (including ``base_class`` at index
+            0) recorded at serialise time. May be empty for older payloads.
+
+        Returns
+        -------
+        type
+            A class to instantiate as the loaded model.
+        """
+        try:
+            return Serialise._import_dotted_class(base_class)
+        except (ModuleNotFoundError, AttributeError, ValueError) as primary_err:
+            for ancestor in base_class_mro:
+                if ancestor == base_class:
+                    continue
+                try:
+                    resolved = Serialise._import_dotted_class(ancestor)
+                except (ModuleNotFoundError, AttributeError, ValueError):
+                    continue
+                warnings.warn(
+                    f"Could not import base class '{base_class}': "
+                    f"{primary_err}. Falling back to ancestor "
+                    f"'{ancestor}' from the recorded MRO.",
+                    stacklevel=3,
+                )
+                return resolved
+            warnings.warn(
+                f"Could not import base class '{base_class}': "
+                f"{primary_err}. Falling back to pybamm.BaseModel; the loaded "
+                "model will contain the symbolic equations but not any "
+                "subclass-specific Python behaviour.",
+                stacklevel=3,
+            )
+            return pybamm.BaseModel
+
+    @staticmethod
     def serialise_custom_model(model: pybamm.BaseModel, compress: bool = False) -> dict:
         """
         Converts a custom (non-discretised) PyBaMM model to a JSON-serialisable dictionary.
@@ -425,9 +511,22 @@ class Serialise:
         else:
             base_cls_str = f"{base_cls.__module__}.{base_cls.__name__}"
 
+        # Record the full ancestor chain so a loader running in an environment
+        # without the user's subclass package can fall back to the closest
+        # ancestor it can import (typically a pybamm-provided class) rather
+        # than silently dropping all the way to ``pybamm.BaseModel``. ``object``
+        # and other ``builtins`` entries are excluded as they are not useful
+        # fallbacks.
+        base_class_mro = [
+            f"{ancestor.__module__}.{ancestor.__name__}"
+            for ancestor in base_cls.__mro__
+            if ancestor is not object and ancestor.__module__ != "builtins"
+        ]
+
         model_content = {
             "name": getattr(model, "name", "unnamed_model"),
             "base_class": base_cls_str,
+            "base_class_mro": base_class_mro,
             "options": getattr(model, "options", {}),
             "rhs": [
                 (
@@ -1366,19 +1465,10 @@ class Serialise:
         if battery_model in ("", "pybamm.BaseModel", "builtins.object"):
             base_cls = pybamm.BaseModel
         else:
-            module_name, class_name = battery_model.rsplit(".", 1)
-            try:
-                module = importlib.import_module(module_name)
-                base_cls = getattr(module, class_name)
-            except (ModuleNotFoundError, AttributeError) as e:
-                warnings.warn(
-                    f"Could not import base class '{battery_model}': {e}. "
-                    "Falling back to pybamm.BaseModel; the loaded model will "
-                    "contain the symbolic equations but not any subclass-specific "
-                    "Python behaviour.",
-                    stacklevel=2,
-                )
-                base_cls = pybamm.BaseModel
+            base_cls = Serialise._resolve_base_class(
+                battery_model,
+                model_data.get("base_class_mro") or [],
+            )
 
         model = base_cls()
         model.name = model_data["name"]

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -972,6 +972,149 @@ class TestSerialise:
         assert "positive particle" in loaded.default_geometry
         assert "positive particle" in loaded.default_spatial_methods
 
+    def test_serialise_records_base_class_mro(self, tmp_path):
+        """``serialise_custom_model`` records the model's MRO (excluding
+        ``object``) so loaders can fall back to an importable ancestor when
+        the user's subclass package is not available."""
+        from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
+            BaseModel as LiIonBaseModel,
+        )
+
+        model = LiIonBaseModel(options={"working electrode": "positive"})
+        a = pybamm.Variable("a", domain="positive particle")
+        model.rhs = {a: -a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
+
+        payload = Serialise.serialise_custom_model(model)
+        mro = payload["model"]["base_class_mro"]
+
+        assert payload["model"]["base_class"] == mro[0]
+        assert "pybamm.models.base_model.BaseModel" in mro
+        assert (
+            "pybamm.models.full_battery_models.lithium_ion."
+            "base_lithium_ion_model.BaseModel"
+        ) in mro
+        # ``object`` and other ``builtins`` entries must be filtered out so
+        # they cannot end up shadowing a more useful pybamm ancestor.
+        assert all(not entry.startswith("builtins.") for entry in mro)
+
+    def test_load_falls_back_to_mro_ancestor_when_base_class_unimportable(
+        self, tmp_path
+    ):
+        """When ``base_class`` references a class that the loader's environment
+        cannot import (typical when a user's subclass is defined in a private
+        package that isn't installed on a backend), ``load_custom_model`` must
+        walk the recorded MRO and resolve to the closest importable ancestor —
+        not silently drop to ``pybamm.BaseModel``."""
+        from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
+            BaseModel as LiIonBaseModel,
+        )
+
+        model = LiIonBaseModel()
+        a = pybamm.Variable("a", domain="positive particle")
+        model.rhs = {a: -a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
+
+        file_path = tmp_path / "model.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+
+        # Simulate a payload that originated from a user subclass living in a
+        # package the loader does not have installed. The MRO still contains
+        # the pybamm-provided lithium-ion BaseModel as an ancestor.
+        with open(file_path) as f:
+            data = json.load(f)
+        data["model"]["base_class"] = "user_private_pkg.MyLiIon"
+        data["model"]["base_class_mro"] = [
+            "user_private_pkg.MyLiIon",
+            *data["model"]["base_class_mro"],
+        ]
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        with pytest.warns(
+            UserWarning,
+            match=(
+                r"Could not import base class 'user_private_pkg\.MyLiIon'.*"
+                r"Falling back to ancestor "
+                r"'pybamm\.models\.full_battery_models\.lithium_ion\."
+                r"base_lithium_ion_model\.BaseModel'"
+            ),
+        ):
+            loaded = Serialise.load_custom_model(str(file_path))
+
+        # The loaded model has the lithium-ion defaults — crucially,
+        # ``default_spatial_methods`` includes the ``positive particle`` mesh
+        # so downstream discretisation works. A bare ``pybamm.BaseModel``
+        # would have an empty ``default_spatial_methods``.
+        assert isinstance(loaded, LiIonBaseModel)
+        assert "positive particle" in loaded.default_spatial_methods
+
+    def test_load_falls_back_to_base_model_when_no_mro_entry_importable(
+        self, tmp_path
+    ):
+        """If neither ``base_class`` nor any MRO ancestor can be imported,
+        the loader still falls back to ``pybamm.BaseModel`` (the legacy
+        behaviour) rather than raising."""
+        model = pybamm.BaseModel(name="DummyModel")
+        a = pybamm.Variable("a")
+        model.rhs = {a: a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
+
+        file_path = tmp_path / "model.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+
+        with open(file_path) as f:
+            data = json.load(f)
+        data["model"]["base_class"] = "nonexistent_module.A"
+        data["model"]["base_class_mro"] = [
+            "nonexistent_module.A",
+            "another_missing_module.B",
+        ]
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        with pytest.warns(
+            UserWarning,
+            match=(
+                r"Could not import base class 'nonexistent_module\.A'.*"
+                r"Falling back to pybamm\.BaseModel"
+            ),
+        ):
+            loaded = Serialise.load_custom_model(str(file_path))
+
+        assert type(loaded) is pybamm.BaseModel
+
+    def test_load_legacy_payload_without_base_class_mro(self, tmp_path):
+        """Payloads written before ``base_class_mro`` was added must still
+        load: missing the field is equivalent to an empty MRO, and the loader
+        falls back to ``pybamm.BaseModel`` when ``base_class`` is unimportable."""
+        model = pybamm.BaseModel(name="DummyModel")
+        a = pybamm.Variable("a")
+        model.rhs = {a: a}
+        model.initial_conditions = {a: pybamm.Scalar(1)}
+        model.variables = {"a": a}
+
+        file_path = tmp_path / "model.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+
+        with open(file_path) as f:
+            data = json.load(f)
+        data["model"]["base_class"] = "nonexistent_module.A"
+        data["model"].pop("base_class_mro", None)
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+
+        with pytest.warns(
+            UserWarning,
+            match=r"Could not import base class 'nonexistent_module\.A'",
+        ):
+            loaded = Serialise.load_custom_model(str(file_path))
+
+        assert type(loaded) is pybamm.BaseModel
+
     def test_function_parameter_with_diff_variable_serialisation(self):
         x = pybamm.Variable("x")
         diff_var = pybamm.Variable("r")

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -973,9 +973,6 @@ class TestSerialise:
         assert "positive particle" in loaded.default_spatial_methods
 
     def test_serialise_records_base_class_mro(self, tmp_path):
-        """``serialise_custom_model`` records the model's MRO (excluding
-        ``object``) so loaders can fall back to an importable ancestor when
-        the user's subclass package is not available."""
         from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
             BaseModel as LiIonBaseModel,
         )
@@ -995,18 +992,11 @@ class TestSerialise:
             "pybamm.models.full_battery_models.lithium_ion."
             "base_lithium_ion_model.BaseModel"
         ) in mro
-        # ``object`` and other ``builtins`` entries must be filtered out so
-        # they cannot end up shadowing a more useful pybamm ancestor.
         assert all(not entry.startswith("builtins.") for entry in mro)
 
     def test_load_falls_back_to_mro_ancestor_when_base_class_unimportable(
         self, tmp_path
     ):
-        """When ``base_class`` references a class that the loader's environment
-        cannot import (typical when a user's subclass is defined in a private
-        package that isn't installed on a backend), ``load_custom_model`` must
-        walk the recorded MRO and resolve to the closest importable ancestor —
-        not silently drop to ``pybamm.BaseModel``."""
         from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
             BaseModel as LiIonBaseModel,
         )
@@ -1020,9 +1010,6 @@ class TestSerialise:
         file_path = tmp_path / "model.json"
         Serialise.save_custom_model(model, filename=str(file_path))
 
-        # Simulate a payload that originated from a user subclass living in a
-        # package the loader does not have installed. The MRO still contains
-        # the pybamm-provided lithium-ion BaseModel as an ancestor.
         with open(file_path) as f:
             data = json.load(f)
         data["model"]["base_class"] = "user_private_pkg.MyLiIon"
@@ -1037,24 +1024,15 @@ class TestSerialise:
             UserWarning,
             match=(
                 r"Could not import base class 'user_private_pkg\.MyLiIon'.*"
-                r"Falling back to ancestor "
-                r"'pybamm\.models\.full_battery_models\.lithium_ion\."
-                r"base_lithium_ion_model\.BaseModel'"
+                r"Falling back to ancestor '.*base_lithium_ion_model.*'"
             ),
         ):
             loaded = Serialise.load_custom_model(str(file_path))
 
-        # The loaded model has the lithium-ion defaults — crucially,
-        # ``default_spatial_methods`` includes the ``positive particle`` mesh
-        # so downstream discretisation works. A bare ``pybamm.BaseModel``
-        # would have an empty ``default_spatial_methods``.
         assert isinstance(loaded, LiIonBaseModel)
         assert "positive particle" in loaded.default_spatial_methods
 
     def test_load_falls_back_to_base_model_when_no_mro_entry_importable(self, tmp_path):
-        """If neither ``base_class`` nor any MRO ancestor can be imported,
-        the loader still falls back to ``pybamm.BaseModel`` (the legacy
-        behaviour) rather than raising."""
         model = pybamm.BaseModel(name="DummyModel")
         a = pybamm.Variable("a")
         model.rhs = {a: a}
@@ -1086,9 +1064,6 @@ class TestSerialise:
         assert type(loaded) is pybamm.BaseModel
 
     def test_load_legacy_payload_without_base_class_mro(self, tmp_path):
-        """Payloads written before ``base_class_mro`` was added must still
-        load: missing the field is equivalent to an empty MRO, and the loader
-        falls back to ``pybamm.BaseModel`` when ``base_class`` is unimportable."""
         model = pybamm.BaseModel(name="DummyModel")
         a = pybamm.Variable("a")
         model.rhs = {a: a}

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -1051,9 +1051,7 @@ class TestSerialise:
         assert isinstance(loaded, LiIonBaseModel)
         assert "positive particle" in loaded.default_spatial_methods
 
-    def test_load_falls_back_to_base_model_when_no_mro_entry_importable(
-        self, tmp_path
-    ):
+    def test_load_falls_back_to_base_model_when_no_mro_entry_importable(self, tmp_path):
         """If neither ``base_class`` nor any MRO ancestor can be imported,
         the loader still falls back to ``pybamm.BaseModel`` (the legacy
         behaviour) rather than raising."""


### PR DESCRIPTION
## Description

`Serialise.load_custom_model` previously fell back to `pybamm.BaseModel` whenever the recorded `base_class` could not be imported (e.g. a user subclass defined in a package not installed on the loader). This is fragile: bare `pybamm.BaseModel` has an empty `default_spatial_methods`, so the loaded model carries the right symbolic equations but fails downstream at discretisation in a way that is hard to trace back to the silent fallback.

This PR records the full MRO at serialise time and walks it at load time, resolving to the closest importable ancestor (typically the lithium-ion `BaseModel`) so subclass defaults are preserved. `pybamm.BaseModel` is still the last-resort fallback if nothing in the MRO is importable. Legacy payloads written before this change continue to load.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Key changes

- `serialise_custom_model` now writes a `base_class_mro` field — the model class's full ancestor chain, fully-qualified `module.ClassName` strings, with `object` and other `builtins` entries filtered out.
- `load_custom_model` delegates resolution to a new `Serialise._resolve_base_class` helper that tries `base_class` first, then walks `base_class_mro`, and only falls back to `pybamm.BaseModel` if nothing imports.
- New helper `Serialise._import_dotted_class` performs the dotted-path import.
- The fallback warning now identifies the ancestor used (or that the final fallback to `pybamm.BaseModel` was taken).
- Schema version is unchanged; `base_class_mro` is optional on read so older payloads still load.

## Why this matters

Custom models are commonly serialised on a developer machine and loaded on a separate backend that has only `pybamm` installed. Under the previous behaviour, a subclass of the lithium-ion `BaseModel` would silently load as `pybamm.BaseModel` and fail at discretisation with a confusing error about missing spatial methods on the `positive particle` domain. The new behaviour preserves the closest pybamm-provided ancestor and discretisation proceeds correctly.

## Testing

New tests in `tests/unit/test_serialisation/test_serialisation.py`:

- `test_serialise_records_base_class_mro` — the new field is present, includes `pybamm`-provided ancestors, and excludes `builtins`.
- `test_load_falls_back_to_mro_ancestor_when_base_class_unimportable` — payload pointing at an unimportable `base_class` resolves to the lithium-ion `BaseModel` via the MRO and the loaded model has `positive particle` in `default_spatial_methods`.
- `test_load_falls_back_to_base_model_when_no_mro_entry_importable` — when no MRO entry can be imported, `pybamm.BaseModel` is still used (legacy behaviour).
- `test_load_legacy_payload_without_base_class_mro` — payloads predating this change still load.

The existing `test_import_base_class_non_builtin_object` still passes: its corruption only mutates `base_class`, so the MRO walk finds the original `pybamm.models.base_model.BaseModel` entry.

All 178 tests in `tests/unit/test_serialisation/` pass locally.