### PR TITLE
Fix sensitivities crash when experiment input is not a sensitivity target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- Fixed `ProcessedVariable.sensitivities` raising `KeyError` when `calculate_sensitivities` was passed a subset of inputs and a non-target input parameter (e.g. a `pybamm.InputParameter` used in an experiment step) appeared in the variable's expression tree. ([#5517](https://github.com/pybamm-team/PyBaMM/issues/5517))
+- Fixed `ProcessedVariable.sensitivities` raising `KeyError` when `calculate_sensitivities` was passed a subset of inputs and a non-target input parameter (e.g. a `pybamm.InputParameter` used in an experiment step) appeared in the variable's expression tree. ([#5518](https://github.com/pybamm-team/PyBaMM/pull/5518))
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Fixed `ProcessedVariable.sensitivities` raising `KeyError` when `calculate_sensitivities` was passed a subset of inputs and a non-target input parameter (e.g. a `pybamm.InputParameter` used in an experiment step) appeared in the variable's expression tree. ([#5517](https://github.com/pybamm-team/PyBaMM/issues/5517))
+
 ## Features
 
 - Default `summary_variables` now include per-phase LAM%, capacity, total lithium, SEI loss, SEI-on-cracks loss, and lithium plating loss for composite electrodes; aggregate per-electrode entries are unchanged. ([#5516](https://github.com/pybamm-team/PyBaMM/pull/5516))

--- a/src/pybamm/solvers/processed_variable.py
+++ b/src/pybamm/solvers/processed_variable.py
@@ -447,8 +447,14 @@ class ProcessedVariable(BaseProcessedVariable):
 
             p_casadi_stacked = casadi.vertcat(*[p for p in p_casadi.values()])
 
-            # Convert variable to casadi format for differentiating
-            var_casadi = base_variable.to_casadi(t_casadi, y_casadi, inputs=p_casadi)
+            # Symbolic for sensitivity targets, concrete for the rest. Non-target
+            # inputs may still appear in the expression tree (e.g. from
+            # experiment steps) so they must be present for casadi conversion.
+            inputs_for_casadi = {**inputs, **p_casadi}
+
+            var_casadi = base_variable.to_casadi(
+                t_casadi, y_casadi, inputs=inputs_for_casadi
+            )
             dvar_dy = casadi.jacobian(var_casadi, y_casadi)
             dvar_dp = casadi.jacobian(var_casadi, p_casadi_stacked)
 

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1042,6 +1042,30 @@ class TestSimulationExperiment:
         assert input_param_name in sensitivity_keys
         assert experiment_input_name not in sensitivity_keys
 
+    def test_processed_variable_sensitivities_ignore_experiment_input(self):
+        # Regression test for #5517.
+        model = pybamm.lithium_ion.SPM()
+        param = model.default_parameter_values
+        diffusivity_name = "Positive particle diffusivity [m2.s-1]"
+        param.update({diffusivity_name: "[input]"})
+
+        experiment = pybamm.Experiment(
+            [pybamm.step.Current(pybamm.InputParameter("current"), duration=10)]
+        )
+        sim = pybamm.Simulation(
+            model, experiment=experiment, parameter_values=param
+        )
+        sol = sim.solve(
+            inputs={"current": 0.1, diffusivity_name: 1e-14},
+            calculate_sensitivities=[diffusivity_name],
+        )
+
+        sensitivities = sol["Voltage [V]"].sensitivities
+        assert set(sensitivities) == {"all", diffusivity_name}
+        sens = np.asarray(sensitivities[diffusivity_name])
+        assert np.all(np.isfinite(sens))
+        assert np.any(sens != 0)
+
     def test_run_experiment_drive_cycle(self):
         drive_cycle = np.array([np.arange(10), np.arange(10)]).T
         experiment = pybamm.Experiment(

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1052,9 +1052,7 @@ class TestSimulationExperiment:
         experiment = pybamm.Experiment(
             [pybamm.step.Current(pybamm.InputParameter("current"), duration=10)]
         )
-        sim = pybamm.Simulation(
-            model, experiment=experiment, parameter_values=param
-        )
+        sim = pybamm.Simulation(model, experiment=experiment, parameter_values=param)
         sol = sim.solve(
             inputs={"current": 0.1, diffusivity_name: 1e-14},
             calculate_sensitivities=[diffusivity_name],


### PR DESCRIPTION
## Summary

Fixes #5517.

When `sim.solve(calculate_sensitivities=[...])` is passed a *subset* of input parameters, `ProcessedVariable.initialise_sensitivity_explicit_forward` built a casadi-conversion `inputs` dict containing only the sensitivity *targets* as symbolic `MX.sym` variables. If the variable's expression tree referenced any *other* input parameter — for example a `pybamm.InputParameter` used as the step current in an experiment — the casadi tree walk hit `InputParameter._base_evaluate`, failed to find the name in the dict, and raised:

```
KeyError: "Input parameter 'current' not found"
```

The fix merges the concrete `inputs` dict with the symbolic `p_casadi` (`{**inputs, **p_casadi}`) so non-target inputs are passed through as constants. The jacobian is still taken with respect to `p_casadi_stacked`, which contains only the sensitivity targets, so the output shape and values are unaffected in the existing working case.

## Test plan

- [x] New regression test `test_processed_variable_sensitivities_ignore_experiment_input` (the MWE from #5517) — asserts `sol["Voltage [V]"].sensitivities` returns the correct keys, all values finite, non-zero.
- [x] All 71 existing `tests/unit/test_solvers/test_processed_variable.py` tests still pass.
- [x] Nearby existing test `test_solve_with_sensitivity_list_ignores_internal_experiment_input` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)