### PR TITLE
fix: EISSimulation.solve must forward inputs to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 - Fixed legacy experiment stepping: the precalculated state mapper is evaluated with the *previous* step model's input layout, not the next model's. Fixes CasADi mapper shape errors when transitioning from a scalar `Current` step to a piecewise (array) `Current` step with additional `InputParameter`s.
+- Fixed `EISSimulation.solve(initial_soc=..., inputs=...)` not forwarding `inputs` to `build`.
 
 # [v26.4.1](https://github.com/pybamm-team/PyBaMM/tree/v26.4.1) - 2026-04-24
 

--- a/src/pybamm/simulation/eis_simulation.py
+++ b/src/pybamm/simulation/eis_simulation.py
@@ -258,7 +258,7 @@ class EISSimulation(BaseSimulation):
         timer = pybamm.Timer()
 
         if initial_soc is not None:
-            self.build(initial_soc=initial_soc)
+            self.build(initial_soc=initial_soc, inputs=inputs)
         elif self._built_model is None:
             self.build()
 

--- a/tests/unit/test_eis_simulation.py
+++ b/tests/unit/test_eis_simulation.py
@@ -191,6 +191,48 @@ class TestEISSimulationSolve:
         result = eis_sim.solve(frequencies, initial_soc="3.8 V")
         assert result.impedance.shape == (10,)
 
+    def test_initial_soc_forwards_inputs(self):
+        """``solve(initial_soc=..., inputs=...)`` must forward ``inputs`` to
+        ``build``. Without it, the ``set_initial_state`` path evaluates
+        symbols (e.g. ``Q_init`` on the half-cell) without inputs and raises
+        ``"symbol must evaluate to a constant scalar or array"`` whenever a
+        parameter value is a symbolic expression that references an
+        :class:`InputParameter`.
+        """
+        model = pybamm.lithium_ion.SPM(
+            options={
+                "working electrode": "positive",
+                "surface form": "differential",
+            }
+        )
+        parameter_values = pybamm.ParameterValues(
+            "OKane2022_graphite_SiOx_halfcell"
+        )
+        # Active material volume fraction depends on an InputParameter, so
+        # ``Q_init`` (which depends on it) is non-constant and must be
+        # evaluated with the corresponding input supplied.
+        eps = parameter_values["Positive electrode porosity"]
+        parameter_values.update(
+            {
+                "Positive electrode active material volume fraction": (
+                    (1 - eps) * pybamm.InputParameter("vf_solid")
+                ),
+            },
+        )
+        eis_sim = pybamm.EISSimulation(model, parameter_values=parameter_values)
+        frequencies = np.logspace(-2, 2, 5)
+
+        # Both numeric SOC and voltage-string SOC paths must work.
+        z_soc = eis_sim.solve(
+            frequencies, inputs={"vf_solid": 0.94}, initial_soc=0.5
+        )
+        assert z_soc.impedance.shape == (5,)
+
+        z_v = eis_sim.solve(
+            frequencies, inputs={"vf_solid": 0.94}, initial_soc="0.5 V"
+        )
+        assert z_v.impedance.shape == (5,)
+
     def test_high_freq_intercept_matches_contact_resistance(self):
         model = pybamm.lithium_ion.SPM(
             options={"surface form": "differential", "contact resistance": "true"}

--- a/tests/unit/test_eis_simulation.py
+++ b/tests/unit/test_eis_simulation.py
@@ -205,9 +205,7 @@ class TestEISSimulationSolve:
                 "surface form": "differential",
             }
         )
-        parameter_values = pybamm.ParameterValues(
-            "OKane2022_graphite_SiOx_halfcell"
-        )
+        parameter_values = pybamm.ParameterValues("OKane2022_graphite_SiOx_halfcell")
         # Active material volume fraction depends on an InputParameter, so
         # ``Q_init`` (which depends on it) is non-constant and must be
         # evaluated with the corresponding input supplied.
@@ -223,14 +221,10 @@ class TestEISSimulationSolve:
         frequencies = np.logspace(-2, 2, 5)
 
         # Both numeric SOC and voltage-string SOC paths must work.
-        z_soc = eis_sim.solve(
-            frequencies, inputs={"vf_solid": 0.94}, initial_soc=0.5
-        )
+        z_soc = eis_sim.solve(frequencies, inputs={"vf_solid": 0.94}, initial_soc=0.5)
         assert z_soc.impedance.shape == (5,)
 
-        z_v = eis_sim.solve(
-            frequencies, inputs={"vf_solid": 0.94}, initial_soc="0.5 V"
-        )
+        z_v = eis_sim.solve(frequencies, inputs={"vf_solid": 0.94}, initial_soc="0.5 V")
         assert z_v.impedance.shape == (5,)
 
     def test_high_freq_intercept_matches_contact_resistance(self):


### PR DESCRIPTION
## Summary

`EISSimulation.solve(initial_soc=..., inputs=...)` rebuilds the simulation for the requested SOC by calling `self.build(initial_soc=...)`, but it did not pass `inputs` through. Inside `set_initial_state`, the half-cell ESOH path evaluates `Q_init` (which depends on the active material volume fraction). When a parameter value is a symbolic expression that references an `InputParameter` — e.g. a linked-parameter expression `(1 - porosity) * pybamm.InputParameter("vf_solid")` for the active material volume fraction — evaluation with `inputs=None` raises:

```
ValueError: symbol must evaluate to a constant scalar or array
```

This patch forwards `inputs` to `build` so the ESOH path can substitute them.

## Change

Single line in `src/pybamm/simulation/eis_simulation.py`:

```diff
 if initial_soc is not None:
-    self.build(initial_soc=initial_soc)
+    self.build(initial_soc=initial_soc, inputs=inputs)
 elif self._built_model is None:
     self.build()
```

## Test plan

- [x] Added `test_initial_soc_forwards_inputs` to `tests/unit/test_eis_simulation.py` covering both numeric SOC and voltage-string SOC paths with a half-cell SPM whose active material volume fraction is `(1 - porosity) * pybamm.InputParameter("vf_solid")`. Fails on `main` with the exact `"symbol must evaluate to a constant scalar or array"` error; passes with the fix.
- [x] Existing EIS tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)