### PR TITLE
fix: round-trip per-step temperature through Serialise.serialise_experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+## Bug fixes
+
+- Fixed `Serialise.serialise_experiment` silently dropping per-step `temperature` overrides. The JSON-config round-trip via `Experiment.to_config()` / `Experiment.from_config()` now preserves `temperature` for current, voltage, power, c-rate, and rest steps. ([#5496](https://github.com/pybamm-team/PyBaMM/pull/5496))
+
 # [v26.4.2](https://github.com/pybamm-team/PyBaMM/tree/v26.4.2) - 2026-05-05
 
 ## Bug fixes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1851,6 +1851,9 @@ class Serialise:
                     terminations.append(term_config)
                 step_config["terminations"] = terminations
 
+            if getattr(step, "temperature", None) is not None:
+                step_config["temperature"] = step.temperature
+
             return step_config
 
         steps_config = [_serialise_step(step) for step in experiment.steps]
@@ -1936,9 +1939,17 @@ class Serialise:
                     _parse_termination(t) for t in step_dict["terminations"]
                 ]
 
+            extra_kwargs = {}
+            if step_dict.get("temperature") is not None:
+                extra_kwargs["temperature"] = step_dict["temperature"]
+
             if step_type == "rest":
-                return step_func(duration=duration, termination=terminations)
-            return step_func(value, duration=duration, termination=terminations)
+                return step_func(
+                    duration=duration, termination=terminations, **extra_kwargs
+                )
+            return step_func(
+                value, duration=duration, termination=terminations, **extra_kwargs
+            )
 
         if "cycles" in data and data["cycles"] is not None:
             processed_cycles = []

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -3099,3 +3099,20 @@ class TestSolverSerialization:
         assert len(exp2.steps) == len(exp.steps)
         # The deserialized step should be a drive cycle
         assert exp2.steps[0].is_drive_cycle
+
+    def test_step_temperature_roundtrip(self):
+        """Per-step temperature override survives serialise/deserialise."""
+        exp = pybamm.Experiment(
+            [
+                pybamm.step.current(1.0, duration=100, temperature=298.15),
+                pybamm.step.rest(duration=60, temperature=313.15),
+                pybamm.step.voltage(4.2, duration=200),
+            ]
+        )
+        data = Serialise.serialise_experiment(exp)
+        json_str = json.dumps(data)
+        exp2 = Serialise.deserialise_experiment(json.loads(json_str))
+
+        assert exp2.steps[0].temperature == pytest.approx(298.15)
+        assert exp2.steps[1].temperature == pytest.approx(313.15)
+        assert exp2.steps[2].temperature is None


### PR DESCRIPTION
## Summary

`Serialise.serialise_experiment` silently dropped the per-step `temperature` override when emitting a JSON config. Steps built with e.g. `pybamm.step.string("...", temperature=298.15)` carry the override correctly in-memory and `step.to_dict()` already serialises it, but `_serialise_step` had no clause for the field, and `_parse_step` had no hook to restore it. Round-tripping an experiment through `to_config()` / `from_config()` therefore lost the distinction, which matters for protocols where some steps need to run at a fixed temperature regardless of the surrounding cycle's ambient temperature override.

## Changes

- `_serialise_step` now emits `"temperature"` when `step.temperature is not None` (the value is already normalised to a Kelvin float by `_convert_temperature_to_kelvin`, so it is JSON-safe).
- `_parse_step` reads `"temperature"` from the dict and forwards it to the step factory for both `rest` and value-bearing steps. Existing payloads without the key deserialise unchanged.
- Adds `test_step_temperature_roundtrip` covering a current step with override, a rest step with override, and a step without one (preserved as `None`).

`step.to_dict()` is unaffected — the bug was only in the JSON-config path.

## Test plan

- [x] `pytest tests/unit/test_serialisation/test_serialisation.py` passes (179 tests)
- [x] New `test_step_temperature_roundtrip` passes
- [x] Existing `test_drive_cycle_step_roundtrip` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)