### PR TITLE
Add solver timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Features
 
+- Adds `timeout` option to `BaseSolver`. ([#5520](https://github.com/pybamm-team/PyBaMM/pull/5520))
 - Default `summary_variables` now include per-phase LAM%, capacity, total lithium, SEI loss, SEI-on-cracks loss, and lithium plating loss for composite electrodes; aggregate per-electrode entries are unchanged. ([#5516](https://github.com/pybamm-team/PyBaMM/pull/5516))
 - Added a `store_first_last` kwarg to solvers. When `True`, only the first and last sample of each integration window (one experiment step in `Simulation.solve`, or the full `[t_eval[0], t_eval[-1]]` window in `solve`) are stored. Composes with `output_variables` for memory-light ageing simulations whose post-processing only reads per-step first/last values. Has effect on solvers that support intra-solve interpolation (`IDAKLUSolver`); other solvers warn and no-op. Note: with this flag set, intra-step interpolation falls back to linear across the whole step, so it is not appropriate when post-processing queries an intra-step time. ([#5499](https://github.com/pybamm-team/PyBaMM/pull/5499))
 - Added `NonlinearSolver` as the default nonlinear solver, which replaces `CasadiAlgebraicSolver`. `IDAKLUSolver` now computes the initial conditions in C++ by default. ([#5459](https://github.com/pybamm-team/PyBaMM/pull/5459))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "posthog",
     "pyyaml",
     "platformdirs",
+    "pebble",
 ]
 
 [project.urls]

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -8,6 +8,7 @@ import warnings
 
 import casadi
 import numpy as np
+from pebble import ProcessPool
 
 import pybamm
 from pybamm import ParameterValues
@@ -810,23 +811,35 @@ class BaseSolver:
             )
             new_solutions = [new_solution]
         else:
-            with mp.get_context(self._mp_context).Pool(processes=nproc) as p:
+            with ProcessPool(
+                context=mp.get_context(self._mp_context), max_workers=nproc
+            ) as p:
                 model_list = [model] * ninputs
                 t_eval_list = [t_eval] * ninputs
                 y0_list = model.y0_list
-                async_solutions = p.starmap_async(
+
+                futures = p.map(
                     self._integrate_single,
-                    zip(
-                        model_list,
-                        t_eval_list,
-                        inputs_list,
-                        y0_list,
-                        strict=True,
-                    ),
+                    model_list,
+                    t_eval_list,
+                    inputs_list,
+                    y0_list,
+                    timeout=self.timeout,
                 )
-                new_solutions = async_solutions.get(timeout=self.timeout)
-                p.terminate()
-                p.join()
+                iterator = futures.result()
+
+                new_solutions = []
+                while True:
+                    try:
+                        new_solutions.append(next(iterator))
+                    except StopIteration:
+                        break
+                    except TimeoutError as e:
+                        raise pybamm.SolverError(
+                            f"Timeout after {e.args[1]:d} seconds."
+                        ) from e
+                    except Exception as e:
+                        raise pybamm.SolverError(str(e)) from None
 
         return new_solutions
 

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -58,6 +58,9 @@ class BaseSolver:
         back to linear across the whole step, so it is **not** appropriate when
         post-processing queries a non-endpoint time within a step.
         Default is False.
+    timeout : float, optional
+        If timeout is a positive number, simulations are terminated after timeout
+        seconds if not completed successfully within this time. Default is None.
     """
 
     def __init__(
@@ -72,6 +75,7 @@ class BaseSolver:
         on_failure=None,
         output_variables=None,
         store_first_last=False,
+        timeout=None,
     ):
         self.method = method
         self.rtol = rtol
@@ -98,6 +102,7 @@ class BaseSolver:
         self._supports_t_eval_discontinuities = False
         self.computed_var_fcns = {}
         self._mp_context = self.get_platform_context(platform.system())
+        self.timeout = timeout
 
     def to_config(self) -> dict:
         """Convert this solver to a JSON-serialisable config dict.
@@ -795,32 +800,23 @@ class BaseSolver:
 
         inputs_list = inputs_list or [{}]
 
-        ninputs = len(inputs_list)
-        if ninputs == 1:
-            new_solution = self._integrate_single(
-                model,
-                t_eval,
-                inputs_list[0],
-                model.y0_list[0],
+        with mp.get_context(self._mp_context).Pool(processes=nproc) as p:
+            model_list = [model] * len(inputs_list)
+            t_eval_list = [t_eval] * len(inputs_list)
+            y0_list = model.y0_list
+            async_solutions = p.starmap_async(
+                self._integrate_single,
+                zip(
+                    model_list,
+                    t_eval_list,
+                    inputs_list,
+                    y0_list,
+                    strict=True,
+                ),
             )
-            new_solutions = [new_solution]
-        else:
-            with mp.get_context(self._mp_context).Pool(processes=nproc) as p:
-                model_list = [model] * len(inputs_list)
-                t_eval_list = [t_eval] * len(inputs_list)
-                y0_list = model.y0_list
-                new_solutions = p.starmap(
-                    self._integrate_single,
-                    zip(
-                        model_list,
-                        t_eval_list,
-                        inputs_list,
-                        y0_list,
-                        strict=True,
-                    ),
-                )
-                p.close()
-                p.join()
+            new_solutions = async_solutions.get(timeout=self.timeout)
+            p.terminate()
+            p.join()
 
         return new_solutions
 

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -800,23 +800,33 @@ class BaseSolver:
 
         inputs_list = inputs_list or [{}]
 
-        with mp.get_context(self._mp_context).Pool(processes=nproc) as p:
-            model_list = [model] * len(inputs_list)
-            t_eval_list = [t_eval] * len(inputs_list)
-            y0_list = model.y0_list
-            async_solutions = p.starmap_async(
-                self._integrate_single,
-                zip(
-                    model_list,
-                    t_eval_list,
-                    inputs_list,
-                    y0_list,
-                    strict=True,
-                ),
+        ninputs = len(inputs_list)
+        if ninputs == 1 and self.timeout is None:
+            new_solution = self._integrate_single(
+                model,
+                t_eval,
+                inputs_list[0],
+                model.y0_list[0],
             )
-            new_solutions = async_solutions.get(timeout=self.timeout)
-            p.terminate()
-            p.join()
+            new_solutions = [new_solution]
+        else:
+            with mp.get_context(self._mp_context).Pool(processes=nproc) as p:
+                model_list = [model] * ninputs
+                t_eval_list = [t_eval] * ninputs
+                y0_list = model.y0_list
+                async_solutions = p.starmap_async(
+                    self._integrate_single,
+                    zip(
+                        model_list,
+                        t_eval_list,
+                        inputs_list,
+                        y0_list,
+                        strict=True,
+                    ),
+                )
+                new_solutions = async_solutions.get(timeout=self.timeout)
+                p.terminate()
+                p.join()
 
         return new_solutions
 

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -812,7 +812,8 @@ class BaseSolver:
             new_solutions = [new_solution]
         else:
             with ProcessPool(
-                context=mp.get_context(self._mp_context), max_workers=nproc
+                context=mp.get_context(self._mp_context),
+                max_workers=nproc or mp.cpu_count(),
             ) as p:
                 model_list = [model] * ninputs
                 t_eval_list = [t_eval] * ninputs


### PR DESCRIPTION
# Description

Adds a `timeout` option to `BaseSolver` to avoid system freezes during integration. These changes address long-standing issue #5161. The `timeout` option is set to `None` by default to avoid any breaking changes.

## Type of change

Please add a line in the relevant section of [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md) to document the change (include PR #)

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
