### PR TITLE
Add per-phase summary variables for composite electrodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- Default `summary_variables` now include per-phase LAM%, capacity, total lithium, SEI loss, SEI-on-cracks loss, and lithium plating loss for composite electrodes; aggregate per-electrode entries are unchanged.
 - Added a `store_first_last` kwarg to solvers. When `True`, only the first and last sample of each integration window (one experiment step in `Simulation.solve`, or the full `[t_eval[0], t_eval[-1]]` window in `solve`) are stored. Composes with `output_variables` for memory-light ageing simulations whose post-processing only reads per-step first/last values. Has effect on solvers that support intra-solve interpolation (`IDAKLUSolver`); other solvers warn and no-op. Note: with this flag set, intra-step interpolation falls back to linear across the whole step, so it is not appropriate when post-processing queries an intra-step time. ([#5499](https://github.com/pybamm-team/PyBaMM/pull/5499))
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Default `summary_variables` now include per-phase LAM%, capacity, total lithium, SEI loss, SEI-on-cracks loss, and lithium plating loss for composite electrodes; aggregate per-electrode entries are unchanged.
+- Default `summary_variables` now include per-phase LAM%, capacity, total lithium, SEI loss, SEI-on-cracks loss, and lithium plating loss for composite electrodes; aggregate per-electrode entries are unchanged. ([#5516](https://github.com/pybamm-team/PyBaMM/pull/5516))
 - Added a `store_first_last` kwarg to solvers. When `True`, only the first and last sample of each integration window (one experiment step in `Simulation.solve`, or the full `[t_eval[0], t_eval[-1]]` window in `solve`) are stored. Composes with `output_variables` for memory-light ageing simulations whose post-processing only reads per-step first/last values. Has effect on solvers that support intra-solve interpolation (`IDAKLUSolver`); other solvers warn and no-op. Note: with this flag set, intra-step interpolation falls back to linear across the whole step, so it is not appropriate when post-processing queries an intra-step time. ([#5499](https://github.com/pybamm-team/PyBaMM/pull/5499))
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))
 

--- a/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -146,6 +146,19 @@ class BaseModel(pybamm.BaseBatteryModel):
                 }
             )
 
+            # Per-phase LAM (only registered for composite electrodes)
+            phases = self.options.phases[domain.split()[0]]
+            if len(phases) > 1:
+                for phase in phases:
+                    Q_k_phase = self.variables[
+                        f"{Domain} {phase} phase capacity [A.h]"
+                    ]
+                    Q_k_phase_init = domain_param.phase_params[phase].Q_init
+                    LAM_k_phase = (1 - Q_k_phase / Q_k_phase_init) * 100
+                    self.variables[
+                        f"Loss of active material in {phase} phase in {domain} [%]"
+                    ] = LAM_k_phase
+
         # LLI
         n_Li_e = self.variables["Total lithium in electrolyte [mol]"]
         n_Li_particles = sum(
@@ -233,26 +246,32 @@ class BaseModel(pybamm.BaseBatteryModel):
             "Local ECM resistance [Ohm]",
         ]
 
-        if self.options.electrode_types["negative"] == "porous":
+        for domain in [d for d in self.options.whole_cell_domains if d != "separator"]:
+            Domain = domain.capitalize()
+            dom = domain.split()[0]
             summary_variables += [
-                "Negative electrode capacity [A.h]",
-                "Loss of active material in negative electrode [%]",
-                "Total lithium in negative electrode [mol]",
-                "Loss of lithium to negative lithium plating [mol]",
-                "Loss of capacity to negative lithium plating [A.h]",
-                "Loss of lithium to negative SEI on cracks [mol]",
-                "Loss of capacity to negative SEI on cracks [A.h]",
+                f"{Domain} capacity [A.h]",
+                f"Loss of active material in {domain} [%]",
+                f"Total lithium in {domain} [mol]",
+                f"Loss of lithium to {dom} lithium plating [mol]",
+                f"Loss of capacity to {dom} lithium plating [A.h]",
+                f"Loss of lithium to {dom} SEI on cracks [mol]",
+                f"Loss of capacity to {dom} SEI on cracks [A.h]",
             ]
-        if self.options.electrode_types["positive"] == "porous":
-            summary_variables += [
-                "Positive electrode capacity [A.h]",
-                "Loss of active material in positive electrode [%]",
-                "Total lithium in positive electrode [mol]",
-                "Loss of lithium to positive lithium plating [mol]",
-                "Loss of capacity to positive lithium plating [A.h]",
-                "Loss of lithium to positive SEI on cracks [mol]",
-                "Loss of capacity to positive SEI on cracks [A.h]",
-            ]
+            phases = self.options.phases[dom]
+            if len(phases) > 1:
+                for phase in phases:
+                    summary_variables += [
+                        f"{Domain} {phase} phase capacity [A.h]",
+                        f"Loss of active material in {phase} phase in {domain} [%]",
+                        f"Total lithium in {phase} phase in {domain} [mol]",
+                        f"Loss of lithium to {dom} {phase} SEI [mol]",
+                        f"Loss of capacity to {dom} {phase} SEI [A.h]",
+                        f"Loss of lithium to {dom} {phase} SEI on cracks [mol]",
+                        f"Loss of capacity to {dom} {phase} SEI on cracks [A.h]",
+                        f"Loss of lithium to {dom} {phase} lithium plating [mol]",
+                        f"Loss of capacity to {dom} {phase} lithium plating [A.h]",
+                    ]
 
         self.summary_variables = summary_variables
 

--- a/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -150,9 +150,7 @@ class BaseModel(pybamm.BaseBatteryModel):
             phases = self.options.phases[domain.split()[0]]
             if len(phases) > 1:
                 for phase in phases:
-                    Q_k_phase = self.variables[
-                        f"{Domain} {phase} phase capacity [A.h]"
-                    ]
+                    Q_k_phase = self.variables[f"{Domain} {phase} phase capacity [A.h]"]
                     Q_k_phase_init = domain_param.phase_params[phase].Q_init
                     LAM_k_phase = (1 - Q_k_phase / Q_k_phase_init) * 100
                     self.variables[

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
@@ -79,6 +79,5 @@ class TestBaseLithiumIonModel:
             in model.summary_variables
         )
         assert (
-            "Negative electrode primary phase capacity [A.h]"
-            in model.summary_variables
+            "Negative electrode primary phase capacity [A.h]" in model.summary_variables
         )

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py
@@ -52,3 +52,33 @@ class TestBaseLithiumIonModel:
 
         with pytest.raises(TypeError, match=r"`calc_esoh` arg needs to be a bool"):
             model.calc_esoh = "Yes"
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {},
+            {"particle phases": ("2", "1")},
+            {"particle phases": ("1", "2")},
+            {"particle phases": ("2", "2")},
+            {"working electrode": "positive"},
+        ],
+    )
+    def test_summary_variables_resolve(self, options):
+        model = pybamm.lithium_ion.DFN(options=options)
+        for v in model.summary_variables:
+            assert v in model.variables, f"{v} not in model.variables"
+
+    def test_composite_per_phase_summary_variables(self):
+        model = pybamm.lithium_ion.DFN(options={"particle phases": ("2", "1")})
+        assert (
+            "Loss of active material in primary phase in negative electrode [%]"
+            in model.summary_variables
+        )
+        assert (
+            "Loss of active material in secondary phase in negative electrode [%]"
+            in model.summary_variables
+        )
+        assert (
+            "Negative electrode primary phase capacity [A.h]"
+            in model.summary_variables
+        )


