### PR TITLE
Update changelog and CITATION.cff for v26.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added a `store_first_last` kwarg to solvers. When `True`, only the first and last sample of each integration window (one experiment step in `Simulation.solve`, or the full `[t_eval[0], t_eval[-1]]` window in `solve`) are stored. Composes with `output_variables` for memory-light ageing simulations whose post-processing only reads per-step first/last values. Has effect on solvers that support intra-solve interpolation (`IDAKLUSolver`); other solvers warn and no-op. Note: with this flag set, intra-step interpolation falls back to linear across the whole step, so it is not appropriate when post-processing queries an intra-step time. ([#5499](https://github.com/pybamm-team/PyBaMM/pull/5499))
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 
+# [v26.4.3](https://github.com/pybamm-team/PyBaMM/tree/v26.4.3) - 2026-05-12
+
 ## Bug fixes
 
 - `ProcessedVariableComputed.__init__` now defers the heavy `initialise_*` work (numpy concatenate/flatten, xarray `DataArray` build) until `entries` or `_xr_data_array` is actually read. On a 500-cycle SPM with `output_variables` set and `save_at_cycles=N`, solve wall time dropped from ~30 s to ~2.5 s (~12×); per-step `__init__` cost dropped from 47% of solve to 1.7%.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.4.2"
+version: "26.4.3"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"


### PR DESCRIPTION
## Summary

- Move the 7 bug-fix bullets from the `Unreleased` section of `CHANGELOG.md` into a `v26.4.3` section dated 2026-05-12.
- Bump `CITATION.cff` version from `26.4.2` to `26.4.3`.

Cherry-pick set lives on [`release/v26.4.3`](https://github.com/pybamm-team/PyBaMM/tree/release/v26.4.3); the GitHub release `v26.4.3` will be cut from that branch (not `main`), per `.github/release_workflow.md` step 7 of "Creating a patch release". This PR is the separate main-side changelog sync — **do not** merge the release branch back to `main`.

The two Features bullets (`#5499`, `#5459`) and the dependabot bumps stay under `Unreleased` for the next minor.

## Test plan

- [ ] CI passes
- [ ] `v26.4.3` GitHub release is cut from `release/v26.4.3` and PyPI upload succeeds before merging this PR (so `main`'s `CITATION.cff` bump only lands once the release tag actually exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)