### PR TITLE
Serialisation kernel: safe-or-loud encode/decode and Symbol surface migration

### DIFF
--- a/src/pybamm/expression_tree/array.py
+++ b/src/pybamm/expression_tree/array.py
@@ -39,6 +39,9 @@ class Array(pybamm.Symbol):
         String representing the entries (slow to recalculate when copying)
     """
 
+    # entries_string is a derived hash cache of entries, which to_json emits.
+    _serialise_derived_params = frozenset({"entries_string"})
+
     def __init__(
         self,
         entries: npt.NDArray | list[float] | csr_matrix,

--- a/src/pybamm/expression_tree/array.py
+++ b/src/pybamm/expression_tree/array.py
@@ -187,7 +187,6 @@ class Array(pybamm.Symbol):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "entries": matrix,
         }

--- a/src/pybamm/expression_tree/averages.py
+++ b/src/pybamm/expression_tree/averages.py
@@ -359,7 +359,6 @@ class SizeAverage(_BaseAverage):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": [self.children[0], self.f_a_dist],
         }

--- a/src/pybamm/expression_tree/averages.py
+++ b/src/pybamm/expression_tree/averages.py
@@ -356,6 +356,18 @@ class SizeAverage(_BaseAverage):
         super().__init__(child, "size-average", integration_variable)
         self.f_a_dist = f_a_dist
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": [self.children[0], self.f_a_dist],
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["children"][1])
+
     def _unary_new_copy(
         self, child: pybamm.Symbol, perform_simplifications: bool = True
     ):

--- a/src/pybamm/expression_tree/binary_operators.py
+++ b/src/pybamm/expression_tree/binary_operators.py
@@ -226,7 +226,7 @@ class BinaryOperator(pybamm.Symbol):
         Method to serialise a BinaryOperator object into JSON.
         """
 
-        json_dict = {"name": self.name, "id": self.id, "domains": self.domains}
+        json_dict = {"name": self.name, "domains": self.domains}
 
         return json_dict
 

--- a/src/pybamm/expression_tree/broadcasts.py
+++ b/src/pybamm/expression_tree/broadcasts.py
@@ -198,8 +198,11 @@ class PrimaryBroadcast(Broadcast):
 
     @classmethod
     def _from_json(cls, snippet):
+        # Legacy compact JSON omitted "name"; fall back to the __init__ default.
         return cls(
-            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+            snippet["children"][0],
+            snippet["broadcast_domain"],
+            name=snippet.get("name"),
         )
 
     def reduce_one_dimension(self):
@@ -342,8 +345,11 @@ class SecondaryBroadcast(Broadcast):
 
     @classmethod
     def _from_json(cls, snippet):
+        # Legacy compact JSON omitted "name"; fall back to the __init__ default.
         return cls(
-            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+            snippet["children"][0],
+            snippet["broadcast_domain"],
+            name=snippet.get("name"),
         )
 
     def reduce_one_dimension(self):
@@ -473,8 +479,11 @@ class TertiaryBroadcast(Broadcast):
 
     @classmethod
     def _from_json(cls, snippet):
+        # Legacy compact JSON omitted "name"; fall back to the __init__ default.
         return cls(
-            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+            snippet["children"][0],
+            snippet["broadcast_domain"],
+            name=snippet.get("name"),
         )
 
     def reduce_one_dimension(self):
@@ -554,10 +563,11 @@ class FullBroadcast(Broadcast):
 
     @classmethod
     def _from_json(cls, snippet):
+        # Legacy compact JSON omitted "name"; fall back to the __init__ default.
         return cls(
             snippet["children"][0],
             broadcast_domains=snippet["domains"],
-            name=snippet["name"],
+            name=snippet.get("name"),
         )
 
     def _evaluate_for_shape(self):

--- a/src/pybamm/expression_tree/broadcasts.py
+++ b/src/pybamm/expression_tree/broadcasts.py
@@ -191,7 +191,6 @@ class PrimaryBroadcast(Broadcast):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "broadcast_domain": self.broadcast_domain,
         }
@@ -338,7 +337,6 @@ class SecondaryBroadcast(Broadcast):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "broadcast_domain": self.broadcast_domain,
         }
@@ -472,7 +470,6 @@ class TertiaryBroadcast(Broadcast):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "broadcast_domain": self.broadcast_domain,
         }
@@ -559,7 +556,7 @@ class FullBroadcast(Broadcast):
         return self.__class__(child, broadcast_domains=self.domains)
 
     def to_json(self):
-        return {"name": self.name, "id": self.id, "domains": self.domains}
+        return {"name": self.name, "domains": self.domains}
 
     @classmethod
     def _from_json(cls, snippet):

--- a/src/pybamm/expression_tree/broadcasts.py
+++ b/src/pybamm/expression_tree/broadcasts.py
@@ -188,6 +188,20 @@ class PrimaryBroadcast(Broadcast):
         vec = pybamm.evaluate_for_shape_using_domain(self.domains["primary"])
         return np.outer(child_eval, vec).reshape(-1, 1)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "broadcast_domain": self.broadcast_domain,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+        )
+
     def reduce_one_dimension(self):
         """Reduce the broadcast by one dimension."""
         return self.orphans[0]
@@ -318,6 +332,20 @@ class SecondaryBroadcast(Broadcast):
         vec = pybamm.evaluate_for_shape_using_domain(self.domains["secondary"])
         return np.outer(vec, child_eval).reshape(-1, 1)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "broadcast_domain": self.broadcast_domain,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+        )
+
     def reduce_one_dimension(self):
         """Reduce the broadcast by one dimension."""
         return self.orphans[0]
@@ -435,6 +463,20 @@ class TertiaryBroadcast(Broadcast):
         vec = pybamm.evaluate_for_shape_using_domain(self.domains["tertiary"])
         return np.outer(vec, child_eval).reshape(-1, 1)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "broadcast_domain": self.broadcast_domain,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["children"][0], snippet["broadcast_domain"], name=snippet["name"]
+        )
+
     def reduce_one_dimension(self):
         """Reduce the broadcast by one dimension."""
         raise NotImplementedError
@@ -459,6 +501,10 @@ class TertiaryBroadcastToEdges(TertiaryBroadcast):
 
 class FullBroadcast(Broadcast):
     """A class for full broadcasts."""
+
+    # broadcast_domain and broadcast_domains are reconstructed from the stored
+    # full domains dict; opt them out of the coverage guard.
+    _serialise_derived_params = frozenset({"broadcast_domain", "broadcast_domains"})
 
     def __init__(
         self,
@@ -502,6 +548,17 @@ class FullBroadcast(Broadcast):
     def _unary_new_copy(self, child, perform_simplifications=True):
         """See :meth:`pybamm.UnaryOperator._unary_new_copy()`."""
         return self.__class__(child, broadcast_domains=self.domains)
+
+    def to_json(self):
+        return {"name": self.name, "id": self.id, "domains": self.domains}
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["children"][0],
+            broadcast_domains=snippet["domains"],
+            name=snippet["name"],
+        )
 
     def _evaluate_for_shape(self):
         """

--- a/src/pybamm/expression_tree/concatenations.py
+++ b/src/pybamm/expression_tree/concatenations.py
@@ -463,7 +463,6 @@ class DomainConcatenation(Concatenation):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "slices": unpack_defaultDict(self._slices),
             "size": self._size,

--- a/src/pybamm/expression_tree/concatenations.py
+++ b/src/pybamm/expression_tree/concatenations.py
@@ -27,6 +27,10 @@ class Concatenation(pybamm.Symbol):
         The symbols to concatenate
     """
 
+    # concat_fun is a numpy callable (np.concatenate / vstack), check_domain a
+    # constructor flag -- both re-derived on construction, never serialised.
+    _serialise_derived_params = frozenset({"concat_fun", "check_domain"})
+
     def __init__(
         self,
         *children: pybamm.Symbol,
@@ -60,7 +64,9 @@ class Concatenation(pybamm.Symbol):
         """Creates a new Concatenation instance from a json object"""
         instance = cls.__new__(cls)
 
-        instance.concatenation_function = snippet["concat_fun"]
+        # .get: base Concatenation and ConcatenationVariable default to None; Numpy/Domain
+        # Concatenation still inject a value before calling super(), so unchanged.
+        instance.concatenation_function = snippet.get("concat_fun")
 
         super(Concatenation, instance).__init__(
             snippet["name"], tuple(snippet["children"]), domains=snippet["domains"]
@@ -496,6 +502,12 @@ class SparseStack(Concatenation):
             check_domain=False,
             concat_fun=concatenation_function,
         )
+
+    @classmethod
+    def _from_json(cls, snippet):
+        # Route through __init__ so concatenation_function (np.vstack / scipy vstack)
+        # is re-derived from the children; the tolerant base would set it to None.
+        return cls(*snippet["children"])
 
     def _to_casadi(self, t, y, y_dot, inputs, casadi_symbols):
         """See :meth:`pybamm.Symbol._to_casadi()`."""

--- a/src/pybamm/expression_tree/discrete_time_sum.py
+++ b/src/pybamm/expression_tree/discrete_time_sum.py
@@ -31,7 +31,6 @@ class DiscreteTimeData(pybamm.Interpolant):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "time_points": self.x[0].tolist(),
             "data": self.y.tolist(),

--- a/src/pybamm/expression_tree/discrete_time_sum.py
+++ b/src/pybamm/expression_tree/discrete_time_sum.py
@@ -28,6 +28,23 @@ class DiscreteTimeData(pybamm.Interpolant):
     ):
         super().__init__(time_points, data, pybamm.t, name)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "time_points": self.x[0].tolist(),
+            "data": self.y.tolist(),
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            np.array(snippet["time_points"]),
+            np.array(snippet["data"]),
+            snippet["name"],
+        )
+
     def create_copy(self, new_children=None, perform_simplifications=True):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return pybamm.DiscreteTimeData(self.x[0], self.y, self.name)
@@ -80,6 +97,12 @@ class DiscreteTimeSum(pybamm.UnaryOperator):
                 "DiscreteTimeSum must contain a DiscreteTimeData node"
             )
         super().__init__("discrete time sum", child)
+
+    @classmethod
+    def _from_json(cls, snippet):
+        # Route through __init__ so self.data is re-derived from the child;
+        # the inherited UnaryOperator._from_json uses __new__ and would skip it.
+        return cls(snippet["children"][0])
 
     @property
     def sum_values(self):

--- a/src/pybamm/expression_tree/functions.py
+++ b/src/pybamm/expression_tree/functions.py
@@ -389,6 +389,9 @@ class Arcsinh2(Function):
         The regularised arcsinh(a/b) value
     """
 
+    # a and b are Symbol operands carried via children (Function base); eps is emitted.
+    _serialise_derived_params = frozenset({"a", "b"})
+
     def __init__(
         self,
         a: pybamm.Symbol,
@@ -896,6 +899,9 @@ class RegPower(Function):
     ----------
     .. [1] Modelica.Fluid.Utilities.regPow
     """
+
+    # base, exponent, scale are Symbol operands carried via children; delta is emitted.
+    _serialise_derived_params = frozenset({"base", "exponent", "scale"})
 
     def __init__(
         self,

--- a/src/pybamm/expression_tree/functions.py
+++ b/src/pybamm/expression_tree/functions.py
@@ -313,7 +313,6 @@ class SpecificFunction(Function):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "function": self.function.__name__,
         }
 
@@ -485,7 +484,6 @@ class Arcsinh2(Function):
         """Method to serialise a Arcsinh2 object into JSON."""
         return {
             "name": self.name,
-            "id": self.id,
             "function": "arcsinh2",
             "eps": self.eps,
         }
@@ -1080,7 +1078,6 @@ class RegPower(Function):
         """Method to serialise a RegPower object into JSON."""
         return {
             "name": self.name,
-            "id": self.id,
             "function": "reg_power",
             "delta": self.delta,
         }

--- a/src/pybamm/expression_tree/functions.py
+++ b/src/pybamm/expression_tree/functions.py
@@ -305,6 +305,11 @@ class SpecificFunction(Function):
         """
         Method to serialise a SpecificFunction object into JSON.
         """
+        # Concrete subclasses (Sin, Exp, ...) restore their callable in _from_json
+        # via the class itself. The bare base class only stores the function name,
+        # which cannot be turned back into a callable, so refuse to serialise it.
+        if self.__class__ is SpecificFunction:
+            raise NotImplementedError("SpecificFunction is not supported directly")
 
         json_dict = {
             "name": self.name,

--- a/src/pybamm/expression_tree/independent_variable.py
+++ b/src/pybamm/expression_tree/independent_variable.py
@@ -190,7 +190,6 @@ class SpatialVariable(IndependentVariable):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "coord_sys": self.coord_sys,
             "direction": getattr(self, "direction", None),

--- a/src/pybamm/expression_tree/independent_variable.py
+++ b/src/pybamm/expression_tree/independent_variable.py
@@ -187,6 +187,22 @@ class SpatialVariable(IndependentVariable):
         """See :meth:`pybamm.Symbol.new_copy()`."""
         return self.__class__(self.name, domains=self.domains, coord_sys=self.coord_sys)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "coord_sys": self.coord_sys,
+            "direction": getattr(self, "direction", None),
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        kwargs = {"domains": snippet["domains"], "coord_sys": snippet.get("coord_sys")}
+        if snippet.get("direction") is not None:
+            kwargs["direction"] = snippet["direction"]
+        return cls(snippet["name"], **kwargs)
+
 
 class SpatialVariableEdge(SpatialVariable):
     """

--- a/src/pybamm/expression_tree/input_parameter.py
+++ b/src/pybamm/expression_tree/input_parameter.py
@@ -141,7 +141,6 @@ class InputParameter(pybamm.Symbol):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "domain": self.domain,
             "expected_size": self._expected_size,
         }

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -51,6 +51,9 @@ class Interpolant(pybamm.Function):
         the higher potential for errors in extrapolation.
     """
 
+    # entries_string is a derived hash cache of x/y, which are emitted by to_json.
+    _serialise_derived_params = frozenset({"entries_string"})
+
     def __init__(
         self,
         x: npt.NDArray[np.float64] | Sequence[npt.NDArray[np.float64]],
@@ -172,9 +175,9 @@ class Interpolant(pybamm.Function):
             np.array(snippet["y"]),
             snippet["children"],
             name=snippet["name"],
-            interpolator=snippet["interpolator"],
-            extrapolate=snippet["extrapolate"],
-            _num_derivatives=snippet["_num_derivatives"],
+            interpolator=snippet.get("interpolator", "linear"),
+            extrapolate=snippet.get("extrapolate", True),
+            _num_derivatives=snippet.get("_num_derivatives", 0),
         )
 
     @property

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -406,7 +406,6 @@ class Interpolant(pybamm.Function):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "x": [x_item.tolist() for x_item in self.x],
             "y": self.y.tolist(),
             "interpolator": self.interpolator,

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -175,7 +175,8 @@ class Interpolant(pybamm.Function):
             np.array(snippet["y"]),
             snippet["children"],
             name=snippet["name"],
-            interpolator=snippet.get("interpolator", "linear"),
+            interpolator=snippet["interpolator"],
+            # the legacy compact format omits these two; default like its decoder did
             extrapolate=snippet.get("extrapolate", True),
             _num_derivatives=snippet.get("_num_derivatives", 0),
         )

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1473,16 +1473,6 @@ class Serialise:
         if opts is not None:
             model.options = dict(opts)
 
-        def _require_symbol(raw):
-            # The kernel decoder returns unrecognised JSON (raw dicts/strings)
-            # unchanged rather than raising. Where the model expects a Symbol,
-            # reject the leftover so malformed JSON fails here with a clear error
-            # instead of much later as a confusing downstream failure.
-            symbol = convert_symbol_from_json(raw)
-            if not isinstance(symbol, pybamm.Symbol):
-                raise ValueError(f"expected a pybamm.Symbol, got {raw!r}")
-            return symbol
-
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]
             + [lhs_json for lhs_json, _ in model_data["initial_conditions"]]
@@ -2281,6 +2271,20 @@ def convert_symbol_from_json(json_data):
     from pybamm.expression_tree.operations.serialise_kernel import decode
 
     return decode(json_data)
+
+
+def _require_symbol(raw):
+    """Decode *raw* and reject anything that is not a pybamm.Symbol.
+
+    The kernel decoder returns unrecognised JSON (raw dicts/strings) unchanged
+    rather than raising. Where the caller expects a Symbol, reject the leftover
+    so malformed JSON fails here with a clear error instead of much later as a
+    confusing downstream failure.
+    """
+    symbol = convert_symbol_from_json(raw)
+    if not isinstance(symbol, pybamm.Symbol):
+        raise ValueError(f"expected a pybamm.Symbol, got {raw!r}")
+    return symbol
 
 
 def convert_symbol_to_json(symbol):

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -56,7 +56,6 @@ class ExpressionFunctionParameter(pybamm.UnaryOperator):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "func_name": self.func_name,
             "func_args": self.func_args,

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -53,6 +53,24 @@ class ExpressionFunctionParameter(pybamm.UnaryOperator):
         """Evaluate the symbolic expression (the child)"""
         return child
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "func_name": self.func_name,
+            "func_args": self.func_args,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["name"],
+            snippet["children"][0],
+            snippet["func_name"],
+            snippet["func_args"],
+        )
+
     def to_source(self):
         """
         Creates python source code for the function.
@@ -821,7 +839,7 @@ class Serialise:
                     spatial_var = symbol_keys[key]
                     reconstructed_value = {}
                     for k, v in value.items():
-                        if isinstance(v, dict) and "type" in v:
+                        if isinstance(v, dict) and ("$type" in v or "type" in v):
                             # Reconstruct PyBaMM Symbol using convert_symbol_from_json
                             reconstructed_value[k] = convert_symbol_from_json(v)
                         else:
@@ -832,7 +850,7 @@ class Serialise:
                     if isinstance(value, dict):
                         reconstructed_value = {}
                         for k, v in value.items():
-                            if isinstance(v, dict) and "type" in v:
+                            if isinstance(v, dict) and ("$type" in v or "type" in v):
                                 reconstructed_value[k] = convert_symbol_from_json(v)
                             else:
                                 reconstructed_value[k] = v
@@ -1455,6 +1473,16 @@ class Serialise:
         if opts is not None:
             model.options = dict(opts)
 
+        def _require_symbol(raw):
+            # The kernel decoder returns unrecognised JSON (raw dicts/strings)
+            # unchanged rather than raising. Where the model expects a Symbol,
+            # reject the leftover so malformed JSON fails here with a clear error
+            # instead of much later as a confusing downstream failure.
+            symbol = convert_symbol_from_json(raw)
+            if not isinstance(symbol, pybamm.Symbol):
+                raise ValueError(f"expected a pybamm.Symbol, got {raw!r}")
+            return symbol
+
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]
             + [lhs_json for lhs_json, _ in model_data["initial_conditions"]]
@@ -1465,7 +1493,7 @@ class Serialise:
         symbol_map = {}
         for variable_json in all_variable_keys:
             try:
-                symbol = convert_symbol_from_json(variable_json)
+                symbol = _require_symbol(variable_json)
                 key = Serialise._create_symbol_key(variable_json)
                 symbol_map[key] = symbol
             except Exception as e:
@@ -1513,7 +1541,7 @@ class Serialise:
                 sides = {}
                 for side, (expression_json, boundary_type) in condition_dict.items():
                     try:
-                        expr = convert_symbol_from_json(expression_json)
+                        expr = _require_symbol(expression_json)
                         sides[side] = (expr, boundary_type)
                     except Exception as e:
                         raise ValueError(
@@ -1546,7 +1574,7 @@ class Serialise:
                 key = Serialise._create_symbol_key(expression_json)
                 symbol = symbol_map.get(key)
                 if symbol is None:
-                    symbol = convert_symbol_from_json(expression_json)
+                    symbol = _require_symbol(expression_json)
                 model.variables[variable_name] = symbol
             except Exception as e:
                 raise ValueError(
@@ -1594,7 +1622,8 @@ class Serialise:
         or from a standard pybamm.ParameterValues.save), and return a
         pybamm.ParameterValues object.
 
-        - If a value is a dict with a "type" key, deserialize it as a PyBaMM symbol.
+        - If a value is a dict with a "$type" (kernel) or legacy "type" key,
+          deserialize it as a PyBaMM symbol.
         - Otherwise (float, int, bool, str, list, dict-without-type), leave it as-is.
         """
         with open(filename) as f:
@@ -1602,7 +1631,7 @@ class Serialise:
 
         deserialized = {}
         for key, val in raw_dict.items():
-            if isinstance(val, dict) and "type" in val:
+            if isinstance(val, dict) and ("$type" in val or "type" in val):
                 deserialized[key] = convert_symbol_from_json(val)
 
             elif isinstance(val, list):
@@ -2248,293 +2277,14 @@ def convert_function_to_symbolic_expression(func, name=None):
 
 
 def convert_symbol_from_json(json_data):
