### PR TITLE
Add NamedFunctionParameter for name-based input binding

### DIFF
--- a/src/pybamm/__init__.py
+++ b/src/pybamm/__init__.py
@@ -35,7 +35,11 @@ from .expression_tree.conditional import Conditional
 from .expression_tree.interpolant import Interpolant
 from .expression_tree.discrete_time_sum import *
 from .expression_tree.input_parameter import InputParameter
-from .expression_tree.parameter import Parameter, FunctionParameter
+from .expression_tree.parameter import (
+    Parameter,
+    FunctionParameter,
+    NamedFunctionParameter,
+)
 from .expression_tree.scalar import Scalar, Constant
 from .expression_tree.variable import *
 from .expression_tree.coupled_variable import *

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -22,10 +22,17 @@ SUPPORTED_SCHEMA_VERSION = "1.1"
 
 
 class ExpressionFunctionParameter(pybamm.UnaryOperator):
-    def __init__(self, name, child, func_name, func_args):
+    def __init__(self, name, child, func_name, func_args, input_names=None):
         super().__init__(name, child)
         self.func_name = func_name
+        # func_args are the function's own argument identifiers (used for codegen
+        # and as the Parameter names inside `child`).
         self.func_args = func_args
+        # input_names, when given, is parallel to func_args and names the model
+        # input each arg binds to. When set, the consuming FunctionParameter binds
+        # by matching these against its own input_names (order-independent) rather
+        # than zipping func_args to children positionally.
+        self.input_names = input_names
 
     def _unary_evaluate(self, child):
         """Evaluate the symbolic expression (the child)"""
@@ -2187,7 +2194,7 @@ class Serialise:
         return solver_class(**data)
 
 
