### PR TITLE
perf: remove two O(N^2) slowdowns in Solution accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Optimizations
+
+- Fixed two O(N²) slowdowns in long experiment/ageing simulations where `Solution.__add__`/`copy` re-did whole-accumulation work on every step append: time-series validation now re-checks only the joined boundary, and `Solution.observable` is computed lazily. ([#5550](https://github.com/pybamm-team/PyBaMM/pull/5550))
+
 # [v26.5.0](https://github.com/pybamm-team/PyBaMM/tree/v26.5.0) - 2026-05-27
 
 ## Breaking changes

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -256,10 +256,12 @@ class Solution(SolutionBase):
         variables_returned=False,
         check_solution=True,
         options=None,
+        _validate_time_structure=True,
     ):
         if not isinstance(all_ts, list):
             all_ts = [all_ts]
-        self._ensure_sorted_t(all_ts, "all_ts")
+        if _validate_time_structure:
+            self._ensure_sorted_t(all_ts, "all_ts")
         if not isinstance(all_ys, list):
             all_ys = [all_ys]
         if not isinstance(all_models, list):
@@ -278,14 +280,14 @@ class Solution(SolutionBase):
         else:
             if not isinstance(all_t_evals, list):
                 all_t_evals = [all_t_evals]
-            self._ensure_t_evals(all_ts=all_ts, all_t_evals=all_t_evals)
+            if _validate_time_structure:
+                self._ensure_t_evals(all_ts=all_ts, all_t_evals=all_t_evals)
         self._all_t_evals = all_t_evals
         self._user_options = options or {}
         self._options = _DEFAULT_SOLUTION_OPTIONS | self._user_options
         self.variables_returned = variables_returned
-        self._observable = self._all_models and all(
-            model.solution_observable for model in self._all_models
-        )
+        # computed lazily on first access; see the `observable` property
+        self._observable = None
 
         # Set up inputs
         if not isinstance(all_inputs, list):
@@ -550,10 +552,14 @@ class Solution(SolutionBase):
 
     @property
     def observable(self) -> bool:
+        if self._observable is None:
+            self._observable = bool(self._all_models) and all(
+                model.solution_observable for model in self._all_models
+            )
         return self._observable
 
     def _check_observable(self):
-        if self._observable:
+        if self.observable:
             return
 
         # Collect unique reasons from all models
@@ -1107,6 +1113,18 @@ class Solution(SolutionBase):
         if not hermite_interpolation:
             all_yps = None
 
+        # Validate only the newly-joined region (self's last segment + other's
+        # contribution), not the whole accumulation. self's earlier segments
+        # were already validated when self was built, so this stays O(size of
+        # other) per add, i.e. O(N) total instead of O(N^2).
+        n = len(self.all_ts)
+        self._ensure_sorted_t([self.all_ts[-1], *all_ts[n:]], "all_ts")
+        if all_t_evals is not None:
+            self._ensure_t_evals(
+                all_ts=[self.all_ts[-1], *all_ts[n:]],
+                all_t_evals=[self._all_t_evals[-1], *all_t_evals[n:]],
+            )
+
         # sensitivities are a dict of {parameter: [sensitivities]}
         # we can assume that the keys are the same for both solutions
         all_sensitivities = self._all_sensitivities
@@ -1130,6 +1148,7 @@ class Solution(SolutionBase):
             all_t_evals=all_t_evals,
             variables_returned=other.variables_returned,
             options=options,
+            _validate_time_structure=False,
         )
 
         new_sol.closest_event_idx = other.closest_event_idx
@@ -1172,6 +1191,7 @@ class Solution(SolutionBase):
             all_t_evals=self._all_t_evals,
             variables_returned=self.variables_returned,
             options=self.user_options,
+            _validate_time_structure=False,
         )
         new_sol._all_inputs_stacked = self.all_inputs_stacked
         new_sol._all_inputs_casadi = self.all_inputs_casadi

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -6,6 +6,7 @@ import json
 import logging
 import subprocess  # nosec B404 - used in tests with trusted input
 import sys
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -368,6 +369,126 @@ class TestSolution:
         sol2 = pybamm.Solution(t3, y3, pybamm.BaseModel(), {}, all_sensitivities={})
         sol3 = sol1 + sol2
         assert not sol3._all_sensitivities