### PR DESCRIPTION
## Summary

- The aggregate degradation variables (`Loss of active material in {domain} [%]`, `Loss of lithium inventory [%]`, etc.) already sum correctly across phases for composite electrodes, but there is no way to inspect how much LAM or side-reaction loss happened on each phase individually.
- Register per-phase LAM% in `set_degradation_variables` and add per-phase capacity, LAM%, total lithium, and SEI / SEI-on-cracks / lithium plating losses to the default `summary_variables` list whenever an electrode has more than one phase.
- Aggregate per-electrode entries are unchanged in name, value, and list position, so single-phase output is byte-identical.

## Changes

`src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py`:
- `set_degradation_variables` now registers `"Loss of active material in {phase} phase in {domain} [%]"` per phase when `len(phases) > 1`, computed from the existing `"{Domain} {phase} phase capacity [A.h]"` variable and `domain_param.phase_params[phase].Q_init`.
- `set_default_summary_variables` refactored from two hardcoded blocks into a single loop over `whole_cell_domains` (matching the idiom in `set_degradation_variables`), appending per-phase entries when `len(phases) > 1`.

`tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py`:
- Adds `test_summary_variables_resolve` parameterised over default, both composite orientations, dual composite, and half-cell, asserting that every entry in `model.summary_variables` resolves to a key in `model.variables`.
- Adds `test_composite_per_phase_summary_variables` asserting the new per-phase entries are present for a composite negative electrode.

## Test plan

- [x] `pytest tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_base_lithium_ion_model.py` — 10 passed
- [x] Smoke check: default DFN summary list unchanged at 33 entries with 0 missing keys
- [x] Smoke check: composite negative DFN at 51 entries, composite positive at 51, dual composite at 69, half-cell at 26 — all with 0 missing keys
- [x] End-to-end 2-cycle SPM experiment with `Chen2020_composite` parameters returns sensible per-phase capacities and LAM% across cycles