-def convert_function_to_symbolic_expression(func, name=None):
+def convert_function_to_symbolic_expression(func, name=None, input_names=None):
     """
     Converts a Python function to a PyBaMM symbolic expression
 
@@ -2199,6 +2206,11 @@ def convert_function_to_symbolic_expression(func, name=None):
     name : str, optional
         The name of the function to use in the symbolic expression. If not provided,
         the name of the function is used.
+
+    input_names : sequence of str, optional
+        The model input names each argument binds to, parallel to the function's
+        arguments. When given, the resulting ``ExpressionFunctionParameter`` binds
+        to the consuming ``FunctionParameter`` by name rather than by position.
 
     Returns
     -------
@@ -2229,7 +2241,14 @@ def convert_function_to_symbolic_expression(func, name=None):
     # Wrap the symbolic expression in an ExpressionFunctionParameter to allow access
     # to the function name and arguments
     name = name or func_name
-    return ExpressionFunctionParameter(name, sym_output, func_name, func_args)
+    if input_names is not None and len(input_names) != len(func_args):
+        raise ValueError(
+            f"input_names {list(input_names)} length does not match the function's "
+            f"{len(func_args)} argument(s) {func_args}"
+        )
+    return ExpressionFunctionParameter(
+        name, sym_output, func_name, func_args, input_names
+    )
 
 
 def convert_symbol_from_json(json_data):
@@ -2295,6 +2314,7 @@ def convert_symbol_from_json(json_data):
             convert_symbol_from_json(json_data["children"][0]),
             json_data["func_name"],
             json_data["func_args"],
+            json_data.get("input_names"),
         )
     elif json_data["type"] == "PrimaryBroadcast":
         child = convert_symbol_from_json(json_data["children"][0])
@@ -2382,6 +2402,7 @@ def convert_symbol_to_json(symbol):
             "children": [convert_symbol_to_json(symbol.child)],
             "func_name": symbol.func_name,
             "func_args": symbol.func_args,
+            "input_names": symbol.input_names,
         }
     elif isinstance(symbol, numbers.Number | list):
         return symbol

--- a/src/pybamm/expression_tree/parameter.py
+++ b/src/pybamm/expression_tree/parameter.py
@@ -248,3 +248,72 @@ class FunctionParameter(pybamm.Symbol):
             "pybamm.FunctionParameter:"
             "Please use a discretised model when reading in from JSON."
         )
+
+
+class NamedFunctionParameter:
+    """A parameter value that binds to a model input by name rather than position.
+
+    A plain callable supplied for a :class:`FunctionParameter` is bound to the
+    model's inputs *positionally* — the callable's arguments are matched to
+    ``FunctionParameter.input_names`` in order, so the caller must know both how
+    many inputs the consuming model declares and the order it declares them in.
+    Wrapping the callable in a ``NamedFunctionParameter`` and naming the inputs
+    it consumes removes that coupling: binding selects and orders children by
+    matching ``inputs`` against ``FunctionParameter.input_names``, so the
+    declaration order of the model's inputs is irrelevant and unused inputs are
+    dropped.
+
+    Parameters
+    ----------
+    function : callable
+        The function to evaluate. It is called with one positional argument per
+        entry in ``inputs``, in the order ``inputs`` is given — not the order the
+        model declares them.
+    inputs : sequence of str
+        The model input names this function consumes (e.g.
+        ``["Electrolyte concentration [mol.m-3]"]``). Each must match one of the
+        consuming ``FunctionParameter``'s ``input_names``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        # conductivity depends only on electrolyte concentration; the model calls
+        # the parameter with (c_e, T) but we never need to know that, or its order
+        kappa = pybamm.NamedFunctionParameter(
+            lambda c_e: pybamm.Interpolant(x, y, c_e, name="kappa"),
+            inputs=["Electrolyte concentration [mol.m-3]"],
+        )
+        param = pybamm.ParameterValues({"Electrolyte conductivity [S.m-1]": kappa})
+    """
+
+    def __init__(self, function, inputs):
+        if not callable(function):
+            raise TypeError("NamedFunctionParameter `function` must be callable")
+        self.function = function
+        self.inputs = list(inputs)
+
+    def bind(self, input_names, children):
+        """Select and order ``children`` by matching ``self.inputs`` against the
+        consuming ``FunctionParameter``'s ``input_names``, then evaluate.
+
+        Parameters
+        ----------
+        input_names : list of str
+            The consuming ``FunctionParameter``'s declared input names.
+        children : list of pybamm.Symbol
+            The processed children, in the same order as ``input_names``.
+
+        Returns
+        -------
+        pybamm.Symbol
+            ``self.function`` evaluated on the named subset of children.
+        """
+        name_to_child = dict(zip(input_names, children, strict=False))
+        missing = [name for name in self.inputs if name not in name_to_child]
+        if missing:
+            raise KeyError(
+                f"NamedFunctionParameter inputs {missing} not found among the "
+                f"consuming FunctionParameter's input_names {list(input_names)}"
+            )
+        return self.function(*[name_to_child[name] for name in self.inputs])

--- a/src/pybamm/parameters/parameter_substitutor.py
+++ b/src/pybamm/parameters/parameter_substitutor.py
@@ -185,6 +185,10 @@ class ParameterSubstitutor:
                 # If the "function" is provided is actually a scalar, return a Scalar
                 # object instead of throwing an error.
                 function = pybamm.Scalar(function_name, name=symbol.name)
+            elif isinstance(function_name, pybamm.NamedFunctionParameter):
+                # bind children to the function's declared inputs by name, so the
+                # order/position the model declares its inputs in is irrelevant
+                function = function_name.bind(symbol.input_names, new_children)
             elif callable(function_name):
                 # otherwise evaluate the function to create a new PyBaMM object
                 function = function_name(*new_children)
@@ -304,12 +308,30 @@ class ParameterSubstitutor:
 
             # Get the expression and inputs for the function.
             expression = function_parameter.child
-            inputs = {
-                arg: child
-                for arg, child in zip(
-                    function_parameter.func_args, new_children, strict=False
+            if function_parameter.input_names is not None:
+                # name-bound: map each arg to the child whose model input name it
+                # declares, so the order the model declares inputs in is irrelevant
+                # and unused model inputs are dropped
+                name_to_child = dict(
+                    zip(symbol.input_names, new_children, strict=False)
                 )
-            }
+                inputs = {
+                    arg: name_to_child[input_name]
+                    for arg, input_name in zip(
+                        function_parameter.func_args,
+                        function_parameter.input_names,
+                        strict=False,
+                    )
+                }
+            else:
+                # legacy positional binding: zip the function's args to the model's
+                # children in declaration order
+                inputs = {
+                    arg: child
+                    for arg, child in zip(
+                        function_parameter.func_args, new_children, strict=False
+                    )
+                }
 
             # Set domains for function inputs in post-order traversal
             for node in expression.post_order():

--- a/src/pybamm/parameters/parameter_values.py
+++ b/src/pybamm/parameters/parameter_values.py
@@ -1584,7 +1584,13 @@ def convert_parameter_values_to_json(
     parameter_values_dict = {}
 
     for k, v in parameter_values.items():
-        if callable(v):
+        if isinstance(v, pybamm.NamedFunctionParameter):
+            parameter_values_dict[k] = convert_symbol_to_json(
+                convert_function_to_symbolic_expression(
+                    v.function, k, input_names=v.inputs
+                )
+            )
+        elif callable(v):
             parameter_values_dict[k] = convert_symbol_to_json(
                 convert_function_to_symbolic_expression(v, k)
             )

--- a/tests/unit/test_parameters/test_parameter_substitutor.py
+++ b/tests/unit/test_parameters/test_parameter_substitutor.py
@@ -162,3 +162,60 @@ class TestProcessGeometry:
         # Check that the parameter was replaced
         assert isinstance(geometry["negative electrode"][x_n]["max"], pybamm.Scalar)
         assert geometry["negative electrode"][x_n]["max"].evaluate() == 0.1
+
+
+class TestNamedFunctionParameter:
+    """Bind a value to a FunctionParameter by input name, not position."""
+
+    NAME = "Electrolyte conductivity [S.m-1]"
+    CONC = "Electrolyte concentration [mol.m-3]"
+    TEMP = "Temperature [K]"
+
+    def _function_parameter(self, input_order):
+        children = {self.CONC: pybamm.Scalar(1000.0), self.TEMP: pybamm.Scalar(298.0)}
+        inputs = {name: children[name] for name in input_order}
+        return pybamm.FunctionParameter(self.NAME, inputs)
+
+    def _evaluate(self, value, input_order):
+        fp = self._function_parameter(input_order)
+        return pybamm.ParameterValues({self.NAME: value}).process_symbol(fp).evaluate()
+
+    def test_binds_named_input_ignores_others(self):
+        named = pybamm.NamedFunctionParameter(lambda c: c * 2, inputs=[self.CONC])
+        assert self._evaluate(named, [self.CONC, self.TEMP]) == 2000.0
+
+    def test_order_independent(self):
+        named = pybamm.NamedFunctionParameter(lambda c: c * 2, inputs=[self.CONC])
+        # model declares inputs in the opposite order -> still binds to c_e
+        assert self._evaluate(named, [self.TEMP, self.CONC]) == 2000.0
+
+    def test_bare_lambda_is_positional(self):
+        # contrast: a bare positional lambda binds to whatever is declared first
+        bare = lambda c_e, T: c_e * 2  # noqa: E731
+        assert self._evaluate(bare, [self.CONC, self.TEMP]) == 2000.0
+        assert self._evaluate(bare, [self.TEMP, self.CONC]) == 596.0
+
+    def test_json_roundtrip_preserves_named_binding(self):
+        from pybamm.expression_tree.operations.serialise import (
+            convert_symbol_from_json,
+        )
+
+        named = pybamm.NamedFunctionParameter(lambda c: c * 2, inputs=[self.CONC])
+        pv_json = pybamm.ParameterValues({self.NAME: named}).to_json()
+        reconstructed = convert_symbol_from_json(pv_json[self.NAME])
+        assert self._evaluate(reconstructed, [self.CONC, self.TEMP]) == 2000.0
+        assert self._evaluate(reconstructed, [self.TEMP, self.CONC]) == 2000.0
+
+    def test_missing_input_raises(self):
+        named = pybamm.NamedFunctionParameter(lambda c: c, inputs=["Not an input"])
+        with pytest.raises(KeyError, match="not found among"):
+            self._evaluate(named, [self.CONC, self.TEMP])
+
+    def test_inputs_length_mismatch_raises(self):
+        named = pybamm.NamedFunctionParameter(lambda c_e, T: c_e, inputs=[self.CONC])
+        with pytest.raises(ValueError, match="length does not match"):
+            pybamm.ParameterValues({self.NAME: named}).to_json()
+
+    def test_non_callable_function_raises(self):
+        with pytest.raises(TypeError, match="must be callable"):
+            pybamm.NamedFunctionParameter(42, inputs=[self.CONC])


### PR DESCRIPTION
## Description

A callable supplied as the value for a `FunctionParameter` is currently bound to the model's inputs **positionally**: the callable's arguments are matched to `FunctionParameter.input_names` in declaration order. So a caller providing, say, a concentration-dependent `Electrolyte conductivity [S.m-1]` must write a function whose arguments match both the **arity** and the **order** the consuming model declares its inputs in — and that order lives only in a dict literal inside the parameter classes (e.g. `{"Electrolyte concentration [mol.m-3]": c_e, "Temperature [K]": T}`). Reorder that dict and every hand-written value function silently misbinds (no error — `c_e` data ends up bound to `T`).

This is especially painful for serialized parameter values (e.g. interpolants round-tripped through `ParameterValues.to_json`), where the function must be authored with exactly the right positional signature far from the model that consumes it.

## What this adds

`NamedFunctionParameter(function, inputs=[...])` — an **opt-in** value type that binds by name:

```python
kappa = pybamm.NamedFunctionParameter(
    lambda c_e: pybamm.Interpolant(x, y, c_e, name="kappa_e"),
    inputs=["Electrolyte concentration [mol.m-3]"],
)
params["Electrolyte conductivity [S.m-1]"] = kappa
```

Binding selects and orders children by matching the declared `inputs` against the consuming `FunctionParameter.input_names`, so:
- the order the model declares its inputs in is **irrelevant**,
- inputs the function does not consume (e.g. `T` for an isothermal interpolant) are **dropped**,
- a missing/misspelled input name **raises** instead of silently misbinding.

It is opt-in: existing positional callables are untouched (`input_names` defaults to `None` → positional fallback).

## Implementation

Both consumption paths are covered:
- **in-memory** — `ParameterSubstitutor` binds a `NamedFunctionParameter` by name before the generic `callable` branch.
- **serialized round-trip** — `ExpressionFunctionParameter` gains a parallel optional `input_names` field. `func_args` stay valid Python identifiers (so `to_source` codegen is unaffected); `_process_function_parameter` binds by name when `input_names` is present, positional otherwise.

`ParameterValues.to_json` serializes a `NamedFunctionParameter` by tracing its function with the declared input names.

## Tests

- New `TestNamedFunctionParameter` (7 tests): named binding, order-independence, JSON round-trip, positional-lambda contrast, and the error paths (missing input, arity mismatch, non-callable).
- Regression: full `test_parameter_substitutor` + `test_parameter_values_serialisation` suites pass (88 tests), including the stress round-trip across all bundled parameter sets — confirming the positional path is unchanged.
- Manually verified end-to-end: a real `SPMe` solves with a name-bound, JSON-round-tripped concentration-dependent conductivity interpolant; the interpolant binds to the model's own `c_e` (input names taken from pybamm, not a hand-built dict).

## Notes / open questions for maintainers

- `func_args` vs `input_names` are kept as separate parallel lists rather than overloading `func_args` with model-name strings, specifically so `to_source`'s `def f(arg)` codegen stays valid.
- `ParameterStore.get_info(...).is_function` reports `False` for a `NamedFunctionParameter` (it is intentionally not callable, to avoid generic `callable()` branches catching it before the `isinstance` dispatch). Happy to special-case if preferred.
- No `CHANGELOG.md` entry added yet — will add once you confirm the API shape/name.