-    """
-    Recursively converts a JSON dictionary back into PyBaMM symbolic expressions
+    """Reconstruct a pybamm.Symbol from kernel/legacy JSON."""
+    from pybamm.expression_tree.operations.serialise_kernel import decode
 
-    Parameters
-    ----------
-    json_data : dict
-        Dictionary containing the serialized PyBaMM expression
-
-    Returns
-    -------
-    pybamm.Symbol
-        The reconstructed PyBaMM symbolic expression
-    """
-    if isinstance(json_data, float | int | bool):
-        return json_data
-
-    if isinstance(json_data, str):
-        raise ValueError(f"Unexpected raw string in JSON: {json_data}")
-
-    if json_data is None:
-        return None
-    if "type" not in json_data:
-        raise ValueError(f"Missing 'type' key in JSON data: {json_data}")
-    if isinstance(json_data, numbers.Number | list):
-        return json_data
-    elif json_data["type"] == "Parameter":
-        # Convert stored parameters back to PyBaMM Parameter objects
-        return pybamm.Parameter(json_data["name"])
-    elif json_data["type"] == "InputParameter":
-        return pybamm.InputParameter(json_data["name"])
-    elif json_data["type"] == "Constant":
-        return pybamm.Constant(json_data["value"], json_data["name"])
-    elif json_data["type"] == "Scalar":
-        # Convert stored numerical values back to PyBaMM Scalar objects
-        return pybamm.Scalar(json_data["value"])
-    elif json_data["type"] == "Interpolant":
-        return pybamm.Interpolant(
-            [np.array(x) for x in json_data["x"]],
-            np.array(json_data["y"]),
-            [convert_symbol_from_json(c) for c in json_data["children"]],
-            name=json_data["name"],
-            interpolator=json_data["interpolator"],
-            entries_string=json_data["entries_string"],
-        )
-    elif json_data["type"] == "FunctionParameter":
-        diff_variable = json_data["diff_variable"]
-        if diff_variable is not None:
-            diff_variable = convert_symbol_from_json(diff_variable)
-        # Use the parameter name as print_name to avoid showing
-        # 'convert_symbol_from_json' in displays
-        return pybamm.FunctionParameter(
-            json_data["name"],
-            {k: convert_symbol_from_json(v) for k, v in json_data["inputs"].items()},
-            diff_variable=diff_variable,
-            print_name=json_data["name"],
-        )
-    elif json_data["type"] == "ExpressionFunctionParameter":
-        return ExpressionFunctionParameter(
-            json_data["name"],
-            convert_symbol_from_json(json_data["children"][0]),
-            json_data["func_name"],
-            json_data["func_args"],
-        )
-    elif json_data["type"] == "PrimaryBroadcast":
-        child = convert_symbol_from_json(json_data["children"][0])
-        domain = json_data["broadcast_domain"]
-        return pybamm.PrimaryBroadcast(child, domain)
-    elif json_data["type"] == "FullBroadcast":
-        child = convert_symbol_from_json(json_data["children"][0])
-        domains = json_data["domains"]
-        return pybamm.FullBroadcast(child, broadcast_domains=domains)
-    elif json_data["type"] == "SecondaryBroadcast":
-        child = convert_symbol_from_json(json_data["children"][0])
-        domain = json_data["broadcast_domain"]
-        return pybamm.SecondaryBroadcast(child, domain)
-    elif json_data["type"] == "BoundaryValue":
-        child = convert_symbol_from_json(json_data["children"][0])
-        side = json_data["side"]
-        return pybamm.BoundaryValue(child, side)
-    elif json_data["type"] == "Variable":
-        bounds_data = json_data.get("bounds")
-        if bounds_data is None:
-            bounds = (
-                pybamm.Scalar(-np.inf),
-                pybamm.Scalar(np.inf),
-            )
-        else:
-            bounds = tuple(convert_symbol_from_json(b) for b in bounds_data)
-        return pybamm.Variable(
-            json_data["name"],
-            domains=json_data["domains"],
-            bounds=bounds,
-        )
-    elif json_data["type"] == "IndefiniteIntegral":
-        child = convert_symbol_from_json(json_data["children"][0])
-        integration_var_json = json_data["integration_variable"]
-        integration_variable = convert_symbol_from_json(integration_var_json)
-        if not isinstance(integration_variable, pybamm.SpatialVariable):
-            raise TypeError(
-                f"Expected SpatialVariable, got {type(integration_variable)}"
-            )
-        return pybamm.IndefiniteIntegral(child, [integration_variable])
-    elif json_data["type"] == "SpatialVariable":
-        return pybamm.SpatialVariable(
-            json_data["name"],
-            coord_sys=json_data.get("coord_sys", "cartesian"),
-            domains=json_data.get("domains"),
-        )
-    elif json_data["type"] == "Time":
-        return pybamm.Time()
-    elif json_data["type"] == "CoupledVariable":
-        return pybamm.CoupledVariable(
-            json_data["name"],
-            domain=json_data.get("domains", {}).get("primary", None),
-        )
-    elif json_data["type"] == "Symbol":
-        return pybamm.Symbol(
-            json_data["name"],
-            domains=json_data.get("domains", {}),
-        )
-    elif "children" in json_data:
-        return getattr(pybamm, json_data["type"])(
-            *[convert_symbol_from_json(c) for c in json_data["children"]]
-        )
-    else:
-        raise ValueError(f"Unknown symbol type: {json_data['type']}")
+    return decode(json_data)
 
 
 def convert_symbol_to_json(symbol):
-    """
-    Converts a PyBaMM symbolic expression to a JSON-serializable dictionary
+    """Serialise a pybamm.Symbol to a JSON-compatible dict via the kernel."""
+    from pybamm.expression_tree.operations.serialise_kernel import encode
 
-    Parameters
-    ----------
-    symbol : pybamm.Symbol
-        The PyBaMM symbolic expression to convert
-
-    Returns
-    -------
-    dict
-        The JSON-serializable dictionary
-    """
-    if isinstance(symbol, ExpressionFunctionParameter):
-        return {
-            "type": "ExpressionFunctionParameter",
-            "name": symbol.name,
-            "children": [convert_symbol_to_json(symbol.child)],
-            "func_name": symbol.func_name,
-            "func_args": symbol.func_args,
-        }
-    elif isinstance(symbol, numbers.Number | list):
-        return symbol
-    elif isinstance(symbol, pybamm.Parameter):
-        # Parameters are stored with their type and name
-        return {"type": "Parameter", "name": symbol.name}
-    elif isinstance(symbol, pybamm.Constant):
-        return {"type": "Constant", "value": symbol.value, "name": symbol.name}
-    elif isinstance(symbol, pybamm.Scalar):
-        # Scalar values are stored with their numerical value
-        # Sanitize inf/nan to JSON-safe string sentinels
-        val = symbol.value
-        if isinstance(val, float) or isinstance(val, np.floating):
-            if np.isposinf(val):
-                val = "Infinity"
-            elif np.isneginf(val):
-                val = "-Infinity"
-            elif np.isnan(val):
-                val = "NaN"
-        return {"type": "Scalar", "value": val}
-    elif isinstance(symbol, pybamm.SpecificFunction):
-        if symbol.__class__ == pybamm.SpecificFunction:
-            raise NotImplementedError("SpecificFunction is not supported directly")
-        else:
-            # Subclasses of SpecificFunction (e.g. Exp, Sin, etc.) can be reconstructed
-            # from only the children
-            return {
-                "type": symbol.__class__.__name__,
-                "children": [convert_symbol_to_json(c) for c in symbol.children],
-            }
-    elif isinstance(symbol, pybamm.PrimaryBroadcast):
-        json_dict = {
-            "type": "PrimaryBroadcast",
-            "children": [convert_symbol_to_json(symbol.child)],
-            "broadcast_domain": symbol.broadcast_domain,
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.IndefiniteIntegral):
-        integration_var = (
-            symbol.integration_variable[0]
-            if isinstance(symbol.integration_variable, list)
-            else symbol.integration_variable
-        )
-        json_dict = {
-            "type": "IndefiniteIntegral",
-            "children": [convert_symbol_to_json(symbol.child)],
-            "integration_variable": convert_symbol_to_json(integration_var),
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.BoundaryValue):
-        json_dict = {
-            "type": "BoundaryValue",
-            "side": symbol.side,
-            "children": [convert_symbol_to_json(symbol.orphans[0])],
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.SecondaryBroadcast):
-        json_dict = {
-            "type": "SecondaryBroadcast",
-            "children": [convert_symbol_to_json(symbol.child)],
-            "broadcast_domain": symbol.broadcast_domain,
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.FullBroadcast):
-        json_dict = {
-            "type": "FullBroadcast",
-            "children": [convert_symbol_to_json(symbol.child)],
-            "domains": symbol.domains,
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.Interpolant):
-        return {
-            "type": symbol.__class__.__name__,
-            "x": [x.tolist() for x in symbol.x],
-            "y": symbol.y.tolist(),
-            "children": [convert_symbol_to_json(c) for c in symbol.children],
-            "name": symbol.name,
-            "interpolator": symbol.interpolator,
-            "entries_string": symbol.entries_string,
-        }
-    elif isinstance(symbol, pybamm.Variable):
-        lb, ub = symbol.bounds[0], symbol.bounds[1]
-        if (
-            isinstance(lb, pybamm.Scalar)
-            and isinstance(ub, pybamm.Scalar)
-            and np.isinf(lb.value)
-            and np.isinf(ub.value)
-            and lb.value < 0
-            and ub.value > 0
-        ):
-            bounds_json = None
-        else:
-            bounds_json = [
-                convert_symbol_to_json(lb),
-                convert_symbol_to_json(ub),
-            ]
-        json_dict = {
-            "type": "Variable",
-            "name": symbol.name,
-            "domains": symbol.domains,
-            "bounds": bounds_json,
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.ConcatenationVariable):
-        json_dict = {
-            "type": "ConcatenationVariable",
-            "name": symbol.name,
-            "children": [convert_symbol_to_json(child) for child in symbol.children],
-        }
-        return json_dict
-    elif isinstance(symbol, pybamm.Time):
-        return {"type": "Time"}
-    elif isinstance(symbol, pybamm.FunctionParameter):
-        input_names = symbol.input_names
-        inputs = {
-            input_names[i]: convert_symbol_to_json(symbol.orphans[i])
-            for i in range(len(input_names))
-        }
-        diff_variable = symbol.diff_variable
-        if diff_variable is not None:
-            diff_variable = convert_symbol_to_json(diff_variable)
-        return {
-            "type": symbol.__class__.__name__,
-            "inputs": inputs,
-            "diff_variable": diff_variable,
-            "name": symbol.name,
-        }
-    elif isinstance(symbol, pybamm.Symbol):
-        # Generic fallback for other symbols with children
-        json_dict = {
-            "type": symbol.__class__.__name__,
-            "domains": symbol.domains,
-            "children": [convert_symbol_to_json(c) for c in symbol.children],
-        }
-        if hasattr(symbol, "name"):
-            json_dict["name"] = symbol.name
-        return json_dict
-    else:
-        raise ValueError(
-            f"Error processing '{symbol.name}'. Unknown symbol type: {type(symbol)}"
-        )
+    return encode(symbol)

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -8,6 +8,7 @@ raises :class:`SerialisationError` rather than silently dropping any value.
 from __future__ import annotations
 
 import importlib
+import inspect
 
 import numpy as np
 
@@ -151,9 +152,95 @@ def decode(node):
     raise SerialisationError(f"Cannot decode value of type {type(node)}")
 
 
-def _lookup_codec(cls: type):
-    return None  # replaced in Task 1.5
-
-
 def normalise_legacy(node: dict) -> dict:
     return node  # replaced in Task 1.6
+
+
+# ---------------------------------------------------------------------------
+# DefaultCodec
+# ---------------------------------------------------------------------------
+
+_CHILD_PARAMS = frozenset({"child", "children", "child_input", "left", "right"})
+_SKIP_PARAMS = frozenset({"self", "domain", "domains", "auxiliary_domains"})
+_MISSING = object()
+
+
+def _read_attr(obj, name):
+    for candidate in (name, f"_{name}"):
+        if hasattr(obj, candidate):
+            return getattr(obj, candidate)
+    return _MISSING
+
+
+class DefaultCodec:
+    """Introspection-based codec: derive fields from ``__init__``.
+
+    Captures every resolvable non-child parameter (including defaulted ones);
+    raises if a *required* parameter cannot be read from the instance.
+    """
+
+    def to_json(self, obj, encode) -> dict:
+        node: dict = {}
+        node["domains"] = obj.domains
+        sig = inspect.signature(type(obj).__init__)
+        # Validate and collect non-child params first so that missing-required-param
+        # errors surface before any encoding attempt (fail-fast, predictable order).
+        extra: dict = {}
+        for name, param in sig.parameters.items():
+            if name in _SKIP_PARAMS or name in _CHILD_PARAMS:
+                continue
+            if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
+                raise SerialisationError(
+                    f"{type(obj).__name__}.__init__ uses *args/**kwargs ({name}); "
+                    f"add a to_json/_from_json hook."
+                )
+            value = _read_attr(obj, name)
+            if value is _MISSING:
+                if param.default is inspect.Parameter.empty:
+                    raise SerialisationError(
+                        f"{type(obj).__name__}.__init__ requires {name!r}; no "
+                        f"attribute {name}/_{name} found -- add a to_json/_from_json "
+                        f"hook or register a codec."
+                    )
+                continue
+            extra[name] = value
+        # Encode children and collected params only after validation succeeds.
+        if obj.children:
+            node["children"] = [encode(c) for c in obj.children]
+        for name, value in extra.items():
+            node[name] = encode(value)
+        return node
+
+    def from_json(self, node, decode, cls):
+        children = [decode(c) for c in node.get("children", [])]
+        param_names = set(inspect.signature(cls.__init__).parameters)
+        # Forward only real __init__ params; ignore bookkeeping/legacy extras
+        # (e.g. the old switch's "name") rather than passing them as kwargs.
+        # "domains" is excluded here and handled separately below.
+        kwargs = {
+            key: decode(raw)
+            for key, raw in node.items()
+            if key not in (TAG, "children", "domains") and key in param_names
+        }
+        # to_json always writes node["domains"]; map it onto whichever param the
+        # signature accepts -- `domains` (full dict), `domain` (primary list), or
+        # neither (class infers domain from children). Prevents the silent
+        # domain-drop for `domain`-param classes like CoupledVariable.
+        domains = node.get("domains")
+        if domains:
+            if "domains" in param_names:
+                kwargs.setdefault("domains", domains)
+            elif "domain" in param_names:
+                kwargs.setdefault("domain", domains.get("primary") or None)
+        return cls(*children, **kwargs)
+
+
+_default_codec = DefaultCodec()
+
+
+def _lookup_codec(cls: type):
+    import pybamm  # local import to avoid circular dependency at module level
+
+    if issubclass(cls, pybamm.Symbol):
+        return _default_codec
+    return None  # extended in Task 1.5 with hook detection

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -278,14 +278,14 @@ def _guarded_params(cls: type) -> tuple[str, ...]:
 
 
 def _is_structural(value) -> bool:
-    """True if value is (or contains) a Symbol, so it travels through children
-    and the hook need not emit it as a scalar field."""
+    """True if value is (or contains, at any nesting depth) a Symbol, so it
+    travels through children and the hook need not emit it as a scalar field."""
     if isinstance(value, pybamm.Symbol):
         return True
     if isinstance(value, (list, tuple)):
-        return any(isinstance(v, pybamm.Symbol) for v in value)
+        return any(_is_structural(v) for v in value)
     if isinstance(value, dict):
-        return any(isinstance(v, pybamm.Symbol) for v in value.values())
+        return any(_is_structural(v) for v in value.values())
     return False
 
 

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -73,16 +73,87 @@ def _decode_leaf(node):
         return node
     tag = node.get(TAG)
     if tag == "builtins.float":
-        return _FLOAT_SENTINELS_INV[node["value"]]
+        value = node["value"]
+        if value not in _FLOAT_SENTINELS_INV:
+            raise SerialisationError(f"Unknown float sentinel: {value!r}")
+        return _FLOAT_SENTINELS_INV[value]
     if tag == "numpy.ndarray":
         return np.array(node["data"], dtype=node["dtype"])
     if tag == "builtins.slice":
         return slice(node["start"], node["stop"], node["step"])
     if tag == "builtins.tuple":
-        return tuple(decode(x) for x in node["items"])  # noqa: F821 - decode added in Task 1.3
+        return tuple(decode(x) for x in node["items"])
     raise SerialisationError(f"Not a leaf node: {tag!r}")
 
 
 _LEAF_TAGS = frozenset(
     {"builtins.float", "numpy.ndarray", "builtins.slice", "builtins.tuple"}
 )
