### PR TITLE
Fix convert_symbol round-trip for symbols with non-child constructor args (#5548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Fixed `convert_symbol_to_json` / `convert_symbol_from_json` dropping non-child constructor arguments (numpy entries, slice/int index, `y_slices`, side/direction/region strings, a position, an integration domain, or a sibling `Symbol`), and silently rewriting the `*ToEdges` broadcasts to their parent class, on round-trip. ([#5549](https://github.com/pybamm-team/PyBaMM/pull/5549))
+
 # [v26.5.0](https://github.com/pybamm-team/PyBaMM/tree/v26.5.0) - 2026-05-27
 
 ## Breaking changes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -2232,6 +2232,163 @@ def convert_function_to_symbolic_expression(func, name=None):
     return ExpressionFunctionParameter(name, sym_output, func_name, func_args)
 
 
+# Symbols that already implement a complete ``to_json`` / ``_from_json`` round-trip
+# but whose constructors take non-Symbol positional arguments (a numpy array of
+# entries, a slice index, ``y_slices``...). The generic ``convert_symbol_*``
+# fallbacks only serialise ``children``, so these args were silently dropped,
+# causing ``TypeError``/``IndexError`` on load (see #5548). Delegate to the
+# per-class protocol instead. Listing the base classes also covers their
+# subclasses (``Matrix``/``Vector`` <: ``Array``; ``StateVector``/
+# ``StateVectorDot`` <: ``StateVectorBase``), so a single definition keeps the
+# ``to_json`` (class) and ``convert_symbol_from_json`` (type-name) sides in sync.
+def _protocol_classes():
+    return (pybamm.Index, pybamm.Array, pybamm.StateVectorBase)
+
+
+def _symbol_serialises_via_protocol(symbol):
+    return isinstance(symbol, _protocol_classes())
+
+
+def _type_serialises_via_protocol(type_name):
+    cls = getattr(pybamm, type_name, None)
+    return isinstance(cls, type) and issubclass(cls, _protocol_classes())
+
+
+# Symbols whose constructors take non-Symbol positional arguments (a side/direction
+# string, a region, a numeric position, an integration domain...) or a sibling Symbol
+# that is not one of ``symbol.children`` (an initial condition, a distribution). The
+# generic ``convert_symbol_*`` fallbacks only round-trip ``children``/``domains``, so
+# those arguments were silently dropped — raising ``TypeError``/``IndexError`` on load
+# or, worse, reconstructing an equivalent-but-different object (see #5548). This
+# registry records, per class, how to serialise the extra arguments and how to rebuild
+# the instance from its (already-reconstructed) children plus the JSON dict.
+#
+# Keying on the exact class name (rather than ``isinstance``) also fixes the silent
+# subclass-identity loss for the ``*ToEdges`` broadcasts: ``convert_symbol_to_json``'s
+# ``isinstance(symbol, pybamm.PrimaryBroadcast)`` branch used to fire for
+# ``PrimaryBroadcastToEdges`` and write the parent's ``type``, so the value round-tripped
+# back as the parent class. Dispatching these here, before the ``isinstance`` chain,
+# preserves the concrete subclass.
+def _extra_arg_serialisers():
+    return {
+        # --- broadcasts whose extra arg / concrete subclass was dropped ---
+        "PrimaryBroadcastToEdges": (
+            lambda s: {"broadcast_domain": s.broadcast_domain},
+            lambda ch, d: pybamm.PrimaryBroadcastToEdges(ch[0], d["broadcast_domain"]),
+        ),
+        "SecondaryBroadcastToEdges": (
+            lambda s: {"broadcast_domain": s.broadcast_domain},
+            lambda ch, d: pybamm.SecondaryBroadcastToEdges(
+                ch[0], d["broadcast_domain"]
+            ),
+        ),
+        "FullBroadcastToEdges": (
+            lambda s: {},
+            lambda ch, d: pybamm.FullBroadcastToEdges(
+                ch[0], broadcast_domains=d["domains"]
+            ),
+        ),
+        "TertiaryBroadcast": (
+            lambda s: {"broadcast_domain": s.broadcast_domain},
+            lambda ch, d: pybamm.TertiaryBroadcast(ch[0], d["broadcast_domain"]),
+        ),
+        "TertiaryBroadcastToEdges": (
+            lambda s: {"broadcast_domain": s.broadcast_domain},
+            lambda ch, d: pybamm.TertiaryBroadcastToEdges(ch[0], d["broadcast_domain"]),
+        ),
+        # --- unary operators with a dropped string/numeric argument ---
+        "BoundaryMeshSize": (
+            lambda s: {"side": s.side},
+            lambda ch, d: pybamm.BoundaryMeshSize(ch[0], d["side"]),
+        ),
+        "DeltaFunction": (
+            lambda s: {"side": s.side, "delta_domain": s.domain},
+            lambda ch, d: pybamm.DeltaFunction(ch[0], d["side"], d["delta_domain"]),
+        ),
+        "EvaluateAt": (
+            lambda s: {"position": s.position},
+            lambda ch, d: pybamm.EvaluateAt(ch[0], d["position"]),
+        ),
+        "Magnitude": (
+            lambda s: {"direction": s.direction},
+            lambda ch, d: pybamm.Magnitude(ch[0], d["direction"]),
+        ),
+        "NodeToEdge2D": (
+            lambda s: {"direction": s.direction},
+            lambda ch, d: pybamm.NodeToEdge2D(ch[0], d["direction"]),
+        ),
+        "UpwindDownwind2D": (
+            lambda s: {"lr_direction": s.lr_direction, "tb_direction": s.tb_direction},
+            lambda ch, d: pybamm.UpwindDownwind2D(
+                ch[0], d["lr_direction"], d["tb_direction"]
+            ),
+        ),
+        "OneDimensionalIntegral": (
+            lambda s: {
+                "integration_domain": s.integration_domain,
+                "direction": s.direction,
+                "region": s.region,
+            },
+            lambda ch, d: pybamm.OneDimensionalIntegral(
+                ch[0], d["integration_domain"], d["direction"], region=d["region"]
+            ),
+        ),
+        "BoundaryIntegral": (
+            lambda s: {"region": s.region},
+            lambda ch, d: pybamm.BoundaryIntegral(ch[0], region=d["region"]),
+        ),
+        "BackwardIndefiniteIntegral": (
+            lambda s: {
+                "integration_variable": convert_symbol_to_json(
+                    s.integration_variable[0]
+                )
+            },
+            lambda ch, d: pybamm.BackwardIndefiniteIntegral(
+                ch[0], convert_symbol_from_json(d["integration_variable"])
+            ),
+        ),
+        "ExplicitTimeIntegral": (
+            lambda s: {
+                "initial_condition": convert_symbol_to_json(s.initial_condition)
+            },
+            lambda ch, d: pybamm.ExplicitTimeIntegral(
+                ch[0], convert_symbol_from_json(d["initial_condition"])
+            ),
+        ),
+        "SizeAverage": (
+            lambda s: {"f_a_dist": convert_symbol_to_json(s.f_a_dist)},
+            lambda ch, d: pybamm.SizeAverage(
+                ch[0], convert_symbol_from_json(d["f_a_dist"])
+            ),
+        ),
+        "TensorField": (
+            lambda s: {},
+            lambda ch, d: pybamm.TensorField(list(ch)),
+        ),
+        # --- leaf symbols (no children) with a dropped argument ---
+        "VariableDot": (
+            lambda s: {},
+            lambda ch, d: pybamm.VariableDot(d["name"], domains=d["domains"]),
+        ),
+        "SpatialVariableEdge": (
+            lambda s: {"coord_sys": s.coord_sys, "direction": s.direction},
+            lambda ch, d: pybamm.SpatialVariableEdge(
+                d["name"],
+                domains=d["domains"],
+                coord_sys=d["coord_sys"],
+                direction=d["direction"],
+            ),
+        ),
+        # --- Interpolant subclass: rebuild from its stored (x, y) arrays ---
+        "DiscreteTimeData": (
+            lambda s: {"time_points": s.x[0].tolist(), "data": s.y.tolist()},
+            lambda ch, d: pybamm.DiscreteTimeData(
+                np.array(d["time_points"]), np.array(d["data"]), d["name"]
+            ),
+        ),
+    }
+
+
 def convert_symbol_from_json(json_data):
     """
     Recursively converts a JSON dictionary back into PyBaMM symbolic expressions
@@ -2353,6 +2510,25 @@ def convert_symbol_from_json(json_data):
             json_data["name"],
             domains=json_data.get("domains", {}),
         )
+    elif json_data["type"] in _extra_arg_serialisers():
+        # Rebuild via the registered constructor, which supplies the non-Symbol
+        # arguments (side/direction/region strings, a position, a distribution...)
+        # that the generic fallback below would drop (#5548).
+        _, from_json = _extra_arg_serialisers()[json_data["type"]]
+        children = [convert_symbol_from_json(c) for c in json_data.get("children", [])]
+        return from_json(children, json_data)
+    elif _type_serialises_via_protocol(json_data["type"]):
+        # Reconstruct via the class's own ``_from_json``, which knows how to
+        # rebuild the non-Symbol constructor args (slice index, numpy entries,
+        # ``y_slices``) that the generic fallback below would drop (#5548).
+        cls = getattr(pybamm, json_data["type"])
+        snippet = {
+            **json_data,
+            "children": [
+                convert_symbol_from_json(c) for c in json_data.get("children", [])
+            ],
+        }
+        return cls._from_json(snippet)
     elif "children" in json_data:
         return getattr(pybamm, json_data["type"])(
             *[convert_symbol_from_json(c) for c in json_data["children"]]
@@ -2385,6 +2561,22 @@ def convert_symbol_to_json(symbol):
         }
     elif isinstance(symbol, numbers.Number | list):
         return symbol
+    elif symbol.__class__.__name__ in _extra_arg_serialisers():
+        # Capture the non-Symbol constructor arguments (and the concrete subclass
+        # name) that the generic / parent-class branches below would drop (#5548).
+        # Keyed on the exact class so e.g. ``PrimaryBroadcastToEdges`` is handled
+        # here rather than by the ``isinstance(symbol, pybamm.PrimaryBroadcast)``
+        # branch, which would otherwise rewrite it to the parent type.
+        to_json, _ = _extra_arg_serialisers()[symbol.__class__.__name__]
+        json_dict = {
+            "type": symbol.__class__.__name__,
+            "domains": symbol.domains,
+            "children": [convert_symbol_to_json(c) for c in symbol.children],
+        }
+        if hasattr(symbol, "name"):
+            json_dict["name"] = symbol.name
+        json_dict.update(to_json(symbol))
+        return json_dict
     elif isinstance(symbol, pybamm.Parameter):
         # Parameters are stored with their type and name
         return {"type": "Parameter", "name": symbol.name}
@@ -2509,6 +2701,15 @@ def convert_symbol_to_json(symbol):
             "diff_variable": diff_variable,
             "name": symbol.name,
         }
+    elif _symbol_serialises_via_protocol(symbol):
+        # Delegate to the class's own ``to_json``, which captures the non-Symbol
+        # constructor args (slice index, numpy entries, ``y_slices``) that the
+        # generic fallback below would drop (#5548). Children are nested inline,
+        # as elsewhere in this serialiser.
+        json_dict = symbol.to_json()
+        json_dict["type"] = symbol.__class__.__name__
+        json_dict["children"] = [convert_symbol_to_json(c) for c in symbol.children]
+        return json_dict
     elif isinstance(symbol, pybamm.Symbol):
         # Generic fallback for other symbols with children
         json_dict = {

--- a/tests/unit/test_serialisation/test_round_trip.py
+++ b/tests/unit/test_serialisation/test_round_trip.py
@@ -148,6 +148,12 @@ def _custom_model_with_events():
 def _build_symbol_fixtures():
     a = pybamm.Variable("a")
     b = pybamm.Parameter("b")
+    n = pybamm.Variable("u", domains={"primary": ["negative electrode"]})
+    p = pybamm.Variable("v", domains={"primary": ["negative particle"]})
+    pst = pybamm.Variable(
+        "w",
+        domains={"primary": ["negative particle"], "secondary": ["negative electrode"]},
+    )
     return [
         pybamm.Scalar(3.14),
         pybamm.Scalar(np.inf),
@@ -169,6 +175,46 @@ def _build_symbol_fixtures():
         ),
         pybamm.Interpolant(np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 4.0]), a),
         pybamm.FunctionParameter("f", {"a": a}),
+        # Symbols whose constructors take non-Symbol positional args (numpy
+        # entries, a slice/int index, ``y_slices``). These were dropped by the
+        # generic fallback and crashed on load before #5548.
+        pybamm.Array(np.array([[1.0, 2.0], [3.0, 4.0]])),
+        pybamm.Matrix(np.array([[1.0, 2.0], [3.0, 4.0]])),
+        pybamm.Vector(np.array([1.0, 2.0, 3.0])),
+        pybamm.StateVector(slice(0, 3)),
+        pybamm.StateVectorDot(slice(0, 3)),
+        pybamm.Index(pybamm.StateVector(slice(0, 6)), slice(0, 3), check_size=False),
+        pybamm.Index(pybamm.StateVector(slice(0, 6)), 2, check_size=False),
+        # Symbols whose constructor takes a non-Symbol arg (a side/direction/region
+        # string, a numeric position, an integration domain) or a sibling Symbol
+        # that is not a child. The generic fallback dropped these, crashing on load
+        # or silently reconstructing a different object before #5548.
+        pybamm.BoundaryMeshSize(p, "left"),
+        pybamm.DeltaFunction(p, "left", "negative electrode"),
+        pybamm.EvaluateAt(n, 0.5),
+        pybamm.Magnitude(n, "x"),
+        pybamm.NodeToEdge2D(n, "lr"),
+        pybamm.UpwindDownwind2D(n, "x", "y"),
+        pybamm.OneDimensionalIntegral(n, "x", "y"),
+        pybamm.BoundaryIntegral(n, region="negative tab"),
+        pybamm.BackwardIndefiniteIntegral(
+            n, pybamm.SpatialVariable("x", domain=["negative electrode"])
+        ),
+        pybamm.ExplicitTimeIntegral(n, pybamm.Scalar(0.0)),
+        pybamm.SizeAverage(p, pybamm.Scalar(1.0)),
+        pybamm.TensorField([pybamm.Scalar(1.0), pybamm.Scalar(2.0)]),
+        pybamm.VariableDot("vdot"),
+        pybamm.SpatialVariableEdge("x", domain=["negative electrode"]),
+        pybamm.DiscreteTimeData(
+            np.array([0.0, 1.0]), np.array([2.0, 3.0]), "discrete data"
+        ),
+        # Broadcast subclasses whose concrete type was silently rewritten to the
+        # parent class on round-trip (#5548), plus the dropped ``broadcast_domain``.
+        pybamm.PrimaryBroadcastToEdges(pybamm.Scalar(1.0), "negative electrode"),
+        pybamm.SecondaryBroadcastToEdges(p, "negative electrode"),
+        pybamm.FullBroadcastToEdges(pybamm.Scalar(1.0), "negative electrode"),
+        pybamm.TertiaryBroadcast(pst, "current collector"),
+        pybamm.TertiaryBroadcastToEdges(pst, "current collector"),
     ]
 
 


### PR DESCRIPTION
## Description

Fixes the bulk of the round-trip failures catalogued in #5548.

The standalone `convert_symbol_to_json` / `convert_symbol_from_json` helpers in
`serialise.py` round-trip only a symbol's `children` (and `domains`). Symbols whose
constructors take **other** arguments therefore lost those arguments on round-trip:

- a numpy array of entries (`Array`/`Matrix`/`Vector`), a slice/int index (`Index`),
  `y_slices` (`StateVector`/`StateVectorDot`) → `TypeError`/`IndexError` on load;
- a side/direction/region string, a numeric position, an integration domain, or a
  sibling `Symbol` that is not a child (an initial condition, a distribution) →
  `TypeError` on load, or a silently *different* object;
- the three `*ToEdges` broadcasts additionally round-tripped back as their **parent
  class**, because `convert_symbol_to_json` matched them against the parent's
  `isinstance` branch and wrote the parent's `type`.

## Approach

Two complementary mechanisms, both routed through the existing dispatch chains:

1. **Protocol delegation.** Data/index nodes that already implement a complete
   `to_json` / `_from_json` protocol — `Index`, `Array` (+ `Matrix`/`Vector`), and
   `StateVectorBase` (+ `StateVector`/`StateVectorDot`) — now delegate to it instead of
   the generic child-only fallback. Listing the base classes covers their subclasses, so
   one definition keeps the `to_json` (class) and `convert_symbol_from_json` (type-name)
   sides in sync.

2. **A class-keyed registry** (`_extra_arg_serialisers`) records, per affected class, how
   to serialise the extra constructor arguments and how to rebuild the instance from its
   reconstructed children plus the JSON dict. Keying on the **exact class name** (rather
   than `isinstance`) is also what fixes the `*ToEdges` subclass-identity loss — these are
   dispatched here, before the `isinstance` chain, so the concrete subclass is preserved.

Classes covered by the registry: `PrimaryBroadcastToEdges`, `SecondaryBroadcastToEdges`,
`FullBroadcastToEdges`, `TertiaryBroadcast`, `TertiaryBroadcastToEdges`, `BoundaryMeshSize`,
`DeltaFunction`, `EvaluateAt`, `Magnitude`, `NodeToEdge2D`, `UpwindDownwind2D`,
`OneDimensionalIntegral`, `BoundaryIntegral`, `BackwardIndefiniteIntegral`,
`ExplicitTimeIntegral`, `SizeAverage`, `TensorField`, `VariableDot`, `SpatialVariableEdge`,
`DiscreteTimeData`.

## Scope / what is deferred

This addresses every failure in #5548 **except** the four already handled by the unmerged
commit `5fecb74` referenced in the issue — `BoundaryGradient` (`side`), `Variable`
(`scale`/`reference`), and `FullBroadcast` (`name`) — to avoid conflicting with that work.
Those can be merged independently or folded in if preferred.

## Verification

Each repro from the issue now round-trips with the correct class **and** a matching
structural `id` (or raises no error and preserves the relevant arg). New parametrized
fixtures in `tests/unit/test_serialisation/test_round_trip.py::TestSymbolRoundTrip` cover
all 20 newly-handled classes through a full `json.dumps`/`loads` cycle.

```
tests/unit/test_serialisation/  →  269 passed
TestSymbolRoundTrip             →  43 passed (was 23)
```

`ruff check` and `ruff format --check` are clean on both files.
