### PR TITLE
Look up roughness ratio with the phase prefix in SEI on cracks (#5281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fixed the `pybammsolvers` source distribution bundling the SUNDIALS/SuiteSparse submodule trees (~291 MB, over PyPI's per-file limit) when built from a checkout with the submodules initialised; the sdist now excludes them. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the `pybammsolvers` editable auto-rebuild failing to configure when the SUNDIALS/SuiteSparse submodules are absent even though the libraries were already built in `.idaklu`; the from-source bootstrap (and its submodule requirement) is now skipped once the libraries exist. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the Read the Docs documentation build, which broke once `pybammsolvers` became a workspace member with no published wheel during the release: RTD now fetches the SUNDIALS/SuiteSparse submodules and installs `gfortran`/`libopenblas` so the solver builds from source. Link checking was also restructured so transient external-link failures no longer block builds: Sphinx `linkcheck` is advisory, and the CI `lychee` check runs offline on PRs with a weekly external sweep that files a tracking issue. ([#5659](https://github.com/pybamm-team/PyBaMM/pull/5659))
+- Fixed `SEI on cracks` failing to build on composite electrodes (`"particle phases": "2"`). `SEIThickness` and `SEIGrowth.set_rhs` now look up the per-phase `"<Domain> <phase> electrode roughness ratio"` instead of the un-phased key. ([#5281](https://github.com/pybamm-team/PyBaMM/issues/5281))
 
 # [v26.6.2.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.2.0) - 2026-06-16
 

--- a/packages/pybamm/src/pybamm/models/submodels/interface/sei/sei_growth.py
+++ b/packages/pybamm/src/pybamm/models/submodels/interface/sei/sei_growth.py
@@ -268,9 +268,13 @@ class SEIGrowth(BaseModel):
         # This is done here by replacing a with a_cr using a *= roughness - 1
         if self.reaction == "SEI on cracks":
             if self.reaction_loc == "x-average":
-                roughness = variables[f"X-averaged {domain} electrode roughness ratio"]
+                roughness = variables[
+                    f"X-averaged {domain} {self.phase_name}electrode roughness ratio"
+                ]
             else:
-                roughness = variables[f"{Domain} electrode roughness ratio"]
+                roughness = variables[
+                    f"{Domain} {self.phase_name}electrode roughness ratio"
+                ]
             a *= roughness - 1  # Replace surface area with crack area
 
         # a * j_sei / F is the rate of consumption of Li moles by SEI reaction

--- a/packages/pybamm/src/pybamm/models/submodels/interface/sei/sei_thickness.py
+++ b/packages/pybamm/src/pybamm/models/submodels/interface/sei/sei_thickness.py
@@ -88,7 +88,9 @@ class SEIThickness(BaseModel):
             if crack_option == "false":
                 L_sei = c_sei * c_to_L
             else:
-                roughness = variables[f"{Domain} electrode roughness ratio"]
+                roughness = variables[
+                    f"{Domain} {self.phase_name}electrode roughness ratio"
+                ]
                 L_sei = c_sei * c_to_L / (roughness - 1)  # SEI on cracks thickness
             if self.size_distribution:
                 L_sei_sav = pybamm.size_average(L_sei)

--- a/packages/pybamm/tests/unit/test_models/test_submodels/test_interface/test_sei_on_cracks_composite_phase_5281.py
+++ b/packages/pybamm/tests/unit/test_models/test_submodels/test_interface/test_sei_on_cracks_composite_phase_5281.py
@@ -1,0 +1,103 @@
+"""
+Guards for #5281: SEI on cracks looks up the roughness ratio variable
+without the per-phase prefix, so models with composite electrodes
+(``"particle phases": "2"``) fail to build with::
+
+    KeyError: 'Negative primary SEI on cracks thickness [m]'
+
+The actual missing variable is ``"Negative electrode roughness ratio"``;
+PyBaMM's submodel-loop reports the downstream SEI on cracks thickness
+key once the build runs out of retries. The particle mechanics submodel
+registers the roughness as ``"Negative <phase> electrode roughness
+ratio"`` (see ``particle_mechanics/base_mechanics.py``), and the
+volumetric current density helper in ``interface/base_interface.py``
+already looks it up with the phase prefix. The SEI submodels were the
+only consumers that dropped the prefix.
+
+The fix is in:
+- ``src/pybamm/models/submodels/interface/sei/sei_thickness.py``
+- ``src/pybamm/models/submodels/interface/sei/sei_growth.py``
+
+which now read ``f"{Domain} {self.phase_name}electrode roughness ratio"``
+(and the X-averaged variant for the ``x-average`` reaction location).
+"""
+
+import pybamm
+
+# Reproducer from issue #5281 (user satishrapol). Single-phase positive,
+# composite negative with primary cracking + ec-reaction-limited SEI.
+COMPOSITE_OPTS_5281 = {
+    "particle phases": ("2", "1"),
+    "open-circuit potential": (("single", "current sigmoid"), "single"),
+    "SEI": "ec reaction limited",
+    "particle mechanics": ("swelling and cracking", "swelling only"),
+    "loss of active material": "stress-driven",
+    "SEI on cracks": "true",
+    "surface form": "algebraic",
+}
+
+
+class TestSEIOnCracksCompositePhase5281:
+    """Guards #5281: composite electrode + SEI on cracks must build."""
+
+    def test_spme_composite_ec_reaction_limited_builds(self):
+        """Exact reproducer from #5281 — SPMe with composite negative."""
+        # Before the fix this raised ``ModelError: Missing variable for
+        # submodel 'negative primary sei on cracks': 'Negative primary SEI
+        # on cracks thickness [m]'`` because ``SEIThickness`` (and the
+        # ``set_rhs`` branch of ``SEIGrowth`` in the ``"x-average"`` case)
+        # was looking up ``"Negative electrode roughness ratio"`` instead
+        # of ``"Negative primary electrode roughness ratio"``.
+        model = pybamm.lithium_ion.SPMe(options=COMPOSITE_OPTS_5281)
+        assert "Negative primary SEI on cracks thickness [m]" in model.variables
+        assert "Negative secondary SEI on cracks thickness [m]" in model.variables
+
+    def test_dfn_composite_ec_reaction_limited_builds(self):
+        """DFN reaches the same SEI submodels through the full-electrode
+        branch of ``SEIGrowth.set_rhs`` rather than the x-averaged branch,
+        so it covers the second occurrence of the bug in sei_growth.py."""
+        model = pybamm.lithium_ion.DFN(options=COMPOSITE_OPTS_5281)
+        assert "Negative primary SEI on cracks thickness [m]" in model.variables
+        assert "Negative secondary SEI on cracks thickness [m]" in model.variables
+
+    def test_spm_composite_solvent_diffusion_builds(self):
+        """SEI options other than 'ec reaction limited' must not regress."""
+        opts = dict(COMPOSITE_OPTS_5281, **{"SEI": "solvent-diffusion limited"})
+        # SPM uses x-averaged SEI; the 'x-average' branch of
+        # SEIGrowth.set_rhs hits the X-averaged roughness ratio lookup.
+        model = pybamm.lithium_ion.SPM(options=opts)
+        assert "Negative primary SEI on cracks thickness [m]" in model.variables
+        assert "Negative secondary SEI on cracks thickness [m]" in model.variables
+
+    def test_per_phase_roughness_keys_are_consumed(self):
+        """The fixed lookups must reference the phased roughness keys
+        (``"Negative primary/secondary electrode roughness ratio"``) and
+        not the un-phased ``"Negative electrode roughness ratio"``."""
+        model = pybamm.lithium_ion.DFN(options=COMPOSITE_OPTS_5281)
+        # Particle mechanics registers the phased keys; SEI on cracks
+        # consumes them. We verify the model exposes the registered keys.
+        assert "Negative primary electrode roughness ratio" in model.variables
+        assert "Negative secondary electrode roughness ratio" in model.variables
+        # The phase-stripped key historically existed only via the
+        # single-phase code path; for composite electrodes the SEI
+        # submodels must not depend on it.
+        assert "Negative electrode roughness ratio" not in model.variables
+
+    def test_single_phase_regression(self):
+        """Non-composite models that previously worked must keep working
+        after switching the lookups to use ``self.phase_name``. For a
+        single-phase electrode ``phase_name`` is empty, recovering the
+        original variable name verbatim."""
+        opts = {
+            "SEI": "solvent-diffusion limited",
+            "particle mechanics": "swelling and cracking",
+            "SEI on cracks": "true",
+        }
+        for cls in (
+            pybamm.lithium_ion.SPM,
+            pybamm.lithium_ion.SPMe,
+            pybamm.lithium_ion.DFN,
+        ):
+            model = cls(options=opts)
+            assert "Negative SEI on cracks thickness [m]" in model.variables
+            assert "Negative electrode roughness ratio" in model.variables

--- a/packages/pybamm/tests/unit/test_models/test_submodels/test_interface/test_sei_on_cracks_composite_phase_5281.py
+++ b/packages/pybamm/tests/unit/test_models/test_submodels/test_interface/test_sei_on_cracks_composite_phase_5281.py
@@ -62,7 +62,7 @@ class TestSEIOnCracksCompositePhase5281:
 
     def test_spm_composite_solvent_diffusion_builds(self):
         """SEI options other than 'ec reaction limited' must not regress."""
-        opts = dict(COMPOSITE_OPTS_5281, **{"SEI": "solvent-diffusion limited"})
+        opts = dict(COMPOSITE_OPTS_5281, SEI="solvent-diffusion limited")
         # SPM uses x-averaged SEI; the 'x-average' branch of
         # SEIGrowth.set_rhs hits the X-averaged roughness ratio lookup.
         model = pybamm.lithium_ion.SPM(options=opts)


### PR DESCRIPTION
## Description

Fixes #5281.

Building any lithium-ion model with a composite electrode (`"particle phases": "2"`) and `"SEI on cracks": "true"` raises

```
ModelError: Missing variable for submodel 'negative primary sei on cracks':
            'Negative primary SEI on cracks thickness [m]'
```

PyBaMM's build loop reports the unresolved downstream key after 100 retries; the actual `KeyError` raised from inside `SEIThickness.get_coupled_variables` is `'Negative electrode roughness ratio'`.

## Root cause

The particle-mechanics submodel (see `particle_mechanics/base_mechanics.py:458–459`) registers roughness with a phase prefix:

```python
f"{Domain} {phase_name}electrode roughness ratio": roughness,
f"X-averaged {domain} {phase_name}electrode roughness ratio": roughness_xavg,
```

For composite electrodes `phase_name = "primary "` (or `"secondary "`), so the keys are `"Negative primary electrode roughness ratio"` etc. For a single-phase electrode `phase_name = ""` and the key is `"Negative electrode roughness ratio"`.

The volumetric current density helper at `interface/base_interface.py:327` already looks the variable up with the phase prefix. The SEI on cracks submodels did not — they hard-coded `f"{Domain} electrode roughness ratio"` at three sites. On single-phase electrodes that happens to match; on composite electrodes nothing produces that key, so the SEI on cracks submodels fail in every build loop iteration until `count == 100` and PyBaMM raises with whichever submodel happened to fail last.

## Fix

Three lookups now use `self.phase_name`:

* `src/pybamm/models/submodels/interface/sei/sei_thickness.py:91` — SEI-on-cracks thickness formula `L_sei = c_sei * c_to_L / (roughness - 1)`.
* `src/pybamm/models/submodels/interface/sei/sei_growth.py:271` — `x-average` branch of `set_rhs` (covers SPM/SPMe).
* `src/pybamm/models/submodels/interface/sei/sei_growth.py:273` — `full electrode` branch of `set_rhs` (covers DFN).

For single-phase electrodes `phase_name = ""` so the lookup is unchanged. For composite electrodes the lookup now matches what `particle_mechanics` registers.

The fix is purely a variable-name correction; the SEI on cracks dynamics themselves are unchanged. As @DrSOKane noted on the issue, no published parameter set yet exposes the full set of phase-prefixed cracking parameters needed to actually *solve* an `"ec reaction limited"` SEI-on-cracks composite model end-to-end, but that is a separate parameter-set gap — this PR removes the structural build error so the missing data is the only remaining obstacle.

## Reproducer

Exact options from the issue:

```python
import pybamm

opts = {
    "particle phases": ("2", "1"),
    "open-circuit potential": (("single", "current sigmoid"), "single"),
    "SEI": "ec reaction limited",
    "particle mechanics": ("swelling and cracking", "swelling only"),
    "loss of active material": "stress-driven",
    "SEI on cracks": "true",
    "surface form": "algebraic",
}
pybamm.lithium_ion.SPMe(options=opts)   # ModelError on main, OK on this branch
pybamm.lithium_ion.DFN(options=opts)    # ModelError on main, OK on this branch
```

## Verification

* The exact `SPMe` + `DFN` reproducer above now builds cleanly. Both expose `"Negative primary SEI on cracks thickness [m]"` and `"Negative secondary SEI on cracks thickness [m]"`.
* Equivalent build matrix with `"SEI": "solvent-diffusion limited"` and with `"SEI on cracks": "false"` also passes.
* Single-phase regression: `SPM`/`SPMe`/`DFN` with `"particle mechanics": "swelling and cracking"` and `"SEI on cracks": "true"` continue to build and still expose `"Negative SEI on cracks thickness [m]"` and `"Negative electrode roughness ratio"`.
* `pytest tests/unit/test_models/test_submodels/test_interface/` → 34 passed.
* `pytest tests/unit/test_models/test_full_battery_models/test_lithium_ion/` → 634 passed, 12 skipped.
* `ruff check` + `ruff format --check` clean.

## Regression test

New `tests/unit/test_models/test_submodels/test_interface/test_sei_on_cracks_composite_phase_5281.py` pins five guards:

1. SPMe + composite + `ec reaction limited` builds (the x-averaged set_rhs branch + thickness branch).
2. DFN + composite + `ec reaction limited` builds (the full-electrode set_rhs branch).
3. SPM + composite + `solvent-diffusion limited` builds (a different SEI option exercising the same lookups).
4. The phased roughness keys are exposed and the un-phased key is *absent* — guards both directions of the rename.
5. Single-phase non-regression for SPM/SPMe/DFN: the un-phased key is still registered and consumed.

## Checklist

- [x] No style issues (ruff check, ruff format --check)
- [x] All tests passed
- [x] CHANGELOG.md updated (Bug fixes / Unreleased)
- [x] Updated docs if needed — n/a, internal variable name only
- [x] Issue reference in the PR description and the commit message
