### PR TITLE
Fix Serialise.serialise_solver dropping nested BaseSolver values (root_method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-- Fixed `Serialise.serialise_solver` silently dropping `root_method` (and any other nested `BaseSolver` `__init__` argument). After construction, `root_method` is a `BaseSolver` instance rather than the original string, so it failed `json.dumps` and was omitted from the config — making the deserialised solver fall back to the default. `to_config()` / `from_config()` now recurse into nested solver values, preserving `root_method` and its tolerances across the round-trip.
+- Fixed `Serialise.serialise_solver` silently dropping `root_method` (and any other nested `BaseSolver` `__init__` argument). After construction, `root_method` is a `BaseSolver` instance rather than the original string, so it failed `json.dumps` and was omitted from the config — making the deserialised solver fall back to the default. `to_config()` / `from_config()` now recurse into nested solver values, preserving `root_method` and its tolerances across the round-trip. ([#5497](https://github.com/pybamm-team/PyBaMM/pull/5497))
 - Fixed `Serialise.serialise_experiment` silently dropping per-step `temperature` overrides. The JSON-config round-trip via `Experiment.to_config()` / `Experiment.from_config()` now preserves `temperature` for current, voltage, power, c-rate, and rest steps. ([#5496](https://github.com/pybamm-team/PyBaMM/pull/5496))
 - Fixed `Serialise._to_json_safe` coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int`. `IDAKLUSolver.to_config()` now emits its bool options (`compile`, `print_stats`, `silence_sundials_errors`, etc.) as JSON `true`/`false` so they round-trip through strict-bool deserialisers. ([#5495](https://github.com/pybamm-team/PyBaMM/pull/5495))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug fixes
 
+- Fixed `Serialise.serialise_solver` silently dropping `root_method` (and any other nested `BaseSolver` `__init__` argument). After construction, `root_method` is a `BaseSolver` instance rather than the original string, so it failed `json.dumps` and was omitted from the config — making the deserialised solver fall back to the default. `to_config()` / `from_config()` now recurse into nested solver values, preserving `root_method` and its tolerances across the round-trip.
 - Fixed `Serialise.serialise_experiment` silently dropping per-step `temperature` overrides. The JSON-config round-trip via `Experiment.to_config()` / `Experiment.from_config()` now preserves `temperature` for current, voltage, power, c-rate, and rest steps. ([#5496](https://github.com/pybamm-team/PyBaMM/pull/5496))
 - Fixed `Serialise._to_json_safe` coercing Python `bool` values to `0`/`1` ints because `bool` is a subclass of `int`. `IDAKLUSolver.to_config()` now emits its bool options (`compile`, `print_stats`, `silence_sundials_errors`, etc.) as JSON `true`/`false` so they round-trip through strict-bool deserialisers. ([#5495](https://github.com/pybamm-team/PyBaMM/pull/5495))
 

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -2070,9 +2070,8 @@ class Serialise:
         for k, v in list(data.items()):
             if isinstance(v, dict) and isinstance(v.get("type"), str):
                 nested_cls = getattr(pybamm, v["type"], None)
-                if (
-                    isinstance(nested_cls, type)
-                    and issubclass(nested_cls, pybamm.BaseSolver)
+                if isinstance(nested_cls, type) and issubclass(
+                    nested_cls, pybamm.BaseSolver
                 ):
                     data[k] = Serialise.deserialise_solver(v)
 

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -2009,6 +2009,12 @@ class Serialise:
             if not found:
                 continue
 
+            # ``root_method`` strings are resolved into ``BaseSolver`` instances
+            # by ``BaseSolver.__init__``; recurse so they survive JSON.
+            if isinstance(value, pybamm.BaseSolver):
+                config[param_name] = Serialise.serialise_solver(value)
+                continue
+
             value = Serialise._to_json_safe(value)
             try:
                 json.dumps(value)
@@ -2058,6 +2064,17 @@ class Serialise:
                 )
             sub_solvers = [Serialise.deserialise_solver(c) for c in sub_solvers_config]
             return solver_class(sub_solvers)
+
+        # Rebuild any nested solver dicts (mirror of the recursion in
+        # ``serialise_solver``) before passing them to the constructor.
+        for k, v in list(data.items()):
+            if isinstance(v, dict) and isinstance(v.get("type"), str):
+                nested_cls = getattr(pybamm, v["type"], None)
+                if (
+                    isinstance(nested_cls, type)
+                    and issubclass(nested_cls, pybamm.BaseSolver)
+                ):
+                    data[k] = Serialise.deserialise_solver(v)
 
         return solver_class(**data)
 

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import tempfile
+import warnings
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import mock_open, patch
@@ -3057,6 +3058,40 @@ class TestSolverSerialization:
     def test_unknown_solver_type_raises(self):
         with pytest.raises(ValueError, match="Unknown solver type"):
             pybamm.BaseSolver.from_config({"type": "NonExistentSolver"})
+
+    @pytest.mark.parametrize(
+        "root_method,expected_cls",
+        [
+            ("casadi", pybamm.CasadiAlgebraicSolver),
+            ("nonlinear_solver", pybamm.NonlinearSolver),
+            ("lm", pybamm.AlgebraicSolver),
+            ("hybr", pybamm.AlgebraicSolver),
+        ],
+    )
+    def test_idaklu_root_method_round_trip(self, root_method, expected_cls):
+        """Nested ``root_method`` solver survives to_config/from_config."""
+        solver = pybamm.IDAKLUSolver(root_method=root_method)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            config = solver.to_config()
+
+        json_str = json.dumps(config)
+        restored = pybamm.BaseSolver.from_config(json.loads(json_str))
+
+        assert isinstance(restored, pybamm.IDAKLUSolver)
+        assert isinstance(restored.root_method, expected_cls), (
+            f"root_method={root_method!r} round-tripped as "
+            f"{type(restored.root_method).__name__}, expected "
+            f"{expected_cls.__name__}"
+        )
+
+    def test_idaklu_root_method_preserves_nested_tolerance(self):
+        """Tolerances on the nested root-method solver round-trip too."""
+        solver = pybamm.IDAKLUSolver(root_method="casadi", root_tol=1e-9)
+        config = json.loads(json.dumps(solver.to_config()))
+        restored = pybamm.BaseSolver.from_config(config)
+        assert isinstance(restored.root_method, pybamm.CasadiAlgebraicSolver)
+        assert restored.root_tol == pytest.approx(1e-9)
 
     def test_to_json_safe_preserves_bool(self):
         # bool is a subclass of int; the int branch must not match first.


### PR DESCRIPTION
## Summary

- `BaseSolver.__init__` resolves a string `root_method` (e.g. `"casadi"`, `"nonlinear_solver"`, `"lm"`) into a `BaseSolver` instance and stores it on `self._root_method`. After PR #5459 changed the default nonlinear solver, the existing reflection-based dumper in `Serialise.serialise_solver` silently dropped this field (the instance failed `json.dumps`, the except-clause hit `warnings.warn` + `continue`, and the param never made it into the config). The deserialised solver on the receiving side then picked up the post-#5459 default regardless of what the user actually passed.
- Recurse on nested `BaseSolver` values on both the dump and load paths so `root_method` (and any future nested-solver init arg) survives JSON round-trip.
- Adds parametrised regression tests over the three branches of the `root_method` setter (`"casadi"`, `"nonlinear_solver"`, generic algebraic string `"lm"` / `"hybr"`) plus a tolerance-preservation test on the inner solver. The new test wraps `to_config()` in `warnings.simplefilter("error")` so it asserts directly that the silent-drop warning no longer fires.

This is the third in a recent run of `Serialise` round-trip bugs (#5495 bool→int coercion, #5496 dropped per-step temperature). They share a common shape — silent value loss in opt-in dumpers — that I will look at structurally in a follow-up.

## Test plan

- [x] `pytest tests/unit/test_serialisation/test_serialisation.py::TestSolverSerialization` (17 passed, including 4 new parametrised cases + nested-tolerance test)
- [x] `pytest tests/unit/test_serialisation/` (187 passed, no regressions)
- [x] `pytest tests/unit/test_solvers/ --ignore=tests/unit/test_solvers/test_idaklu_jax.py` (305 passed; the `test_idaklu_jax.py` failures pre-exist and are due to `jax.lax.zeros_like_array` being removed in JAX v0.9.0, unrelated to this PR)
- [x] Reproduced the bug pre-fix: `IDAKLUSolver(root_method="casadi")` round-trips with `root_method=None` and emits the `"...not JSON-serializable and will be omitted from the config"` warning.
- [x] Confirmed post-fix: all three string forms round-trip to the correct algebraic-solver class with tolerances preserved, no warnings emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)