### PR TITLE
Let CRate accept callables for its default duration (#4926)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fixed the `pybammsolvers` source distribution bundling the SUNDIALS/SuiteSparse submodule trees (~291 MB, over PyPI's per-file limit) when built from a checkout with the submodules initialised; the sdist now excludes them. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the `pybammsolvers` editable auto-rebuild failing to configure when the SUNDIALS/SuiteSparse submodules are absent even though the libraries were already built in `.idaklu`; the from-source bootstrap (and its submodule requirement) is now skipped once the libraries exist. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the Read the Docs documentation build, which broke once `pybammsolvers` became a workspace member with no published wheel during the release: RTD now fetches the SUNDIALS/SuiteSparse submodules and installs `gfortran`/`libopenblas` so the solver builds from source. Link checking was also restructured so transient external-link failures no longer block builds: Sphinx `linkcheck` is advisory, and the CI `lychee` check runs offline on PRs with a weekly external sweep that files a tracking issue. ([#5659](https://github.com/pybamm-team/PyBaMM/pull/5659))
+- Fixed `pybamm.step.CRate(callable)` crashing in `_default_timespan`. `CRate` now falls back to the 24-hour base default whenever the value is callable, matching the other `step.*` subclasses. ([#4926](https://github.com/pybamm-team/PyBaMM/issues/4926))
 
 # [v26.6.2.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.2.0) - 2026-06-16
 

--- a/packages/pybamm/src/pybamm/experiment/step/steps.py
+++ b/packages/pybamm/src/pybamm/experiment/step/steps.py
@@ -176,7 +176,15 @@ class CRate(BaseStepExplicit):
 
     def _default_timespan(self, value):
         # "value" is C-rate, so duration is "1 / value" hours in seconds
-        # with a 2x safety factor
+        # with a 2x safety factor. For a callable ``value`` we cannot
+        # invert "1 / C-rate" at construction time without evaluating
+        # the function (whose C-rate varies in time and may change
+        # sign), so we fall back to the base 24-hour default — matching
+        # how ``Current``/``Voltage``/``Power``/``Resistance`` handle
+        # callables. Users wanting a tighter bound can still pass
+        # ``duration=...`` explicitly. See issue #4926.
+        if callable(value):
+            return super()._default_timespan(value)
         return 1 / abs(value) * 3600 * 2
 
 

--- a/packages/pybamm/tests/unit/test_experiments/test_base_step.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_base_step.py
@@ -133,3 +133,54 @@ def test_parse_termination_requires_operator_for_input_parameter():
         pybamm.experiment.step.base_step._parse_termination(
             "2A", pybamm.InputParameter("I_app")
         )
+
+
+def _crate_one(t):
+    """A C-rate callable that ignores time. Defined at module scope so
+    that the regression tests below carry a real ``callable(value) is True``
+    rather than relying on lambdas that ``pickle`` cannot round-trip."""
+    return 1.0
+
+
+def test_crate_default_duration_with_callable_falls_back_to_24h():
+    """Guards #4926: ``CRate(callable)`` used to raise
+    ``TypeError: bad operand type for abs(): 'function'`` from
+    ``CRate._default_timespan`` evaluating ``1 / abs(value) * 3600 * 2``
+    on the function object instead of its return value.
+
+    The fix delegates to the base class's 24-hour default whenever the
+    value is callable, matching how every other ``step.*`` subclass
+    (``Current``, ``Voltage``, ``Power``, ``Resistance``) behaves for
+    callables. ``CRate(scalar)`` keeps the C-rate-derived bound."""
+    step = pybamm.step.CRate(_crate_one)
+    assert step.duration == 24 * 3600
+    assert step.uses_default_duration is True
+
+
+def test_crate_default_duration_with_scalar_unchanged():
+    """Non-regression for the existing fast path: a numeric C-rate
+    still resolves to ``1 / |C| * 3600 * 2`` seconds."""
+    step = pybamm.step.CRate(0.5)
+    assert step.duration == pytest.approx(1 / 0.5 * 3600 * 2)
+    step = pybamm.step.CRate(-2.0)
+    assert step.duration == pytest.approx(1 / 2.0 * 3600 * 2)
+
+
+def test_all_step_types_accept_callable_for_default_duration():
+    """Every explicit/implicit step subclass must accept a callable
+    without crashing in ``default_duration``. Before #4926's fix only
+    ``CRate`` was broken; this test pins all five to the same contract."""
+    for step_cls in (
+        pybamm.step.Current,
+        pybamm.step.CRate,
+        pybamm.step.Voltage,
+        pybamm.step.Power,
+        pybamm.step.Resistance,
+    ):
+        step = step_cls(_crate_one)
+        assert step.duration == 24 * 3600
+        # ``BaseStep.__init__`` materialises ``value`` by calling the
+        # function at ``t=0``, so ``step.value`` is the scalar result
+        # rather than the function object; the contract under test is
+        # that construction succeeds with the 24-hour fallback duration.
+        assert step.is_python_function is True


### PR DESCRIPTION
## Description

Fixes #4926.

`pybamm.step.CRate(callable)` fails at construction with

```
TypeError: bad operand type for abs(): 'function'
```

raised from `CRate._default_timespan`, which always tries to compute `1 / abs(value) * 3600 * 2` even when `value` is a Python function rather than a scalar.

## Root cause

`BaseStep.default_duration` (`base_step.py:289`) dispatches:

* ndarray → use the last time in the drive cycle table,
* anything else → call `self._default_timespan(value)`.

`BaseStep._default_timespan` (line 283) is a flat 24-hour fallback. Only `CRate` overrides it (`steps.py:171`):

```python
def _default_timespan(self, value):
    # "value" is C-rate, so duration is "1 / value" hours in seconds
    # with a 2x safety factor
    return 1 / abs(value) * 3600 * 2
```

Every other `step.*` subclass (`Current`, `Voltage`, `Power`, `Resistance`) inherits the base 24-hour default and therefore already accepts callables today — only `CRate(callable)` is broken.

## Fix

When `value` is callable, fall back to the base default:

```python
def _default_timespan(self, value):
    if callable(value):
        return super()._default_timespan(value)
    return 1 / abs(value) * 3600 * 2
```

The 24-hour fallback is a safe upper bound — voltage cutoffs and the experiment's own events end the step early in practice. Users wanting a tighter bound can still pass `duration=...` explicitly.

## Reproducer

```python
import pybamm

def crate_fn(t):
    return 1.0

step = pybamm.step.CRate(crate_fn)   # TypeError on main, OK on this branch
```

End-to-end on SPM:

```python
model = pybamm.lithium_ion.SPM()
exp = pybamm.Experiment([pybamm.step.CRate(crate_fn)])
sol = pybamm.Simulation(model, experiment=exp).solve()
# voltage drops from ~3.78 V to ~2.10 V as the solver hits the cutoff
```

## Verification

* `pybamm.step.CRate(crate_fn)` constructs with `duration == 86400` (matches `Current`/`Voltage`/`Power`/`Resistance`).
* `pybamm.step.CRate(0.5)` still gives `duration == 14400.0` (= `1/0.5 * 3600 * 2`).
* SPM + Chen2020 + `CRate(crate_fn)` solves end-to-end, terminating on the voltage cutoff.
* `pytest tests/unit/test_experiments/test_base_step.py` → 20 passed (+3 new regression tests).
* `ruff check` + `ruff format --check` clean.

## Regression test

New tests in `tests/unit/test_experiments/test_base_step.py`:

1. `test_crate_default_duration_with_callable_falls_back_to_24h` — exact issue reproducer.
2. `test_crate_default_duration_with_scalar_unchanged` — non-regression for the numeric fast path (`CRate(0.5)` and `CRate(-2.0)`).
3. `test_all_step_types_accept_callable_for_default_duration` — contract that every explicit/implicit subclass accepts a callable without crashing in `default_duration`.

## Checklist

- [x] No style issues (ruff check, ruff format --check)
- [x] All tests passed
- [x] CHANGELOG.md updated (Bug fixes / Unreleased)
- [x] Updated docs if needed — n/a, no public-API change
- [x] Issue reference in the PR description and the commit message