+
+
+def _encode_class_ref(cls: type) -> dict:
+    return {TAG: "type", "class": _class_path(cls)}
+
+
+def encode(obj):
+    """Encode any serialisable object into a JSON-compatible structure.
+
+    Raises SerialisationError for objects with no codec (safe-or-loud).
+    """
+    if obj is None or isinstance(obj, (bool, int, str)):
+        return obj
+    if isinstance(obj, float):
+        return _encode_float(obj)
+    if isinstance(obj, np.ndarray):
+        return _encode_ndarray(obj)
+    if isinstance(obj, slice):
+        return _encode_slice(obj)
+    if isinstance(obj, tuple):
+        return {TAG: "builtins.tuple", "items": [encode(x) for x in obj]}
+    if isinstance(obj, list):
+        return [encode(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: encode(v) for k, v in obj.items()}
+    if isinstance(obj, type):
+        return _encode_class_ref(obj)
+
+    codec = _lookup_codec(type(obj))
+    if codec is None:
+        raise SerialisationError(
+            f"Cannot serialise {type(obj).__module__}.{type(obj).__qualname__}: "
+            f"no codec registered. Register the class or add a to_json/_from_json hook."
+        )
+    node = codec.to_json(obj, encode)
+    node[TAG] = _class_path(type(obj))
+    return node
+
+
+def decode(node):
+    """Inverse of :func:`encode`."""
+    if node is None or isinstance(node, (bool, int, str, float)):
+        return node
+    if isinstance(node, list):
+        return [decode(x) for x in node]
+    if isinstance(node, dict):
+        node = normalise_legacy(node)
+        tag = node.get(TAG)
+        if tag in _LEAF_TAGS:
+            return _decode_leaf(node)
+        if tag == "type":
+            return _resolve_class(node["class"])
+        if tag is None:
+            return {k: decode(v) for k, v in node.items()}
+        cls = _resolve_class(tag)
+        codec = _lookup_codec(cls)
+        if codec is None:
+            raise SerialisationError(f"No codec to decode '{tag}'")
+        return codec.from_json(node, decode, cls)
+    raise SerialisationError(f"Cannot decode value of type {type(node)}")
+
+
+def _lookup_codec(cls: type):
+    return None  # replaced in Task 1.5
+
+
+def normalise_legacy(node: dict) -> dict:
+    return node  # replaced in Task 1.6

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -234,7 +234,7 @@ class DefaultCodec:
         children = [decode(c) for c in node.get("children", [])]
         param_names = set(inspect.signature(cls.__init__).parameters)
         # Forward only real __init__ params; ignore bookkeeping/legacy extras
-        # (e.g. the old switch's "name") rather than passing them as kwargs.
+        # (e.g. the legacy format's always-present "name") rather than as kwargs.
         # "domains" is excluded here and handled separately below.
         kwargs = {
             key: decode(raw)
@@ -323,6 +323,12 @@ class HookCodec:
     codec adds them and decodes them back into the snippet before calling
     _from_json. After building the node it runs the coverage guard, extending
     safe-or-loud to the hook surface.
+
+    Contract: only ``children`` are encoded/decoded by the kernel. Every other
+    field a hook emits must already be JSON-native (scalars, or lists/dicts of
+    them) -- it reaches ``_from_json`` undecoded. Route any Symbol-, ndarray-,
+    slice- or tuple-valued argument through ``children``, or have the hook
+    (de)serialise it itself in ``to_json``/``_from_json``.
     """
 
     def to_json(self, obj, encode) -> dict:

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -337,11 +337,16 @@ class HookCodec:
     def to_json(self, obj, encode) -> dict:
         node = dict(obj.to_json())
         node.pop("id", None)  # identity is not part of the round-trip contract
-        # Phase 1 only auto-attaches obj.children; Task 2.1 extends this to
-        # hook-supplied children (and updates raw_children accordingly).
-        raw_children = list(obj.children) if getattr(obj, "children", None) else []
+        if "children" in node:  # hook supplied its own children
+            raw_children = list(node["children"])
+        elif getattr(obj, "children", None):  # else attach the node's children
+            raw_children = list(obj.children)
+        else:
+            raw_children = []
         if raw_children:
             node["children"] = [encode(c) for c in raw_children]
+        # guard against raw_children (pre-encode), so a non-Symbol routed through a
+        # hook-supplied children list is covered by identity.
         _assert_hook_covers_params(obj, node, raw_children)
         return node
 

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -1,0 +1,33 @@
+"""Unified safe-or-loud serialisation kernel.
+
+One encode/decode engine for pybamm serialisable objects. Dispatches by type to
+per-class ``to_json``/``_from_json`` hooks or an introspection default, and
+raises :class:`SerialisationError` rather than silently dropping any value.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+TAG = "$type"  # canonical key holding a dotted "module.ClassName" path
+
+
+class SerialisationError(Exception):
+    """Raised when a value cannot be serialised or reconstructed safely."""
+
+
+def _class_path(cls: type) -> str:
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _resolve_class(path: str) -> type:
+    module_name, _, qualname = path.rpartition(".")
+    try:
+        obj: object = importlib.import_module(module_name)
+        for part in qualname.split("."):
+            obj = getattr(obj, part)
+    except (ImportError, AttributeError, ValueError) as err:
+        raise SerialisationError(f"Cannot resolve class '{path}'") from err
+    if not isinstance(obj, type):
+        raise SerialisationError(f"'{path}' did not resolve to a class")
+    return obj

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -7,10 +7,13 @@ raises :class:`SerialisationError` rather than silently dropping any value.
 
 from __future__ import annotations
 
+import functools
 import importlib
 import inspect
 
 import numpy as np
+
+import pybamm  # safe at module top: kernel is imported lazily by serialise.py
 
 TAG = "$type"  # canonical key holding a dotted "module.ClassName" path
 
@@ -238,9 +241,118 @@ class DefaultCodec:
 _default_codec = DefaultCodec()
 
 
-def _lookup_codec(cls: type):
-    import pybamm  # local import to avoid circular dependency at module level
+# ---------------------------------------------------------------------------
+# HookCodec + coverage guard
+# ---------------------------------------------------------------------------
 
-    if issubclass(cls, pybamm.Symbol):
-        return _default_codec
-    return None  # extended in Task 1.5 with hook detection
+
+@functools.cache
+def _guarded_params(cls: type) -> tuple[str, ...]:
+    """Non-child, non-domain __init__ params the HookCodec guard checks.
+
+    Cached per class -- encode walks this for every hooked node.
+    """
+    try:
+        params = inspect.signature(cls.__init__).parameters
+    except (TypeError, ValueError):
+        return ()
+    return tuple(
+        name
+        for name, p in params.items()
+        if name not in _SKIP_PARAMS
+        and name not in _CHILD_PARAMS
+        and name != "name"  # always emitted by to_json / handled by Symbol base
+        and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    )
+
+
+def _is_structural(value) -> bool:
+    """True if value is (or contains) a Symbol, so it travels through children
+    and the hook need not emit it as a scalar field."""
+    if isinstance(value, pybamm.Symbol):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(isinstance(v, pybamm.Symbol) for v in value)
+    if isinstance(value, dict):
+        return any(isinstance(v, pybamm.Symbol) for v in value.values())
+    return False
+
+
+def _assert_hook_covers_params(obj, node: dict, raw_children: list) -> None:
+    """Safe-or-loud guard for HookCodec -- closes the inherited-hook leak.
+
+    Every non-child __init__ param of type(obj) must be emitted as a field,
+    carried in children (by identity or as a Symbol/collection of Symbols), or
+    declared in _serialise_derived_params -- else it is a silent field drop and
+    raises. Keys on coverage, not value, so it fails identically for default and
+    non-default values (the prevention is structural).
+    """
+    cls = type(obj)
+    derived = getattr(cls, "_serialise_derived_params", frozenset())
+    child_ids = {id(c) for c in raw_children}
+    for name in _guarded_params(cls):
+        if name in node or name in derived:
+            continue
+        value = _read_attr(obj, name)
+        if value is not _MISSING and (id(value) in child_ids or _is_structural(value)):
+            continue
+        raise SerialisationError(
+            f"{cls.__module__}.{cls.__qualname__}.to_json drops the __init__ "
+            f"parameter {name!r}: not emitted as a field, not carried in children, "
+            f"and not in _serialise_derived_params. Emit it in the hook, or -- if it "
+            f"is re-derived on construction or a non-serialisable transient -- list it "
+            f"in _serialise_derived_params (a reviewed, in-diff decision)."
+        )
+
+
+class HookCodec:
+    """Codec backed by a class's own to_json/_from_json.
+
+    to_json returns the node's own fields; the kernel attaches children, so this
+    codec adds them and decodes them back into the snippet before calling
+    _from_json. After building the node it runs the coverage guard, extending
+    safe-or-loud to the hook surface.
+    """
+
+    def to_json(self, obj, encode) -> dict:
+        node = dict(obj.to_json())
+        node.pop("id", None)  # identity is not part of the round-trip contract
+        # Phase 1 only auto-attaches obj.children; Task 2.1 extends this to
+        # hook-supplied children (and updates raw_children accordingly).
+        raw_children = list(obj.children) if getattr(obj, "children", None) else []
+        if raw_children:
+            node["children"] = [encode(c) for c in raw_children]
+        _assert_hook_covers_params(obj, node, raw_children)
+        return node
+
+    def from_json(self, node, decode, cls):
+        snippet = dict(node)
+        snippet.pop(TAG, None)
+        snippet["children"] = [decode(c) for c in node.get("children", [])]
+        return cls._from_json(snippet)
+
+
+_hook_codec = HookCodec()
+
+
+# Bases whose concrete subclasses are serialisable.
+_KNOWN_BASES = (pybamm.Symbol,)
+
+
+def _overrides_hooks(cls: type) -> bool:
+    # Asymmetric on purpose: to_json is a regular method, so `cls.to_json` is a
+    # plain function comparable by identity; _from_json is a classmethod, so
+    # `cls._from_json` is bound and we compare the underlying `.__func__`. Do not
+    # "simplify" either branch to match the other.
+    return (
+        cls.to_json is not pybamm.Symbol.to_json
+        or cls._from_json.__func__ is not pybamm.Symbol._from_json.__func__
+    )
+
+
+def _lookup_codec(cls: type):
+    if not issubclass(cls, _KNOWN_BASES):
+        return None
+    if _overrides_hooks(cls):
+        return _hook_codec
+    return _default_codec

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -156,7 +156,27 @@ def decode(node):
 
 
 def normalise_legacy(node: dict) -> dict:
-    return node  # replaced in Task 1.6
+    """Map the three pre-kernel wire shapes onto the canonical tag.
+
+    Read-only compatibility layer. Canonical nodes pass through untouched.
+    """
+    if TAG in node:
+        return node
+    if "py/object" in node:
+        out = {k: v for k, v in node.items() if k != "py/id"}
+        out[TAG] = out.pop("py/object")
+        return out
+    if "class" in node and "module" in node:
+        out = dict(node)
+        out[TAG] = "type"
+        out["class"] = f"{out.pop('module')}.{out.pop('class')}"
+        return out
+    if "type" in node:
+        out = dict(node)
+        type_val = out.pop("type")
+        out[TAG] = type_val if "." in type_val else f"pybamm.{type_val}"
+        return out
+    return node
 
 
 # ---------------------------------------------------------------------------

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -179,10 +179,6 @@ def normalise_legacy(node: dict) -> dict:
     return node
 
 
-# ---------------------------------------------------------------------------
-# DefaultCodec
-# ---------------------------------------------------------------------------
-
 _CHILD_PARAMS = frozenset({"child", "children", "child_input", "left", "right"})
 _SKIP_PARAMS = frozenset({"self", "domain", "domains", "auxiliary_domains"})
 _MISSING = object()
@@ -259,11 +255,6 @@ class DefaultCodec:
 
 
 _default_codec = DefaultCodec()
-
-
-# ---------------------------------------------------------------------------
-# HookCodec + coverage guard
-# ---------------------------------------------------------------------------
 
 
 @functools.cache

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import importlib
 
+import numpy as np
+
 TAG = "$type"  # canonical key holding a dotted "module.ClassName" path
 
 
@@ -31,3 +33,56 @@ def _resolve_class(path: str) -> type:
     if not isinstance(obj, type):
         raise SerialisationError(f"'{path}' did not resolve to a class")
     return obj
+
+
+_FLOAT_SENTINELS = {float("inf"): "Infinity", float("-inf"): "-Infinity"}
+_FLOAT_SENTINELS_INV = {
+    "Infinity": float("inf"),
+    "-Infinity": float("-inf"),
+    "NaN": float("nan"),
+}
+
+
+def _encode_float(value: float):
+    if value != value:  # NaN
+        return {TAG: "builtins.float", "value": "NaN"}
+    if value in _FLOAT_SENTINELS:
+        return {TAG: "builtins.float", "value": _FLOAT_SENTINELS[value]}
+    return value
+
+
+def _encode_ndarray(value: np.ndarray) -> dict:
+    return {TAG: "numpy.ndarray", "data": value.tolist(), "dtype": str(value.dtype)}
+
+
+def _encode_slice(value: slice) -> dict:
+    return {
+        TAG: "builtins.slice",
+        "start": value.start,
+        "stop": value.stop,
+        "step": value.step,
+    }
+
+
+def _decode_leaf(node):
+    """Decode a leaf node previously produced by an _encode_* helper.
+
+    Accepts already-native floats unchanged.
+    """
+    if not isinstance(node, dict):
+        return node
+    tag = node.get(TAG)
+    if tag == "builtins.float":
+        return _FLOAT_SENTINELS_INV[node["value"]]
+    if tag == "numpy.ndarray":
+        return np.array(node["data"], dtype=node["dtype"])
+    if tag == "builtins.slice":
+        return slice(node["start"], node["stop"], node["step"])
+    if tag == "builtins.tuple":
+        return tuple(decode(x) for x in node["items"])  # noqa: F821 - decode added in Task 1.3
+    raise SerialisationError(f"Not a leaf node: {tag!r}")
+
+
+_LEAF_TAGS = frozenset(
+    {"builtins.float", "numpy.ndarray", "builtins.slice", "builtins.tuple"}
+)

--- a/src/pybamm/expression_tree/parameter.py
+++ b/src/pybamm/expression_tree/parameter.py
@@ -56,15 +56,11 @@ class Parameter(pybamm.Symbol):
             return sympy.Symbol(self.name)
 
     def to_json(self):
-        raise NotImplementedError(
-            "pybamm.Parameter: Serialisation is only implemented for discretised models"
-        )
+        return {"name": self.name, "id": self.id, "domains": self.domains}
 
     @classmethod
     def _from_json(cls, snippet):
-        raise NotImplementedError(
-            "pybamm.Parameter: Please use a discretised model when reading in from JSON"
-        )
+        return cls(snippet["name"])
 
 
 class FunctionParameter(pybamm.Symbol):
@@ -236,15 +232,50 @@ class FunctionParameter(pybamm.Symbol):
         else:
             return sympy.Symbol(self.name)
 
+    # inputs -> children + input_names; diff_variable -> a trailing child (flagged
+    # by has_diff_variable); post_processor is a non-serialisable transient callable.
+    _serialise_derived_params = frozenset({"inputs", "diff_variable", "post_processor"})
+
     def to_json(self):
-        raise NotImplementedError(
-            "pybamm.FunctionParameter:"
-            "Serialisation is only implemented for discretised models."
-        )
+        children = list(self.children)
+        if self.diff_variable is not None:
+            children = [*children, self.diff_variable]
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "input_names": list(self.input_names),
+            "print_name": self.print_name,
+            "has_diff_variable": self.diff_variable is not None,
+            "children": children,
+        }
 
     @classmethod
     def _from_json(cls, snippet):
-        raise NotImplementedError(
-            "pybamm.FunctionParameter:"
-            "Please use a discretised model when reading in from JSON."
+        if "input_names" in snippet:
+            # Kernel-era shape: inputs carried as children keyed by input_names;
+            # diff_variable is the trailing child when present.
+            names = snippet["input_names"]
+            children = snippet["children"]
+            inputs = {names[i]: children[i] for i in range(len(names))}
+            n = len(names)
+            diff_variable = children[n] if snippet["has_diff_variable"] else None
+            print_name = snippet["print_name"]
+        else:
+            # Legacy compact shape: inputs is a name->node dict and diff_variable a
+            # node (or None), both undecoded since they are not in "children".
+            from pybamm.expression_tree.operations.serialise_kernel import decode
+
+            inputs = {k: decode(v) for k, v in snippet["inputs"].items()}
+            diff_variable = snippet.get("diff_variable")
+            if diff_variable is not None:
+                diff_variable = decode(diff_variable)
+            # Legacy reused the parameter name as print_name to avoid leaking the
+            # serialiser frame name into displays.
+            print_name = snippet["name"]
+        return cls(
+            snippet["name"],
+            inputs,
+            diff_variable=diff_variable,
+            print_name=print_name,
         )

--- a/src/pybamm/expression_tree/parameter.py
+++ b/src/pybamm/expression_tree/parameter.py
@@ -56,7 +56,7 @@ class Parameter(pybamm.Symbol):
             return sympy.Symbol(self.name)
 
     def to_json(self):
-        return {"name": self.name, "id": self.id, "domains": self.domains}
+        return {"name": self.name, "domains": self.domains}
 
     @classmethod
     def _from_json(cls, snippet):
@@ -242,7 +242,6 @@ class FunctionParameter(pybamm.Symbol):
             children = [*children, self.diff_variable]
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "input_names": list(self.input_names),
             "print_name": self.print_name,

--- a/src/pybamm/expression_tree/scalar.py
+++ b/src/pybamm/expression_tree/scalar.py
@@ -42,7 +42,8 @@ class Scalar(pybamm.Symbol):
 
     @classmethod
     def _from_json(cls, snippet: dict):
-        return cls(snippet["value"], name=snippet["name"])
+        # Legacy compact JSON omitted "name"; fall back to the __init__ default.
+        return cls(snippet["value"], name=snippet.get("name"))
 
     def __str__(self):
         return str(self.value)

--- a/src/pybamm/expression_tree/scalar.py
+++ b/src/pybamm/expression_tree/scalar.py
@@ -126,7 +126,7 @@ class Scalar(pybamm.Symbol):
             elif np.isnan(value):
                 value = "NaN"
 
-        json_dict = {"name": self.name, "id": self.id, "value": value}
+        json_dict = {"name": self.name, "value": value}
 
         return json_dict
 

--- a/src/pybamm/expression_tree/scalar.py
+++ b/src/pybamm/expression_tree/scalar.py
@@ -114,7 +114,18 @@ class Scalar(pybamm.Symbol):
         Method to serialise a Symbol object into JSON.
         """
 
-        json_dict = {"name": self.name, "id": self.id, "value": self.value}
+        # The kernel does not recurse into hook fields, so the float-sentinel leaf
+        # codec never sees self.value; carry inf/nan as standard-JSON tokens here.
+        value = self.value
+        if isinstance(value, np.floating):
+            if np.isposinf(value):
+                value = "Infinity"
+            elif np.isneginf(value):
+                value = "-Infinity"
+            elif np.isnan(value):
+                value = "NaN"
+
+        json_dict = {"name": self.name, "id": self.id, "value": value}
 
         return json_dict
 

--- a/src/pybamm/expression_tree/state_vector.py
+++ b/src/pybamm/expression_tree/state_vector.py
@@ -221,7 +221,6 @@ class StateVectorBase(pybamm.Symbol):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "y_slice": [
                 {

--- a/src/pybamm/expression_tree/symbol.py
+++ b/src/pybamm/expression_tree/symbol.py
@@ -1210,7 +1210,6 @@ class Symbol:
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
         }
 

--- a/src/pybamm/expression_tree/tensor_field.py
+++ b/src/pybamm/expression_tree/tensor_field.py
@@ -137,6 +137,18 @@ class TensorField(pybamm.Symbol):
 
         return TensorField(new_components, domain=self.domain)
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": list(self._components),
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"])
+
     def _evaluate_for_shape(self):
         """Delegate shape evaluation to first component."""
         return self.children[0].evaluate_for_shape()

--- a/src/pybamm/expression_tree/tensor_field.py
+++ b/src/pybamm/expression_tree/tensor_field.py
@@ -140,7 +140,6 @@ class TensorField(pybamm.Symbol):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": list(self._components),
         }

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -820,6 +820,19 @@ class BaseIndefiniteIntegral(Integral):
         # overwrite domains with child domains
         self.copy_domains(child)
 
+    def to_json(self):
+        var = self.integration_variable[0]
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": [self.children[0], var],
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["children"][1])
+
     def _evaluate_for_shape(self):
         return self.children[0].evaluate_for_shape()
 
@@ -1263,9 +1276,22 @@ class ExplicitTimeIntegral(UnaryOperator):
         super().__init__("explicit time integral", children)
         self.initial_condition = initial_condition
 
+    def to_json(self):
+        """Convert ExplicitTimeIntegral to JSON for serialisation.
+
+        Routes ``initial_condition`` through the children list so the kernel
+        encodes/decodes it as a Symbol rather than a bare scalar field.
+        """
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": [self.children[0], self.initial_condition],
+        }
+
     @classmethod
     def _from_json(cls, snippet: dict):
-        return cls(snippet["children"][0], snippet["initial_condition"])
+        return cls(snippet["children"][0], snippet["children"][1])
 
     def _unary_new_copy(self, child, perform_simplifications=True):
         return self.__class__(child, self.initial_condition)
@@ -1276,20 +1302,6 @@ class ExplicitTimeIntegral(UnaryOperator):
 
     def is_constant(self):
         return False
-
-    def to_json(self):
-        """
-        Convert ExplicitTimeIntegral to json for serialisation.
-
-        Both `children` and `initial_condition` contain Symbols, and are therefore
-        dealt with by `pybamm.Serialise._SymbolEncoder.default()` directly.
-        """
-        json_dict = {
-            "name": self.name,
-            "id": self.id,
-        }
-
-        return json_dict
 
 
 class BoundaryGradient(BoundaryOperator):
@@ -1342,6 +1354,18 @@ class EvaluateAt(SpatialOperator):
         }
 
         super().__init__("evaluate", child, domains)
+
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": [self.children[0], self.position],
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["children"][1])
 
     def set_id(self):
         """See :meth:`pybamm.Symbol.set_id()`"""

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -459,7 +459,6 @@ class Index(UnaryOperator):
 
         json_dict = {
             "name": self.name,
-            "id": self.id,
             "index": {
                 "start": self.slice.start,
                 "stop": self.slice.stop,
@@ -504,7 +503,7 @@ class SpatialOperator(UnaryOperator):
     _json_extra_fields: tuple[str, ...] = ()
 
     def to_json(self):
-        json_dict = {"name": self.name, "id": self.id, "domains": self.domains}
+        json_dict = {"name": self.name, "domains": self.domains}
         for field in self._json_extra_fields:
             json_dict[field] = getattr(self, field)
         return json_dict
@@ -824,7 +823,6 @@ class BaseIndefiniteIntegral(Integral):
         var = self.integration_variable[0]
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": [self.children[0], var],
         }
@@ -1048,7 +1046,6 @@ class OneDimensionalIntegral(BoundaryIntegral):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "integration_domain": self.integration_domain,
             "direction": self.direction,
@@ -1104,7 +1101,6 @@ class DeltaFunction(SpatialOperator):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "side": self.side,
             "domain": self.domains["primary"],
@@ -1284,7 +1280,6 @@ class ExplicitTimeIntegral(UnaryOperator):
         """
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": [self.children[0], self.initial_condition],
         }
@@ -1358,7 +1353,6 @@ class EvaluateAt(SpatialOperator):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": [self.children[0], self.position],
         }
@@ -1493,7 +1487,6 @@ class Magnitude(UnaryOperator):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "direction": self.direction,
         }

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -1490,6 +1490,18 @@ class Magnitude(UnaryOperator):
         super().__init__("magnitude" + f"({direction})", child)
         self.direction = direction
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "direction": self.direction,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["direction"])
+
     def _unary_new_copy(self, child, perform_simplifications=True):
         """See :meth:`UnaryOperator._unary_new_copy()`."""
         return self.__class__(child, self.direction)

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -500,18 +500,19 @@ class SpatialOperator(UnaryOperator):
     ):
         super().__init__(name, child, domains)
 
+    # Names of __init__ args (besides the child) to serialise; subclasses set this.
+    _json_extra_fields: tuple[str, ...] = ()
+
     def to_json(self):
-        raise NotImplementedError(
-            "pybamm.SpatialOperator:"
-            "Serialisation is only implemented for discretised models."
-        )
+        json_dict = {"name": self.name, "id": self.id, "domains": self.domains}
+        for field in self._json_extra_fields:
+            json_dict[field] = getattr(self, field)
+        return json_dict
 
     @classmethod
     def _from_json(cls, snippet):
-        raise NotImplementedError(
-            "pybamm.SpatialOperator:"
-            "Please use a discretised model when reading in from JSON."
-        )
+        kwargs = {f: snippet[f] for f in cls._json_extra_fields}
+        return cls(snippet["children"][0], **kwargs)
 
 
 class Gradient(SpatialOperator):
@@ -900,6 +901,8 @@ class DefiniteIntegralVector(SpatialOperator):
         Whether to return a row or column vector (default is row)
     """
 
+    _json_extra_fields = ("vector_type",)
+
     def __init__(self, child, vector_type="row"):
         name = "basis integral"
         self.vector_type = vector_type
@@ -950,6 +953,8 @@ class BoundaryIntegral(SpatialOperator):
         carried out over the appropriate part of the boundary corresponding to
         the tab.
     """
+
+    _json_extra_fields = ("region",)
 
     def __init__(self, child, region="entire"):
         # boundary integral removes domains
@@ -1027,6 +1032,25 @@ class OneDimensionalIntegral(BoundaryIntegral):
         self.name = name
         self.domains = {}
 
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "integration_domain": self.integration_domain,
+            "direction": self.direction,
+            "region": self.region,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(
+            snippet["children"][0],
+            snippet["integration_domain"],
+            snippet["direction"],
+            region=snippet["region"],
+        )
+
     def set_id(self):
         """See :meth:`pybamm.Symbol.set_id()`"""
         self._id = hash(
@@ -1063,6 +1087,19 @@ class DeltaFunction(SpatialOperator):
         if child.domain != []:
             domains["secondary"] = child.domain
         super().__init__("delta_function", child, domains)
+
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "side": self.side,
+            "domain": self.domains["primary"],
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["side"], snippet["domain"])
 
     def set_id(self):
         """See :meth:`pybamm.Symbol.set_id()`"""
@@ -1164,6 +1201,8 @@ class BoundaryValue(BoundaryOperator):
         spatial method. Can be "constant", "linear" or "quadratic".
     """
 
+    _json_extra_fields = ("side", "order")
+
     def __init__(self, child, side, order=None):
         super().__init__("boundary value", child, side)
         self.order = order
@@ -1212,6 +1251,8 @@ class BoundaryMeshSize(BoundaryOperator):
     side : str
         Which side to take the boundary value on ("left" or "right")
     """
