### PR TITLE
Release v26.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+# [v26.5.0](https://github.com/pybamm-team/PyBaMM/tree/v26.5.0) - 2026-05-27
+
 ## Breaking changes
 
 - `Simulation.solve` now always clears `Simulation.solution` before solving, so a failed solve leaves it as `None` rather than retaining the previous result. ([#5528](https://github.com/pybamm-team/PyBaMM/pull/5528))

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.4.4"
+version: "26.5.0"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"


### PR DESCRIPTION
Release PR for **v26.5.0**.

Per `.github/release_workflow.md`, merging this changelog/version-bump PR and then publishing the GitHub release (`v26.5.0`, target `main`) tags the repo and triggers `publish_pypi.yml`.

Version + changelog bumped in this branch.

## Release notes (from CHANGELOG `[Unreleased]`)

### Breaking changes
- `Simulation.solve` now always clears `Simulation.solution` before solving (#5528)

### Bug fixes
- Fixed `Simulation.solve` retaining the prior solution during repeated solves (#5528)
- `IDAKLUSolver` no longer caches redundant serialised function bytes (#5528)

### Features
- Per-phase summary variables for composite electrodes (#5516)
- Added `store_first_last` solver kwarg (#5499)
- `NonlinearSolver` is now the default nonlinear solver (#5459)