### PR TITLE
fix: O(N²) blow-up in unified experiment mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- Fixed unified experiment mode using excessive memory and time for experiments with many cycles.
+- Fixed unified experiment mode using excessive memory and time for experiments with many cycles. ([#5554](https://github.com/pybamm-team/PyBaMM/pull/5554))
 
 ## Optimizations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- Fixed unified experiment mode using excessive memory and time for experiments with many cycles.
+
 ## Optimizations
 
 - Fixed two O(N²) slowdowns in long experiment/ageing simulations where `Solution.__add__`/`copy` re-did whole-accumulation work on every step append: time-series validation now re-checks only the joined boundary, and `Solution.observable` is computed lazily. ([#5550](https://github.com/pybamm-team/PyBaMM/pull/5550))

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -254,14 +254,24 @@ class Simulation(BaseSimulation):
 
     def _set_up_unified_experiment_model(self, parameter_values):
         self._experiment_uses_unified_model = True
-        self._experiment_step_indices = list(range(1, len(self.experiment.steps) + 1))
+
+        # Branch the switching Conditionals over unique steps, not instances: one
+        # branch per instance is O(n_steps) per timestep -> O(n_steps**2) overall.
+        unique_steps = []
+        unique_branch_by_repr = {}
+        for step in self.experiment.steps:
+            key = step.basic_repr()
+            if key not in unique_branch_by_repr:
+                unique_branch_by_repr[key] = len(unique_steps) + 1  # 1-based selector
+                unique_steps.append(step)
+        self._experiment_step_indices = [
+            unique_branch_by_repr[step.basic_repr()] for step in self.experiment.steps
+        ]
         self._experiment_includes_padding_rest = bool(
             self.experiment.initial_start_time
         )
         self._experiment_padding_rest_index = (
-            len(self.experiment.steps) + 1
-            if self._experiment_includes_padding_rest
-            else None
+            len(unique_steps) + 1 if self._experiment_includes_padding_rest else None
         )
 
         new_model = self._model.new_copy()
@@ -272,9 +282,7 @@ class Simulation(BaseSimulation):
 
         # Build one conditional control residual that selects the active step's
         # control law via the experiment step index input.
-        step_control_builders = [
-            step.get_control_residual for step in self.experiment.steps
-        ]
+        step_control_builders = [step.get_control_residual for step in unique_steps]
         if self._experiment_includes_padding_rest:
             padding_rest_step = pybamm.step.Rest(duration=1)
             step_control_builders.append(padding_rest_step.get_control_residual)
@@ -295,8 +303,7 @@ class Simulation(BaseSimulation):
         # Combine each step's local termination expression into one experiment event,
         # selecting the active branch with the step index input.
         termination_branches = [
-            step.get_combined_termination_expression(variables)
-            for step in self.experiment.steps
+            step.get_combined_termination_expression(variables) for step in unique_steps
         ]
         if self._experiment_includes_padding_rest:
             termination_branches.append(pybamm.Scalar(1))

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -413,6 +413,63 @@ class TestSimulationExperiment:
                 f"build counts grow with n_cycles instead of staying flat: {counts}"
             )
 
+    def test_unified_model_switching_size_independent_of_cycle_count(self):
+        # The unified model's switching Conditional must branch on unique steps, not
+        # step instances, or it is O(n_steps) per timestep -> O(n_steps**2) over the
+        # experiment. Branch count must stay bounded by unique steps and flat in
+        # cycle count.
+        def max_conditional_branches(model):
+            roots = (
+                list(model.rhs.values())
+                + list(model.algebraic.values())
+                + [event.expression for event in model.events]
+            )
+            seen = set()
+            stack = list(roots)
+            most = 0
+            while stack:
+                sym = stack.pop()
+                if id(sym) in seen:
+                    continue
+                seen.add(id(sym))
+                if isinstance(sym, pybamm.Conditional):
+                    most = max(most, len(sym.branches))
+                stack.extend(sym.children)
+            return most
+
+        unit_cycle = (
+            "Discharge at 1C until 3.0V",
+            "Charge at 1C until 4.2V",
+            "Hold at 4.2V until C/50",
+        )
+        n_unique = len(unit_cycle)
+
+        branch_counts = []
+        step_index_maps = []
+        for n_cycles in (2, 5, 20):
+            experiment = pybamm.Experiment([unit_cycle] * n_cycles)
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode="unified",
+            )
+            sim.build_for_experiment()
+            assert sim._experiment_uses_unified_model
+            branch_counts.append(max_conditional_branches(sim._built_experiment_model))
+            step_index_maps.append(sim._experiment_step_indices)
+
+        assert branch_counts[0] == branch_counts[-1], (
+            f"unified switching grows with cycles: {branch_counts}"
+        )
+        assert max(branch_counts) <= n_unique
+
+        # Duplicate instances collapse onto the same branch index, repeating per cycle.
+        for n_cycles, indices in zip((2, 5, 20), step_index_maps, strict=True):
+            assert len(indices) == n_unique * n_cycles
+            assert set(indices) == set(range(1, n_unique + 1))
+            assert indices == [(i % n_unique) + 1 for i in range(len(indices))]
+
     def test_experiment_state_mapper_has_full_state_size_for_2d_current_collector(self):
         experiment = pybamm.Experiment(
             ["Discharge at C/20 for 1 hour", "Rest for 10 minutes"]


### PR DESCRIPTION
# Description

`experiment_model_mode="unified"` built its control-law and termination `Conditional`s with one branch per step *instance* rather than per *unique* step. For an experiment with many cycles the `Conditional` therefore has O(n_steps) branches, and CasADi evaluates that O(n_steps)-way switch at every solver timestep — so the whole experiment is O(n_steps²) in both time and memory (e.g. the reported ~32 GB / ~12× slowdown at a few thousand cycles).

Identical operating conditions (same `basic_repr()`, already the dedup key for built models) now share a single branch, and each step instance maps to its unique branch index. The unified model is O(n_unique) to evaluate, restoring linear time/memory scaling with cycle count.

Measured on SPMe + a 3-step cycle (telemetry off):

| cycles | time before → after | peak mem before → after |
|--------|---------------------|-------------------------|
| 160    | 16.4 s → 4.2 s      | 290 → 187 MB            |
| 240    | 30.6 s → 6.2 s      | 403 → 272 MB            |

Unified vs legacy voltage matches to 5e-6, so results are unchanged.

No linked issue.

## Type of change

Bug fix — CHANGELOG entry added under `## Bug fixes`.

# Important checks:

- No style issues: ran ruff-check / ruff-format / whitespace pre-commit hooks on the changed files
- Tests pass: added `test_unified_model_switching_size_independent_of_cycle_count`; ran the experiment, simulation, and expression-tree unit suites (green). Full `nox -s tests` / `doctests` not run locally.
- Tests added that prove the fix: the new test asserts the switching `Conditional` stays bounded by unique steps and flat in cycle count

🤖 Generated with [Claude Code](https://claude.com/claude-code)