+
+    _json_extra_fields = ("side",)
 
     def __init__(self, child, side):
         super().__init__("boundary mesh size", child, side)
@@ -1266,6 +1307,8 @@ class BoundaryGradient(BoundaryOperator):
         The order of the boundary gradient. If None, the order is determined by the
         spatial method. Can be "constant", "linear" or "quadratic".
     """
+
+    _json_extra_fields = ("side", "order")
 
     def __init__(self, child, side, order=None):
         super().__init__("boundary flux", child, side)
@@ -1361,6 +1404,8 @@ class UpwindDownwind2D(UpwindDownwind):
     Usually to be used for better stability in convection-dominated equations.
     """
 
+    _json_extra_fields = ("lr_direction", "tb_direction")
+
     def __init__(self, child, lr_direction, tb_direction):
         super().__init__("upwind_downwind_2d", child)
         self.lr_direction = lr_direction
@@ -1383,6 +1428,8 @@ class NodeToEdge2D(SpatialOperator):
     direction : str
         The direction for the edges: "lr" (left-right) or "tb" (top-bottom)
     """
+
+    _json_extra_fields = ("direction",)
 
     def __init__(self, child, direction):
         if direction not in ("lr", "tb"):

--- a/src/pybamm/expression_tree/variable.py
+++ b/src/pybamm/expression_tree/variable.py
@@ -155,11 +155,25 @@ class VariableBase(pybamm.Symbol):
         else:
             return self.name
 
-    def to_json(
-        self,
-    ):
-        raise NotImplementedError(
-            "pybamm.Variable: Serialisation is only implemented for discretised models."
+    def to_json(self):
+        return {
+            "name": self.name,
+            "id": self.id,
+            "domains": self.domains,
+            "children": [self._scale, self._reference, self.bounds[0], self.bounds[1]],
+            "print_name": self._raw_print_name,
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        scale, reference, lower, upper = snippet["children"]
+        return cls(
+            snippet["name"],
+            domains=snippet["domains"],
+            scale=scale,
+            reference=reference,
+            bounds=(lower, upper),
+            print_name=snippet["print_name"],
         )
 
 

--- a/src/pybamm/expression_tree/variable.py
+++ b/src/pybamm/expression_tree/variable.py
@@ -158,7 +158,6 @@ class VariableBase(pybamm.Symbol):
     def to_json(self):
         return {
             "name": self.name,
-            "id": self.id,
             "domains": self.domains,
             "children": [self._scale, self._reference, self.bounds[0], self.bounds[1]],
             "print_name": self._raw_print_name,

--- a/src/pybamm/expression_tree/variable.py
+++ b/src/pybamm/expression_tree/variable.py
@@ -166,14 +166,28 @@ class VariableBase(pybamm.Symbol):
 
     @classmethod
     def _from_json(cls, snippet):
-        scale, reference, lower, upper = snippet["children"]
+        children = snippet.get("children") or []
+        if len(children) == 4:
+            # Kernel-era shape: scale/reference/bounds carried as children.
+            scale, reference, lower, upper = children
+            bounds = (lower, upper)
+        else:
+            # Legacy compact shape: scale/reference defaulted, bounds stored as a
+            # top-level [lower, upper] pair of (undecoded) nodes, or None for the
+            # default. The kernel only decodes "children", so decode bounds here.
+            from pybamm.expression_tree.operations.serialise_kernel import decode
+
+            scale = reference = None
+            bounds = snippet.get("bounds")
+            if bounds is not None:
+                bounds = tuple(decode(b) for b in bounds)
         return cls(
             snippet["name"],
             domains=snippet["domains"],
             scale=scale,
             reference=reference,
-            bounds=(lower, upper),
-            print_name=snippet["print_name"],
+            bounds=bounds,
+            print_name=snippet.get("print_name"),
         )
 
 

--- a/src/pybamm/expression_tree/vector_field.py
+++ b/src/pybamm/expression_tree/vector_field.py
@@ -31,6 +31,11 @@ class VectorField(TensorField):
         # Override the name to maintain backward compatibility
         self.name = "vector_field"
 
+    @classmethod
+    def _from_json(cls, snippet):
+        # Two positional args, not a single list -- override TensorField._from_json.
+        return cls(snippet["children"][0], snippet["children"][1])
+
     @property
     def lr_field(self):
         """The left-right (x) component of the vector field."""

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -2333,15 +2333,13 @@ class BaseModel:
             ``custom_variables``, ``removed_variables``, and/or
             ``events``.
         """
-        from pybamm.expression_tree.operations.serialise import (
-            convert_symbol_from_json,
-        )
+        from pybamm.expression_tree.operations.serialise import _require_symbol
 
         # --- Custom variables ---
         extra = data.get("custom_variables")
         if extra:
             for name, expr_json in extra.items():
-                model.variables[name] = convert_symbol_from_json(expr_json)
+                model.variables[name] = _require_symbol(expr_json)
 
         # --- Removed variables ---
         removed = data.get("removed_variables")
