### PR TITLE
Fix EIS impedance scale: compute z_scale after model transformation

### DIFF
--- a/src/pybamm/simulation/eis_simulation.py
+++ b/src/pybamm/simulation/eis_simulation.py
@@ -46,13 +46,15 @@ class EISSimulation(BaseSimulation):
         # Validate required variables and surface form before any processing
         self._validate_model_for_eis(model)
 
-        # Compute impedance scale factor before model transformation
-        V_scale = getattr(model.variables["Voltage [V]"], "scale", 1)
-        I_scale = getattr(model.variables["Current [A]"], "scale", 1)
-        self._z_scale = parameter_values.evaluate(V_scale / I_scale)
-
         pybamm.logger.info(f"Setting up {model_name} for EIS")
         eis_model = self._set_up_model_for_eis(model)
+
+        # Compute impedance scale factor after model transformation: the
+        # external-circuit FunctionControl swap rescales "Current [A]" by
+        # the nominal cell capacity, which must be reflected in z = V/I.
+        V_scale = getattr(eis_model.variables["Voltage [V]"], "scale", 1)
+        I_scale = getattr(eis_model.variables["Current [A]"], "scale", 1)
+        self._z_scale = parameter_values.evaluate(V_scale / I_scale)
 
         parameter_values["Current function [A]"] = 0
 

--- a/tests/unit/test_eis_simulation.py
+++ b/tests/unit/test_eis_simulation.py
@@ -191,6 +191,21 @@ class TestEISSimulationSolve:
         result = eis_sim.solve(frequencies, initial_soc="3.8 V")
         assert result.impedance.shape == (10,)
 
+    def test_high_freq_intercept_matches_contact_resistance(self):
+        model = pybamm.lithium_ion.SPM(
+            options={"surface form": "differential", "contact resistance": "true"}
+        )
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        parameter_values.update({"Contact resistance [Ohm]": 1.0})
+
+        eis_sim = pybamm.EISSimulation(model, parameter_values=parameter_values)
+        frequencies = np.logspace(-4, 4, 30)
+        result = eis_sim.solve(frequencies)
+
+        high_freq_z = result.impedance[-1]
+        assert high_freq_z.real == pytest.approx(1.0, abs=1e-3)
+        assert abs(high_freq_z.imag) < 1e-3
+
 
 class TestNyquistPlot:
     """Tests for Nyquist plotting."""


### PR DESCRIPTION
## Summary

`pybamm.EISSimulation` was returning impedances inflated by the nominal cell capacity (~5× for `Chen2020`), so a 1 Ohm contact resistance showed up at ~5 Ohm on the Nyquist plot instead of ~1 Ohm.

`_set_up_model_for_eis` swaps `Current [A]` for the external-circuit `FunctionControl` variable, whose scale is `Nominal cell capacity [A.h]`. The original code read `V_scale / I_scale` from the *un-transformed* model (both = 1), so `z_scale = 1.0` instead of `1 / Q_nom`. Moving the scale lookup to after `_set_up_model_for_eis` matches what the `pybamm-eis` package does and gives the correct impedance.

## Reproduction

```python
import numpy as np
import pybamm

model = pybamm.lithium_ion.SPM(
    options={"surface form": "differential", "contact resistance": "true"}
)
parameter_values = pybamm.ParameterValues("Chen2020")
parameter_values.update({"Contact resistance [Ohm]": 1.0})

eis_sim = pybamm.EISSimulation(model, parameter_values=parameter_values)
eis_sim.solve(np.logspace(-4, 4, 30))
eis_sim.nyquist_plot()  # before: intercepts x-axis at ~5; after: ~1
```

## Before / after

Overlay against `pybamm-eis` (which is correct):

**Before fix:** 
<img width="960" height="720" alt="nyquist_comparison" src="https://github.com/user-attachments/assets/30936cc4-b103-43d7-aa9c-ad36c4f7504c" />

**After fix:**
<img width="960" height="720" alt="nyquist_comparison_fixed" src="https://github.com/user-attachments/assets/271cd807-fcfa-4795-8315-8a808c8ebffb" />

## Test plan
- [x] Added `test_high_freq_intercept_matches_contact_resistance` — verified it fails on the buggy code and passes on the fix
- [x] Existing 25 EIS tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)