+
+    def test_add_validates_only_boundary(self):
+        # __add__ must validate only the joined region, not re-scan the whole
+        # accumulation (that re-scan was the O(N^2) source).
+        base = None
+        for i in range(5):
+            t = np.array([3.0 * i, 3.0 * i + 1.0])  # non-adjacent, no strip
+            s = pybamm.Solution(t, np.tile(t, (3, 1)), pybamm.BaseModel(), {})
+            base = s if base is None else base + s
+        nseg = len(base.all_ts)
+        assert nseg >= 4
+        t = np.array([3.0 * 5, 3.0 * 5 + 1.0])
+        nxt = pybamm.Solution(t, np.tile(t, (3, 1)), pybamm.BaseModel(), {})
+        with mock.patch.object(
+            pybamm.Solution,
+            "_ensure_sorted_t",
+            wraps=pybamm.Solution._ensure_sorted_t,
+        ) as spy:
+            _ = base + nxt
+        # every validation is on a bounded boundary slice, never the full
+        # nseg+1 segment list (that re-scan was the O(N^2) source)
+        assert spy.call_count >= 1
+        for call in spy.call_args_list:
+            assert len(call[0][0]) < nseg
+
+    def test_add_out_of_order_raises(self):
+        # The boundary re-scan preserves the strictly-increasing invariant the
+        # full re-scan used to enforce.
+        t1 = np.linspace(0, 2)
+        t2 = np.linspace(1, 3)  # starts before sol1 ends
+        sol1 = pybamm.Solution(t1, np.tile(t1, (5, 1)), pybamm.BaseModel(), {})
+        sol2 = pybamm.Solution(t2, np.tile(t2, (5, 1)), pybamm.BaseModel(), {})
+        with pytest.raises(ValueError, match=r"strictly increasing across"):
+            _ = sol1 + sol2
+
+    def test_add_duplicate_junction_raises(self):
+        # A segment like [10, 10, 11] passes per-segment sort (<= allows
+        # equal), so `other` is a valid solution; merging it onto a solution
+        # ending at 10 leaves a non-strictly-increasing junction after the
+        # repeated-boundary strip. The boundary re-scan must catch it.
+        t1 = np.array([0.0, 5.0, 10.0])
+        t2 = np.array([10.0, 10.0, 11.0])
+        sol1 = pybamm.Solution(t1, np.tile(t1, (5, 1)), pybamm.BaseModel(), {})
+        sol2 = pybamm.Solution(t2, np.tile(t2, (5, 1)), pybamm.BaseModel(), {})
+        with pytest.raises(ValueError, match=r"strictly increasing across"):
+            _ = sol1 + sol2
+
+    def test_add_validates_t_evals_only_at_boundary(self):
+        # all_t_evals gets the same bounded boundary re-scan as all_ts: one
+        # call on the joined region, not the whole accumulation.
+        base = None
+        for i in range(5):
+            t = np.array([3.0 * i, 3.0 * i + 1.0])  # non-adjacent, no strip
+            s = pybamm.Solution(
+                t, np.tile(t, (3, 1)), pybamm.BaseModel(), {}, all_t_evals=t
+            )
+            base = s if base is None else base + s
+        nseg = len(base.all_ts)
+        assert nseg >= 4
+        t = np.array([15.0, 16.0])
+        nxt = pybamm.Solution(
+            t, np.tile(t, (3, 1)), pybamm.BaseModel(), {}, all_t_evals=t
+        )
+        with mock.patch.object(
+            pybamm.Solution,
+            "_ensure_t_evals",
+            wraps=pybamm.Solution._ensure_t_evals,
+        ) as spy:
+            _ = base + nxt
+        assert spy.call_count == 1
+        assert len(spy.call_args.kwargs["all_t_evals"]) < nseg
+
+    def test_check_solution_false_still_validates_time(self):
+        # check_solution controls only the large-y scan; time structure is
+        # still validated, so unsorted segments raise regardless.
+        bad_ts = [np.array([1.0, 2.0, 3.0]), np.array([2.0, 3.0, 4.0])]
+        bad_ys = [np.ones((1, 3)), np.ones((1, 3))]
+        with pytest.raises(ValueError, match=r"strictly increasing"):
+            pybamm.Solution(
+                bad_ts, bad_ys, pybamm.BaseModel(), [{}, {}], check_solution=False
+            )
+
+    def test_check_solution_false_skips_only_large_y(self):
+        # check_solution=False skips check_ys_are_not_too_large but not the
+        # time-structure validation.
+        t = np.linspace(0, 1)
+        y = np.tile(t, (5, 1))
+        with (
+            mock.patch.object(pybamm.Solution, "check_ys_are_not_too_large") as large_y,
+            mock.patch.object(pybamm.Solution, "_ensure_sorted_t") as sorted_t,
+        ):
+            pybamm.Solution(t, y, pybamm.BaseModel(), {}, check_solution=False)
+        large_y.assert_not_called()
+        sorted_t.assert_called_once()
+
+    def test_validate_time_structure_false_skips_time_validation(self):
+        # The private fast path used by __add__/copy: unsorted segments are
+        # accepted only when time validation is explicitly disabled.
+        bad_ts = [np.array([1.0, 2.0, 3.0]), np.array([2.0, 3.0, 4.0])]
+        bad_ys = [np.ones((1, 3)), np.ones((1, 3))]
+        sol = pybamm.Solution(
+            bad_ts, bad_ys, pybamm.BaseModel(), [{}, {}], _validate_time_structure=False
+        )
+        assert len(sol.all_ts) == 2
+
+    def test_observable_computed_lazily(self):
+        # `observable` scans all_models; computing it eagerly on every
+        # construction makes accumulation O(N^2). It must be deferred to
+        # first access and then cached.
+        t1 = np.linspace(0, 1)
+        t2 = np.linspace(1, 2)
+        sol1 = pybamm.Solution(t1, np.tile(t1, (5, 1)), pybamm.BaseModel(), {})
+        sol2 = pybamm.Solution(t2, np.tile(t2, (5, 1)), pybamm.BaseModel(), {})
+        sol_sum = sol1 + sol2
+        assert sol_sum._observable is None  # not computed during __add__
+        expected = bool(sol_sum.all_models) and all(
+            m.solution_observable for m in sol_sum.all_models
+        )
+        assert sol_sum.observable == expected  # computed on access
+        assert sol_sum._observable == expected  # and cached
 
     def test_add_solutions_different_models(self):
         # Set up first solution