@@ -2355,7 +2353,7 @@ class BaseModel:
             model.events = [
                 pybamm.Event(
                     e["name"],
-                    convert_symbol_from_json(e["expression"]),
+                    _require_symbol(e["expression"]),
                     EventType(e["event_type"])
                     if isinstance(e["event_type"], int)
                     else e["event_type"],

--- a/tests/strategies/symbols.py
+++ b/tests/strategies/symbols.py
@@ -778,7 +778,7 @@ def _tensor_field_branch(
     """TensorField from a flat list of domain-free Symbols.
 
     Rank-1 ONLY: the components are a flat list of Symbols, never a nested
-    list-of-lists. Rank-2 TensorField is intentionally unsupported in PR1.
+    list-of-lists. Rank-2 TensorField serialisation is intentionally unsupported.
     """
     return st.builds(
         pybamm.TensorField,

--- a/tests/strategies/symbols.py
+++ b/tests/strategies/symbols.py
@@ -205,16 +205,6 @@ def _boundary_value_branch(
     )
 
 
-def _boundary_gradient_branch(
-    child_strategy: st.SearchStrategy[pybamm.Symbol],
-) -> st.SearchStrategy[pybamm.BoundaryGradient]:
-    return st.builds(
-        pybamm.BoundaryGradient,
-        child_strategy,
-        st.sampled_from(["left", "right"]),
-    )
-
-
 # Non-empty domains only — FullBroadcast and PrimaryBroadcast both reject [].
 _NONEMPTY_DOMAINS = st.sampled_from(
     [
@@ -257,7 +247,11 @@ def _constant_strategy() -> st.SearchStrategy[pybamm.Constant]:
 
 def _coupled_variable_strategy() -> st.SearchStrategy[pybamm.CoupledVariable]:
     """A variable whose equation is set by another model/submodel."""
-    return st.builds(pybamm.CoupledVariable, _NAMES)
+    return st.builds(
+        pybamm.CoupledVariable,
+        _NAMES,
+        domain=st.sampled_from([[], ["negative electrode"], ["separator"]]),
+    )
 
 
 def _spatial_variable_strategy() -> st.SearchStrategy[pybamm.SpatialVariable]:
@@ -548,6 +542,313 @@ def _vector_field_branch(
     return _FIELD_DOMAINS.flatmap(make_vf)
 
 
+# Sides shared by boundary operators.
+_SIDES = st.sampled_from(["left", "right"])
+
+
+def _backward_indefinite_integral_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.BackwardIndefiniteIntegral]:
+    """BackwardIndefiniteIntegral: integrates a domain-bearing child w.r.t. its spatial var."""
+
+    def make_backward(child: pybamm.Symbol) -> pybamm.BackwardIndefiniteIntegral:
+        x = pybamm.SpatialVariable("x", domain=child.domain)
+        return pybamm.BackwardIndefiniteIntegral(child, x)
+
+    return _electrode_domain_leaves().map(make_backward)
+
+
+def _boundary_gradient_branch(
+    child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.BoundaryGradient]:
+    """BoundaryGradient(child, side) — child must have a non-empty domain."""
+    return st.builds(pybamm.BoundaryGradient, _any_domain_leaves(), _SIDES)
+
+
+def _boundary_mesh_size_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.BoundaryMeshSize]:
+    """BoundaryMeshSize(child, side) — child must have a non-empty domain."""
+    return st.builds(pybamm.BoundaryMeshSize, _any_domain_leaves(), _SIDES)
+
+
+def _boundary_integral_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.BoundaryIntegral]:
+    """BoundaryIntegral(child, region) — exercises both default and non-default regions."""
+    return st.builds(
+        pybamm.BoundaryIntegral,
+        _any_domain_leaves(),
+        st.sampled_from(["entire", "negative tab", "positive tab"]),
+    )
+
+
+def _explicit_time_integral_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.ExplicitTimeIntegral]:
+    """ExplicitTimeIntegral(child, initial_condition) — initial_condition a Scalar."""
+    return st.builds(
+        pybamm.ExplicitTimeIntegral,
+        _any_domain_leaves(),
+        scalar_strategy(),
+    )
+
+
+def _index_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.Index]:
+    """Index(StateVector, index) — check_size disabled so any index builds cleanly."""
+    return st.builds(
+        pybamm.Index,
+        st.just(pybamm.StateVector(slice(0, 1))),
+        st.just(0),
+        check_size=st.just(False),
+    )
+
+
+def _delta_function_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.DeltaFunction]:
+    """DeltaFunction(child, side, domain) — child domain must differ from the target domain."""
+    return st.builds(
+        pybamm.DeltaFunction,
+        _neg_electrode_leaves(),
+        _SIDES,
+        st.just("separator"),
+    )
+
+
+def _evaluate_at_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.EvaluateAt]:
+    """EvaluateAt(child, position) — numeric position on a domain-bearing child."""
+    return st.builds(pybamm.EvaluateAt, _any_domain_leaves(), _FINITE_FLOATS)
+
+
+def _one_dimensional_integral_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.OneDimensionalIntegral]:
+    """OneDimensionalIntegral(child, integration_domain, direction)."""
+
+    def make_odi(child: pybamm.Symbol) -> pybamm.OneDimensionalIntegral:
+        return pybamm.OneDimensionalIntegral(child, child.domain, "x")
+
+    return _electrode_domain_leaves().map(make_odi)
+
+
+def _upwind_downwind_2d_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.UpwindDownwind2D]:
+    """UpwindDownwind2D(child, lr_direction, tb_direction) — domain-bearing child."""
+    return st.builds(
+        pybamm.UpwindDownwind2D,
+        _any_domain_leaves(),
+        st.sampled_from(["upwind", "downwind"]),
+        st.sampled_from(["upwind", "downwind"]),
+    )
+
+
+def _node_to_edge_2d_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.NodeToEdge2D]:
+    """NodeToEdge2D(child, direction) — domain-bearing node child (not on edges)."""
+    return st.builds(
+        pybamm.NodeToEdge2D,
+        _any_domain_leaves(),
+        st.sampled_from(["lr", "tb"]),
+    )
+
+
+def _magnitude_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.Magnitude]:
+    """Magnitude(child, direction) — domain-bearing child, directional component."""
+    return st.builds(
+        pybamm.Magnitude,
+        _any_domain_leaves(),
+        st.sampled_from(["x", "y", "z"]),
+    )
+
+
+def _discrete_time_sum_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.DiscreteTimeSum]:
+    """DiscreteTimeSum: built around a DiscreteTimeData child."""
+    return st.builds(pybamm.DiscreteTimeSum, _discrete_time_data_branch(None))
+
+
+def _size_average_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.SizeAverage]:
+    """SizeAverage(child, f_a_dist) — child on a particle-size domain."""
+    child = st.builds(
+        pybamm.Variable,
+        _NAMES,
+        domains=st.sampled_from(
+            [
+                {"primary": ["negative particle size"]},
+                {"primary": ["positive particle size"]},
+            ]
+        ),
+    )
+    return st.builds(pybamm.SizeAverage, child, scalar_strategy())
+
+
+def _primary_broadcast_to_edges_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.PrimaryBroadcastToEdges]:
+    """PrimaryBroadcastToEdges — mirror PrimaryBroadcast with a domain-free child."""
+    return st.builds(
+        pybamm.PrimaryBroadcastToEdges,
+        _domain_free_leaves(),
+        _NONEMPTY_DOMAINS,
+    )
+
+
+def _secondary_broadcast_to_edges_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.SecondaryBroadcastToEdges]:
+    """SecondaryBroadcastToEdges — particle child broadcast to an electrode."""
+    return st.builds(
+        pybamm.SecondaryBroadcastToEdges,
+        _neg_particle_leaves(),
+        st.just(["negative electrode"]),
+    )
+
+
+def _tertiary_secondary_leaves() -> st.SearchStrategy[pybamm.Symbol]:
+    """Variable leaves with primary + secondary domains (valid TertiaryBroadcast child)."""
+    return st.builds(
+        pybamm.Variable,
+        _NAMES,
+        domains=st.just(
+            {"primary": ["negative particle"], "secondary": ["negative electrode"]}
+        ),
+    )
+
+
+def _tertiary_broadcast_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.TertiaryBroadcast]:
+    """TertiaryBroadcast — child with primary+secondary domains broadcast to a tertiary."""
+    return st.builds(
+        pybamm.TertiaryBroadcast,
+        _tertiary_secondary_leaves(),
+        st.just(["current collector"]),
+    )
+
+
+def _tertiary_broadcast_to_edges_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.TertiaryBroadcastToEdges]:
+    """TertiaryBroadcastToEdges — as TertiaryBroadcast but to edges."""
+    return st.builds(
+        pybamm.TertiaryBroadcastToEdges,
+        _tertiary_secondary_leaves(),
+        st.just(["current collector"]),
+    )
+
+
+def _full_broadcast_to_edges_branch(
+    child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.FullBroadcastToEdges]:
+    """FullBroadcastToEdges — mirror FullBroadcast with a non-empty target domain."""
+    return st.builds(
+        pybamm.FullBroadcastToEdges,
+        child_strategy,
+        _NONEMPTY_DOMAINS,
+    )
+
+
+def _heaviside_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[_HeavisideClass]:
+    """_Heaviside(name, left, right) — semi-private base from two domain-free leaves."""
+    return st.builds(
+        _HeavisideClass,
+        _NAMES,
+        _domain_free_leaves(),
+        _domain_free_leaves(),
+    )
+
+
+def _tensor_field_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.TensorField]:
+    """TensorField from a flat list of domain-free Symbols.
+
+    Rank-1 ONLY: the components are a flat list of Symbols, never a nested
+    list-of-lists. Rank-2 TensorField is intentionally unsupported in PR1.
+    """
+    return st.builds(
+        pybamm.TensorField,
+        st.lists(_domain_free_leaves(), min_size=1, max_size=3),
+    )
+
+
+def _state_vector_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.StateVector]:
+    """StateVector with a sampled y-slice."""
+    return st.builds(pybamm.StateVector, st.sampled_from([slice(0, 1), slice(0, 2)]))
+
+
+def _state_vector_dot_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.StateVectorDot]:
+    """StateVectorDot with a sampled y-slice."""
+    return st.builds(pybamm.StateVectorDot, st.sampled_from([slice(0, 1), slice(0, 2)]))
+
+
+def _variable_dot_strategy() -> st.SearchStrategy[pybamm.VariableDot]:
+    """VariableDot — like Variable (a named, optionally domain-bearing leaf)."""
+    return st.builds(
+        pybamm.VariableDot,
+        _NAMES,
+        domain=_DOMAINS,
+    )
+
+
+def _spatial_variable_edge_strategy() -> st.SearchStrategy[pybamm.SpatialVariableEdge]:
+    """SpatialVariableEdge — like SpatialVariable but the Edge subclass."""
+    safe_names = st.sampled_from(["x", "y", "z"])
+    safe_domains = st.sampled_from(
+        [
+            ["negative electrode"],
+            ["positive electrode"],
+            ["separator"],
+            ["current collector"],
+        ]
+    )
+    return st.builds(pybamm.SpatialVariableEdge, safe_names, domain=safe_domains)
+
+
+# Small fixed 2x2 / 2x1 numpy arrays for Array/Matrix/Vector leaves.
+_SMALL_MATRIX = st.just(np.array([[1.0, 2.0], [3.0, 4.0]]))
+_SMALL_VECTOR = st.just(np.array([[1.0], [2.0]]))
+
+
+def _array_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.Array]:
+    """Array leaf from a fixed small numpy array."""
+    return st.builds(pybamm.Array, _SMALL_MATRIX)
+
+
+def _matrix_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.Matrix]:
+    """Matrix leaf from a fixed small numpy array."""
+    return st.builds(pybamm.Matrix, _SMALL_MATRIX)
+
+
+def _vector_branch(
+    _child_strategy: st.SearchStrategy[pybamm.Symbol],
+) -> st.SearchStrategy[pybamm.Vector]:
+    """Vector leaf from a fixed small column numpy array."""
+    return st.builds(pybamm.Vector, _SMALL_VECTOR)
+
+
 # Register branches in the lookup table. Each value is a callable that
 # takes the child strategy and returns a strategy for that node.
 _STRATEGIES.update(
@@ -652,8 +953,10 @@ _STRATEGIES.update(
         pybamm.BoundaryMass: lambda _children: _any_domain_leaves().map(
             pybamm.BoundaryMass
         ),
-        pybamm.DefiniteIntegralVector: lambda _children: _any_domain_leaves().map(
-            pybamm.DefiniteIntegralVector
+        pybamm.DefiniteIntegralVector: lambda _children: st.builds(
+            pybamm.DefiniteIntegralVector,
+            _any_domain_leaves(),
+            vector_type=st.sampled_from(["row", "column"]),
         ),
         # Upwind / Downwind: (self, child) only — round-trip via generic fallback.
         # Both require non-empty-domain children.
@@ -664,6 +967,36 @@ _STRATEGIES.update(
         pybamm.Divergence: lambda _children: _any_domain_leaves().map(
             lambda leaf: pybamm.Divergence(pybamm.Gradient(leaf))
         ),
+        # formerly-failing classes (#5548): now round-trip through the kernel
+        pybamm.BackwardIndefiniteIntegral: _backward_indefinite_integral_branch,
+        pybamm.BoundaryGradient: _boundary_gradient_branch,
+        pybamm.BoundaryMeshSize: _boundary_mesh_size_branch,
+        pybamm.BoundaryIntegral: _boundary_integral_branch,
+        pybamm.OneDimensionalIntegral: _one_dimensional_integral_branch,
+        pybamm.ExplicitTimeIntegral: _explicit_time_integral_branch,
+        pybamm.Index: _index_branch,
+        pybamm.DeltaFunction: _delta_function_branch,
+        pybamm.EvaluateAt: _evaluate_at_branch,
+        pybamm.UpwindDownwind2D: _upwind_downwind_2d_branch,
+        pybamm.NodeToEdge2D: _node_to_edge_2d_branch,
+        pybamm.Magnitude: _magnitude_branch,
+        pybamm.DiscreteTimeData: _discrete_time_data_branch,
+        pybamm.DiscreteTimeSum: _discrete_time_sum_branch,
+        pybamm.SizeAverage: _size_average_branch,
+        pybamm.PrimaryBroadcastToEdges: _primary_broadcast_to_edges_branch,
+        pybamm.SecondaryBroadcastToEdges: _secondary_broadcast_to_edges_branch,
+        pybamm.TertiaryBroadcast: _tertiary_broadcast_branch,
+        pybamm.TertiaryBroadcastToEdges: _tertiary_broadcast_to_edges_branch,
+        pybamm.FullBroadcastToEdges: _full_broadcast_to_edges_branch,
+        _HeavisideClass: _heaviside_branch,
+        pybamm.TensorField: _tensor_field_branch,
+        pybamm.StateVector: _state_vector_branch,
+        pybamm.StateVectorDot: _state_vector_dot_branch,
+        pybamm.VariableDot: lambda _children: _variable_dot_strategy(),
+        pybamm.SpatialVariableEdge: lambda _children: _spatial_variable_edge_strategy(),
+        pybamm.Array: _array_branch,
+        pybamm.Matrix: _matrix_branch,
+        pybamm.Vector: _vector_branch,
     }
 )
 
@@ -701,41 +1034,9 @@ _NOT_ROUND_TRIPPABLE: frozenset[type[pybamm.Symbol]] = frozenset(
 # a defect in convert_symbol_to_json / convert_symbol_from_json (tracked in
 # #5548). When the serialiser is fixed for a class, move it out of this set and
 # into _STRATEGIES so the property test guards it against regressions.
-# (The Variable.scale/reference and FullBroadcast.name shapes additionally have
-# strict xfail tripwires in TestKnownSymbolSerialiserBugs.)
-_KNOWN_FAILING: frozenset[type[pybamm.Symbol]] = frozenset(
-    {
-        pybamm.BackwardIndefiniteIntegral,  # from_json missing case (calls generic fallback, drops integration_variable)
-        pybamm.BoundaryGradient,  # from_json missing case (drops 'side' arg)
-        pybamm.DiscreteTimeData,  # from_json generic fallback drops 'data' and 'name' args
-        pybamm.ExplicitTimeIntegral,  # from_json generic fallback drops initial_condition
-        pybamm.Index,  # from_json generic fallback drops 'index' positional arg
-        pybamm.BoundaryIntegral,  # round-trips for default region, loses non-default region arg
-        pybamm.VariableDot,  # generic fallback loses the 'name' positional arg; convert_symbol_from_json raises TypeError
-        pybamm.StateVector,  # generic fallback writes children=[] and loses y_slices; from_json fails
-        pybamm.StateVectorDot,  # same as StateVector
-        pybamm.Array,  # generic fallback loses 'entries'; dedicated Serialise.to_json exists but not for round-trip func
-        pybamm.Matrix,  # same as Array
-        pybamm.Vector,  # same as Array
-        pybamm.BoundaryMeshSize,  # generic fallback loses 'side' positional arg; from_json fails
-        pybamm.OneDimensionalIntegral,  # complex constructor (integration_domain, direction); no from_json case
-        pybamm.DeltaFunction,  # requires explicit side + domain args not in generic fallback
-        pybamm.EvaluateAt,  # requires position arg; from_json generic fallback loses it
-        pybamm.UpwindDownwind2D,  # requires lr_direction + tb_direction; no from_json case
-        pybamm.NodeToEdge2D,  # requires direction arg and domain-bearing child; no from_json case
-        pybamm.Magnitude,  # requires direction arg; generic fallback loses it
-        pybamm.DiscreteTimeSum,  # requires DiscreteTimeData child; from_json generic fails
-        pybamm.SizeAverage,  # requires f_a_dist arg; from_json generic loses it
-        pybamm.PrimaryBroadcastToEdges,  # serialises as PrimaryBroadcast; loses subclass
-        pybamm.SecondaryBroadcastToEdges,  # serialises as SecondaryBroadcast; loses subclass
-        pybamm.TertiaryBroadcast,  # from_json generic needs broadcast_domain positional arg; fails
-        pybamm.TertiaryBroadcastToEdges,  # same as TertiaryBroadcast
-        pybamm.FullBroadcastToEdges,  # serialises as FullBroadcast; loses subclass
-        pybamm.TensorField,  # from_json does pybamm.TensorField(*children) but ctor needs list
-        pybamm.SpatialVariableEdge,  # convert_symbol_from_json dispatches to SpatialVariable, not Edge
-        _HeavisideClass,  # semi-private; from_json generic loses 'right' kwarg
-    }
-)
+# The unified kernel (#5548) closed every former defect, so this set is empty:
+# all formerly-failing classes now have a strategy in _STRATEGIES.
+_KNOWN_FAILING: frozenset[type[pybamm.Symbol]] = frozenset()
 
 # Union consumed by the coverage meta-test: every concrete Symbol subclass must
 # be in _STRATEGIES or excluded here.

--- a/tests/strategies/symbols.py
+++ b/tests/strategies/symbols.py
@@ -942,8 +942,8 @@ _STRATEGIES.update(
         pybamm.RAverage: _r_average_branch,
         # vector/tensor fields
         pybamm.VectorField: _vector_field_branch,
-        # spatial unary operators: round-trip via the generic fallback;
-        # all require a non-empty-domain child (DomainError otherwise)
+        # spatial unary operators: child-only, round-trip via the generic spatial
+        # hook; all require a non-empty-domain child (DomainError otherwise)
         pybamm.Gradient: lambda _children: _any_domain_leaves().map(pybamm.Gradient),
         pybamm.Laplacian: lambda _children: _any_domain_leaves().map(pybamm.Laplacian),
         pybamm.GradientSquared: lambda _children: _any_domain_leaves().map(
@@ -958,16 +958,16 @@ _STRATEGIES.update(
             _any_domain_leaves(),
             vector_type=st.sampled_from(["row", "column"]),
         ),
-        # Upwind / Downwind: (self, child) only — round-trip via generic fallback.
+        # Upwind / Downwind: (self, child) only — round-trip via the generic spatial hook.
         # Both require non-empty-domain children.
         pybamm.Upwind: lambda _children: _any_domain_leaves().map(pybamm.Upwind),
         pybamm.Downwind: lambda _children: _any_domain_leaves().map(pybamm.Downwind),
         # Divergence needs an edge-evaluating child, so wrap a domain-bearing
-        # leaf in a Gradient. Round-trips correctly via the generic fallback.
+        # leaf in a Gradient. Round-trips via the generic spatial hook.
         pybamm.Divergence: lambda _children: _any_domain_leaves().map(
             lambda leaf: pybamm.Divergence(pybamm.Gradient(leaf))
         ),
-        # formerly-failing classes (#5548): now round-trip through the kernel
+        # classes with non-children constructor args; serialise losslessly (#5548)
         pybamm.BackwardIndefiniteIntegral: _backward_indefinite_integral_branch,
         pybamm.BoundaryGradient: _boundary_gradient_branch,
         pybamm.BoundaryMeshSize: _boundary_mesh_size_branch,
@@ -1030,12 +1030,10 @@ _NOT_ROUND_TRIPPABLE: frozenset[type[pybamm.Symbol]] = frozenset(
     }
 )
 
-# Concrete classes that should round-trip but currently do not, each because of
-# a defect in convert_symbol_to_json / convert_symbol_from_json (tracked in
-# #5548). When the serialiser is fixed for a class, move it out of this set and
-# into _STRATEGIES so the property test guards it against regressions.
-# The unified kernel (#5548) closed every former defect, so this set is empty:
-# all formerly-failing classes now have a strategy in _STRATEGIES.
+# Concrete classes known not to round-trip, tracked so the coverage meta-test
+# tolerates them. Empty: every concrete Symbol subclass has a strategy in
+# _STRATEGIES and round-trips losslessly (#5548). A class that regresses here
+# should be fixed, not re-added.
 _KNOWN_FAILING: frozenset[type[pybamm.Symbol]] = frozenset()
 
 # Union consumed by the coverage meta-test: every concrete Symbol subclass must

--- a/tests/strategies/symbols.py
+++ b/tests/strategies/symbols.py
@@ -755,7 +755,7 @@ def _full_broadcast_to_edges_branch(
     """FullBroadcastToEdges — mirror FullBroadcast with a non-empty target domain."""
     return st.builds(
         pybamm.FullBroadcastToEdges,
-        child_strategy,
+        child_strategy.filter(lambda c: c.domain != ["current collector"]),
         _NONEMPTY_DOMAINS,
     )
 

--- a/tests/strategies/symbols.py
+++ b/tests/strategies/symbols.py
@@ -775,15 +775,16 @@ def _heaviside_branch(
 def _tensor_field_branch(
     _child_strategy: st.SearchStrategy[pybamm.Symbol],
 ) -> st.SearchStrategy[pybamm.TensorField]:
-    """TensorField from a flat list of domain-free Symbols.
-
-    Rank-1 ONLY: the components are a flat list of Symbols, never a nested
-    list-of-lists. Rank-2 TensorField serialisation is intentionally unsupported.
-    """
-    return st.builds(
-        pybamm.TensorField,
-        st.lists(_domain_free_leaves(), min_size=1, max_size=3),
+    """TensorField of rank 1 (flat list) or rank 2 (list of equal-length rows)."""
+    rank_1 = st.lists(_domain_free_leaves(), min_size=1, max_size=3)
+    rank_2 = st.integers(min_value=1, max_value=3).flatmap(
+        lambda n_cols: st.lists(
+            st.lists(_domain_free_leaves(), min_size=n_cols, max_size=n_cols),
+            min_size=1,
+            max_size=3,
+        )
     )
+    return st.builds(pybamm.TensorField, st.one_of(rank_1, rank_2))
 
 
 def _state_vector_branch(

--- a/tests/unit/test_expression_tree/test_array.py
+++ b/tests/unit/test_expression_tree/test_array.py
@@ -43,7 +43,6 @@ class TestArray:
 
         json_dict = {
             "name": "Array of shape (3, 1)",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],

--- a/tests/unit/test_expression_tree/test_binary_operators.py
+++ b/tests/unit/test_expression_tree/test_binary_operators.py
@@ -855,7 +855,6 @@ class TestBinaryOperators:
         # Test Addition
         add_json = {
             "name": "+",
-            "id": mocker.ANY,
             "domains": EMPTY_DOMAINS,
         }
         add = pybamm.Addition(2, 4)
@@ -868,7 +867,6 @@ class TestBinaryOperators:
         # Test Power
         pow_json = {
             "name": "**",
-            "id": mocker.ANY,
             "domains": EMPTY_DOMAINS,
         }
 
@@ -881,7 +879,6 @@ class TestBinaryOperators:
         # Test Division
         div_json = {
             "name": "/",
-            "id": mocker.ANY,
             "domains": EMPTY_DOMAINS,
         }
 
@@ -894,7 +891,6 @@ class TestBinaryOperators:
         # Test EqualHeaviside
         equal_json = {
             "name": "<=",
-            "id": mocker.ANY,
             "domains": EMPTY_DOMAINS,
         }
 
@@ -907,7 +903,6 @@ class TestBinaryOperators:
         # Test notEqualHeaviside
         not_equal_json = {
             "name": "<",
-            "id": mocker.ANY,
             "domains": EMPTY_DOMAINS,
         }
 

--- a/tests/unit/test_expression_tree/test_broadcasts.py
+++ b/tests/unit/test_expression_tree/test_broadcasts.py
@@ -351,4 +351,4 @@ class TestBroadcasts:
         node = b.to_json()
         assert node["broadcast_domain"] == ["separator"]
         assert node["name"] == "broadcast"
-        assert "id" in node
+        assert "id" not in node  # identity is not part of the round-trip contract

--- a/tests/unit/test_expression_tree/test_broadcasts.py
+++ b/tests/unit/test_expression_tree/test_broadcasts.py
@@ -345,11 +345,10 @@ class TestBroadcasts:
         assert isinstance(d, pybamm.Scalar)
         assert d.evaluate(y=y) == 0
 
-    def test_to_from_json_error(self):
-        a = pybamm.StateVector(slice(0, 1))
-        b = pybamm.PrimaryBroadcast(a, "separator")
-        with pytest.raises(NotImplementedError):
-            b.to_json()
-
-        with pytest.raises(NotImplementedError):
-            pybamm.PrimaryBroadcast._from_json({})
+    def test_to_json_emits_broadcast_domain_and_name(self):
+        # Verify that to_json emits the expected fields (kernel contract).
+        b = pybamm.PrimaryBroadcast(pybamm.Scalar(1.0), "separator")
+        node = b.to_json()
+        assert node["broadcast_domain"] == ["separator"]
+        assert node["name"] == "broadcast"
+        assert "id" in node

--- a/tests/unit/test_expression_tree/test_concatenations.py
+++ b/tests/unit/test_expression_tree/test_concatenations.py
@@ -401,7 +401,6 @@ class TestConcatenations:
 
         json_dict = {
             "name": "domain_concatenation",
-            "id": mocker.ANY,
             "domains": {
                 "primary": ["negative electrode", "separator", "positive electrode"],
                 "secondary": [],
@@ -444,7 +443,6 @@ class TestConcatenations:
 
         np_json = {
             "name": "numpy_concatenation",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],

--- a/tests/unit/test_expression_tree/test_functions.py
+++ b/tests/unit/test_expression_tree/test_functions.py
@@ -203,7 +203,6 @@ class TestFunction:
 
         input_json = {
             "name": "arcsinh2",
-            "id": mocker.ANY,
             "function": "arcsinh2",
             "children": [a, b],
             "eps": eps,
@@ -307,7 +306,6 @@ class TestSpecificFunctions:
 
         expected_json = {
             "name": "function (cos)",
-            "id": mocker.ANY,
             "function": "cos",
         }
 
@@ -347,7 +345,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "arcsinh",
-            "id": mocker.ANY,
             "function": "arcsinh",
             "children": [a],
         }
@@ -371,7 +368,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "arctan",
-            "id": mocker.ANY,
             "function": "arctan",
             "children": [a],
         }
@@ -396,7 +392,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "cos",
-            "id": mocker.ANY,
             "function": "cos",
             "children": [a],
         }
@@ -421,7 +416,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "cosh",
-            "id": mocker.ANY,
             "function": "cosh",
             "children": [a],
         }
@@ -446,7 +440,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "exp",
-            "id": mocker.ANY,
             "function": "exp",
             "children": [a],
         }
@@ -484,7 +477,6 @@ class TestSpecificFunctions:
         fun = pybamm.log(a)
         input_json = {
             "name": "log",
-            "id": mocker.ANY,
             "function": "log",
             "children": [a],
         }
@@ -523,7 +515,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "sin",
-            "id": mocker.ANY,
             "function": "sin",
             "children": [a],
         }
@@ -548,7 +539,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "sinh",
-            "id": mocker.ANY,
             "function": "sinh",
             "children": [a],
         }
@@ -572,7 +562,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "sqrt",
-            "id": mocker.ANY,
             "function": "sqrt",
             "children": [a],
         }
@@ -609,7 +598,6 @@ class TestSpecificFunctions:
         # test creation from json
         input_json = {
             "name": "erf",
-            "id": mocker.ANY,
             "function": "erf",
             "children": [a],
         }

--- a/tests/unit/test_expression_tree/test_input_parameter.py
+++ b/tests/unit/test_expression_tree/test_input_parameter.py
@@ -54,7 +54,6 @@ class TestInputParameter:
 
         json_dict = {
             "name": "a",
-            "id": mocker.ANY,
             "domain": [],
             "expected_size": 1,
         }

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -373,7 +373,6 @@ class TestInterpolant:
 
         expected_json = {
             "name": "interpolating_function",
-            "id": mocker.ANY,
             "x": [
                 [
                     0.0,

--- a/tests/unit/test_expression_tree/test_matrix.py
+++ b/tests/unit/test_expression_tree/test_matrix.py
@@ -41,7 +41,6 @@ class TestMatrix:
         arr = pybamm.Matrix(csr_matrix([[0, 1, 0, 0], [0, 0, 0, 1]]))
         json_dict = {
             "name": "Sparse Matrix (2, 4)",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],

--- a/tests/unit/test_expression_tree/test_parameter.py
+++ b/tests/unit/test_expression_tree/test_parameter.py
@@ -31,14 +31,18 @@ class TestParameter:
         # Test name
         assert func1.to_equation() == sympy.Symbol("test_name")
 
-    def test_to_json_error(self):
+    def test_to_from_json_round_trip(self):
+        from pybamm.expression_tree.operations.serialise import (
+            convert_symbol_from_json,
+            convert_symbol_to_json,
+        )
+
         func = pybamm.Parameter("test_string")
+        reconstructed = convert_symbol_from_json(convert_symbol_to_json(func))
 
-        with pytest.raises(NotImplementedError):
-            func.to_json()
-
-        with pytest.raises(NotImplementedError):
-            pybamm.Parameter._from_json({})
+        assert isinstance(reconstructed, pybamm.Parameter)
+        assert reconstructed.name == func.name
+        assert reconstructed.id == func.id
 
 
 class TestFunctionParameter:
@@ -118,14 +122,19 @@ class TestFunctionParameter:
         func1.print_name = None
         assert func1.to_equation() == sympy.Symbol("func")
 
-    def test_to_json_error(self):
+    def test_to_from_json_round_trip(self):
+        from pybamm.expression_tree.operations.serialise import (
+            convert_symbol_from_json,
+            convert_symbol_to_json,
+        )
+
         func = pybamm.FunctionParameter("test", {"x": pybamm.Scalar(1)})
+        reconstructed = convert_symbol_from_json(convert_symbol_to_json(func))
 
-        with pytest.raises(NotImplementedError):
-            func.to_json()
-
-        with pytest.raises(NotImplementedError):
-            pybamm.FunctionParameter._from_json({})
+        assert isinstance(reconstructed, pybamm.FunctionParameter)
+        assert reconstructed.name == func.name
+        assert reconstructed.input_names == func.input_names
+        assert reconstructed.id == func.id
 
     def test_function_parameter_post_processor(self):
         """Test that post_processor is stored and propagated correctly."""

--- a/tests/unit/test_expression_tree/test_scalar.py
+++ b/tests/unit/test_expression_tree/test_scalar.py
@@ -45,7 +45,7 @@ class TestScalar:
 
     def test_to_from_json(self, mocker):
         a = pybamm.Scalar(5)
-        json_dict = {"name": "5.0", "id": mocker.ANY, "value": 5.0}
+        json_dict = {"name": "5.0", "value": 5.0}
 
         assert a.to_json() == json_dict
 

--- a/tests/unit/test_expression_tree/test_state_vector.py
+++ b/tests/unit/test_expression_tree/test_state_vector.py
@@ -76,7 +76,6 @@ class TestStateVector:
 
         json_dict = {
             "name": "y[0:10]",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],

--- a/tests/unit/test_expression_tree/test_symbol.py
+++ b/tests/unit/test_expression_tree/test_symbol.py
@@ -563,7 +563,6 @@ class TestSymbol:
 
         json_dict = {
             "name": "parent",
-            "id": mocker.ANY,
             "domains": {
                 "primary": ["domain_3"],
                 "secondary": [],

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -854,12 +854,17 @@ class TestUnaryOperators:
         assert pybamm.Gradient._from_json(grad_json) == grad
 
         # ExplicitTimeIntegral
-        expr = pybamm.ExplicitTimeIntegral(pybamm.Parameter("param"), pybamm.Scalar(1))
+        param = pybamm.Parameter("param")
+        ic = pybamm.Scalar(1)
+        expr = pybamm.ExplicitTimeIntegral(param, ic)
 
-        expr_json = {"name": "explicit time integral", "id": mocker.ANY}
+        expr_json = {
+            "name": "explicit time integral",
+            "id": mocker.ANY,
+            "domains": expr.domains,
+            "children": [param, ic],
+        }
 
         assert expr.to_json() == expr_json
 
-        expr_json["children"] = [pybamm.Parameter("param")]
-        expr_json["initial_condition"] = [pybamm.Scalar(1)]
         assert pybamm.ExplicitTimeIntegral._from_json(expr_json) == expr

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -57,7 +57,6 @@ class TestUnaryOperators:
         # Test from_json
         input_json = {
             "name": "-",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -99,7 +98,6 @@ class TestUnaryOperators:
         # Test from_json
         input_json = {
             "name": "abs",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -152,7 +150,6 @@ class TestUnaryOperators:
         c = pybamm.Multiplication(pybamm.Variable("a"), pybamm.Scalar(random_value))
         sign_json = {
             "name": "sign",
-            "id": 5341515228900508018,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -186,7 +183,6 @@ class TestUnaryOperators:
         # Test from_json
         input_json = {
             "name": "floor",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -219,7 +215,6 @@ class TestUnaryOperators:
         # Test from_json
         input_json = {
             "name": "ceil",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -802,7 +797,6 @@ class TestUnaryOperators:
 
         un_json = {
             "name": "unary test",
-            "id": mocker.ANY,
             "domains": {
                 "primary": ["test"],
                 "secondary": [],
@@ -822,7 +816,6 @@ class TestUnaryOperators:
 
         ind_json = {
             "name": "Index[3]",
-            "id": mocker.ANY,
             "index": {"start": 3, "stop": 4, "step": None},
             "check_size": False,
         }
@@ -839,7 +832,6 @@ class TestUnaryOperators:
 
         grad_json = {
             "name": "grad",
-            "id": mocker.ANY,
             "domains": {
                 "primary": ["negative electrode"],
                 "secondary": [],
@@ -860,7 +852,6 @@ class TestUnaryOperators:
 
         expr_json = {
             "name": "explicit time integral",
-            "id": mocker.ANY,
             "domains": expr.domains,
             "children": [param, ic],
         }

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -832,13 +832,26 @@ class TestUnaryOperators:
         ind_json["children"] = [vec]
         assert pybamm.Index._from_json(ind_json) == ind
 
-        # SpatialOperator
-        spatial_vec = pybamm.SpatialOperator("name", vec)
-        with pytest.raises(NotImplementedError):
-            spatial_vec.to_json()
+        # SpatialOperator now serialises its name and domains (subclasses extend
+        # this via _json_extra_fields); a concrete subclass round-trips via the
+        # generic hook.
+        grad = pybamm.Gradient(pybamm.Variable("u", domain=["negative electrode"]))
 
-        with pytest.raises(NotImplementedError):
-            pybamm.SpatialOperator._from_json({})
+        grad_json = {
+            "name": "grad",
+            "id": mocker.ANY,
+            "domains": {
+                "primary": ["negative electrode"],
+                "secondary": [],
+                "tertiary": [],
+                "quaternary": [],
+            },
+        }
+
+        assert grad.to_json() == grad_json
+
+        grad_json["children"] = [grad.children[0]]
+        assert pybamm.Gradient._from_json(grad_json) == grad
 
         # ExplicitTimeIntegral
         expr = pybamm.ExplicitTimeIntegral(pybamm.Parameter("param"), pybamm.Scalar(1))

--- a/tests/unit/test_expression_tree/test_variable.py
+++ b/tests/unit/test_expression_tree/test_variable.py
@@ -63,10 +63,14 @@ class TestVariable:
         # Test name
         assert pybamm.Variable("name").to_equation() == sympy.Symbol("name")
 
-    def test_to_json_error(self):
-        func = pybamm.Variable("test_string")
-        with pytest.raises(NotImplementedError):
-            func.to_json()
+    def test_to_json(self):
+        func = pybamm.Variable(
+            "test_string", scale=pybamm.Scalar(2.0), reference=pybamm.Scalar(1.0)
+        )
+        rebuilt = pybamm.Variable._from_json(func.to_json())
+        assert rebuilt.id == func.id
+        assert rebuilt.scale == func.scale
+        assert rebuilt.reference == func.reference
 
 
 class TestVariableDot:

--- a/tests/unit/test_models/test_model_to_json.py
+++ b/tests/unit/test_models/test_model_to_json.py
@@ -213,13 +213,20 @@ class TestBaseModelToConfig:
             model.to_config(filename="config.txt")
 
     def test_model_with_default_bounds_variables_produces_valid_json(self):
-        """Variables (default bounds) serialise to valid JSON (no Infinity)."""
+        """Variables (default bounds) serialise to strictly valid JSON.
+
+        Non-finite floats must be carried as string sentinels, never as the
+        bare ``Infinity``/``NaN`` tokens that strict JSON parsers reject.
+        """
         model = _minimal_custom_model()
         d = model.to_json()
-        json_str = json.dumps(d)
-        assert "Infinity" not in json_str
+        # allow_nan=False raises ValueError on any bare inf/nan float
+        json_str = json.dumps(d, allow_nan=False)
         loaded = pybamm.BaseModel.from_json(json.loads(json_str))
         assert loaded.name == model.name
+        lower, upper = loaded.variables["a"].bounds
+        assert np.isneginf(lower.value)
+        assert np.isposinf(upper.value)
 
     def test_custom_subclass_not_detected_as_builtin(self):
         """A subclass with a different class name is not a built-in."""

--- a/tests/unit/test_models/test_model_to_json.py
+++ b/tests/unit/test_models/test_model_to_json.py
@@ -403,6 +403,26 @@ class TestBaseModelToConfig:
         assert type(loaded) is type(model)
         assert "My variable" in loaded.variables
 
+    def test_from_config_invalid_custom_variable_raises(self):
+        """Malformed custom_variables JSON is rejected, not loaded as a raw dict."""
+        config = {
+            "type": "SPM",
+            "module": "lithium_ion",
+            "custom_variables": {"bad": {"a": 1}},
+        }
+        with pytest.raises(ValueError, match=r"expected a pybamm\.Symbol"):
+            pybamm.BaseModel.from_config(config)
+
+    def test_from_config_invalid_event_expression_raises(self):
+        """Malformed event expression JSON is rejected, not loaded as a raw string."""
+        config = {
+            "type": "SPM",
+            "module": "lithium_ion",
+            "events": [{"name": "e", "expression": "not a symbol", "event_type": 0}],
+        }
+        with pytest.raises(ValueError, match=r"expected a pybamm\.Symbol"):
+            pybamm.BaseModel.from_config(config)
+
     def test_to_config_builtin_with_cleared_events_round_trip(self):
         """Clearing events survives to_config / from_config round-trip."""
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_parameters/test_parameter_values_serialisation.py
+++ b/tests/unit/test_parameters/test_parameter_values_serialisation.py
@@ -312,7 +312,7 @@ class TestRoundtripValueTypes:
             (pybamm.constants.q_e, "q_e"),
         ]:
             json_data = convert_symbol_to_json(const)
-            assert json_data["type"] == "Constant"
+            assert json_data["$type"].endswith("Constant")
             restored = convert_symbol_from_json(json_data)
             assert type(restored) is pybamm.Constant
             assert restored.is_constant() is False

--- a/tests/unit/test_serialisation/fixtures/legacy/.gitignore
+++ b/tests/unit/test_serialisation/fixtures/legacy/.gitignore
@@ -1,0 +1,3 @@
+# Discretised-model fixture is ~19 MB — too large for git.
+# Regenerate locally with: tests/unit/test_serialisation/fixtures/legacy/generate.py
+discretised_model.json

--- a/tests/unit/test_serialisation/fixtures/legacy/compact_symbols.json
+++ b/tests/unit/test_serialisation/fixtures/legacy/compact_symbols.json
@@ -1,0 +1,127 @@
+{
+  "addition_broadcast_time": {
+    "type": "PrimaryBroadcast",
+    "children": [
+      {
+        "type": "Addition",
+        "domains": {
+          "primary": [],
+          "secondary": [],
+          "tertiary": [],
+          "quaternary": []
+        },
+        "children": [
+          {
+            "type": "Scalar",
+            "value": 2.0
+          },
+          {
+            "type": "Time"
+          }
+        ],
+        "name": "+"
+      }
+    ],
+    "broadcast_domain": [
+      "negative electrode"
+    ]
+  },
+  "negate_generic_fallback": {
+    "type": "Negate",
+    "domains": {
+      "primary": [
+        "negative electrode"
+      ],
+      "secondary": [],
+      "tertiary": [],
+      "quaternary": []
+    },
+    "children": [
+      {
+        "type": "Variable",
+        "name": "u",
+        "domains": {
+          "primary": [
+            "negative electrode"
+          ],
+          "secondary": [],
+          "tertiary": [],
+          "quaternary": []
+        },
+        "bounds": null
+      }
+    ],
+    "name": "-"
+  },
+  "interpolant_entries_string": {
+    "type": "Interpolant",
+    "x": [
+      [
+        0.0,
+        0.3333333333333333,
+        0.6666666666666666,
+        1.0
+      ]
+    ],
+    "y": [
+      0.0,
+      1.0,
+      0.5,
+      0.2
+    ],
+    "children": [
+      {
+        "type": "Variable",
+        "name": "a",
+        "domains": {
+          "primary": [],
+          "secondary": [],
+          "tertiary": [],
+          "quaternary": []
+        },
+        "bounds": null
+      }
+    ],
+    "name": "interpolating_function",
+    "interpolator": "linear",
+    "entries_string": "x0_b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00UUUUUU\\xd5?UUUUUU\\xe5?\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?'y_b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xf0?\\x00\\x00\\x00\\x00\\x00\\x00\\xe0?\\x9a\\x99\\x99\\x99\\x99\\x99\\xc9?'"
+  },
+  "variable_with_bounds": {
+    "type": "Variable",
+    "name": "v",
+    "domains": {
+      "primary": [],
+      "secondary": [],
+      "tertiary": [],
+      "quaternary": []
+    },
+    "bounds": [
+      {
+        "type": "Scalar",
+        "value": 0.0
+      },
+      {
+        "type": "Scalar",
+        "value": 5.0
+      }
+    ]
+  },
+  "function_parameter": {
+    "type": "FunctionParameter",
+    "inputs": {
+      "T": {
+        "type": "Variable",
+        "name": "T",
+        "domains": {
+          "primary": [],
+          "secondary": [],
+          "tertiary": [],
+          "quaternary": []
+        },
+        "bounds": null
+      }
+    },
+    "diff_variable": null,
+    "name": "k"
+  }
+}

--- a/tests/unit/test_serialisation/fixtures/legacy/generate.py
+++ b/tests/unit/test_serialisation/fixtures/legacy/generate.py
@@ -1,0 +1,59 @@
+"""Regenerate the legacy fixtures (run from repo root with uv run python <this file>).
+
+discretised_model.json is ~19 MB and excluded from git; the other two files ARE
+tracked. Re-run this whenever the serialisation format changes so the pinned
+fixtures stay in sync.
+"""
+
+import json
+import pathlib
+
+import numpy as np
+
+import pybamm
+from pybamm.expression_tree.operations.serialise import (
+    Serialise,
+    convert_symbol_to_json,
+)
+
+out = pathlib.Path(__file__).parent
+out.mkdir(parents=True, exist_ok=True)
+
+# 1. Compact-symbol format
+neg = -pybamm.Variable("u", domains={"primary": ["negative electrode"]})
+interp = pybamm.Interpolant(
+    np.linspace(0.0, 1.0, 4), np.array([0.0, 1.0, 0.5, 0.2]), pybamm.Variable("a")
+)
+var = pybamm.Variable("v", bounds=(pybamm.Scalar(0.0), pybamm.Scalar(5.0)))
+fp = pybamm.FunctionParameter("k", {"T": pybamm.Variable("T")})
+compact_cases = {
+    "addition_broadcast_time": pybamm.PrimaryBroadcast(
+        pybamm.Scalar(2.0), "negative electrode"
+    )
+    + pybamm.Time(),
+    "negate_generic_fallback": neg,
+    "interpolant_entries_string": interp,
+    "variable_with_bounds": var,
+    "function_parameter": fp,
+}
+(out / "compact_symbols.json").write_text(
+    json.dumps(
+        {k: convert_symbol_to_json(v) for k, v in compact_cases.items()}, indent=2
+    )
+)
+print("wrote compact_symbols.json")
+
+# 2. Discretised-model format (~19 MB, git-ignored)
+model = pybamm.lithium_ion.SPM()
+sim = pybamm.Simulation(model)
+sim.build()
+model_json = Serialise().serialise_model(sim.built_model, mesh=sim.mesh)
+(out / "discretised_model.json").write_text(json.dumps(model_json, indent=2))
+print("wrote discretised_model.json")
+
+# 3. Submesh-types format
+(out / "submesh_types.json").write_text(
+    json.dumps(Serialise.serialise_submesh_types(sim.submesh_types), indent=2)
+)
+print("wrote submesh_types.json")
+print("done")

--- a/tests/unit/test_serialisation/fixtures/legacy/submesh_types.json
+++ b/tests/unit/test_serialisation/fixtures/legacy/submesh_types.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.1",
+  "pybamm_version": "26.5.1.dev3+g50075c64c",
+  "submesh_types": {
+    "negative electrode": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "separator": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive electrode": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative primary particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive primary particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative secondary particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive secondary particle": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative primary particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive primary particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "negative secondary particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "positive secondary particle size": {
+      "class": "Uniform1DSubMesh",
+      "module": "pybamm.meshes.one_dimensional_submeshes"
+    },
+    "current collector": {
+      "class": "SubMesh0D",
+      "module": "pybamm.meshes.zero_dimensional_submesh"
+    }
+  }
+}

--- a/tests/unit/test_serialisation/test_issue_5548_repro.py
+++ b/tests/unit/test_serialisation/test_issue_5548_repro.py
@@ -1,5 +1,5 @@
-"""Round-trip regression test for the #5548 cases (all formerly dropped a
-non-children constructor arg under the old type-switch serialiser).
+"""Round-trip regression test for the #5548 cases (each previously dropped a
+non-children constructor argument on round-trip).
 """
 
 from __future__ import annotations

--- a/tests/unit/test_serialisation/test_issue_5548_repro.py
+++ b/tests/unit/test_serialisation/test_issue_5548_repro.py
@@ -1,0 +1,74 @@
+"""Round-trip regression test for the #5548 cases (all formerly dropped a
+non-children constructor arg under the old type-switch serialiser).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pybamm
+from pybamm.expression_tree.operations.serialise import (
+    convert_symbol_from_json as _from,
+)
+from pybamm.expression_tree.operations.serialise import (
+    convert_symbol_to_json as _to,
+)
+
+
+def _V(d=None):
+    return pybamm.Variable("u", domains={"primary": [d]} if d else {})
+
+
+_CASES = [
+    pybamm.BoundaryGradient(pybamm.Time(), "left"),
+    pybamm.BackwardIndefiniteIntegral(
+        _V("negative electrode"),
+        pybamm.SpatialVariable("x", domain=["negative electrode"]),
+    ),
+    pybamm.ExplicitTimeIntegral(_V("negative electrode"), pybamm.Scalar(0.0)),
+    pybamm.Index(pybamm.StateVector(slice(0, 1)), 0, check_size=False),
+    pybamm.BoundaryIntegral(_V("negative electrode"), region="negative tab"),
+    pybamm.DeltaFunction(_V("negative particle"), "left", "negative electrode"),
+    pybamm.EvaluateAt(_V("negative electrode"), 0.5),
+    pybamm.Magnitude(_V("negative electrode"), "x"),
+    pybamm.SizeAverage(_V("negative particle size"), pybamm.Scalar(1.0)),
+    pybamm.TensorField([pybamm.Scalar(1.0), pybamm.Scalar(2.0)]),
+    pybamm.TertiaryBroadcast(
+        pybamm.Variable(
+            "v",
+            domains={
+                "primary": ["negative particle"],
+                "secondary": ["negative electrode"],
+            },
+        ),
+        "current collector",
+    ),
+    pybamm.PrimaryBroadcastToEdges(pybamm.Scalar(1.0), "negative electrode"),
+    pybamm.SpatialVariableEdge("x", domain=["negative electrode"]),
+    pybamm.BoundaryValue(_V("negative electrode"), "left"),
+    pybamm.DefiniteIntegralVector(_V("negative electrode")),
+    pybamm.VectorField(_V("negative electrode"), _V("negative electrode")),
+    pybamm.DiscreteTimeSum(
+        pybamm.DiscreteTimeData(np.array([0.0, 1.0]), np.array([1.0, 2.0]), "dtd")
+    ),
+    pybamm.Concatenation(
+        pybamm.FullBroadcast(
+            pybamm.Scalar(1.0),
+            broadcast_domains={"primary": ["negative electrode"]},
+        ),
+        pybamm.FullBroadcast(
+            pybamm.Scalar(2.0),
+            broadcast_domains={"primary": ["separator"]},
+        ),
+    ),
+    pybamm.ConcatenationVariable(_V("negative electrode"), _V("separator")),
+    pybamm.SparseStack(_V("negative electrode"), _V("separator")),
+]
+
+
+@pytest.mark.parametrize("tree", _CASES, ids=lambda t: type(t).__name__)
+def test_issue_5548_repro_round_trips(tree):
+    restored = _from(_to(tree))
+    assert type(restored) is type(tree)
+    assert restored.id == tree.id

--- a/tests/unit/test_serialisation/test_legacy_fixtures.py
+++ b/tests/unit/test_serialisation/test_legacy_fixtures.py
@@ -1,5 +1,7 @@
-"""Pre-refactor JSON must keep loading after the kernel refactor (#5548 spec:
-'existing files must keep loading'). Fixtures generated from main in Task 0.2.
+"""JSON written by the previous serialiser must keep loading (#5548).
+
+Fixtures are pinned bytes captured from the previous on-disk format, so a
+decode regression shows up here.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_serialisation/test_legacy_fixtures.py
+++ b/tests/unit/test_serialisation/test_legacy_fixtures.py
@@ -1,0 +1,34 @@
+"""Pre-refactor JSON must keep loading after the kernel refactor (#5548 spec:
+'existing files must keep loading'). Fixtures generated from main in Task 0.2.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pybamm
+from pybamm.expression_tree.operations.serialise import (
+    Serialise,
+    convert_symbol_from_json,
+)
+
+_FIX = pathlib.Path(__file__).parent / "fixtures" / "legacy"
+
+
+def _load(name):
+    return json.loads((_FIX / name).read_text())
+
+
+def test_legacy_compact_symbols_load():
+    cases = _load("compact_symbols.json")
+    assert cases  # non-empty
+    for label, node in cases.items():
+        tree = convert_symbol_from_json(node)
+        assert isinstance(tree, pybamm.Symbol), label
+
+
+def test_legacy_submesh_types_loads():
+    restored = Serialise.load_submesh_types(_load("submesh_types.json"))
+    assert isinstance(restored, dict) and restored
+    assert all(isinstance(v, pybamm.MeshGenerator) for v in restored.values())

--- a/tests/unit/test_serialisation/test_round_trip_property.py
+++ b/tests/unit/test_serialisation/test_round_trip_property.py
@@ -168,9 +168,8 @@ def test_model_option_strategy_tracks_canonical():
 
 
 class TestKnownSymbolSerialiserBugs:
-    """Specific shapes where convert_symbol_to_json/from_json drop a non-children
-    constructor arg. Each is xfail(strict=True): the test FAILS the day the fix
-    lands, prompting removal of the entry. All referenced in tracking issue #5548.
+    """Shapes that previously dropped a non-children constructor arg under the old
+    serialiser. Fixed by the unified kernel (tracking issue #5548).
     """
 
     @pytest.mark.parametrize(
@@ -178,18 +177,10 @@ class TestKnownSymbolSerialiserBugs:
         [
             pytest.param(
                 pybamm.Variable("v", scale=pybamm.Scalar(2.0)),
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason="tracked in #5548 — Variable.scale dropped by convert_symbol_to_json",
-                ),
                 id="Variable-with-non-default-scale",
             ),
             pytest.param(
                 pybamm.Variable("v", reference=pybamm.Scalar(1.0)),
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason="tracked in #5548 — Variable.reference dropped by convert_symbol_to_json",
-                ),
                 id="Variable-with-non-default-reference",
             ),
             pytest.param(
@@ -197,10 +188,6 @@ class TestKnownSymbolSerialiserBugs:
                     pybamm.Scalar(1.0),
                     broadcast_domains={"primary": ["negative electrode"]},
                     name="custom",
-                ),
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason="tracked in #5548 — FullBroadcast custom name dropped",
                 ),
                 id="FullBroadcast-with-custom-name",
             ),

--- a/tests/unit/test_serialisation/test_round_trip_property.py
+++ b/tests/unit/test_serialisation/test_round_trip_property.py
@@ -168,8 +168,8 @@ def test_model_option_strategy_tracks_canonical():
 
 
 class TestKnownSymbolSerialiserBugs:
-    """Shapes that previously dropped a non-children constructor arg under the old
-    serialiser. Fixed by the unified kernel (tracking issue #5548).
+    """Shapes that previously dropped a non-children constructor argument on
+    round-trip; they now serialise losslessly (#5548).
     """
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -296,6 +296,8 @@ class TestSerialise:
                         "quaternary": [],
                     },
                     "children": [],
+                    "coord_sys": None,
+                    "direction": None,
                 },
                 "x": {"min": 0.0, "max": 2.0},
             }

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -35,7 +35,6 @@ def scalar_var_dict(mocker):
         "py/id": mocker.ANY,
         "py/object": "pybamm.expression_tree.scalar.Scalar",
         "name": "5.0",
-        "id": mocker.ANY,
         "value": 5.0,
         "children": [],
     }
@@ -179,7 +178,6 @@ class TestSerialise:
             "py/id": mocker.ANY,
             "py/object": "pybamm.expression_tree.binary_operators.Addition",
             "name": "+",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -191,7 +189,6 @@ class TestSerialise:
                     "py/id": mocker.ANY,
                     "py/object": "pybamm.expression_tree.scalar.Scalar",
                     "name": "2.0",
-                    "id": mocker.ANY,
                     "value": 2.0,
                     "children": [],
                 },
@@ -199,7 +196,6 @@ class TestSerialise:
                     "py/id": mocker.ANY,
                     "py/object": "pybamm.expression_tree.scalar.Scalar",
                     "name": "4.0",
-                    "id": mocker.ANY,
                     "value": 4.0,
                     "children": [],
                 },
@@ -218,7 +214,6 @@ class TestSerialise:
             "py/object": "pybamm.expression_tree.unary_operators.ExplicitTimeIntegral",
             "py/id": mocker.ANY,
             "name": "explicit time integral",
-            "id": mocker.ANY,
             "domains": {
                 "primary": [],
                 "secondary": [],
@@ -230,7 +225,6 @@ class TestSerialise:
                     "py/object": "pybamm.expression_tree.scalar.Scalar",
                     "py/id": mocker.ANY,
                     "name": "5.0",
-                    "id": mocker.ANY,
                     "value": 5.0,
                     "children": [],
                 }
@@ -239,7 +233,6 @@ class TestSerialise:
                 "py/object": "pybamm.expression_tree.scalar.Scalar",
                 "py/id": mocker.ANY,
                 "name": "1.0",
-                "id": mocker.ANY,
                 "value": 1.0,
                 "children": [],
             },
@@ -264,7 +257,6 @@ class TestSerialise:
                 "py/object": "pybamm.expression_tree.scalar.Scalar",
                 "py/id": mocker.ANY,
                 "name": "1.0",
-                "id": mocker.ANY,
                 "value": 1.0,
                 "children": [],
             },
@@ -295,7 +287,6 @@ class TestSerialise:
                     "py/object": "pybamm.expression_tree.independent_variable.SpatialVariable",
                     "py/id": mocker.ANY,
                     "name": "x",
-                    "id": mocker.ANY,
                     "domains": {
                         "primary": ["negative electrode"],
                         "secondary": [],

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -218,6 +218,12 @@ class TestSerialise:
             "py/id": mocker.ANY,
             "name": "explicit time integral",
             "id": mocker.ANY,
+            "domains": {
+                "primary": [],
+                "secondary": [],
+                "tertiary": [],
+                "quaternary": [],
+            },
             "children": [
                 {
                     "py/object": "pybamm.expression_tree.scalar.Scalar",

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -16,6 +16,7 @@ import pytest
 from numpy import testing
 
 import pybamm
+import pybamm.expression_tree.operations.serialise_kernel as sk
 from pybamm.expression_tree.operations.serialise import (
     SUPPORTED_SCHEMA_VERSION,
     ExpressionFunctionParameter,
@@ -648,9 +649,10 @@ class TestSerialise:
             out = convert_symbol_to_json(val)
             assert out is val or out == val
 
+        # The kernel recurses into containers and returns a new, equal list.
         sample = [1, 2, 3, "foo", 4.5]
         out = convert_symbol_to_json(sample)
-        assert out is sample
+        assert out == sample
 
     def test_convert_symbol_from_json_with_primitives(self):
         assert convert_symbol_from_json(3.14) == 3.14
@@ -661,8 +663,9 @@ class TestSerialise:
         assert convert_symbol_from_json(None) is None
 
     def test_convert_symbol_from_json_unexpected_string(self):
-        with pytest.raises(ValueError, match=r"Unexpected raw string in JSON: foo"):
-            convert_symbol_from_json("foo")
+        # A bare string is a native JSON leaf; the kernel decoder returns it
+        # unchanged rather than raising (validation relaxed vs the old switch).
+        assert convert_symbol_from_json("foo") == "foo"
 
     def test_numpy_array_conversion(self):
         arr = np.array([1, 2, 3])
@@ -750,13 +753,25 @@ class TestSerialise:
         assert var2.bounds[0].value == -float("inf")
         assert var2.bounds[1].value == float("inf")
 
-    def test_variable_default_bounds_serialise_as_null_no_infinity(self):
-        """Variable with default bounds serialises as bounds: null (valid JSON)."""
+    def test_variable_default_bounds_serialise_as_strict_json(self):
+        """Variable with default (+/-inf) bounds serialises to strict-valid JSON.
+
+        The kernel carries the inf bounds as Scalar children whose value is the
+        quoted string sentinel "Infinity"/"-Infinity", so the dumped JSON contains
+        no bare Infinity/NaN tokens and parses under a strict (RFC 8259) reader.
+        """
         var = pybamm.Variable("x", domain="electrode")
         json_dict = convert_symbol_to_json(var)
-        assert json_dict.get("bounds") is None
-        json_str = json.dumps(json_dict)
-        assert "Infinity" not in json_str and "inf" not in json_str.lower()
+        json_str = json.dumps(json_dict, default=Serialise._json_encoder)
+        # Strict parse rejecting bare Infinity/-Infinity/NaN tokens must succeed.
+        json.loads(
+            json_str,
+            parse_constant=lambda c: (_ for _ in ()).throw(ValueError(c)),
+        )
+        # And the Variable round-trips with default bounds preserved.
+        var2 = convert_symbol_from_json(json_dict)
+        assert var2.bounds[0].value == -float("inf")
+        assert var2.bounds[1].value == float("inf")
 
     def test_variable_default_bounds_round_trip(self):
         """Variable with default bounds round-trips; loaded has default bounds."""
@@ -769,11 +784,13 @@ class TestSerialise:
         assert var2.bounds[1].value == float("inf")
 
     def test_variable_explicit_bounds_round_trip(self):
-        """Variable with explicit finite bounds serialises and round-trips."""
+        """Variable with explicit finite bounds serialises and round-trips.
+
+        The kernel carries the bounds as Scalar children rather than a top-level
+        "bounds" field, so we assert the round-tripped values, not the wire shape.
+        """
         var = pybamm.Variable("x", domain="electrode", bounds=(0, 1))
         json_dict = convert_symbol_to_json(var)
-        assert json_dict["bounds"] is not None
-        assert len(json_dict["bounds"]) == 2
         var2 = convert_symbol_from_json(json_dict)
         assert var2.bounds[0].value == 0
         assert var2.bounds[1].value == 1
@@ -813,7 +830,8 @@ class TestSerialise:
         concat_var2 = convert_symbol_from_json(json_dict)
 
         assert isinstance(concat_var2, pybamm.ConcatenationVariable)
-        assert concat_var2.name == "a"
+        # The kernel preserves the custom name (the old switch dropped it, #5548).
+        assert concat_var2.name == "conc_var"
         assert len(concat_var2.children) == 3
         domains = [child.domains["primary"] for child in concat_var2.children]
         assert domains == [
@@ -1102,11 +1120,10 @@ class TestSerialise:
         diff_var = pybamm.Variable("r")
         func_param = pybamm.FunctionParameter("my_func", {"x": x}, diff_var)
 
+        # The kernel carries diff_variable as a trailing child (flagged by
+        # has_diff_variable), not a top-level "diff_variable" field; assert the
+        # round-trip rather than the wire shape.
         json_dict = convert_symbol_to_json(func_param)
-        assert "diff_variable" in json_dict
-        assert json_dict["diff_variable"]["type"] == "Variable"
-        assert json_dict["diff_variable"]["name"] == "r"
-
         expr2 = convert_symbol_from_json(json_dict)
         assert isinstance(expr2, pybamm.FunctionParameter)
         assert expr2.diff_variable.name == "r"
@@ -1117,38 +1134,21 @@ class TestSerialise:
         x = pybamm.SpatialVariable("x", domain="negative electrode")
         ind_int = pybamm.IndefiniteIntegral(x, x)
 
+        # Canonical kernel form: dotted "$type" tag and a children list (the
+        # integration_variable now travels via children, not a top-level field).
         json_dict = convert_symbol_to_json(ind_int)
-        assert json_dict["type"] == "IndefiniteIntegral"
-
-        assert (
-            isinstance(json_dict["children"], list) and len(json_dict["children"]) == 1
-        )
-        child_json = json_dict["children"][0]
-        assert child_json["type"] == "SpatialVariable"
-        assert child_json["name"] == "x"
-
-        int_var_json = json_dict["integration_variable"]
-        assert int_var_json["type"] == "SpatialVariable"
-        assert int_var_json["name"] == "x"
+        assert json_dict[sk.TAG].endswith("IndefiniteIntegral")
+        assert isinstance(json_dict["children"], list)
 
         expr2 = convert_symbol_from_json(json_dict)
         assert isinstance(expr2, pybamm.IndefiniteIntegral)
+        assert expr2.id == ind_int.id
         assert isinstance(expr2.child, pybamm.SpatialVariable)
         assert expr2.child.name == "x"
         assert isinstance(expr2.integration_variable, list)
         assert len(expr2.integration_variable) == 1
         assert isinstance(expr2.integration_variable[0], pybamm.SpatialVariable)
         assert expr2.integration_variable[0].name == "x"
-
-        bad_json_dict = json_dict.copy()
-        bad_json_dict["integration_variable"] = {
-            "type": "Symbol",  # Something not a SpatialVariable
-            "name": "not spatial",
-            "domains": {},
-        }
-
-        with pytest.raises(TypeError, match=r"Expected SpatialVariable"):
-            convert_symbol_from_json(bad_json_dict)
 
     def test_invalid_filename(self):
         model = pybamm.lithium_ion.DFN()
@@ -1174,24 +1174,21 @@ class TestSerialise:
                 self.name = "not_a_symbol"
 
         dummy = NotSymbol()
-        with pytest.raises(ValueError) as e:
+        # The kernel is safe-or-loud: a value with no codec raises SerialisationError.
+        with pytest.raises(sk.SerialisationError, match=r"Cannot serialise"):
             convert_symbol_to_json(dummy)
 
-        assert "Error processing 'not_a_symbol'. Unknown symbol type:" in str(e.value)
-
     def test_deserialising_unhandled_type(self):
+        # A legacy "type" naming an unknown class normalises to a dotted tag the
+        # kernel cannot resolve, and it raises (safe-or-loud on decode).
         unhandled_json = {"type": "NotARealSymbol", "foo": "bar"}
-        with pytest.raises(
-            ValueError,
-            match=r"Unknown symbol type: NotARealSymbol",
-        ):
+        with pytest.raises(sk.SerialisationError, match=r"Cannot resolve"):
             convert_symbol_from_json(unhandled_json)
 
+        # A dict with no recognised tag is generic JSON; the kernel decoder
+        # returns it unchanged (validation relaxed vs the old switch).
         unhandled_json2 = {"a": 1, "b": 2}
-        with pytest.raises(
-            ValueError, match=r"Missing 'type' key in JSON data: {'a': 1, 'b': 2}"
-        ):
-            convert_symbol_from_json(unhandled_json2)
+        assert convert_symbol_from_json(unhandled_json2) == {"a": 1, "b": 2}
 
     def test_file_write_raises_ioerror(self):
         # testing behaviour when file system is read-only to raise exception
@@ -2852,7 +2849,7 @@ class TestRegularisationSerialisation:
 
         # Convert to JSON and back
         json_dict = convert_symbol_to_json(rp)
-        assert json_dict["type"] == "RegPower"
+        assert json_dict[sk.TAG].endswith("RegPower")
         # Scale is serialized as the third child
         assert len(json_dict["children"]) == 3
 
@@ -2868,7 +2865,7 @@ class TestRegularisationSerialisation:
         rp = pybamm.RegPower(x, 0.5)
 
         json_dict = convert_symbol_to_json(rp)
-        assert json_dict["type"] == "RegPower"
+        assert json_dict[sk.TAG].endswith("RegPower")
 
         reconstructed = convert_symbol_from_json(json_dict)
         assert isinstance(reconstructed, pybamm.RegPower)
@@ -3157,14 +3154,17 @@ class TestSolverSerialization:
             assert s2.value == val
 
     def test_serialise_scalar_inf_json_safe(self):
-        """Scalar(inf) produces valid JSON (no bare Infinity token)."""
+        """Scalar(inf)/Scalar(nan) produces strict-valid JSON (no bare tokens)."""
         for val in [np.inf, -np.inf, np.nan]:
             s = pybamm.Scalar(val)
             json_dict = convert_symbol_to_json(s)
             json_str = json.dumps(json_dict, default=Serialise._json_encoder)
-            # Verify it's valid JSON by round-tripping through json.loads
-            reloaded = json.loads(json_str)
-            assert reloaded["type"] == "Scalar"
+            # Strict parse rejecting bare Infinity/-Infinity/NaN tokens must succeed.
+            reloaded = json.loads(
+                json_str,
+                parse_constant=lambda c: (_ for _ in ()).throw(ValueError(c)),
+            )
+            assert reloaded[sk.TAG].endswith("Scalar")
 
     def test_serialise_scalar_nan_round_trip(self):
         """Scalar(nan) survives round-trip."""

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -664,7 +664,7 @@ class TestSerialise:
 
     def test_convert_symbol_from_json_unexpected_string(self):
         # A bare string is a native JSON leaf; the kernel decoder returns it
-        # unchanged rather than raising (validation relaxed vs the old switch).
+        # unchanged rather than raising (validation relaxed vs the previous serialiser).
         assert convert_symbol_from_json("foo") == "foo"
 
     def test_numpy_array_conversion(self):
@@ -830,7 +830,7 @@ class TestSerialise:
         concat_var2 = convert_symbol_from_json(json_dict)
 
         assert isinstance(concat_var2, pybamm.ConcatenationVariable)
-        # The kernel preserves the custom name (the old switch dropped it, #5548).
+        # The custom name is preserved on round-trip (previously dropped, #5548).
         assert concat_var2.name == "conc_var"
         assert len(concat_var2.children) == 3
         domains = [child.domains["primary"] for child in concat_var2.children]
@@ -1186,7 +1186,7 @@ class TestSerialise:
             convert_symbol_from_json(unhandled_json)
 
         # A dict with no recognised tag is generic JSON; the kernel decoder
-        # returns it unchanged (validation relaxed vs the old switch).
+        # returns it unchanged (validation relaxed vs the previous serialiser).
         unhandled_json2 = {"a": 1, "b": 2}
         assert convert_symbol_from_json(unhandled_json2) == {"a": 1, "b": 2}
 

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -357,3 +357,53 @@ def test_trap_hook_codec_inherited_base_drops_scalar_raises_loudly():
 )
 def test_variable_family_round_trip(tree):
     assert _rt(tree).id == tree.id
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.BoundaryGradient(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "left"
+        ),
+        pybamm.BoundaryMeshSize(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "left"
+        ),
+        pybamm.BoundaryIntegral(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}),
+            region="negative tab",
+        ),
+        pybamm.UpwindDownwind2D(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "x", "y"
+        ),
+        pybamm.NodeToEdge2D(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "lr"
+        ),
+        pybamm.DeltaFunction(
+            pybamm.Variable("u", domains={"primary": ["negative particle"]}),
+            "left",
+            "negative electrode",
+        ),
+        pybamm.OneDimensionalIntegral(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}),
+            ["negative electrode"],
+            "x",
+        ),
+        # currently-green via the switch; MUST keep round-tripping after switch deletion:
+        pybamm.BoundaryValue(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "left"
+        ),
+        pybamm.DefiniteIntegralVector(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]})
+        ),
+    ],
+)
+def test_spatial_native_arg_round_trip(tree):
+    assert _rt(tree).id == tree.id
+
+
+def test_size_average_round_trip():
+    child = pybamm.Variable("u", domains={"primary": ["negative particle size"]})
+    assert (
+        _rt(pybamm.SizeAverage(child, pybamm.Scalar(1.0))).id
+        == pybamm.SizeAverage(child, pybamm.Scalar(1.0)).id
+    )

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -407,3 +407,28 @@ def test_size_average_round_trip():
         _rt(pybamm.SizeAverage(child, pybamm.Scalar(1.0))).id
         == pybamm.SizeAverage(child, pybamm.Scalar(1.0)).id
     )
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.EvaluateAt(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), 0.5
+        ),
+        # symbolic position (a Symbol, not a number): must route through children
+        pybamm.EvaluateAt(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}),
+            pybamm.Scalar(0.5),
+        ),
+        pybamm.BackwardIndefiniteIntegral(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}),
+            pybamm.SpatialVariable("x", domain=["negative electrode"]),
+        ),
+        pybamm.ExplicitTimeIntegral(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}),
+            pybamm.Scalar(0.0),
+        ),
+    ],
+)
+def test_symbol_valued_spatial_round_trip(tree):
+    assert _rt(tree).id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -471,3 +471,16 @@ def test_broadcast_round_trip_preserves_subclass(tree):
     restored = _rt(tree)
     assert type(restored) is type(tree)
     assert restored.id == tree.id
+
+
+def test_tensor_field_round_trip():
+    tree = pybamm.TensorField([pybamm.Scalar(1.0), pybamm.Scalar(2.0)])
+    assert _rt(tree).id == tree.id
+
+
+def test_vector_field_round_trip():
+    leaf = pybamm.Variable("u", domains={"primary": ["negative electrode"]})
+    tree = pybamm.VectorField(leaf, leaf)
+    restored = _rt(tree)
+    assert type(restored) is pybamm.VectorField
+    assert restored.id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -484,3 +484,97 @@ def test_vector_field_round_trip():
     restored = _rt(tree)
     assert type(restored) is pybamm.VectorField
     assert restored.id == tree.id
+
+
+# ---------------------------------------------------------------------------
+# Droppers + Scalar/Interpolant/Concatenation (Task 2.6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.Magnitude(
+            pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "x"
+        ),
+        pybamm.Scalar(float("inf")),
+        pybamm.Scalar(float("-inf")),
+    ],
+)
+def test_dropper_and_scalar_round_trip(tree):
+    assert _rt(tree).id == tree.id
+
+
+def test_magnitude_restores_direction():
+    tree = pybamm.Magnitude(
+        pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "x"
+    )
+    assert _rt(tree).direction == "x"
+
+
+def test_discrete_time_data_round_trip():
+    tree = pybamm.DiscreteTimeData(
+        np.array([0.0, 1.0, 2.0]), np.array([1.0, 2.0, 3.0]), "dtd"
+    )
+    restored = _rt(tree)
+    assert restored.id == tree.id
+    assert np.array_equal(restored.y, tree.y)
+
+
+def test_discrete_time_sum_round_trip():
+    data = pybamm.DiscreteTimeData(np.array([0.0, 1.0]), np.array([1.0, 2.0]), "dtd")
+    tree = pybamm.DiscreteTimeSum(data)
+    restored = _rt(tree)
+    assert restored.id == tree.id
+    assert restored.data is not None  # __init__ ran, self.data re-derived
+
+
+def _neg_sep_vars():
+    return (
+        pybamm.Variable("a", domains={"primary": ["negative electrode"]}),
+        pybamm.Variable("b", domains={"primary": ["separator"]}),
+    )
+
+
+def _neg_sep_nonvars():
+    return (
+        pybamm.FullBroadcast(
+            pybamm.Scalar(1.0), broadcast_domains={"primary": ["negative electrode"]}
+        ),
+        pybamm.FullBroadcast(
+            pybamm.Scalar(2.0), broadcast_domains={"primary": ["separator"]}
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.Concatenation(*_neg_sep_nonvars()),
+        pybamm.ConcatenationVariable(*_neg_sep_vars()),
+        pybamm.SparseStack(*_neg_sep_vars()),
+    ],
+)
+def test_concatenation_family_round_trip(tree):
+    assert _rt(tree).id == tree.id
+
+
+def test_concatenation_family_sparse_stack_rederives_concat_fun():
+    tree = pybamm.SparseStack(*_neg_sep_vars())
+    assert _rt(tree).concatenation_function is not None
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.Index(pybamm.StateVector(slice(0, 1)), 0, check_size=False),
+        pybamm.Array(np.array([[1.0, 2.0], [3.0, 4.0]])),
+        pybamm.Matrix(np.array([[1.0, 0.0], [0.0, 1.0]])),
+        pybamm.Vector(np.array([1.0, 2.0, 3.0])),
+        pybamm.StateVector(slice(0, 2)),
+        pybamm.StateVectorDot(slice(0, 2)),
+        pybamm.Scalar(1.0) < pybamm.Scalar(2.0),  # EqualHeaviside / NotEqualHeaviside
+    ],
+)
+def test_already_correct_classes_round_trip(tree):
+    assert _rt(tree).id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -432,3 +432,42 @@ def test_size_average_round_trip():
 )
 def test_symbol_valued_spatial_round_trip(tree):
     assert _rt(tree).id == tree.id
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.PrimaryBroadcastToEdges(pybamm.Scalar(1.0), "negative electrode"),
+        pybamm.SecondaryBroadcast(
+            pybamm.PrimaryBroadcast(pybamm.Scalar(1.0), "negative particle"),
+            "negative electrode",
+        ),
+        pybamm.TertiaryBroadcast(
+            pybamm.Variable(
+                "v",
+                domains={
+                    "primary": ["negative particle"],
+                    "secondary": ["negative electrode"],
+                },
+            ),
+            "current collector",
+        ),
+        pybamm.FullBroadcast(
+            pybamm.Scalar(1.0),
+            broadcast_domains={"primary": ["negative electrode"]},
+            name="custom",
+        ),
+        pybamm.FullBroadcastToEdges(
+            pybamm.Scalar(1.0),
+            broadcast_domains={"primary": ["negative electrode"]},
+        ),
+        # custom name on a non-Full broadcast -- locks the "restore name on all" decision:
+        pybamm.PrimaryBroadcast(
+            pybamm.Scalar(1.0), "negative electrode", name="custom"
+        ),
+    ],
+)
+def test_broadcast_round_trip_preserves_subclass(tree):
+    restored = _rt(tree)
+    assert type(restored) is type(tree)
+    assert restored.id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
 import pybamm
 from pybamm.expression_tree.operations import serialise_kernel as sk
+
+
+def _rt(tree):
+    # Round-trip through real JSON text (not in-memory) so a hook that leaves a
+    # non-JSON-native value (raw slice/ndarray/Symbol) is caught by json.dumps.
+    return sk.decode(json.loads(json.dumps(sk.encode(tree))))
 
 
 def test_class_path_round_trips_a_pybamm_class():
@@ -336,3 +344,16 @@ def test_trap_hook_codec_inherited_base_drops_scalar_raises_loudly():
 
     with pytest.raises(sk.SerialisationError, match="knob"):
         sk.encode(_TrapUnary(pybamm.Scalar(1.0), knob="z"))
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.Variable("v", scale=pybamm.Scalar(2.0)),
+        pybamm.Variable("v", reference=pybamm.Scalar(1.0)),
+        pybamm.VariableDot("v'", domains={"primary": ["negative electrode"]}),
+        pybamm.SpatialVariableEdge("x", domain=["negative electrode"]),
+    ],
+)
+def test_variable_family_round_trip(tree):
+    assert _rt(tree).id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -481,6 +481,19 @@ def test_tensor_field_round_trip():
     assert _rt(tree).id == tree.id
 
 
+def test_tensor_field_rank_2_round_trip():
+    tree = pybamm.TensorField(
+        [
+            [pybamm.Scalar(1.0), pybamm.Scalar(2.0)],
+            [pybamm.Scalar(3.0), pybamm.Scalar(4.0)],
+        ]
+    )
+    restored = _rt(tree)
+    assert restored.rank == 2
+    assert restored.shape == (2, 2)
+    assert restored.id == tree.id
+
+
 def test_vector_field_round_trip():
     leaf = pybamm.Variable("u", domains={"primary": ["negative electrode"]})
     tree = pybamm.VectorField(leaf, leaf)

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -39,3 +39,28 @@ def test_tuple_round_trips_as_tuple_not_list():
     node = sk.encode((1, 2, 3))
     out = sk.decode(node)
     assert out == (1, 2, 3) and isinstance(out, tuple)
+
+
+def test_encode_native_leaves_pass_through():
+    assert sk.encode(3) == 3
+    assert sk.encode("x") == "x"
+    assert sk.encode(True) is True
+    assert sk.encode(None) is None
+
+
+def test_containers_recurse():
+    assert sk.encode([1, "a", None]) == [1, "a", None]
+    assert sk.decode(sk.encode({"k": [1, 2]})) == {"k": [1, 2]}
+
+
+def test_class_reference_round_trip():
+    node = sk.encode(pybamm.Scalar)  # a class, not an instance
+    assert sk.decode(node) is pybamm.Scalar
+
+
+def test_encode_unknown_object_raises():
+    class Foreign:
+        pass
+
+    with pytest.raises(sk.SerialisationError, match="Cannot serialise"):
+        sk.encode(Foreign())

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -74,6 +74,25 @@ def test_encode_unknown_object_raises():
         sk.encode(Foreign())
 
 
+# Safe-or-loud raise sentinels: low-level resolve/decode branches must fail loudly.
+def test_resolve_non_class_path_raises():
+    # A path resolving to a non-class object (here a builtin function) must raise,
+    # not return the object.
+    with pytest.raises(sk.SerialisationError, match="did not resolve to a class"):
+        sk._resolve_class("builtins.len")
+
+
+def test_decode_unknown_float_sentinel_raises():
+    with pytest.raises(sk.SerialisationError, match="Unknown float sentinel"):
+        sk._decode_leaf({sk.TAG: "builtins.float", "value": "Bogus"})
+
+
+def test_decode_unsupported_type_raises():
+    # A value that is neither a JSON scalar, list, nor dict has no decoding.
+    with pytest.raises(sk.SerialisationError, match="Cannot decode value of type"):
+        sk.decode({1, 2, 3})
+
+
 # Synthetic helper classes for DefaultCodec tests
 class _Clean(pybamm.Symbol):
     def __init__(self, child, mode="a"):
@@ -110,9 +129,9 @@ def test_default_codec_raises_on_unresolvable_required_param():
 
 
 def test_default_codec_from_json_ignores_extra_legacy_keys():
-    # The old switch always wrote a "name" key; a clean class whose __init__ has
-    # no `name` param must still reconstruct (the key is ignored, not forwarded
-    # as an unexpected kwarg). Guards legacy compatibility (#5548 spec).
+    # Legacy JSON always wrote a "name" key; a clean class whose __init__ has no
+    # `name` param must still reconstruct (the key is ignored, not forwarded as
+    # an unexpected kwarg). Guards legacy compatibility (#5548).
     codec = sk.DefaultCodec()
     node = codec.to_json(_Clean(pybamm.Scalar(1.0), mode="q"), sk.encode)
     node[sk.TAG] = sk._class_path(_Clean)
@@ -372,7 +391,7 @@ def test_variable_family_round_trip(tree):
             ["negative electrode"],
             "x",
         ),
-        # currently-green via the switch; MUST keep round-tripping after switch deletion:
+        # carry scalar constructor args (side/order, vector_type) that must survive round-trip:
         pybamm.BoundaryValue(
             pybamm.Variable("u", domains={"primary": ["negative electrode"]}), "left"
         ),

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -229,3 +229,39 @@ def test_hook_guard_allows_declared_derived_param():
             return cls(snippet["children"][0])
 
     sk.encode(_Cached(pybamm.Scalar(1.0)))  # no raise
+
+
+# ---------------------------------------------------------------------------
+# normalise_legacy (Task 1.6)
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_legacy_py_object():
+    legacy = {"py/object": "pybamm.Scalar", "py/id": 7, "value": 1.0}
+    out = sk.normalise_legacy(legacy)
+    assert out[sk.TAG] == "pybamm.Scalar"
+    # py/id and py/object are consumed, not carried forward
+    assert "py/id" not in out and "py/object" not in out
+    # read-only: the input node is not mutated
+    assert legacy == {"py/object": "pybamm.Scalar", "py/id": 7, "value": 1.0}
+
+
+def test_normalise_legacy_bare_type_resolves_to_pybamm():
+    legacy = {"type": "Scalar", "value": 1.0}
+    out = sk.normalise_legacy(legacy)
+    assert sk._resolve_class(out[sk.TAG]) is pybamm.Scalar
+
+
+def test_normalise_legacy_class_module():
+    legacy = {
+        "class": "Uniform1DSubMesh",
+        "module": "pybamm.meshes.one_dimensional_submeshes",
+    }
+    out = sk.normalise_legacy(legacy)
+    assert out[sk.TAG] == "type"
+    assert out["class"] == "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh"
+
+
+def test_normalise_legacy_passthrough_canonical():
+    canonical = {sk.TAG: "pybamm.Scalar", "value": 1.0}
+    assert sk.normalise_legacy(canonical) is canonical

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 import pybamm
@@ -14,3 +15,27 @@ def test_class_path_round_trips_a_pybamm_class():
 def test_resolve_unknown_class_raises():
     with pytest.raises(sk.SerialisationError):
         sk._resolve_class("pybamm.NoSuchClassXYZ")
+
+
+def test_float_inf_nan_round_trip():
+    for val in (float("inf"), float("-inf"), 3.5):
+        assert sk._decode_leaf(sk._encode_float(val)) == val
+    nan = sk._decode_leaf(sk._encode_float(float("nan")))
+    assert nan != nan  # NaN
+
+
+def test_ndarray_round_trip():
+    arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+    node = sk.encode(arr)
+    assert np.array_equal(sk.decode(node), arr)
+
+
+def test_slice_round_trip():
+    node = sk.encode(slice(1, 5, 2))
+    assert sk.decode(node) == slice(1, 5, 2)
+
+
+def test_tuple_round_trips_as_tuple_not_list():
+    node = sk.encode((1, 2, 3))
+    out = sk.decode(node)
+    assert out == (1, 2, 3) and isinstance(out, tuple)

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -578,3 +578,22 @@ def test_concatenation_family_sparse_stack_rederives_concat_fun():
 )
 def test_already_correct_classes_round_trip(tree):
     assert _rt(tree).id == tree.id
+
+
+# ---------------------------------------------------------------------------
+# Function operand opt-outs (Task 2.0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tree",
+    [
+        pybamm.Arcsinh2(pybamm.Scalar(0.5), pybamm.Scalar(1.0)),
+        pybamm.RegPower(pybamm.Scalar(0.5), pybamm.Scalar(2.0)),
+    ],
+)
+def test_function_operands_carried_via_children_round_trip(tree):
+    # a/b (Arcsinh2) and base/exponent/scale (RegPower) are Symbol operands passed
+    # as children; eps/delta are emitted scalars. The guard must not false-positive
+    # on the operand params (they are carried via children).
+    assert _rt(tree).id == tree.id

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+import pybamm
+from pybamm.expression_tree.operations import serialise_kernel as sk
+
+
+def test_class_path_round_trips_a_pybamm_class():
+    path = sk._class_path(pybamm.Scalar)
+    assert sk._resolve_class(path) is pybamm.Scalar
+
+
+def test_resolve_unknown_class_raises():
+    with pytest.raises(sk.SerialisationError):
+        sk._resolve_class("pybamm.NoSuchClassXYZ")

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -129,3 +129,103 @@ def test_default_codec_round_trips_singular_domain_param():
     node[sk.TAG] = sk._class_path(pybamm.CoupledVariable)
     restored = codec.from_json(node, sk.decode, pybamm.CoupledVariable)
     assert restored.domain == ["negative electrode"]
+
+
+# ---------------------------------------------------------------------------
+# HookCodec + codec lookup (Task 1.5)
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_returns_hook_codec_for_overriding_class():
+    # Index overrides to_json/_from_json -> HookCodec.
+    codec = sk._lookup_codec(pybamm.Index)
+    assert isinstance(codec, sk.HookCodec)
+
+
+def test_lookup_returns_hook_codec_for_inherited_base_from_json():
+    # Negate defines neither method itself, but inherits UnaryOperator._from_json
+    # which is NOT Symbol._from_json, so _overrides_hooks is True -> HookCodec.
+    codec = sk._lookup_codec(pybamm.Negate)
+    assert isinstance(codec, sk.HookCodec)
+
+
+def test_lookup_returns_default_for_class_overriding_neither():
+    # CoupledVariable subclasses Symbol directly and overrides neither method, so
+    # it is the one concrete Symbol routed to DefaultCodec.
+    codec = sk._lookup_codec(pybamm.CoupledVariable)
+    assert isinstance(codec, sk.DefaultCodec)
+
+
+def test_lookup_returns_none_for_foreign_type():
+    class Foreign:
+        pass
+
+    assert sk._lookup_codec(Foreign) is None
+
+
+def test_hook_guard_passes_when_scalar_param_is_emitted():
+    class _Good(pybamm.Symbol):
+        def __init__(self, child, mode="a"):
+            super().__init__("good", children=[child])
+            self.mode = mode
+
+        def to_json(self):
+            return {"name": self.name, "domains": self.domains, "mode": self.mode}
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(snippet["children"][0], snippet["mode"])
+
+    node = sk.HookCodec().to_json(_Good(pybamm.Scalar(1.0), mode="z"), sk.encode)
+    assert node["mode"] == "z"
+
+
+def test_hook_guard_raises_when_scalar_param_is_dropped():
+    class _Leaky(pybamm.Symbol):
+        def __init__(self, child, mode="a"):
+            super().__init__("leaky", children=[child])
+            self.mode = mode
+
+        def to_json(self):
+            return {"name": self.name, "domains": self.domains}  # drops `mode`
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(snippet["children"][0])
+
+    with pytest.raises(sk.SerialisationError, match="mode"):
+        sk.encode(_Leaky(pybamm.Scalar(1.0), mode="z"))
+
+
+def test_hook_guard_allows_symbol_valued_param_via_children():
+    class _Wrapper(pybamm.Symbol):
+        def __init__(self, child, extra):
+            self.extra = extra  # a Symbol
+            super().__init__("wrap", children=[child, extra])
+
+        def to_json(self):
+            return {"name": self.name, "domains": self.domains}
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(*snippet["children"])
+
+    sk.encode(_Wrapper(pybamm.Scalar(1.0), pybamm.Scalar(2.0)))  # no raise
+
+
+def test_hook_guard_allows_declared_derived_param():
+    class _Cached(pybamm.Symbol):
+        _serialise_derived_params = frozenset({"cache"})
+
+        def __init__(self, child, cache=None):
+            super().__init__("cached", children=[child])
+            self.cache = cache if cache is not None else "derived"
+
+        def to_json(self):
+            return {"name": self.name, "domains": self.domains}
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(snippet["children"][0])
+
+    sk.encode(_Cached(pybamm.Scalar(1.0)))  # no raise

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -231,6 +231,38 @@ def test_hook_guard_allows_declared_derived_param():
     sk.encode(_Cached(pybamm.Scalar(1.0)))  # no raise
 
 
+# Module-level (not function-local) so decode can resolve it by import path during
+# the round-trip below; a `<locals>` class is not importable.
+class _OwnChildren(pybamm.Symbol):
+    def __init__(self, child, extra):
+        self.extra = extra
+        super().__init__("own", children=[child])  # extra not a symbol child
+
+    def to_json(self):
+        return {
+            "name": self.name,
+            "domains": self.domains,
+            "children": [self.children[0], self.extra],
+        }
+
+    @classmethod
+    def _from_json(cls, snippet):
+        return cls(snippet["children"][0], snippet["children"][1])
+
+
+def test_hook_codec_encodes_hook_supplied_children():
+    # A hook whose to_json returns its OWN children list (here [child, extra],
+    # where extra is NOT in obj.children) must have THAT list encoded and guarded,
+    # not obj.children. This is the contract SizeAverage/Variable/EvaluateAt rely on.
+    a, b = pybamm.Scalar(1.0), pybamm.Scalar(2.0)
+    obj = _OwnChildren(a, b)
+    node = sk.HookCodec().to_json(obj, sk.encode)
+    # the hook-supplied list (2 items) is encoded, not obj.children (1 item)
+    assert len(node["children"]) == 2
+    restored = sk.decode(sk.encode(obj))
+    assert restored.children[0].id == a.id and restored.extra.id == b.id
+
+
 # ---------------------------------------------------------------------------
 # normalise_legacy (Task 1.6)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -74,11 +74,7 @@ def test_encode_unknown_object_raises():
         sk.encode(Foreign())
 
 
-# ---------------------------------------------------------------------------
 # Synthetic helper classes for DefaultCodec tests
-# ---------------------------------------------------------------------------
-
-
 class _Clean(pybamm.Symbol):
     def __init__(self, child, mode="a"):
         super().__init__("clean", children=[child])
@@ -139,11 +135,7 @@ def test_default_codec_round_trips_singular_domain_param():
     assert restored.domain == ["negative electrode"]
 
 
-# ---------------------------------------------------------------------------
-# HookCodec + codec lookup (Task 1.5)
-# ---------------------------------------------------------------------------
-
-
+# HookCodec + codec lookup
 def test_lookup_returns_hook_codec_for_overriding_class():
     # Index overrides to_json/_from_json -> HookCodec.
     codec = sk._lookup_codec(pybamm.Index)
@@ -271,11 +263,7 @@ def test_hook_codec_encodes_hook_supplied_children():
     assert restored.children[0].id == a.id and restored.extra.id == b.id
 
 
-# ---------------------------------------------------------------------------
-# normalise_legacy (Task 1.6)
-# ---------------------------------------------------------------------------
-
-
+# normalise_legacy
 def test_normalise_legacy_py_object():
     legacy = {"py/object": "pybamm.Scalar", "py/id": 7, "value": 1.0}
     out = sk.normalise_legacy(legacy)
@@ -307,11 +295,7 @@ def test_normalise_legacy_passthrough_canonical():
     assert sk.normalise_legacy(canonical) is canonical
 
 
-# ---------------------------------------------------------------------------
-# Anti-reintroduction trap tests (Task 1.7)
-# ---------------------------------------------------------------------------
-
-
+# Anti-reintroduction trap tests
 def test_trap_default_codec_unhandleable_required_arg_raises_loudly():
     """A Symbol subclass with a renamed attribute and no hook (-> DefaultCodec)
     must RAISE on encode, never silently drop. Red here = DefaultCodec softened
@@ -486,11 +470,7 @@ def test_vector_field_round_trip():
     assert restored.id == tree.id
 
 
-# ---------------------------------------------------------------------------
-# Droppers + Scalar/Interpolant/Concatenation (Task 2.6)
-# ---------------------------------------------------------------------------
-
-
+# Droppers + Scalar/Interpolant/Concatenation
 @pytest.mark.parametrize(
     "tree",
     [
@@ -580,11 +560,7 @@ def test_already_correct_classes_round_trip(tree):
     assert _rt(tree).id == tree.id
 
 
-# ---------------------------------------------------------------------------
-# Function operand opt-outs (Task 2.0)
-# ---------------------------------------------------------------------------
-
-
+# Function operand opt-outs
 @pytest.mark.parametrize(
     "tree",
     [

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -318,7 +318,7 @@ def test_normalise_legacy_passthrough_canonical():
 def test_trap_default_codec_unhandleable_required_arg_raises_loudly():
     """A Symbol subclass with a renamed attribute and no hook (-> DefaultCodec)
     must RAISE on encode, never silently drop. Red here = DefaultCodec softened
-    back toward silent loss. See spec safe-or-loud invariant.
+    back toward silent loss, breaking the safe-or-loud invariant.
     """
 
     class _Trap(pybamm.Symbol):

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -265,3 +265,42 @@ def test_normalise_legacy_class_module():
 def test_normalise_legacy_passthrough_canonical():
     canonical = {sk.TAG: "pybamm.Scalar", "value": 1.0}
     assert sk.normalise_legacy(canonical) is canonical
+
+
+# ---------------------------------------------------------------------------
+# Anti-reintroduction trap tests (Task 1.7)
+# ---------------------------------------------------------------------------
+
+
+def test_trap_default_codec_unhandleable_required_arg_raises_loudly():
+    """A Symbol subclass with a renamed attribute and no hook (-> DefaultCodec)
+    must RAISE on encode, never silently drop. Red here = DefaultCodec softened
+    back toward silent loss. See spec safe-or-loud invariant.
+    """
+
+    class _Trap(pybamm.Symbol):
+        def __init__(self, child, secret):
+            super().__init__("trap", children=[child])
+            self._hidden = secret  # not secret / _secret -> unresolvable
+
+    with pytest.raises(sk.SerialisationError, match="secret"):
+        sk.encode(_Trap(pybamm.Scalar(1.0), "x"))
+
+
+def test_trap_hook_codec_inherited_base_drops_scalar_raises_loudly():
+    """The inherited-hook leak (#5548's structural cause), locked in. A
+    `UnaryOperator` subclass inherits `Symbol.to_json` (emits name/children/domains,
+    not `knob`) and `UnaryOperator._from_json` (rebuilds via __new__, routes to
+    HookCodec). The extra scalar `knob` is neither emitted, Symbol-valued, nor
+    declared derived -> the HookCodec coverage guard must RAISE. This is exactly the
+    shape `Magnitude.direction` had before its hook. Red here = the guard was
+    weakened and silent field-drop is back.
+    """
+
+    class _TrapUnary(pybamm.UnaryOperator):
+        def __init__(self, child, knob="a"):
+            super().__init__("trap_unary", child)
+            self.knob = knob
+
+    with pytest.raises(sk.SerialisationError, match="knob"):
+        sk.encode(_TrapUnary(pybamm.Scalar(1.0), knob="z"))

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -64,3 +64,68 @@ def test_encode_unknown_object_raises():
 
     with pytest.raises(sk.SerialisationError, match="Cannot serialise"):
         sk.encode(Foreign())
+
+
+# ---------------------------------------------------------------------------
+# Synthetic helper classes for DefaultCodec tests
+# ---------------------------------------------------------------------------
+
+
+class _Clean(pybamm.Symbol):
+    def __init__(self, child, mode="a"):
+        super().__init__("clean", children=[child])
+        self.mode = mode
+
+
+class _Renamed(pybamm.Symbol):
+    def __init__(self, child, mode):
+        super().__init__("renamed", children=[child])
+        self._cfg = mode  # stored under a name that is neither mode nor _mode
+
+
+def test_default_codec_captures_clean_param():
+    codec = sk.DefaultCodec()
+    obj = _Clean(pybamm.Scalar(1.0), mode="z")
+    node = codec.to_json(obj, sk.encode)
+    assert node["mode"] == "z"
+    assert "children" in node
+
+
+def test_default_codec_captures_param_with_default_value():
+    # A non-default value of a defaulted param must still be captured (fixes the
+    # BoundaryIntegral region-reset class of bug).
+    codec = sk.DefaultCodec()
+    node = codec.to_json(_Clean(pybamm.Scalar(1.0), mode="a"), sk.encode)
+    assert node["mode"] == "a"
+
+
+def test_default_codec_raises_on_unresolvable_required_param():
+    codec = sk.DefaultCodec()
+    with pytest.raises(sk.SerialisationError, match="mode"):
+        codec.to_json(_Renamed(pybamm.Scalar(1.0), "x"), sk.encode)
+
+
+def test_default_codec_from_json_ignores_extra_legacy_keys():
+    # The old switch always wrote a "name" key; a clean class whose __init__ has
+    # no `name` param must still reconstruct (the key is ignored, not forwarded
+    # as an unexpected kwarg). Guards legacy compatibility (#5548 spec).
+    codec = sk.DefaultCodec()
+    node = codec.to_json(_Clean(pybamm.Scalar(1.0), mode="q"), sk.encode)
+    node[sk.TAG] = sk._class_path(_Clean)
+    node["name"] = "legacy-name"  # spurious key from the old fallback
+    node["entries_string"] = "noise"  # another legacy-only key
+    restored = codec.from_json(node, sk.decode, _Clean)
+    assert restored.mode == "q"
+
+
+def test_default_codec_round_trips_singular_domain_param():
+    # A class whose __init__ takes `domain` (not `domains`) must still recover
+    # its domain: to_json emits the full `domains` dict, from_json maps it onto
+    # the singular `domain` param. Guards the CoupledVariable silent-drop bug --
+    # CoupledVariable is the one concrete Symbol that reaches DefaultCodec.
+    codec = sk.DefaultCodec()
+    cv = pybamm.CoupledVariable("c", domain=["negative electrode"])
+    node = codec.to_json(cv, sk.encode)
+    node[sk.TAG] = sk._class_path(pybamm.CoupledVariable)
+    restored = codec.from_json(node, sk.decode, pybamm.CoupledVariable)
+    assert restored.domain == ["negative electrode"]

--- a/tests/unit/test_serialisation/test_symbol_strategy_coverage.py
+++ b/tests/unit/test_serialisation/test_symbol_strategy_coverage.py
@@ -35,9 +35,11 @@ from tests.strategies.symbols import (
 
 
 def _all_concrete_subclasses(root: type) -> set[type]:
-    """Recursively collect concrete subclasses of ``root``.
+    """Recursively collect concrete pybamm subclasses of ``root``.
 
-    A class is concrete if it has no ``__abstractmethods__``.
+    A class is concrete if it has no ``__abstractmethods__``. Synthetic Symbol
+    subclasses defined inside test modules are ignored (only classes shipped in
+    the ``pybamm`` package are subject to the strategy-coverage contract).
     """
     seen: set[type] = set()
     stack = list(root.__subclasses__())
@@ -47,7 +49,12 @@ def _all_concrete_subclasses(root: type) -> set[type]:
             continue
         seen.add(cls)
         stack.extend(cls.__subclasses__())
-    return {c for c in seen if not getattr(c, "__abstractmethods__", None)}
+    return {
+        c
+        for c in seen
+        if not getattr(c, "__abstractmethods__", None)
+        and c.__module__.startswith("pybamm")
+    }
 
 
 def test_every_concrete_symbol_subclass_has_a_strategy():


### PR DESCRIPTION
# Description

First of two stacked PRs replacing the lossy `convert_symbol_to_json` / `convert_symbol_from_json` type-switch with a single safe-or-loud serialisation kernel. Every value either round-trips correctly or raises `SerialisationError` at encode time; no code path silently drops a constructor argument.

This PR covers:

- **Legacy fixtures pinned first**: authentic pre-refactor files (compact `type` symbols, `class`+`module` submesh types) committed from `main` and regression-tested through the legacy read shim, so old files keep loading.
- **The kernel** (`expression_tree/operations/serialise_kernel.py`): encode/decode engine, codec registry, introspection-based `DefaultCodec`, explicit `to_json`/`_from_json` hooks, leaf codecs (ndarray, slice, tuple, inf/nan floats), `class_reference` for type references, and a read-only legacy normalisation shim. Trap tests lock in the safe-or-loud guard.
- **Symbol surface migration**: `convert_symbol_*` now route through the kernel and the central isinstance ladder is deleted. Hooks added for the ~20 classes that previously crashed or silently dropped arguments (spatial operators, broadcasts, `Index`, `Variable` scale/reference, concatenations, interpolants, and friends).
- `_KNOWN_FAILING` is empty: every #5548 repro round-trips, verified by dedicated repro tests and property tests over the strategy suite.

Fixes #5548

Stacked on `feat/serialisation-property-tests` (the property-test harness this builds on). A follow-up PR will target this branch to migrate the discretised-model surface and adjacent surfaces (solvers, experiments, parameter values, geometry, meshes) onto the same kernel, with cleanup, docs, and the CHANGELOG entry.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works