### PR TITLE
Release v26.4.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+# [v26.4.2](https://github.com/pybamm-team/PyBaMM/tree/v26.4.2) - 2026-05-05
+
 ## Bug fixes
 
 - Fixed `EISSimulation.solve(initial_soc=..., inputs=...)` not forwarding `inputs` to `build`. ([#5487](https://github.com/pybamm-team/PyBaMM/pull/5487))

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.4.1"
+version: "26.4.2"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"


### PR DESCRIPTION
## Summary

Updates `main` after the v26.4.2 patch release was cut from `release/v26.4.2` (per [release_workflow.md](.github/release_workflow.md)).

- Moves the four v26.4.2 bug-fix entries out of `# [Unreleased]` and into a new `# [v26.4.2] - 2026-05-05` section.
- Bumps `CITATION.cff` to `26.4.2`.

The `release/v26.4.2` branch is intentionally not merged back to `main` (the workflow doc warns that doing so creates duplicate commits with different hashes).

## Test plan

- [ ] CI green
- [ ] Confirm `# [Unreleased]` still contains the `NonlinearSolver` Features entry (#5459) for the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)