### PR TITLE
Fix bool->int coercion in Serialise._to_json_safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-- Fixed `Serialise._to_json_safe` coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int`. `IDAKLUSolver.to_config()` now emits its bool options (`compile`, `print_stats`, `silence_sundials_errors`, etc.) as JSON `true`/`false` so they round-trip through strict-bool deserialisers.
+- Fixed `Serialise._to_json_safe` coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int`. `IDAKLUSolver.to_config()` now emits its bool options (`compile`, `print_stats`, `silence_sundials_errors`, etc.) as JSON `true`/`false` so they round-trip through strict-bool deserialisers. ([#5495](https://github.com/pybamm-team/PyBaMM/pull/5495))
 
 # [v26.4.2](https://github.com/pybamm-team/PyBaMM/tree/v26.4.2) - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- Fixed `Serialise._to_json_safe` coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int`. `IDAKLUSolver.to_config()` now emits its bool options (`compile`, `print_stats`, `silence_sundials_errors`, etc.) as JSON `true`/`false` so they round-trip through strict-bool deserialisers.
+
 # [v26.4.2](https://github.com/pybamm-team/PyBaMM/tree/v26.4.2) - 2026-05-05
 
 ## Bug fixes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1768,14 +1768,14 @@ class Serialise:
 
         Handles numpy scalars, arrays, booleans, and nested dicts/lists.
         """
+        if isinstance(value, (np.bool_, bool)):
+            return bool(value)
         if isinstance(value, (np.floating, float)):
             return float(value)
         if isinstance(value, (np.integer, int)):
             return int(value)
         if isinstance(value, np.ndarray):
             return value.tolist()
-        if isinstance(value, np.bool_):
-            return bool(value)
         if isinstance(value, dict):
             return {k: Serialise._to_json_safe(v) for k, v in value.items()}
         if isinstance(value, list):

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -3058,6 +3058,52 @@ class TestSolverSerialization:
         with pytest.raises(ValueError, match="Unknown solver type"):
             pybamm.BaseSolver.from_config({"type": "NonExistentSolver"})
 
+    def test_to_json_safe_preserves_bool(self):
+        # bool is a subclass of int; the int branch must not match first.
+        assert Serialise._to_json_safe(True) is True
+        assert Serialise._to_json_safe(False) is False
+        assert Serialise._to_json_safe(np.bool_(True)) is True
+        assert Serialise._to_json_safe(np.bool_(False)) is False
+        # Plain ints are still ints.
+        assert Serialise._to_json_safe(1) == 1
+        assert isinstance(Serialise._to_json_safe(1), int)
+        assert not isinstance(Serialise._to_json_safe(1), bool)
+
+    def test_idaklu_solver_bool_options_round_trip(self):
+        solver = pybamm.IDAKLUSolver(
+            options={
+                "print_stats": True,
+                "compile": False,
+                "silence_sundials_errors": True,
+            }
+        )
+        config = solver.to_config()
+        opts = config["options"]
+        for key in ("print_stats", "compile", "silence_sundials_errors"):
+            assert isinstance(opts[key], bool), (
+                f"option {key!r} serialised as {type(opts[key]).__name__}, "
+                f"expected bool"
+            )
+        assert opts["print_stats"] is True
+        assert opts["compile"] is False
+        assert opts["silence_sundials_errors"] is True
+
+        solver2 = pybamm.BaseSolver.from_config(config)
+        assert isinstance(solver2, pybamm.IDAKLUSolver)
+        assert solver2.options["print_stats"] is True
+        assert solver2.options["compile"] is False
+        assert solver2.options["silence_sundials_errors"] is True
+
+    def test_idaklu_solver_config_json_emits_bool_tokens(self):
+        solver = pybamm.IDAKLUSolver(options={"print_stats": True, "compile": False})
+        config = solver.to_config()
+        json_str = json.dumps(config)
+        # Wire format must use JSON bool tokens, not 0/1.
+        assert '"print_stats": true' in json_str
+        assert '"compile": false' in json_str
+        assert '"print_stats": 1' not in json_str
+        assert '"compile": 0' not in json_str
+
     def test_serialise_scalar_inf_round_trip(self):
         """Scalar(inf) and Scalar(-inf) survive round-trip."""
         for val in [np.inf, -np.inf]:


### PR DESCRIPTION
## Summary

- `Serialise._to_json_safe` was coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int` and the `isinstance(value, (np.integer, int))` check matched first. The `np.bool_` branch below it was unreachable for native bools.
- Reorder the isinstance chain so `(np.bool_, bool)` is matched before the numeric branches. One-liner behaviour change.
- Visible failure mode: `IDAKLUSolver.to_config()` emitted its bool options (`compile`, `print_stats`, `silence_sundials_errors`, `calc_ic`, `hermite_interpolation`, `init_all_y_ic`, `linear_solution_scaling`, `linesearch_off_ic`, `suppress_algebraic_error`) as `0`/`1` ints, which any strict-bool consumer of the JSON config would reject. The reverse path (`deserialise_solver` → `IDAKLUSolver(**data)`) was already correct.

## Test plan

- [x] New unit tests in `tests/unit/test_serialisation/test_serialisation.py::TestSolverSerialization`:
  - `test_to_json_safe_preserves_bool` — direct check that `_to_json_safe(True/False/np.bool_(...))` returns a `bool`, and that plain ints are still ints (not bools).
  - `test_idaklu_solver_bool_options_round_trip` — `IDAKLUSolver(options={...}).to_config()` renders bool options as `bool`, and `from_config(...)` restores them.
  - `test_idaklu_solver_config_json_emits_bool_tokens` — `json.dumps(config)` produces the JSON tokens `true`/`false`, never `1`/`0`, for the wire format.
- [x] Full `tests/unit/test_serialisation/test_serialisation.py` passes (181/181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)