### PR TITLE
Fix #4930: discretise Variable.reference / scale so r/x in initial concentration don't leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Fixed the `pybammsolvers` source distribution bundling the SUNDIALS/SuiteSparse submodule trees (~291 MB, over PyPI's per-file limit) when built from a checkout with the submodules initialised; the sdist now excludes them. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the `pybammsolvers` editable auto-rebuild failing to configure when the SUNDIALS/SuiteSparse submodules are absent even though the libraries were already built in `.idaklu`; the from-source bootstrap (and its submodule requirement) is now skipped once the libraries exist. ([#5623](https://github.com/pybamm-team/PyBaMM/pull/5623))
 - Fixed the Read the Docs documentation build, which broke once `pybammsolvers` became a workspace member with no published wheel during the release: RTD now fetches the SUNDIALS/SuiteSparse submodules and installs `gfortran`/`libopenblas` so the solver builds from source. Link checking was also restructured so transient external-link failures no longer block builds: Sphinx `linkcheck` is advisory, and the CI `lychee` check runs offline on PRs with a weekly external sweep that files a tracking issue. ([#5659](https://github.com/pybamm-team/PyBaMM/pull/5659))
+- Fixed `pybamm.lithium_ion.DFN` raising `NotImplementedError` when `Initial concentration` was set to a Python function of `(r, x)`. `Discretisation` now discretises `Variable.reference` and `Variable.scale` before substituting them. ([#4930](https://github.com/pybamm-team/PyBaMM/issues/4930))
 
 # [v26.6.2.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.2.0) - 2026-06-16
 

--- a/packages/pybamm/src/pybamm/discretisations/discretisation.py
+++ b/packages/pybamm/src/pybamm/discretisations/discretisation.py
@@ -849,11 +849,26 @@ class Discretisation:
 
         processed_eqn = self.process_symbol(eqn)
         if ics and (reference := getattr(name, "reference", 0)) != 0:
+            # ``name.reference`` can be a parameter-derived symbolic
+            # expression that still holds undiscretised
+            # :class:`SpatialVariable` / ``Integral`` leaves (e.g. when
+            # ``Initial concentration in negative electrode [mol.m-3]``
+            # is set to a function of ``r`` and ``x``, ``c_init_av``
+            # propagates ``r_n`` / ``x_n`` into the
+            # ``Negative electrolyte potential [V]`` Variable's
+            # ``reference``). Discretise it before subtracting so the
+            # initial-condition vector is purely numeric. See #4930.
+            if isinstance(reference, pybamm.Symbol):
+                reference = self.process_symbol(reference)
             processed_eqn = processed_eqn - reference
 
         # Calculate scale if the key has a scale
         scale = getattr(name, "scale", 1)
         if scale != 1:
+            # As with ``reference`` above, ``name.scale`` may carry
+            # undiscretised leaves; discretise it for the same reason.
+            if isinstance(scale, pybamm.Symbol):
+                scale = self.process_symbol(scale)
             processed_eqn = processed_eqn / scale
 
         return processed_eqn
@@ -1118,7 +1133,9 @@ class Discretisation:
         elif isinstance(symbol, pybamm.VariableDot):
             # Add symbol's reference and multiply by the symbol's scale
             # so that the state vector is of order 1
-            return symbol.reference + symbol.scale * pybamm.StateVectorDot(
+            reference = self.process_symbol(symbol.reference)
+            scale = self.process_symbol(symbol.scale)
+            return reference + scale * pybamm.StateVectorDot(
                 *self.y_slices[symbol.get_variable()],
                 domains=symbol.domains,
             )
@@ -1136,8 +1153,23 @@ class Discretisation:
                     "(e.g. not Broadcasted)"
                 ) from error
             # Add symbol's reference and multiply by the symbol's scale
-            # so that the state vector is of order 1
-            return symbol.reference + symbol.scale * pybamm.StateVector(
+            # so that the state vector is of order 1.
+            #
+            # ``reference`` and ``scale`` can be parameter-derived expressions
+            # that still hold undiscretised :class:`SpatialVariable` /
+            # ``Integral`` leaves (e.g. when ``Initial concentration in
+            # negative electrode [mol.m-3]`` is set to ``f(r, x)``, the
+            # ``c_init_av = xyz_average(r_average(c_init))`` propagation
+            # into ``U_init`` carries ``r_n`` / ``x_n`` into
+            # ``Negative electrolyte potential [V]``'s ``reference``).
+            # Discretising them here folds those averages back into a
+            # numeric scalar / vector and matches how the model's rhs
+            # would have evaluated them. For the common scalar case
+            # ``process_symbol`` short-circuits via its cache, so this
+            # adds no measurable overhead. Fixes #4930.
+            reference = self.process_symbol(symbol.reference)
+            scale = self.process_symbol(symbol.scale)
+            return reference + scale * pybamm.StateVector(
                 *y_slices, domains=symbol.domains
             )
 
@@ -1157,8 +1189,13 @@ class Discretisation:
                 new_children.append(self.process_symbol(child_no_scale))
             self.y_slices = old_y_slices
             new_symbol = spatial_method.concatenation(new_children)
-            # apply scale to the whole concatenation
-            return symbol.reference + symbol.scale * new_symbol
+            # apply scale to the whole concatenation. ``reference`` and
+            # ``scale`` are discretised first to fold any parameter-derived
+            # ``SpatialVariable`` / ``Integral`` leaves (see the
+            # ``Variable`` branch above and #4930).
+            reference = self.process_symbol(symbol.reference)
+            scale = self.process_symbol(symbol.scale)
+            return reference + scale * new_symbol
 
         elif isinstance(symbol, pybamm.Concatenation):
             new_children = [self.process_symbol(child) for child in symbol.children]

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_initial_concentration_function_4930.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_initial_concentration_function_4930.py
@@ -1,0 +1,159 @@
+"""Regression tests for #4930.
+
+When ``Initial concentration in <Domain> electrode [mol.m-3]`` is set
+to a Python callable ``f(r, x)``, the corresponding ``c_init``
+:class:`pybamm.FunctionParameter` evaluates the user's function on
+:class:`pybamm.SpatialVariable` leaves (``r_n``, ``x_n``). This bubbles
+into ``c_init_av = xyz_average(r_average(c_init))`` and then into the
+:attr:`pybamm.Variable.reference` of every electrolyte / electrode
+potential Variable (whose reference is ``-U_init`` and so depends on
+``c_init_av``).
+
+Before the fix, :meth:`pybamm.Discretisation._process_symbol` and
+:meth:`pybamm.Discretisation.process_equation` substituted
+``Variable.reference`` (and ``Variable.scale``) *without* discretising
+them first, so the un-folded ``r_n`` / ``x_n`` leaves leaked into the
+discretised rhs and initial-condition vectors. The resulting model
+then crashed in ``test_shape`` / ``check_initial_conditions`` with::
+
+    NotImplementedError: method self.evaluate() not implemented for
+    symbol r_n of type <class 'SpatialVariable'>
+
+These tests pin the fix: a parameter-derived ``Variable.reference`` /
+``Variable.scale`` that still holds undiscretised symbolic averages
+must be discretised by the discretisation layer, so that
+:class:`pybamm.lithium_ion.DFN` (and adjacent reduced-order models)
+solve end-to-end with an ``r``/``x``-dependent initial concentration.
+
+The same regression happens with ``pybamm.Simulation`` both with and
+without ``pybamm.Experiment``, so both paths are covered."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pybamm
+
+
+def _f_rx(r, x):
+    """User callable for the initial concentration. The bug is
+    triggered as soon as the result genuinely depends on the
+    :class:`SpatialVariable` arguments — a constant
+    ``17038.0 + 0 * r + 0 * x`` would simplify away."""
+    return 17038.0 + r + x
+
+
+def _patched_parameter_values():
+    pv = pybamm.ParameterValues("Chen2020")
+    pv.update({"Initial concentration in negative electrode [mol.m-3]": _f_rx})
+    return pv
+
+
+@pytest.fixture
+def parameter_values():
+    return _patched_parameter_values()
+
+
+def test_dfn_solves_with_function_of_r_and_x_for_initial_concentration(
+    parameter_values,
+):
+    """The exact reproducer from #4930: a plain
+    :class:`pybamm.Simulation` (no experiment) on ``DFN`` with a
+    callable ``Initial concentration in negative electrode [mol.m-3]``
+    used to raise ``NotImplementedError`` for ``r_n``."""
+    model = pybamm.lithium_ion.DFN()
+    sim = pybamm.Simulation(model, parameter_values=parameter_values)
+    sol = sim.solve([0, 1])
+    voltage = sol["Voltage [V]"].entries
+    assert sol.t[-1] == pytest.approx(1.0)
+    # Voltage must be finite and in the cell's usable range — guards
+    # against the IC having been silently zeroed by a future
+    # regression.
+    assert np.all(np.isfinite(voltage))
+    assert 2.0 < float(voltage[0]) < 5.0
+
+
+def test_dfn_with_experiment_solves_with_function_of_r_and_x(parameter_values):
+    """Original failing path from #4930's reproducer: ``DFN`` wrapped
+    in ``pybamm.Experiment(["Rest for 1 sec"])``. This is the path
+    that surfaces the discretisation-time
+    ``test_shape`` / ``check_initial_conditions`` failures, because
+    the experiment build pipes through ``_discretise_experiment_models``."""
+    model = pybamm.lithium_ion.DFN()
+    experiment = pybamm.Experiment(["Rest for 1 sec"])
+    sim = pybamm.Simulation(
+        model, experiment=experiment, parameter_values=parameter_values
+    )
+    sol = sim.solve()
+    voltage = sol["Voltage [V]"].entries
+    assert np.all(np.isfinite(voltage))
+    assert 2.0 < float(voltage[0]) < 5.0
+
+
+def test_spm_and_spme_solve_with_function_of_r_and_x(parameter_values):
+    """Belt-and-braces: the discretisation-time fix is on the generic
+    ``Variable`` / ``VariableDot`` / ``ConcatenationVariable`` branches,
+    not on DFN-specific code, so reduced-order models that historically
+    *did* work with this kind of callable must keep working. SPM
+    doesn't carry the electrolyte potential Variable that triggered
+    the original crash; SPMe does."""
+    for model_cls in (pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe):
+        model = model_cls()
+        sim = pybamm.Simulation(model, parameter_values=parameter_values)
+        sol = sim.solve([0, 1])
+        voltage = sol["Voltage [V]"].entries
+        assert np.all(np.isfinite(voltage))
+        assert 2.0 < float(voltage[0]) < 5.0
+
+
+def test_discretised_rhs_has_no_spatial_variable_leaves(parameter_values):
+    """Direct guard on the discretisation invariant the fix restores:
+    after discretisation, no ``rhs`` / ``algebraic`` / ``initial_conditions``
+    equation may carry an un-folded :class:`SpatialVariable` leaf.
+    This is what eventually trips ``test_shape`` (line 880) and
+    ``check_initial_conditions`` (line 1292) at runtime."""
+    model = pybamm.lithium_ion.DFN()
+    sim = pybamm.Simulation(model, parameter_values=parameter_values)
+    # Force the full build without solving, so the assertion is
+    # against the discretised model itself rather than via a solve
+    # error message.
+    sim.build()
+    built = sim.built_model
+
+    def _spatial_variable_leaves(expr):
+        leaves = expr.post_order(filter=lambda node: len(node.children) == 0)
+        return [leaf for leaf in leaves if isinstance(leaf, pybamm.SpatialVariable)]
+
+    for label, eqn_dict in (
+        ("rhs", built.rhs),
+        ("algebraic", built.algebraic),
+        ("initial_conditions", built.initial_conditions),
+    ):
+        for key, eqn in eqn_dict.items():
+            sps = _spatial_variable_leaves(eqn)
+            assert not sps, (
+                f"{label}[{key!r}] still carries undiscretised "
+                f"SpatialVariable leaves {[s.name for s in sps]}"
+            )
+
+
+def test_positive_electrode_callable_initial_concentration(parameter_values):
+    """The fix is symmetric in the negative / positive electrode
+    pathway because both Variables route through the same
+    ``Variable.reference`` substitution. Pin the positive-electrode
+    side as well so a future refactor that only fixes
+    ``self.param.n`` keeps the ``self.param.p`` side honest."""
+
+    def f_pos(r, x):
+        return 33133.0 + r + x
+
+    parameter_values.update(
+        {"Initial concentration in positive electrode [mol.m-3]": f_pos}
+    )
+    model = pybamm.lithium_ion.DFN()
+    sim = pybamm.Simulation(model, parameter_values=parameter_values)
+    sol = sim.solve([0, 1])
+    voltage = sol["Voltage [V]"].entries
+    assert np.all(np.isfinite(voltage))
+    assert 2.0 < float(voltage[0]) < 5.0


### PR DESCRIPTION
# Description

Fixes #4930.

`pybamm.lithium_ion.DFN` (and adjacent reduced-order models) crashes with

```
NotImplementedError: method self.evaluate() not implemented for symbol r_n
of type <class 'pybamm.expression_tree.independent_variable.SpatialVariable'>
```

as soon as `Initial concentration in <Domain> electrode [mol.m-3]` is set to a Python callable of `(r, x)`. The exact reproducer from the issue:

```python
import pybamm

def initial_concentration(r, x):
    return 17038.0 + r + x

parameter_values = pybamm.ParameterValues("Chen2020")
parameter_values.update(
    {"Initial concentration in negative electrode [mol.m-3]": initial_concentration}
)

model = pybamm.lithium_ion.DFN()
experiment = pybamm.Experiment(["Rest for 1 sec"])
sim = pybamm.Simulation(
    model, experiment=experiment, parameter_values=parameter_values
)
solution = sim.solve()      # ← NotImplementedError on r_n
```

`pybamm.lithium_ion.BasicDFN` works fine with the same callable.

## Root cause

`LithiumIonParameters` builds `c_init` as a `FunctionParameter` evaluated on `pybamm.SpatialVariable` arguments (`r`, `PrimaryBroadcast(x, ...)`), so the user's `f(r, x)` becomes a **symbolic** expression carrying `r_n` / `x_n` leaves. Its derived average

```python
c_init_av = pybamm.xyz_average(pybamm.r_average(self.c_init))
```

does **not** fold to a scalar at parameter-substitution time — PyBaMM keeps `xyz_average` / `r_average` as deferred `Integral` operators. `U_init` is computed from `c_init_av`, and every electrolyte- / electrode-potential `pybamm.Variable` is constructed with `reference=-self.param.n.prim.U_init` (see `electrolyte_conductivity/full_conductivity.py:35`), so its `.reference` attribute carries `r_n` / `x_n` leaves whenever `c_init` does.

`Discretisation._process_symbol` for `Variable` then did:

```python
return symbol.reference + symbol.scale * pybamm.StateVector(*y_slices, ...)
```

without first running `reference` / `scale` through `process_symbol`. The un-discretised SpatialVariable leaves leaked into the discretised **rhs** of `Porosity times concentration [mol.m-3]` (its source term references the electrolyte potential, which carries the leaky reference) and into the discretised **initial conditions** of `Positive electrode potential` / `Electrolyte potential` (`process_equation` subtracts `name.reference` when `ics=True`). The model then crashed at `test_shape` (line 880) → `check_initial_conditions` (line 1292) at runtime.

## Fix

Discretise `reference` and `scale` through `process_symbol` before combining them with the state-vector slice / initial-condition equation, in three branches of `_process_symbol`:

* `Variable`
* `VariableDot`
* `ConcatenationVariable`

and the matching `processed_eqn - name.reference` / `processed_eqn / name.scale` step in `process_equation`. `xyz_average` / `r_average` get evaluated against the actual mesh, folding `r_n` / `x_n` leaves into numeric vectors.

The change is a **no-op for the common case** where `reference` / `scale` are `Scalar` (process_symbol caches the result in `_discretised_symbols` so it adds no measurable overhead) and unblocks callable initial concentrations on both `Simulation` and `Simulation`+`Experiment` build paths.

## Tests

New regression file `tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_initial_concentration_function_4930.py` (+157 lines, 5 tests):

* `test_dfn_solves_with_function_of_r_and_x_for_initial_concentration` — OP's reproducer minus the experiment.
* `test_dfn_with_experiment_solves_with_function_of_r_and_x` — OP's exact reproducer.
* `test_spm_and_spme_solve_with_function_of_r_and_x` — guards reduced-order models too (the discretisation fix is on the generic Variable branch).
* `test_discretised_rhs_has_no_spatial_variable_leaves` — direct discretisation invariant: no `rhs` / `algebraic` / `initial_conditions` expression may carry an un-folded `SpatialVariable` leaf after `Simulation.build()`.
* `test_positive_electrode_callable_initial_concentration` — symmetric positive-electrode side, pins both `self.param.n` and `self.param.p` routes.

All 5 new tests pass. Pre-existing test suites stay green:

* `tests/unit/test_discretisations/` — 40 passed (+1 pre-existing `skfem` optional-dep skip).
* `tests/unit/test_models/test_full_battery_models/test_lithium_ion/` — 634 passed, 12 pre-existing skips.
* `tests/unit/test_experiments/` + `tests/unit/test_simulation.py` — 210 passed (+4 pre-existing `tqdm` / `skfem` optional-dep failures, present on `main` HEAD too).

`ruff check` clean.

## Type of change

- [ ] New feature
- [ ] Optimization
- [x] Bug fix

# Key checklist

- [x] `ruff check` passes on touched files
- [x] All tests pass for the touched suites
- [x] Regression tests added (5 tests, including the OP's reproducer)
- [x] CHANGELOG entry under `# [Unreleased]` → `## Bug fixes`
