### PR TITLE
perf: O(N) experiment accumulation via Solution.from_sub_solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Optimizations
 
 - Fixed two O(N²) slowdowns in long experiment/ageing simulations where `Solution.__add__`/`copy` re-did whole-accumulation work on every step append: time-series validation now re-checks only the joined boundary, and `Solution.observable` is computed lazily. ([#5550](https://github.com/pybamm-team/PyBaMM/pull/5550))
+- Experiment/ageing accumulation now folds per-cycle solutions in a single O(N) pass via `Solution.from_sub_solutions`, removing the residual O(N²) list concatenation in repeated `Solution.__add__`, and fixes an aliasing bug where `__add__` mutated the left operand's sensitivities. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
 
 # [v26.5.0](https://github.com/pybamm-team/PyBaMM/tree/v26.5.0) - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Optimizations
 
 - Fixed two O(N²) slowdowns in long experiment/ageing simulations where `Solution.__add__`/`copy` re-did whole-accumulation work on every step append: time-series validation now re-checks only the joined boundary, and `Solution.observable` is computed lazily. ([#5550](https://github.com/pybamm-team/PyBaMM/pull/5550))
-- Experiment/ageing accumulation now folds per-cycle solutions in a single O(N) pass via `Solution.from_sub_solutions`, removing the residual O(N²) list concatenation in repeated `Solution.__add__`, and fixes an aliasing bug where `__add__` mutated the left operand's sensitivities. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+- Experiment/ageing accumulation now folds per-cycle solutions in a single O(N) pass via `Solution.from_sub_solutions`, removing the residual O(N²) list concatenation in repeated `Solution.__add__`, and fixes an aliasing bug where `__add__` mutated the left operand's sensitivities. ([#5551](https://github.com/pybamm-team/PyBaMM/pull/5551))
 
 # [v26.5.0](https://github.com/pybamm-team/PyBaMM/tree/v26.5.0) - 2026-05-27
 

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -641,7 +641,6 @@ class Simulation(BaseSimulation):
                     f"Step '{step_str}' is infeasible at initial conditions, "
                     "but skip_ok is True. Skipping step."
                 )
-                self._solution.termination = steps[0].termination
                 return True  # signal: continue to next cycle
             raise pybamm.SolverError(
                 f"Step '{step_str}' is infeasible "
@@ -894,6 +893,26 @@ class Simulation(BaseSimulation):
         else:
             cycle_lengths = self.experiment.cycle_lengths
 
+        # Collect per-cycle solutions and fold them once after the loop
+        # (O(N)) instead of self._solution = self._solution + cycle_solution
+        # each cycle (O(N^2)).
+        # Seed with the loop-entry self._solution (the starting_solution /
+        # padding-rest carry-over) so the fold reproduces today's left-fold start.
+        cross_cycle_segments = (
+            []
+            if (
+                self._solution is None
+                or isinstance(self._solution, pybamm.EmptySolution)
+            )
+            else [self._solution]
+        )
+
+        # Termination of the running accumulation as the loop mutates it:
+        # updated by each real appended cycle and by skipped steps (which used
+        # to mutate self._solution.termination directly). Applied to the folded
+        # solution below so the final termination matches the old left-fold.
+        last_termination = None
+
         for cycle_num, cycle_length in enumerate(
             cycle_lengths,
             start=1,
@@ -1075,11 +1094,14 @@ class Simulation(BaseSimulation):
             if cycle_solution is not None and (
                 save_this_cycle or feasible is False or stop_experiment
             ):
-                self._solution = self._solution + cycle_solution
+                cross_cycle_segments.append(cycle_solution)
+                if not isinstance(cycle_solution, pybamm.EmptySolution):
+                    last_termination = cycle_solution.termination
 
             if steps:
                 if all(isinstance(s, pybamm.EmptySolution) for s in steps):
                     if self._check_infeasible_steps(steps, step, step_str, cycle_num):
+                        last_termination = steps[0].termination
                         continue
                 cycle_sol = pybamm.make_cycle_solution(
                     steps,
@@ -1139,6 +1161,11 @@ class Simulation(BaseSimulation):
 
             if stop_experiment:
                 break
+
+        if cross_cycle_segments:
+            self._solution = pybamm.Solution.from_sub_solutions(cross_cycle_segments)
+            if last_termination is not None:
+                self._solution.termination = last_termination
 
         if self._solution is not None and len(all_cycle_solutions) > 0:
             self._solution.cycles = all_cycle_solutions

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -893,11 +893,8 @@ class Simulation(BaseSimulation):
         else:
             cycle_lengths = self.experiment.cycle_lengths
 
-        # Collect per-cycle solutions and fold them once after the loop
-        # (O(N)) instead of self._solution = self._solution + cycle_solution
-        # each cycle (O(N^2)).
-        # Seed with the loop-entry self._solution (the starting_solution /
-        # padding-rest carry-over) so the fold reproduces today's left-fold start.
+        # Collect per-cycle solutions and fold once after the loop (O(N), not O(N^2)).
+        # Seed with the loop-entry self._solution to match the old left-fold start.
         cross_cycle_segments = (
             []
             if (
@@ -907,10 +904,8 @@ class Simulation(BaseSimulation):
             else [self._solution]
         )
 
-        # Termination of the running accumulation as the loop mutates it:
-        # updated by each real appended cycle and by skipped steps (which used
-        # to mutate self._solution.termination directly). Applied to the folded
-        # solution below so the final termination matches the old left-fold.
+        # Track running termination (real cycles + skipped steps), applied to the
+        # folded solution below to match the old left-fold's final termination.
         last_termination = None
 
         for cycle_num, cycle_length in enumerate(

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -615,8 +615,7 @@ class Solution(SolutionBase):
             all_yps=all_yps,
             options=self.user_options,
         )
-        new_sol._all_inputs_stacked = self.all_inputs_stacked[:1]
-        new_sol._all_inputs_casadi = self.all_inputs_casadi[:1]
+        # stacked/casadi stay lazy; built from all_inputs[:1] on first access
         new_sol._sub_solutions = self.sub_solutions[:1]
 
         new_sol.solve_time = 0
@@ -660,8 +659,7 @@ class Solution(SolutionBase):
             all_yps=all_yps,
             options=self.user_options,
         )
-        new_sol._all_inputs_stacked = self.all_inputs_stacked[-1:]
-        new_sol._all_inputs_casadi = self.all_inputs_casadi[-1:]
+        # stacked/casadi stay lazy; built from all_inputs[-1:] on first access
         new_sol._sub_solutions = self.sub_solutions[-1:]
         new_sol.solve_time = 0
         new_sol.integration_time = 0
@@ -1192,7 +1190,12 @@ class Solution(SolutionBase):
             if s is not None and not isinstance(s, EmptySolution)
         ]
         if not sols:
-            return EmptySolution()
+            # all empty: match reduce(operator.add, ...) by copying the last empty
+            last_empty = next(
+                (s for s in reversed(sub_solutions) if isinstance(s, EmptySolution)),
+                None,
+            )
+            return last_empty.copy() if last_empty else EmptySolution()
         if len(sols) == 1:
             return sols[0].copy()
 
@@ -1216,8 +1219,7 @@ class Solution(SolutionBase):
         t_evals_present = all(s._all_t_evals is not None for s in segments)
 
         all_ts, all_ys, all_yps, all_t_evals = [], [], [], []
-        all_models, all_inputs = [], []
-        inputs_stacked, inputs_casadi, sub_sols = [], [], []
+        all_models, all_inputs, sub_sols = [], [], []
 
         for s, repeated in kept:
             first = slice(1, None) if repeated else slice(None)
@@ -1235,8 +1237,6 @@ class Solution(SolutionBase):
             # bookkeeping lists
             all_models.extend(s.all_models)
             all_inputs.extend(s.all_inputs)
-            inputs_stacked.extend(s.all_inputs_stacked)
-            inputs_casadi.extend(s.all_inputs_casadi)
             sub_sols.extend(s.sub_solutions)
 
         # sensitivities: fresh dict, no aliasing of any input solution's dict
@@ -1265,22 +1265,15 @@ class Solution(SolutionBase):
             all_t_evals=all_t_evals if t_evals_present else None,
             variables_returned=any(s.variables_returned for s in segments),
             options=options,
-            _validate_time_structure=False,
+            # validates the joined series once (O(N), not O(N^2))
+            _validate_time_structure=True,
         )
-
-        # validate the joined series once (O(N), not O(N^2))
-        new_sol._ensure_sorted_t(new_sol.all_ts, "all_ts")
-        if new_sol._all_t_evals is not new_sol.all_ts:
-            new_sol._ensure_t_evals(
-                all_ts=new_sol.all_ts, all_t_evals=new_sol._all_t_evals
-            )
 
         # last kept segment, not sols[-1]: __add__'s single-sample short-circuit
         # keeps the running closest_event_idx, so a trailing duplicate must not
         # overwrite it.
         new_sol.closest_event_idx = segments[-1].closest_event_idx
-        new_sol._all_inputs_stacked = inputs_stacked
-        new_sol._all_inputs_casadi = inputs_casadi
+        # leave stacked/casadi unset; built lazily from all_inputs (casadi is costly)
         new_sol._sub_solutions = sub_sols
 
         for attr in ["solve_time", "integration_time", "set_up_time"]:

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1177,6 +1177,121 @@ class Solution(SolutionBase):
     def __radd__(self, other):
         return self.__add__(other)
 
+    @classmethod
+    def from_sub_solutions(cls, sub_solutions):
+        """Fold a list of already-validated solutions into one in a single pass.
+
+        Equivalent to ``functools.reduce(operator.add, sub_solutions)`` but O(N)
+        instead of O(N^2): the segment lists are concatenated once rather than a
+        fresh Solution being rebuilt on every step. Inputs must already be valid
+        (as produced by a solver or a prior fold).
+        """
+        sols = [
+            s
+            for s in sub_solutions
+            if s is not None and not isinstance(s, EmptySolution)
+        ]
+        if not sols:
+            return EmptySolution()
+        if len(sols) == 1:
+            return sols[0].copy()
+
+        hermite = all(s.hermite_interpolation for s in sols)
+        t_evals_present = all(s._all_t_evals is not None for s in sols)
+
+        all_ts, all_ys, all_yps, all_t_evals = [], [], [], []
+        all_models, all_inputs = [], []
+        inputs_stacked, inputs_casadi, sub_sols = [], [], []
+
+        prev_last_t = None
+        for s in sols:
+            repeated = prev_last_t is not None and s.all_ts[0][0] == prev_last_t
+            # Single-timestep solution that exactly duplicates the running boundary:
+            # mirror __add__'s special-case short-circuit (it contributes only its
+            # termination/events, taken from `last` below). Appending it would leave
+            # an empty segment after the boundary strip and crash validation.
+            if repeated and len(s.all_ts) == 1 and len(s.all_ts[0]) == 1:
+                prev_last_t = s.all_ts[-1][-1]
+                continue
+            first = slice(1, None) if repeated else slice(None)
+            # time + state
+            all_ts.append(s.all_ts[0][first])
+            all_ts.extend(s.all_ts[1:])
+            all_ys.append(s.all_ys[0][:, first])
+            all_ys.extend(s.all_ys[1:])
+            if hermite:
+                all_yps.append(s.all_yps[0][:, first])
+                all_yps.extend(s.all_yps[1:])
+            if t_evals_present:
+                all_t_evals.append(s._all_t_evals[0][first])
+                all_t_evals.extend(s._all_t_evals[1:])
+            # bookkeeping lists
+            all_models.extend(s.all_models)
+            all_inputs.extend(s.all_inputs)
+            inputs_stacked.extend(s.all_inputs_stacked)
+            inputs_casadi.extend(s.all_inputs_casadi)
+            sub_sols.extend(s.sub_solutions)
+            prev_last_t = s.all_ts[-1][-1]
+
+        # sensitivities: fresh dict, no aliasing of any input solution's dict
+        all_sensitivities = {}
+        for s in sols:
+            for key, val in s._all_sensitivities.items():
+                all_sensitivities.setdefault(key, []).extend(val)
+
+        options = {}
+        for s in sols:
+            options |= s.user_options
+
+        last = sols[-1]
+        new_sol = cls(
+            all_ts,
+            all_ys,
+            all_models,
+            all_inputs,
+            last.t_event,
+            last.y_event,
+            last.termination,
+            all_sensitivities=all_sensitivities,
+            all_yps=all_yps if hermite else None,
+            all_t_evals=all_t_evals if t_evals_present else None,
+            variables_returned=any(s.variables_returned for s in sols),
+            options=options,
+            _validate_time_structure=False,
+        )
+
+        # validate the joined series once (O(N), not O(N^2))
+        new_sol._ensure_sorted_t(new_sol.all_ts, "all_ts")
+        if new_sol._all_t_evals is not new_sol.all_ts:
+            new_sol._ensure_t_evals(
+                all_ts=new_sol.all_ts, all_t_evals=new_sol._all_t_evals
+            )
+
+        new_sol.closest_event_idx = last.closest_event_idx
+        new_sol._all_inputs_stacked = inputs_stacked
+        new_sol._all_inputs_casadi = inputs_casadi
+        new_sol._sub_solutions = sub_sols
+
+        for attr in ["solve_time", "integration_time", "set_up_time"]:
+            vals = [getattr(s, attr, None) for s in sols]
+            if all(v is not None for v in vals):
+                setattr(new_sol, attr, sum(vals))
+
+        # variables derived at the solver stage (output_variables path): reproduce
+        # __add__'s pairwise left-fold. Correct; cost unchanged.
+        if any(s.variables_returned for s in sols):
+            keys = set().union(*[s._variables.keys() for s in sols])
+            merged = {}
+            for v in keys:
+                acc = sols[0][v]
+                for s in sols[1:]:
+                    acc = acc.update(s[v], new_sol)
+                merged[v] = acc
+            new_sol._variables = merged
+            new_sol.variables_returned = True
+
+        return new_sol
+
     def copy(self):
         new_sol = self.__class__(
             self.all_ts,

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1415,35 +1415,7 @@ def make_cycle_solution(
         First state of the cycle.
 
     """
-    sum_sols = step_solutions[0].copy()
-    for step_solution in step_solutions[1:]:
-        sum_sols = sum_sols + step_solution
-
-    cycle_solution = Solution(
-        sum_sols.all_ts,
-        sum_sols.all_ys,
-        sum_sols.all_models,
-        sum_sols.all_inputs,
-        sum_sols.t_event,
-        sum_sols.y_event,
-        sum_sols.termination,
-        all_sensitivities=sum_sols._all_sensitivities,
-        all_yps=sum_sols.all_yps,
-        all_t_evals=sum_sols._all_t_evals,
-        variables_returned=sum_sols.variables_returned,
-        options=sum_sols.user_options,
-    )
-
-    if sum_sols.variables_returned:
-        cycle_solution._variables = sum_sols._variables
-
-    cycle_solution._all_inputs_stacked = sum_sols.all_inputs_stacked
-    cycle_solution._all_inputs_casadi = sum_sols.all_inputs_casadi
-    cycle_solution._sub_solutions = sum_sols.sub_solutions
-
-    cycle_solution.solve_time = sum_sols.solve_time
-    cycle_solution.integration_time = sum_sols.integration_time
-    cycle_solution.set_up_time = sum_sols.set_up_time
+    cycle_solution = Solution.from_sub_solutions(step_solutions)
 
     cycle_solution.steps = step_solutions
 

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1126,11 +1126,12 @@ class Solution(SolutionBase):
             )
 
         # sensitivities are a dict of {parameter: [sensitivities]}
-        # we can assume that the keys are the same for both solutions
-        all_sensitivities = self._all_sensitivities
+        all_sensitivities = {
+            key: list(value) for key, value in self._all_sensitivities.items()
+        }
         for key in other._all_sensitivities:
             all_sensitivities[key] = (
-                all_sensitivities[key] + other._all_sensitivities[key]
+                all_sensitivities.get(key, []) + other._all_sensitivities[key]
             )
 
         options = self.user_options | other.user_options

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1180,12 +1180,11 @@ class Solution(SolutionBase):
 
     @classmethod
     def from_sub_solutions(cls, sub_solutions):
-        """Fold a list of already-validated solutions into one in a single pass.
+        """Fold a list of solutions into one in a single pass.
 
         Equivalent to ``functools.reduce(operator.add, sub_solutions)`` but O(N)
-        instead of O(N^2): the segment lists are concatenated once rather than a
-        fresh Solution being rebuilt on every step. Inputs must already be valid
-        (as produced by a solver or a prior fold).
+        instead of O(N^2): segment lists are concatenated once rather than
+        rebuilding a Solution per step. Inputs must already be valid.
         """
         sols = [
             s
@@ -1205,12 +1204,11 @@ class Solution(SolutionBase):
         inputs_stacked, inputs_casadi, sub_sols = [], [], []
 
         prev_last_t = None
+        last_appended = None
         for s in sols:
             repeated = prev_last_t is not None and s.all_ts[0][0] == prev_last_t
-            # Single-timestep solution that exactly duplicates the running boundary:
-            # mirror __add__'s special-case short-circuit (it contributes only its
-            # termination/events, taken from `last` below). Appending it would leave
-            # an empty segment after the boundary strip and crash validation.
+            # Skip a single-sample duplicate of the boundary: mirrors __add__'s
+            # short-circuit and avoids an empty segment crashing validation.
             if repeated and len(s.all_ts) == 1 and len(s.all_ts[0]) == 1:
                 prev_last_t = s.all_ts[-1][-1]
                 continue
@@ -1233,6 +1231,7 @@ class Solution(SolutionBase):
             inputs_casadi.extend(s.all_inputs_casadi)
             sub_sols.extend(s.sub_solutions)
             prev_last_t = s.all_ts[-1][-1]
+            last_appended = s
 
         # sensitivities: fresh dict, no aliasing of any input solution's dict
         all_sensitivities = {}
@@ -1268,7 +1267,10 @@ class Solution(SolutionBase):
                 all_ts=new_sol.all_ts, all_t_evals=new_sol._all_t_evals
             )
 
-        new_sol.closest_event_idx = last.closest_event_idx
+        # from the last appended segment, not sols[-1]: __add__'s single-sample
+        # short-circuit keeps the running closest_event_idx, so a trailing
+        # duplicate must not overwrite it.
+        new_sol.closest_event_idx = last_appended.closest_event_idx
         new_sol._all_inputs_stacked = inputs_stacked
         new_sol._all_inputs_casadi = inputs_casadi
         new_sol._sub_solutions = sub_sols
@@ -1278,8 +1280,7 @@ class Solution(SolutionBase):
             if all(v is not None for v in vals):
                 setattr(new_sol, attr, sum(vals))
 
-        # variables derived at the solver stage (output_variables path): reproduce
-        # __add__'s pairwise left-fold. Correct; cost unchanged.
+        # output_variables path: reproduce __add__'s pairwise left-fold.
         if any(s.variables_returned for s in sols):
             keys = set().union(*[s._variables.keys() for s in sols])
             merged = {}

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1058,6 +1058,24 @@ class Solution(SolutionBase):
 
         return self._sub_solutions or [self]
 
+    @staticmethod
+    def _segment_series(s, repeated, hermite, t_evals):
+        """Series lists for one segment, dropping the leading sample when
+        ``repeated`` (its first time point duplicates the running boundary).
+        Shared by ``__add__`` and ``from_sub_solutions``."""
+        first = slice(1, None) if repeated else slice(None)
+        ts = [s.all_ts[0][first], *s.all_ts[1:]]
+        ys = [s.all_ys[0][:, first], *s.all_ys[1:]]
+        yps = [s.all_yps[0][:, first], *s.all_yps[1:]] if hermite else None
+        tev = [s._all_t_evals[0][first], *s._all_t_evals[1:]] if t_evals else None
+        return ts, ys, yps, tev
+
+    @staticmethod
+    def _merge_sensitivities(acc, s):
+        """Fold one segment's sensitivities into the running dict ``acc``."""
+        for key, val in s._all_sensitivities.items():
+            acc.setdefault(key, []).extend(val)
+
     def __add__(self, other):
         """Adds two solutions together, e.g. when stepping"""
         if other is None or isinstance(other, EmptySolution):
@@ -1080,36 +1098,22 @@ class Solution(SolutionBase):
             new_sol._y_event = other._y_event
             return new_sol
 
-        # Update list of sub-solutions
+        # Append other onto self (the already-merged left side); only other's
+        # contribution is sliced, keeping accumulation O(N).
         hermite_interpolation = (
             other.hermite_interpolation and self.hermite_interpolation
         )
-        if other.all_ts[0][0] == self.all_ts[-1][-1]:
-            # Skip first time step if it is repeated
-            all_ts = [*self.all_ts, other.all_ts[0][1:], *other.all_ts[1:]]
-            all_ys = [*self.all_ys, other.all_ys[0][:, 1:], *other.all_ys[1:]]
-            if hermite_interpolation:
-                all_yps = [*self.all_yps, other.all_yps[0][:, 1:], *other.all_yps[1:]]
-            if self._all_t_evals is not None and other._all_t_evals is not None:
-                all_t_evals = [
-                    *self._all_t_evals,
-                    other._all_t_evals[0][1:],
-                    *other._all_t_evals[1:],
-                ]
-            else:
-                all_t_evals = None
-        else:
-            all_ts = self.all_ts + other.all_ts
-            all_ys = self.all_ys + other.all_ys
-            if hermite_interpolation:
-                all_yps = self.all_yps + other.all_yps
-            if self._all_t_evals is not None and other._all_t_evals is not None:
-                all_t_evals = self._all_t_evals + other._all_t_evals
-            else:
-                all_t_evals = None
-
-        if not hermite_interpolation:
-            all_yps = None
+        t_evals_present = (
+            self._all_t_evals is not None and other._all_t_evals is not None
+        )
+        repeated = other.all_ts[0][0] == self.all_ts[-1][-1]
+        ts, ys, yps, tev = self._segment_series(
+            other, repeated, hermite_interpolation, t_evals_present
+        )
+        all_ts = self.all_ts + ts
+        all_ys = self.all_ys + ys
+        all_yps = self.all_yps + yps if hermite_interpolation else None
+        all_t_evals = self._all_t_evals + tev if t_evals_present else None
 
         # Validate only the newly-joined region (self's last segment + other's
         # contribution), not the whole accumulation. self's earlier segments
@@ -1123,14 +1127,12 @@ class Solution(SolutionBase):
                 all_t_evals=[self._all_t_evals[-1], *all_t_evals[n:]],
             )
 
-        # sensitivities are a dict of {parameter: [sensitivities]}
+        # sensitivities are a dict of {parameter: [sensitivities]}; start from a
+        # fresh copy of self's lists so the in-place merge never aliases them
         all_sensitivities = {
             key: list(value) for key, value in self._all_sensitivities.items()
         }
-        for key in other._all_sensitivities:
-            all_sensitivities[key] = (
-                all_sensitivities.get(key, []) + other._all_sensitivities[key]
-            )
+        self._merge_sensitivities(all_sensitivities, other)
 
         options = self.user_options | other.user_options
 
@@ -1222,19 +1224,15 @@ class Solution(SolutionBase):
         all_models, all_inputs, sub_sols = [], [], []
 
         for s, repeated in kept:
-            first = slice(1, None) if repeated else slice(None)
-            # time + state
-            all_ts.append(s.all_ts[0][first])
-            all_ts.extend(s.all_ts[1:])
-            all_ys.append(s.all_ys[0][:, first])
-            all_ys.extend(s.all_ys[1:])
+            ts, ys, yps, tev = cls._segment_series(
+                s, repeated, hermite, t_evals_present
+            )
+            all_ts += ts
+            all_ys += ys
             if hermite:
-                all_yps.append(s.all_yps[0][:, first])
-                all_yps.extend(s.all_yps[1:])
+                all_yps += yps
             if t_evals_present:
-                all_t_evals.append(s._all_t_evals[0][first])
-                all_t_evals.extend(s._all_t_evals[1:])
-            # bookkeeping lists
+                all_t_evals += tev
             all_models.extend(s.all_models)
             all_inputs.extend(s.all_inputs)
             sub_sols.extend(s.sub_solutions)
@@ -1242,8 +1240,7 @@ class Solution(SolutionBase):
         # sensitivities: fresh dict, no aliasing of any input solution's dict
         all_sensitivities = {}
         for s in segments:
-            for key, val in s._all_sensitivities.items():
-                all_sensitivities.setdefault(key, []).extend(val)
+            cls._merge_sensitivities(all_sensitivities, s)
 
         options = {}
         for s in segments:

--- a/src/pybamm/solvers/solution.py
+++ b/src/pybamm/solvers/solution.py
@@ -1196,22 +1196,30 @@ class Solution(SolutionBase):
         if len(sols) == 1:
             return sols[0].copy()
 
-        hermite = all(s.hermite_interpolation for s in sols)
-        t_evals_present = all(s._all_t_evals is not None for s in sols)
+        # Decide once which segments contribute. __add__ short-circuits a
+        # single-sample segment whose only sample duplicates the running
+        # boundary to a copy, so it contributes nothing to the merge: skip it
+        # here and derive every quantity below from the kept segments only.
+        # `repeated` records whether a kept segment's leading sample duplicates
+        # the previous boundary (dropped once on concatenation).
+        kept = []
+        prev_last_t = None
+        for s in sols:
+            repeated = prev_last_t is not None and s.all_ts[0][0] == prev_last_t
+            prev_last_t = s.all_ts[-1][-1]
+            if repeated and len(s.all_ts) == 1 and len(s.all_ts[0]) == 1:
+                continue
+            kept.append((s, repeated))
+        segments = [s for s, _ in kept]
+
+        hermite = all(s.hermite_interpolation for s in segments)
+        t_evals_present = all(s._all_t_evals is not None for s in segments)
 
         all_ts, all_ys, all_yps, all_t_evals = [], [], [], []
         all_models, all_inputs = [], []
         inputs_stacked, inputs_casadi, sub_sols = [], [], []
 
-        prev_last_t = None
-        last_appended = None
-        for s in sols:
-            repeated = prev_last_t is not None and s.all_ts[0][0] == prev_last_t
-            # Skip a single-sample duplicate of the boundary: mirrors __add__'s
-            # short-circuit and avoids an empty segment crashing validation.
-            if repeated and len(s.all_ts) == 1 and len(s.all_ts[0]) == 1:
-                prev_last_t = s.all_ts[-1][-1]
-                continue
+        for s, repeated in kept:
             first = slice(1, None) if repeated else slice(None)
             # time + state
             all_ts.append(s.all_ts[0][first])
@@ -1230,19 +1238,19 @@ class Solution(SolutionBase):
             inputs_stacked.extend(s.all_inputs_stacked)
             inputs_casadi.extend(s.all_inputs_casadi)
             sub_sols.extend(s.sub_solutions)
-            prev_last_t = s.all_ts[-1][-1]
-            last_appended = s
 
         # sensitivities: fresh dict, no aliasing of any input solution's dict
         all_sensitivities = {}
-        for s in sols:
+        for s in segments:
             for key, val in s._all_sensitivities.items():
                 all_sensitivities.setdefault(key, []).extend(val)
 
         options = {}
-        for s in sols:
+        for s in segments:
             options |= s.user_options
 
+        # termination/events come from the last operand even when it is a
+        # skipped duplicate: __add__ copies them through the short-circuit.
         last = sols[-1]
         new_sol = cls(
             all_ts,
@@ -1255,7 +1263,7 @@ class Solution(SolutionBase):
             all_sensitivities=all_sensitivities,
             all_yps=all_yps if hermite else None,
             all_t_evals=all_t_evals if t_evals_present else None,
-            variables_returned=any(s.variables_returned for s in sols),
+            variables_returned=any(s.variables_returned for s in segments),
             options=options,
             _validate_time_structure=False,
         )
@@ -1267,26 +1275,26 @@ class Solution(SolutionBase):
                 all_ts=new_sol.all_ts, all_t_evals=new_sol._all_t_evals
             )
 
-        # from the last appended segment, not sols[-1]: __add__'s single-sample
-        # short-circuit keeps the running closest_event_idx, so a trailing
-        # duplicate must not overwrite it.
-        new_sol.closest_event_idx = last_appended.closest_event_idx
+        # last kept segment, not sols[-1]: __add__'s single-sample short-circuit
+        # keeps the running closest_event_idx, so a trailing duplicate must not
+        # overwrite it.
+        new_sol.closest_event_idx = segments[-1].closest_event_idx
         new_sol._all_inputs_stacked = inputs_stacked
         new_sol._all_inputs_casadi = inputs_casadi
         new_sol._sub_solutions = sub_sols
 
         for attr in ["solve_time", "integration_time", "set_up_time"]:
-            vals = [getattr(s, attr, None) for s in sols]
+            vals = [getattr(s, attr, None) for s in segments]
             if all(v is not None for v in vals):
                 setattr(new_sol, attr, sum(vals))
 
         # output_variables path: reproduce __add__'s pairwise left-fold.
-        if any(s.variables_returned for s in sols):
-            keys = set().union(*[s._variables.keys() for s in sols])
+        if any(s.variables_returned for s in segments):
+            keys = set().union(*[s._variables.keys() for s in segments])
             merged = {}
             for v in keys:
-                acc = sols[0][v]
-                for s in sols[1:]:
+                acc = segments[0][v]
+                for s in segments[1:]:
                     acc = acc.update(s[v], new_sol)
                 merged[v] = acc
             new_sol._variables = merged

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -37,6 +37,21 @@ class TestSimulationExperiment:
             **simulation_kwargs,
         )
 
+    def test_batch_cross_cycle_equivalent(self):
+        # Full multi-cycle solution must be identical with batch accumulation.
+        model = pybamm.lithium_ion.SPM()
+        exp = pybamm.Experiment(
+            [("Discharge at 1C until 3.0V", "Charge at 1C until 4.2V")] * 5,
+            period=600,
+        )
+        sim = pybamm.Simulation(model, experiment=exp)
+        sol = sim.solve()
+        v = sol["Voltage [V]"].entries
+        assert np.all(np.isfinite(v))
+        assert np.all(np.diff(sol.t) > 0)  # monotonic time preserved
+        assert len(sol.cycles) == 5  # cycles wiring preserved
+        assert sol.summary_variables is not None
+
     def test_unified_model_mode_validation_and_blockers(self):
         with pytest.raises(ValueError, match="experiment_model_mode must be one of"):
             pybamm.Simulation(

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1666,3 +1666,150 @@ class TestSolution:
             np.testing.assert_array_equal(got, exp)
         assert len(a._all_sensitivities["p"]) == 1  # inputs untouched
         assert len(b._all_sensitivities["p"]) == 1
+
+    def test_from_sub_solutions_skipped_duplicate_excluded_from_timers(self):
+        # A skipped single-sample boundary duplicate must not contribute its
+        # timers: __add__ short-circuits it to a copy, so its solve_time etc.
+        # are dropped. The duplicate sits between two real segments.
+        import functools
+        import operator
+
+        a = pybamm.Solution(
+            np.array([0.0, 0.5, 1.0]),
+            np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+        )
+        dup = pybamm.Solution(
+            np.array([1.0]), np.tile(np.array([1.0]), (2, 1)), pybamm.BaseModel(), {}
+        )
+        b = pybamm.Solution(
+            np.array([1.0, 1.5, 2.0]),
+            np.tile(np.array([1.0, 1.5, 2.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+        )
+        a.solve_time, dup.solve_time, b.solve_time = 1.0, 10.0, 2.0
+        a.integration_time, dup.integration_time, b.integration_time = 0.5, 5.0, 0.7
+        a.set_up_time, dup.set_up_time, b.set_up_time = 0.1, 9.0, 0.2
+
+        out = pybamm.Solution.from_sub_solutions([a.copy(), dup.copy(), b.copy()])
+        folded = functools.reduce(operator.add, [a.copy(), dup.copy(), b.copy()])
+
+        assert out.solve_time == folded.solve_time
+        assert out.integration_time == folded.integration_time
+        assert out.set_up_time == folded.set_up_time
+
+    def test_from_sub_solutions_skipped_duplicate_excluded_from_sensitivities(self):
+        # A skipped duplicate's sensitivities must not be folded in.
+        import functools
+        import operator
+
+        a = pybamm.Solution(
+            np.array([0.0, 0.5, 1.0]),
+            np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [np.ones((2, 1))]},
+        )
+        dup = pybamm.Solution(
+            np.array([1.0]),
+            np.tile(np.array([1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [9 * np.ones((2, 1))]},
+        )
+        b = pybamm.Solution(
+            np.array([1.0, 1.5, 2.0]),
+            np.tile(np.array([1.0, 1.5, 2.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [2 * np.ones((2, 1))]},
+        )
+
+        out = pybamm.Solution.from_sub_solutions([a.copy(), dup.copy(), b.copy()])
+        folded = functools.reduce(operator.add, [a.copy(), dup.copy(), b.copy()])
+
+        assert len(out._all_sensitivities["p"]) == len(folded._all_sensitivities["p"])
+        for got, exp in zip(
+            out._all_sensitivities["p"], folded._all_sensitivities["p"], strict=True
+        ):
+            np.testing.assert_array_equal(got, exp)
+
+    def test_from_sub_solutions_skipped_duplicate_excluded_from_user_options(self):
+        # A skipped duplicate's user_options must not leak into the merged result.
+        import functools
+        import operator
+
+        a = pybamm.Solution(
+            np.array([0.0, 0.5, 1.0]),
+            np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+        )
+        dup = pybamm.Solution(
+            np.array([1.0]), np.tile(np.array([1.0]), (2, 1)), pybamm.BaseModel(), {}
+        )
+        dup._user_options = {"only_in_dup": True}
+
+        out = pybamm.Solution.from_sub_solutions([a.copy(), dup.copy()])
+        folded = functools.reduce(operator.add, [a.copy(), dup.copy()])
+
+        assert out.user_options == folded.user_options
+
+    def test_from_sub_solutions_skipped_duplicate_excluded_from_variables_returned(
+        self,
+    ):
+        # variables_returned must mirror __add__: a skipped duplicate's flag is
+        # ignored because the short-circuit copies the running solution.
+        import functools
+        import operator
+
+        a = pybamm.Solution(
+            np.array([0.0, 0.5, 1.0]),
+            np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+        )
+        dup = pybamm.Solution(
+            np.array([1.0]), np.tile(np.array([1.0]), (2, 1)), pybamm.BaseModel(), {}
+        )
+        a.variables_returned = False
+        dup.variables_returned = True
+
+        out = pybamm.Solution.from_sub_solutions([a.copy(), dup.copy()])
+        folded = functools.reduce(operator.add, [a.copy(), dup.copy()])
+
+        assert out.variables_returned == folded.variables_returned
+
+    def test_from_sub_solutions_skipped_duplicate_preserves_hermite(self):
+        # Real segments are hermite; a trailing single-sample duplicate is not.
+        # __add__ short-circuits the duplicate to a copy, so the result stays
+        # hermite. The hermite flag must be derived from included segments only.
+        import functools
+        import operator
+
+        a = pybamm.Solution(
+            np.array([0.0, 0.5, 1.0]),
+            np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_yps=np.tile(np.array([0.0, 0.5, 1.0]), (2, 1)),
+        )
+        b = pybamm.Solution(
+            np.array([1.0, 1.5, 2.0]),
+            np.tile(np.array([1.0, 1.5, 2.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_yps=np.tile(np.array([1.0, 1.5, 2.0]), (2, 1)),
+        )
+        dup = pybamm.Solution(
+            np.array([2.0]), np.tile(np.array([2.0]), (2, 1)), pybamm.BaseModel(), {}
+        )
+
+        out = pybamm.Solution.from_sub_solutions([a.copy(), b.copy(), dup.copy()])
+        folded = functools.reduce(operator.add, [a.copy(), b.copy(), dup.copy()])
+
+        assert out.hermite_interpolation == folded.hermite_interpolation
+        assert out.hermite_interpolation is True
+        np.testing.assert_array_equal(out.yp, folded.yp)

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1539,3 +1539,24 @@ class TestSolution:
         folded = a.copy() + b
         np.testing.assert_array_equal(out.t, folded.t)
         np.testing.assert_array_equal(out.t, np.array([0.0, 0.5, 1.0]))
+
+    def test_make_cycle_solution_matches_legacy(self):
+        # The cycle solution built via from_sub_solutions must match a manual fold.
+        # make_cycle_solution builds SummaryVariables, which reads
+        # `model.summary_variables`; a bare BaseModel only has `_summary_variables`
+        # and raises AttributeError, so use the same _DummyModel shim that the
+        # existing test_options_make_cycle_solution uses.
+        import functools
+        import operator
+
+        class _DummyModel(pybamm.BaseModel):
+            summary_variables = []
+
+        steps = []
+        for i in range(3):
+            t = np.linspace(i, i + 1, 6)
+            steps.append(pybamm.Solution(t, np.tile(t, (2, 1)), _DummyModel(), {}))
+        cycle_sol, _, _ = pybamm.make_cycle_solution(steps, save_this_cycle=True)
+        folded = functools.reduce(operator.add, [s.copy() for s in steps])
+        np.testing.assert_array_equal(cycle_sol.t, folded.t)
+        assert cycle_sol.steps == steps

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1500,6 +1500,17 @@ class TestSolution:
         out = pybamm.Solution.from_sub_solutions([None, a, pybamm.EmptySolution(), b])
         assert len(out.sub_solutions) == 2
 
+    def test_from_sub_solutions_all_empty_preserves_termination(self):
+        # An all-empty input folds to the last operand's copy (reduce parity),
+        # so its termination must survive.
+        empties = [
+            pybamm.EmptySolution(termination="early"),
+            pybamm.EmptySolution(termination="event: foo"),
+        ]
+        out = pybamm.Solution.from_sub_solutions(empties)
+        assert isinstance(out, pybamm.EmptySolution)
+        assert out.termination == "event: foo"
+
     def test_from_sub_solutions_single_returns_copy(self):
         t = np.linspace(0, 1, 5)
         a = pybamm.Solution(t, np.tile(t, (2, 1)), pybamm.BaseModel(), {})

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -370,6 +370,28 @@ class TestSolution:
         sol3 = sol1 + sol2
         assert not sol3._all_sensitivities
 
+    def test_add_does_not_mutate_operand_sensitivities(self):
+        t1 = np.linspace(0, 1, 5)
+        t2 = np.linspace(1, 2, 5)
+        a = pybamm.Solution(
+            t1,
+            np.tile(t1, (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [np.ones((2, 1))]},
+        )
+        b = pybamm.Solution(
+            t2,
+            np.tile(t2, (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [np.ones((2, 1))]},
+        )
+        before = len(a._all_sensitivities["p"])
+        _ = a + b
+        assert len(a._all_sensitivities["p"]) == before  # a unchanged
+        assert len(b._all_sensitivities["p"]) == 1  # b unchanged
+
     def test_add_validates_only_boundary(self):
         # __add__ must validate only the joined region, not re-scan the whole
         # accumulation (that re-scan was the O(N^2) source).

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1450,3 +1450,70 @@ class TestSolution:
         np.testing.assert_allclose(
             base["2c"].entries, flipped["2c"].entries, rtol=1e-12, atol=1e-12
         )
+
+    def test_from_sub_solutions_matches_repeated_add(self):
+        # from_sub_solutions must equal a left-fold of __add__.
+        import functools
+        import operator
+
+        sols = []
+        for i in range(4):
+            t = np.linspace(i, i + 1, 10)
+            sols.append(
+                pybamm.Solution(t, np.tile(t, (3, 1)), pybamm.BaseModel(), {"a": i})
+            )
+        batch = pybamm.Solution.from_sub_solutions(sols)
+        folded = functools.reduce(operator.add, [s.copy() for s in sols])
+
+        np.testing.assert_array_equal(batch.t, folded.t)
+        np.testing.assert_array_equal(batch.y, folded.y)
+        assert [len(s) for s in batch.all_ts] == [len(s) for s in folded.all_ts]
+        assert len(batch.sub_solutions) == len(folded.sub_solutions)
+        assert batch.all_inputs == folded.all_inputs
+
+    def test_from_sub_solutions_filters_empty_and_none(self):
+        t = np.linspace(0, 1, 5)
+        a = pybamm.Solution(t, np.tile(t, (2, 1)), pybamm.BaseModel(), {})
+        b = pybamm.Solution(t + 1, np.tile(t, (2, 1)), pybamm.BaseModel(), {})
+        out = pybamm.Solution.from_sub_solutions([None, a, pybamm.EmptySolution(), b])
+        assert len(out.sub_solutions) == 2
+
+    def test_from_sub_solutions_single_returns_copy(self):
+        t = np.linspace(0, 1, 5)
+        a = pybamm.Solution(t, np.tile(t, (2, 1)), pybamm.BaseModel(), {})
+        out = pybamm.Solution.from_sub_solutions([a])
+        assert out is not a
+        np.testing.assert_array_equal(out.t, a.t)
+
+    def test_from_sub_solutions_strips_repeated_boundary(self):
+        # b starts exactly where a ends: the duplicate sample is dropped once.
+        t1 = np.array([0.0, 0.5, 1.0])
+        t2 = np.array([1.0, 1.5, 2.0])
+        a = pybamm.Solution(t1, np.tile(t1, (2, 1)), pybamm.BaseModel(), {})
+        b = pybamm.Solution(t2, np.tile(t2, (2, 1)), pybamm.BaseModel(), {})
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        np.testing.assert_array_equal(out.t, np.array([0.0, 0.5, 1.0, 1.5, 2.0]))
+
+    def test_from_sub_solutions_sums_timers(self):
+        t = np.linspace(0, 1, 5)
+        a = pybamm.Solution(t, np.tile(t, (2, 1)), pybamm.BaseModel(), {})
+        b = pybamm.Solution(t + 1, np.tile(t, (2, 1)), pybamm.BaseModel(), {})
+        a.integration_time, b.integration_time = 0.3, 0.5
+        a.solve_time, b.solve_time = 1.0, 2.0
+        a.set_up_time, b.set_up_time = 0.1, 0.1
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        assert out.integration_time == 0.8
+        assert out.solve_time == 3.0
+        assert out.set_up_time == 0.2
+
+    def test_from_sub_solutions_single_timestep_duplicate(self):
+        # A single-timestep solution duplicating the previous end is dropped,
+        # matching __add__'s special case (no empty segment, no IndexError).
+        ta = np.array([0.0, 0.5, 1.0])
+        a = pybamm.Solution(ta, np.tile(ta, (2, 1)), pybamm.BaseModel(), {})
+        tb = np.array([1.0])
+        b = pybamm.Solution(tb, np.tile(tb, (2, 1)), pybamm.BaseModel(), {})
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        folded = a.copy() + b
+        np.testing.assert_array_equal(out.t, folded.t)
+        np.testing.assert_array_equal(out.t, np.array([0.0, 0.5, 1.0]))

--- a/tests/unit/test_solvers/test_solution.py
+++ b/tests/unit/test_solvers/test_solution.py
@@ -1560,3 +1560,109 @@ class TestSolution:
         folded = functools.reduce(operator.add, [s.copy() for s in steps])
         np.testing.assert_array_equal(cycle_sol.t, folded.t)
         assert cycle_sol.steps == steps
+
+    def test_from_sub_solutions_trailing_duplicate_keeps_event_idx(self):
+        # __add__'s single-sample short-circuit keeps the running solution's
+        # closest_event_idx (not the duplicate's), so a trailing duplicate must
+        # not overwrite it. termination/events still come from the last segment.
+        import functools
+        import operator
+
+        ta = np.array([0.0, 0.5, 1.0])
+        tb = np.array([1.0, 1.5, 2.0])
+        a = pybamm.Solution(ta, np.tile(ta, (2, 1)), pybamm.BaseModel(), {})
+        b = pybamm.Solution(tb, np.tile(tb, (2, 1)), pybamm.BaseModel(), {})
+        dup = pybamm.Solution(
+            np.array([2.0]),
+            np.tile(np.array([2.0]), (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            termination="event",
+        )
+        a.closest_event_idx, b.closest_event_idx, dup.closest_event_idx = 0, 5, 99
+
+        out = pybamm.Solution.from_sub_solutions([a, b, dup])
+        folded = functools.reduce(operator.add, [a.copy(), b.copy(), dup.copy()])
+
+        assert out.closest_event_idx == folded.closest_event_idx == 5
+        assert out.termination == folded.termination == "event"
+
+    def test_from_sub_solutions_hermite_matches_add(self):
+        # all_yps (hermite) path matches the left-fold and stays hermite.
+        import functools
+        import operator
+
+        sols = []
+        for i in range(3):
+            t = np.linspace(i, i + 1, 5)
+            y = np.tile(t, (2, 1))
+            sols.append(pybamm.Solution(t, y, pybamm.BaseModel(), {}, all_yps=y * 0.1))
+        out = pybamm.Solution.from_sub_solutions(sols)
+        folded = functools.reduce(operator.add, [s.copy() for s in sols])
+
+        assert out.hermite_interpolation
+        np.testing.assert_array_equal(out.yp, folded.yp)
+
+    def test_from_sub_solutions_mixed_hermite_is_not_hermite(self):
+        # If any segment lacks yps, the fold is non-hermite (mirrors __add__'s AND).
+        t1 = np.linspace(0, 1, 5)
+        t2 = np.linspace(1, 2, 5)
+        a = pybamm.Solution(
+            t1, np.tile(t1, (2, 1)), pybamm.BaseModel(), {}, all_yps=np.tile(t1, (2, 1))
+        )
+        b = pybamm.Solution(t2, np.tile(t2, (2, 1)), pybamm.BaseModel(), {})
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        assert out.hermite_interpolation is False
+        assert out.all_yps is None
+
+    def test_from_sub_solutions_t_evals_matches_add(self):
+        # explicit all_t_evals (distinct from all_ts) propagates and is validated.
+        import functools
+        import operator
+
+        t1 = np.linspace(0, 1, 5)
+        t2 = np.linspace(1, 2, 5)
+        a = pybamm.Solution(
+            t1, np.tile(t1, (2, 1)), pybamm.BaseModel(), {}, all_t_evals=t1
+        )
+        b = pybamm.Solution(
+            t2, np.tile(t2, (2, 1)), pybamm.BaseModel(), {}, all_t_evals=t2
+        )
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        folded = functools.reduce(operator.add, [a.copy(), b.copy()])
+
+        assert out.all_t_evals is not out.all_ts  # explicit, not defaulted to all_ts
+        np.testing.assert_array_equal(out.t_eval, folded.t_eval)
+
+    def test_from_sub_solutions_sensitivities_match_add(self):
+        # sensitivities are concatenated per key and the inputs are not mutated.
+        import functools
+        import operator
+
+        t1 = np.linspace(0, 1, 5)
+        t2 = np.linspace(1, 2, 5)
+        a = pybamm.Solution(
+            t1,
+            np.tile(t1, (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [np.ones((2, 1))]},
+        )
+        b = pybamm.Solution(
+            t2,
+            np.tile(t2, (2, 1)),
+            pybamm.BaseModel(),
+            {},
+            all_sensitivities={"p": [2 * np.ones((2, 1))]},
+        )
+        out = pybamm.Solution.from_sub_solutions([a, b])
+        folded = functools.reduce(operator.add, [a.copy(), b.copy()])
+
+        assert list(out._all_sensitivities) == list(folded._all_sensitivities)
+        assert len(out._all_sensitivities["p"]) == 2
+        for got, exp in zip(
+            out._all_sensitivities["p"], folded._all_sensitivities["p"], strict=True
+        ):
+            np.testing.assert_array_equal(got, exp)
+        assert len(a._all_sensitivities["p"]) == 1  # inputs untouched
+        assert len(b._all_sensitivities["p"]) == 1


### PR DESCRIPTION
## Summary
- Adds `Solution.from_sub_solutions`, an O(N) single-pass fold that is behaviourally equivalent to a left-fold of `Solution.__add__` (`functools.reduce(operator.add, ...)`), and routes both `make_cycle_solution` and the cross-cycle experiment accumulation through it. This removes the residual O(N^2) list concatenation flagged in #5550.
- Fixes an aliasing bug where `Solution.__add__` mutated the left operand's `_all_sensitivities` dict in place.
- Cross-cycle accumulation is now built once after the loop instead of via per-cycle `self._solution = self._solution + cycle_solution`; the skipped-step termination handling (`_check_infeasible_steps`) is preserved via a tracked `last_termination` applied to the folded solution.

Stacked on #5550 (base branch `fix/solution-append-on2`). Merge after #5550 lands.