### PR DESCRIPTION
## Summary

Long experiment/ageing simulations rebuild a fresh `Solution` on every step append via `Solution.__add__`/`copy`. Two pieces of work in `Solution.__init__` re-scanned the entire accumulation on each append, making the total cost O(N^2) in step count. This fixes both.

## Root cause

A scaling profiler (run sim at N and 2N, compare per-function growth) surfaced two clusters scaling ~4x per doubling:

1. **Time-series validation.** `_ensure_sorted_t` / `_ensure_t_evals` ran on every construction. Added in #5390.
2. **Observability.** `Solution.observable` scanned every accumulated model on every construction.

Both are O(N) per append over the growing accumulation, so O(N^2) total. A microbenchmark of the validation scan extrapolates to ~160s at 16.5k steps, matching the original report.

## Fix

1. Gate the time-series validation behind a private `_validate_time_structure` flag. `__add__`/`copy` pass it `False` and instead re-validate only the newly joined boundary (self's last segment plus other's contribution) for both `all_ts` and `all_t_evals`. This is O(size of the appended piece) per add, so O(N) total, and is provably equivalent to the old full re-scan because each operand was already validated when it was built. `check_solution` keeps its original meaning (large-y check only), so the public contract and `CasadiSolver`'s existing `check_solution=False` call sites are unchanged.
2. Compute `Solution.observable` lazily on first access and cache it. It is only read at post-processing, never during accumulation.

## Benchmark

SPM experiment, `period=3600` (integration minimized to isolate the accumulation overhead). `gap` is wall minus reported `solve_time`.

| cycles | steps | unfixed wall | unfixed gap | fixed wall | fixed gap |
|------:|------:|------------:|-----------:|----------:|---------:|
| 200 | 800 | 0.83s | 0.41s | 0.63s | 0.21s |
| 400 | 1600 | 2.00s | 1.14s | 1.14s | 0.29s |
| 800 | 3200 | 5.73s | 4.01s | 2.20s | 0.52s |
| 1600 | 6400 | 19.26s | 15.71s | 4.35s | 0.97s |

Unfixed gap grows ~3.9x per doubling (O(N^2)); fixed grows ~1.85x (O(N)). At 1600 cycles, 4.4x faster wall and 16x less overhead. The win grows with size.

## Tests

- `_ensure_sorted_t`/`_ensure_t_evals` are called during `__add__` only on bounded boundary slices, never the full accumulation.
- Out-of-order and duplicate-junction merges still raise (the boundary re-scan preserves the strictly-increasing invariant; the duplicate-junction case is one the naive O(1) guard would have missed).
- `check_solution=False` still validates time structure and skips only the large-y check.
- `observable` is computed lazily and cached.
- Existing solution/experiment/CasADi/IDAKLU suites pass.

## Out of scope

A residual O(N^2) remains in `__add__` from list concatenation (`all_ts + other.all_ts` etc). It is pure pointer-copy, no longer dominant, and only matters far beyond current sim sizes. Removing it needs a batch-append restructure of the stepping loop, left as a follow-up.
