### PR TITLE
Serialisation kernel: migrate discretised-model, solver, and mesh surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Electrode electronic conductivity can now be specified as a function of stoichiometry (in addition to temperature) for all lithium-ion and sodium-ion models. ([#5556](https://github.com/pybamm-team/PyBaMM/pull/5556))
-- Unified PyBaMM serialisation onto a single safe-or-loud encode/decode kernel. Serialisation now either round-trips or raises `SerialisationError`, never silently dropping a field, across the expression tree, discretised models, meshes, solvers, experiments and parameter values. There is one canonical on-disk format, and files saved by older PyBaMM versions continue to load via backward-compatible readers. ([#5548](https://github.com/pybamm-team/PyBaMM/issues/5548))
+- Unified PyBaMM serialisation onto a single safe-or-loud encode/decode kernel. Serialisation now either round-trips or raises `SerialisationError`, never silently dropping a field, across the expression tree, discretised models, meshes, solvers, experiments and parameter values. There is one canonical on-disk format, and files saved by older PyBaMM versions continue to load via backward-compatible readers. ([#5560](https://github.com/pybamm-team/PyBaMM/pull/5560)) and ([#5561](https://github.com/pybamm-team/PyBaMM/pull/5561))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 - Electrode electronic conductivity can now be specified as a function of stoichiometry (in addition to temperature) for all lithium-ion and sodium-ion models. ([#5556](https://github.com/pybamm-team/PyBaMM/pull/5556))
+- Unified PyBaMM serialisation onto a single safe-or-loud encode/decode kernel. Serialisation now either round-trips or raises `SerialisationError`, never silently dropping a field, across the expression tree, discretised models, meshes, solvers, experiments and parameter values. There is one canonical on-disk format, and files saved by older PyBaMM versions continue to load via backward-compatible readers. ([#5548](https://github.com/pybamm-team/PyBaMM/issues/5548))
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Features
 
 - Electrode electronic conductivity can now be specified as a function of stoichiometry (in addition to temperature) for all lithium-ion and sodium-ion models. ([#5556](https://github.com/pybamm-team/PyBaMM/pull/5556))
-- Unified PyBaMM serialisation onto a single safe-or-loud encode/decode kernel. Serialisation now either round-trips or raises `SerialisationError`, never silently dropping a field, across the expression tree, discretised models, meshes, solvers, experiments and parameter values. There is one canonical on-disk format, and files saved by older PyBaMM versions continue to load via backward-compatible readers. ([#5560](https://github.com/pybamm-team/PyBaMM/pull/5560)) and ([#5561](https://github.com/pybamm-team/PyBaMM/pull/5561))
+- Unified PyBaMM serialisation onto a single safe-or-loud encode/decode kernel. Serialisation now either round-trips or raises `SerialisationError`, never silently dropping a field, across the expression tree, discretised models, meshes, solvers, experiments and parameter values. There is one canonical on-disk format, and files saved by older PyBaMM versions continue to load via backward-compatible readers. Note that `save_model(model, mesh=...)` now raises for meshes containing submeshes that cannot round-trip (those without a `_from_json` hook, e.g. `Exponential1DSubMesh`); previously the save succeeded but the mesh could not be reloaded. ([#5560](https://github.com/pybamm-team/PyBaMM/pull/5560), [#5561](https://github.com/pybamm-team/PyBaMM/pull/5561))
 
 ## Breaking changes
 
@@ -11,6 +11,7 @@
 
 ## Bug fixes
 
+- Fixed legacy geometry deserialisation over-stripping the `symbol_` key prefix as a character set, which raised `KeyError` for variable names composed of those characters (e.g. the current-collector variable `y`). ([#5561](https://github.com/pybamm-team/PyBaMM/pull/5561))
 - Fixed unified experiment mode using excessive memory and time for experiments with many cycles. ([#5554](https://github.com/pybamm-team/PyBaMM/pull/5554))
 
 ## Optimizations

--- a/docs/source/api/expression_tree/operations/serialise.rst
+++ b/docs/source/api/expression_tree/operations/serialise.rst
@@ -1,5 +1,87 @@
 Serialise
 =========
 
+PyBaMM serialises expression trees, discretised models, meshes, solvers and
+related objects through a single encode/decode kernel
+(``pybamm.expression_tree.operations.serialise_kernel``). The kernel is
+**safe-or-loud**: a value either round-trips, or encoding raises
+``SerialisationError`` naming the offending class and field. It never silently
+drops data. There is one canonical wire format (each node carries a ``$type``
+tag holding its dotted ``module.ClassName`` path), and a read-only compatibility
+layer keeps files written by older PyBaMM versions loading.
+
+Making a class serialisable
+---------------------------
+
+**Usually you do nothing.** A new ``Symbol`` (or other serialisable) subclass is
+encoded automatically by the introspection ``DefaultCodec``: it reads each
+``__init__`` parameter back off the instance (by the same name, or the
+``_``-prefixed private attribute) and emits it. If your class stores its
+constructor arguments as same-named attributes, it round-trips with no extra
+code.
+
+**The safe-or-loud contract tells you when you must act.** If a stored or
+required ``__init__`` parameter is *not* captured, ``encode`` raises
+``SerialisationError`` naming the class and the parameter the first time the
+class is serialised. The strategy-coverage meta-tests
+(``tests/unit/test_serialisation/test_symbol_strategy_coverage.py`` and
+``test_base_strategy_coverage.py``) turn a new concrete subclass with no
+round-trip coverage into a CI failure. So a gap is a loud failure, never a silent
+one.
+
+**Add a hook when reconstruction is irregular.** Define ``to_json`` /
+``_from_json`` on the class when it cannot be rebuilt by simply replaying its
+``__init__`` parameters, for example when a constructor argument is itself a
+``Symbol`` or another serialisable object. The kernel only recurses the
+``children`` list, so **any ``Symbol``-valued argument must travel through
+``children``**; every other field a hook emits must already be JSON-native.
+
+.. code-block:: python
+
+    class MyEvent(pybamm.Symbol):
+        def __init__(self, name, expression):
+            super().__init__(name, children=[expression])
+
+        def to_json(self):
+            # ``expression`` is a Symbol, so it rides in children; the kernel
+            # recurses children and reconstructs it for us.
+            return {"name": self.name, "children": [self.children[0]]}
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(snippet["name"], snippet["children"][0])
+
+**Opt out genuinely derived fields explicitly.** If a constructor parameter is
+re-derived on construction (so it need not be stored) or is a non-serialisable
+transient, list its name in the class's ``_serialise_derived_params`` frozenset.
+This is a reviewed, in-diff decision that the coverage guard honours; it is not a
+runtime skip. See ``Mesh``, ``SubMesh`` and ``DomainConcatenation`` for existing
+examples (each waives construction inputs it rebuilds from other serialised
+fields on decode).
+
+.. code-block:: python
+
+    class MySubMesh(pybamm.SubMesh):
+        # ``builder`` is only used to compute ``edges`` in __init__; the mesh is
+        # reconstructed from ``edges``, so ``builder`` is never serialised.
+        _serialise_derived_params = frozenset({"builder"})
+
+**Register round-trip coverage.** Add (or extend) a strategy under
+``tests/strategies/`` so your class is exercised by the round-trip property
+tests, or -- if it is intentionally not independently round-trippable -- add it to
+the relevant base's exemption set in the coverage meta-test with a one-line
+reason. The meta-test will tell you exactly which classes are uncovered.
+
+Class references
+----------------
+
+A bare class (rather than an instance) is serialised through the kernel's
+class-reference codec as ``{"$type": "type", "class": "module.ClassName"}`` (used
+for submesh types and spatial methods). The legacy ``{"class": ..., "module":
+...}`` shape is still read on decode.
+
+API
+---
+
 .. autoclass:: pybamm.expression_tree.operations.serialise.Serialise
   :members:

--- a/docs/source/api/expression_tree/operations/serialise.rst
+++ b/docs/source/api/expression_tree/operations/serialise.rst
@@ -10,6 +10,82 @@ drops data. There is one canonical wire format (each node carries a ``$type``
 tag holding its dotted ``module.ClassName`` path), and a read-only compatibility
 layer keeps files written by older PyBaMM versions loading.
 
+Wire format
+-----------
+
+``encode`` produces plain JSON. Native values (``None``, booleans, integers,
+strings, finite floats) pass through unchanged, lists and dicts stay JSON
+arrays/objects, and every other object becomes a tagged node: its class-specific
+fields plus a ``"$type"`` key holding the dotted ``module.ClassName`` path. Child
+symbols (and other serialisable sub-objects) are recursively encoded under
+``"children"``. For example, ``pybamm.Index(pybamm.StateVector(slice(0, 2)), 0)``
+encodes as:
+
+.. code-block:: json
+
+    {
+      "name": "Index[0]",
+      "index": {"start": 0, "stop": 1, "step": null},
+      "check_size": false,
+      "children": [
+        {
+          "name": "y[0:2]",
+          "domains": {"primary": [], "secondary": [], "tertiary": [], "quaternary": []},
+          "y_slice": [{"start": 0, "stop": 2, "step": null}],
+          "evaluation_array": [true, true],
+          "$type": "pybamm.expression_tree.state_vector.StateVector"
+        }
+      ],
+      "$type": "pybamm.expression_tree.unary_operators.Index"
+    }
+
+On decode the ``"$type"`` path is resolved with ``importlib``, so classes defined
+outside the ``pybamm`` package round-trip too. Apart from ``"$type"`` and
+``"children"``, the keys of a node belong to the class (its constructor
+parameters, or whatever its ``to_json`` hook emits).
+
+A few non-class values the kernel encodes itself use reserved ``"$type"`` tags:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Value
+     - Encoding
+   * - ``nan``, ``inf``, ``-inf``
+     - ``{"$type": "builtins.float", "value": "NaN"}`` (or ``"Infinity"`` / ``"-Infinity"``)
+   * - ``numpy.ndarray``
+     - ``{"$type": "numpy.ndarray", "data": [...], "dtype": "float64"}``
+   * - ``slice``
+     - ``{"$type": "builtins.slice", "start": 0, "stop": 1, "step": null}``
+   * - ``tuple``
+     - ``{"$type": "builtins.tuple", "items": [...]}`` (so it does not decode back as a list)
+   * - a class itself (not an instance)
+     - ``{"$type": "type", "class": "module.ClassName"}``
+
+Legacy formats (read-only)
+--------------------------
+
+Files written by older PyBaMM versions used three different shapes. All three
+still load: ``decode`` passes every dict through ``normalise_legacy``, which maps
+them onto the canonical tag. New files are always written in the canonical
+format; the legacy shapes are never written.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Legacy shape
+     - Previously written by
+     - Normalisation
+   * - ``{"py/object": "dotted.path", "py/id": 1, ...}``
+     - discretised-model files
+     - ``py/object`` becomes ``$type``; ``py/id`` is dropped
+   * - ``{"type": "ClassName", ...}``
+     - symbol, parameter-values and experiment files
+     - bare class names resolve as ``pybamm.ClassName``
+   * - ``{"class": "ClassName", "module": "some.module"}``
+     - submesh and spatial-method type references
+     - becomes a ``{"$type": "type"}`` class reference
+
 Making a class serialisable
 ---------------------------
 

--- a/docs/source/examples/notebooks/models/saving_models.ipynb
+++ b/docs/source/examples/notebooks/models/saving_models.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Models which are discretised (i.e. ready to solve/ previously solved, see [this notebook](https://github.com/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/spatial_methods/finite-volumes.ipynb) for more information on the pybamm.Discretisation class) can be serialised and saved to a JSON file, ready to be read in again either in PyBaMM, or a different modelling library. \n",
+    "Models which are discretised (i.e. ready to solve/ previously solved, see [this notebook](https://github.com/pybamm-team/PyBaMM/blob/main/docs/source/examples/notebooks/spatial_methods/finite-volumes.ipynb) for more information on the pybamm.Discretisation class) can be serialised and saved to a JSON file, ready to be read in again either in PyBaMM, or a different modelling library. The structure of the saved JSON, and the legacy formats written by older PyBaMM versions (which still load), are documented in the [Serialise API docs](https://docs.pybamm.org/en/latest/source/api/expression_tree/operations/serialise.html).\n",
     "\n",
     "In the example below, we build a basic DFN model, and then save the model out to `sim_model_example.json`, which should have appear in the 'models' directory."
    ]

--- a/src/pybamm/expression_tree/concatenations.py
+++ b/src/pybamm/expression_tree/concatenations.py
@@ -292,6 +292,14 @@ class DomainConcatenation(Concatenation):
         from `copy_this`. `mesh` is not used in this case
     """
 
+    # full_mesh is a construction input used only to derive slices/size; those are
+    # serialised directly and _from_json never re-stores the mesh, so it is not
+    # itself serialised (copy_this is defaulted-and-unstored, covered by the guard
+    # grace).
+    _serialise_derived_params = Concatenation._serialise_derived_params | frozenset(
+        {"full_mesh"}
+    )
+
     def __init__(
         self,
         children: Sequence[pybamm.Symbol],

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -2272,6 +2272,44 @@ def convert_function_to_symbolic_expression(func, name=None):
     return ExpressionFunctionParameter(name, sym_output, func_name, func_args)
 
 
+def _relocate_legacy_model_tree(node):
+    """Rewrite the three legacy ``py/object`` nested shapes into the canonical
+    kernel ``children`` shape, in place of the per-class divergences the tag-only
+    ``normalise_legacy`` shim does not touch. Read-only; recursive; applied only to
+    legacy discretised files before ``decode``.
+
+    - ``Event``: ``expression`` sibling -> ``children[0]``.
+    - ``ExplicitTimeIntegral``: ``initial_condition`` sibling -> appended to ``children``.
+    - ``Mesh``: ``sub_meshes`` {domain: node} -> ``children`` + ``sub_mesh_domains``.
+
+    Canonical (``$type``) nodes and non-dicts pass through (their children still
+    recurse). Numpy/leaf nodes have no nested model fields, so they are unaffected.
+    """
+    if isinstance(node, list):
+        return [_relocate_legacy_model_tree(n) for n in node]
+    if not isinstance(node, dict):
+        return node
+
+    out = {k: v for k, v in node.items()}
+    children = [_relocate_legacy_model_tree(c) for c in out.get("children", [])]
+
+    if "sub_meshes" in out:
+        sub = out.pop("sub_meshes")
+        out["sub_mesh_domains"] = list(sub.keys())
+        children = [_relocate_legacy_model_tree(v) for v in sub.values()]
+    if "expression" in out:
+        children = [_relocate_legacy_model_tree(out.pop("expression")), *children]
+    if "initial_condition" in out:
+        children = [
+            *children,
+            _relocate_legacy_model_tree(out.pop("initial_condition")),
+        ]
+
+    if children or "children" in out:
+        out["children"] = children
+    return out
+
+
 def convert_symbol_from_json(json_data):
     """Reconstruct a pybamm.Symbol from kernel/legacy JSON."""
     from pybamm.expression_tree.operations.serialise_kernel import decode

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1964,8 +1964,8 @@ class Serialise:
             raise ValueError("Experiment config must have 'steps' or 'cycles'.")
 
     # Solver __init__ params that are genuinely re-derived on construction or are
-    # non-serialisable transients. Empty today (Task 4.1 audit found no shipped solver
-    # omits anything); anything not listed that fails to serialise raises (safe-or-loud).
+    # non-serialisable transients. Empty today (no shipped solver omits anything);
+    # anything not listed that fails to serialise raises (safe-or-loud).
     _SOLVER_DERIVED_PARAMS: frozenset = frozenset()
 
     @staticmethod

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -168,6 +168,10 @@ class Serialise:
             node_dict = {"py/object": str(type(node))[8:-2], "py/id": id(node)}
             if isinstance(node, pybamm.Mesh):
                 node_dict.update(node.to_json())
+                # Drop the kernel-only keys; the legacy encoder builds sub_meshes
+                # itself. Removed when _MeshEncoder is retired (later task).
+                node_dict.pop("children", None)
+                node_dict.pop("sub_mesh_domains", None)
 
                 submeshes = {}
                 for k, v in node.items():
@@ -1739,15 +1743,16 @@ class Serialise:
         return obj
 
     def _reconstruct_mesh(self, node: dict):
-        """Reconstructs a Mesh object"""
-        if "sub_meshes" in node:
-            for k, v in node["sub_meshes"].items():
-                sub_mesh = self._reconstruct_symbol(v)
-                node["sub_meshes"][k] = sub_mesh
-
-        new_mesh = self._reconstruct_symbol(node)
-
-        return new_mesh
+        """Reconstruct a Mesh from the legacy py/object shape (a ``sub_meshes``
+        dict). Builds the Mesh directly rather than via the canonical (kernel)
+        ``Mesh._from_json``; retired once load_model decodes through the kernel."""
+        mesh = pybamm.Mesh.__new__(pybamm.Mesh)
+        super(pybamm.Mesh, mesh).__init__()
+        mesh.submesh_pts = node["submesh_pts"]
+        mesh.base_domains = node["base_domains"]
+        for k, v in node.get("sub_meshes", {}).items():
+            mesh[k] = self._reconstruct_symbol(v)
+        return mesh
 
     def _reconstruct_pybamm_dict(self, obj: dict):
         """

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1642,9 +1642,9 @@ class Serialise:
                 # rearrange the dictionary to make pybamm objects the dictionary keys
                 if symbol_keys:
                     for k, v in symbol_keys.items():
-                        new_dict[v] = new_dict[k.lstrip("symbol_")]
+                        new_dict[v] = new_dict[k.removeprefix("symbol_")]
                         del new_dict[k]
-                        del new_dict[k.lstrip("symbol_")]
+                        del new_dict[k.removeprefix("symbol_")]
 
                 return new_dict
             return obj

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -152,7 +152,9 @@ class Serialise:
                 return node_dict
 
             if isinstance(node, pybamm.Event):
-                node_dict.update(node.to_json())
+                hook = node.to_json()
+                hook.pop("children", None)  # legacy encoder walks expression itself
+                node_dict.update(hook)
                 node_dict["expression"] = self.default(node._expression)
                 return node_dict
 

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -133,16 +133,6 @@ class Serialise:
     def __init__(self):
         pass
 
-    class _Empty:
-        """A dummy class to aid deserialisation"""
-
-        pass
-
-    class _EmptyDict(dict):
-        """A dummy dictionary class to aid deserialisation"""
-
-        pass
-
     def serialise_model(
         self,
         model: pybamm.BaseModel,
@@ -252,6 +242,28 @@ class Serialise:
         with open(filename + ".json", "w") as f:
             json.dump(model_json, f)
 
+    @staticmethod
+    def _is_legacy_node(node) -> bool:
+        """True if any node in the tree uses the legacy py/object tag."""
+        if isinstance(node, dict):
+            if "py/object" in node:
+                return True
+            return any(Serialise._is_legacy_node(v) for v in node.values())
+        if isinstance(node, list):
+            return any(Serialise._is_legacy_node(v) for v in node)
+        return False
+
+    @staticmethod
+    def _decode_model_node(node):
+        """Decode one serialised model field through the kernel, relocating the
+        legacy py/object nested shapes first so old files load through the same
+        single decode path."""
+        from pybamm.expression_tree.operations.serialise_kernel import decode
+
+        if Serialise._is_legacy_node(node):
+            node = _relocate_legacy_model_tree(node)
+        return decode(node)
+
     def load_model(
         self, filename: str | dict, battery_model: pybamm.BaseModel | None = None
     ) -> pybamm.BaseModel:
@@ -295,44 +307,34 @@ class Serialise:
             "name": model_data["name"],
             "options": self._convert_options(model_data["options"]),
             "bounds": tuple(np.array(bound) for bound in model_data["bounds"]),
-            "concatenated_rhs": self._reconstruct_expression_tree(
-                model_data["concatenated_rhs"]
-            ),
-            "concatenated_algebraic": self._reconstruct_expression_tree(
+            "concatenated_rhs": self._decode_model_node(model_data["concatenated_rhs"]),
+            "concatenated_algebraic": self._decode_model_node(
                 model_data["concatenated_algebraic"]
             ),
-            "concatenated_initial_conditions": self._reconstruct_expression_tree(
+            "concatenated_initial_conditions": self._decode_model_node(
                 model_data["concatenated_initial_conditions"]
             ),
-            "events": [
-                self._reconstruct_expression_tree(event)
-                for event in model_data["events"]
-            ],
-            "mass_matrix": self._reconstruct_expression_tree(model_data["mass_matrix"]),
+            "events": [self._decode_model_node(e) for e in model_data["events"]],
+            "mass_matrix": self._decode_model_node(model_data["mass_matrix"]),
         }
 
         recon_model_dict["geometry"] = (
             self._reconstruct_pybamm_dict(model_data["geometry"])
-            if "geometry" in model_data.keys()
+            if "geometry" in model_data
             else None
         )
-
         recon_model_dict["mesh"] = (
-            self._reconstruct_mesh(model_data["mesh"])
-            if "mesh" in model_data.keys()
+            self._decode_model_node(model_data["mesh"])
+            if "mesh" in model_data
             else None
         )
 
         vars_processed_data = model_data.get("_variables_processed") or {}
         recon_model_dict["_variables_processed"] = (
-            {
-                k: self._reconstruct_expression_tree(v)
-                for k, v in vars_processed_data.items()
-            }
+            {k: self._decode_model_node(v) for k, v in vars_processed_data.items()}
             if vars_processed_data
             else {}
         )
-
         recon_model_dict["_solution_observable"] = model_data.get(
             "_solution_observable", False
         )
@@ -340,15 +342,19 @@ class Serialise:
         if battery_model:
             return battery_model.deserialise(recon_model_dict)
 
-        if "py/object" in model_data.keys():
-            model_framework = self._get_pybamm_class(model_data)
+        tag = model_data.get("$type") or model_data.get("py/object")
+        if tag:
+            from pybamm.expression_tree.operations.serialise_kernel import (
+                _resolve_class,
+            )
+
+            model_framework = (
+                _resolve_class(tag) if "." in tag else _resolve_class(f"pybamm.{tag}")
+            )
+            # deserialise is a BaseModel classmethod inherited by every model class.
             return model_framework.deserialise(recon_model_dict)
 
-        raise TypeError(
-            """
-            The PyBaMM battery model to use has not been provided.
-            """
-        )
+        raise TypeError("The PyBaMM battery model to use has not been provided.")
 
     @staticmethod
     def _json_encoder(obj):
@@ -1596,26 +1602,6 @@ class Serialise:
 
     # Helper functions
 
-    def _get_pybamm_class(self, snippet: dict):
-        """Find a pybamm class to initialise from object path"""
-        parts = snippet["py/object"].split(".")
-        module = importlib.import_module(".".join(parts[:-1]))
-
-        class_ = getattr(module, parts[-1])
-
-        try:
-            empty_class = self._Empty()
-            empty_class.__class__ = class_
-
-            return empty_class
-
-        except TypeError:
-            # Mesh objects have a different layouts
-            empty_dict_class = self._EmptyDict()
-            empty_dict_class.__class__ = class_
-
-            return empty_dict_class
-
     def _deconstruct_pybamm_dicts(self, dct: dict):
         """
         Converts dictionaries which contain pybamm classes as keys
@@ -1658,49 +1644,6 @@ class Serialise:
         except TypeError:  # dct must contain pybamm objects
             return nested_convert(dct)
 
-    def _reconstruct_symbol(self, dct: dict):
-        """Reconstruct an individual pybamm Symbol"""
-        symbol_class = self._get_pybamm_class(dct)
-        symbol = symbol_class._from_json(dct)
-        return symbol
-
-    def _reconstruct_expression_tree(self, node: dict):
-        """
-        Loop through an expression tree creating pybamm Symbol classes
-
-        Conducts post-order tree traversal to turn each tree node into a
-        `pybamm.Symbol` class, starting from leaf nodes without children and
-        working upwards.
-
-        Parameters
-        ----------
-        node: dict
-            A node in an expression tree.
-        """
-        if "children" in node:
-            for i, c in enumerate(node["children"]):
-                child_obj = self._reconstruct_expression_tree(c)
-                node["children"][i] = child_obj
-        elif "expression" in node:
-            expression_obj = self._reconstruct_expression_tree(node["expression"])
-            node["expression"] = expression_obj
-
-        obj = self._reconstruct_symbol(node)
-
-        return obj
-
-    def _reconstruct_mesh(self, node: dict):
-        """Reconstruct a Mesh from the legacy py/object shape (a ``sub_meshes``
-        dict). Builds the Mesh directly rather than via the canonical (kernel)
-        ``Mesh._from_json``; retired once load_model decodes through the kernel."""
-        mesh = pybamm.Mesh.__new__(pybamm.Mesh)
-        super(pybamm.Mesh, mesh).__init__()
-        mesh.submesh_pts = node["submesh_pts"]
-        mesh.base_domains = node["base_domains"]
-        for k, v in node.get("sub_meshes", {}).items():
-            mesh[k] = self._reconstruct_symbol(v)
-        return mesh
-
     def _reconstruct_pybamm_dict(self, obj: dict):
         """
         pybamm.Geometry can contain PyBaMM symbols as dictionary keys.
@@ -1726,7 +1669,7 @@ class Serialise:
                 new_dict = {}
                 for k, v in obj.items():
                     if "symbol_" in k:
-                        new_dict[k] = self._reconstruct_symbol(v)
+                        new_dict[k] = self._decode_model_node(v)
                     elif isinstance(v, dict):
                         new_dict[k] = recurse(v)
                     else:

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -819,45 +819,26 @@ class Serialise:
 
     @staticmethod
     def serialise_spatial_method_item(method) -> dict:
-        """
-        Serialise a single spatial method instance.
+        """Serialise a spatial method. The class is encoded via the kernel's
+        class_reference codec; its options ride alongside under "options"."""
+        from pybamm.expression_tree.operations.serialise_kernel import encode
 
-        Parameters
-        ----------
-        method : SpatialMethod
-            A spatial method instance (e.g. FiniteVolume(), ZeroDimensionalSpatialMethod()).
-
-        Returns
-        -------
-        dict
-            JSON-serialisable dict with "class", "module", and "options".
-        """
-        return {
-            "class": type(method).__name__,
-            "module": type(method).__module__,
-            "options": method.options if hasattr(method, "options") else {},
-        }
+        result = encode(type(method))
+        result["options"] = method.options if hasattr(method, "options") else {}
+        return result
 
     @staticmethod
     def deserialise_spatial_method_item(method_info: dict):
-        """
-        Deserialise a single spatial method from a dict (one entry from spatial_methods).
+        """Deserialise a spatial method from either the kernel class_reference shape
+        or the legacy {class, module} shape."""
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            _resolve_class,
+            normalise_legacy,
+        )
 
-        Parameters
-        ----------
-        method_info : dict
-            Dict with "class", "module", and optionally "options".
-
-        Returns
-        -------
-        SpatialMethod
-            A spatial method instance.
-        """
-        module_name = method_info["module"]
-        class_name = method_info["class"]
+        node = normalise_legacy(dict(method_info))
+        method_class = _resolve_class(node["class"])
         options = method_info.get("options") or {}
-        module = importlib.import_module(module_name)
-        method_class = getattr(module, class_name)
         return method_class(options=options)
 
     @staticmethod
@@ -983,17 +964,20 @@ class Serialise:
             raise KeyError("Missing 'spatial_methods' section in JSON data.")
 
         # Reconstruct spatial methods
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            SerialisationError,
+        )
+
         reconstructed_methods = {}
         for domain, method_info in spatial_methods_data.items():
             try:
                 reconstructed_methods[domain] = (
                     Serialise.deserialise_spatial_method_item(method_info)
                 )
-            except (ModuleNotFoundError, AttributeError) as e:
+            except (ModuleNotFoundError, AttributeError, SerialisationError) as e:
                 class_name = method_info.get("class", "?")
-                module_name = method_info.get("module", "?")
                 raise ImportError(
-                    f"Could not import spatial method '{class_name}' from '{module_name}': {e}"
+                    f"Could not import spatial method '{class_name}': {e}"
                 ) from e
             except Exception as e:
                 raise ValueError(
@@ -1129,57 +1113,31 @@ class Serialise:
 
     @staticmethod
     def serialise_submesh_item(submesh_item) -> dict:
-        """
-        Serialise a single submesh type (SubMesh class or MeshGenerator instance).
+        """Serialise a SubMesh class or MeshGenerator. The class is encoded via the
+        kernel's class_reference codec ({"$type": "type", "class": dotted-path}); a
+        MeshGenerator's params ride alongside under "submesh_params"."""
+        from pybamm.expression_tree.operations.serialise_kernel import encode
 
-        Parameters
-        ----------
-        submesh_item : type or MeshGenerator
-            A SubMesh class (e.g. Uniform1DSubMesh) or a MeshGenerator instance.
-
-        Returns
-        -------
-        dict
-            JSON-serialisable dict with "class", "module", and optionally
-            "submesh_params" for MeshGenerator.
-        """
-        if hasattr(submesh_item, "submesh_type"):
-            submesh_class = submesh_item.submesh_type
-            result = {
-                "class": submesh_class.__name__,
-                "module": submesh_class.__module__,
-            }
+        if hasattr(submesh_item, "submesh_type"):  # MeshGenerator instance
+            result = encode(submesh_item.submesh_type)
             if getattr(submesh_item, "submesh_params", None):
                 result["submesh_params"] = dict(submesh_item.submesh_params)
             return result
-        # SubMesh class
-        return {
-            "class": submesh_item.__name__,
-            "module": submesh_item.__module__,
-        }
+        return encode(submesh_item)  # a SubMesh class
 
     @staticmethod
     def deserialise_submesh_item(submesh_info: dict, return_class_only: bool = False):
-        """
-        Deserialise a single submesh type from a dict (one entry from submesh_types).
+        """Deserialise a SubMesh class / MeshGenerator from either the kernel
+        class_reference shape or the legacy {class, module} shape."""
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            _resolve_class,
+            normalise_legacy,
+        )
 
-        Parameters
-        ----------
-        submesh_info : dict
-            Dict with "class", "module", and optionally "submesh_params".
-        return_class_only : bool, optional
-            If True, return the SubMesh class. If False, return a MeshGenerator
-            instance. Default is False.
-
-        Returns
-        -------
-        type or MeshGenerator
-            The SubMesh class or a MeshGenerator instance.
-        """
-        module_name = submesh_info["module"]
-        class_name = submesh_info["class"]
-        module = importlib.import_module(module_name)
-        submesh_class = getattr(module, class_name)
+        node = normalise_legacy(
+            dict(submesh_info)
+        )  # legacy {class,module} -> $type form
+        submesh_class = _resolve_class(node["class"])
         if return_class_only:
             return submesh_class
         params = submesh_info.get("submesh_params") or {}
@@ -1303,6 +1261,10 @@ class Serialise:
             raise KeyError("Missing 'submesh_types' section in JSON data.")
 
         # Reconstruct submesh types
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            SerialisationError,
+        )
+
         reconstructed_submesh_types = {}
         for domain, submesh_info in submesh_types_data.items():
             try:
@@ -1311,11 +1273,10 @@ class Serialise:
                         submesh_info, return_class_only=False
                     )
                 )
-            except (ModuleNotFoundError, AttributeError) as e:
+            except (ModuleNotFoundError, AttributeError, SerialisationError) as e:
                 class_name = submesh_info.get("class", "?")
-                module_name = submesh_info.get("module", "?")
                 raise ImportError(
-                    f"Could not import submesh type '{class_name}' from '{module_name}': {e}"
+                    f"Could not import submesh type '{class_name}': {e}"
                 ) from e
             except Exception as e:
                 raise ValueError(

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -133,62 +133,6 @@ class Serialise:
     def __init__(self):
         pass
 
-    class _SymbolEncoder(json.JSONEncoder):
-        """Converts PyBaMM symbols into a JSON-serialisable format"""
-
-        def default(self, node: dict):
-            node_dict = {"py/object": str(type(node))[8:-2], "py/id": id(node)}
-            if isinstance(node, pybamm.Symbol):
-                node_dict.update(node.to_json())  # this doesn't include children
-                node_dict["children"] = []
-                for c in node.children:
-                    node_dict["children"].append(self.default(c))
-
-                if hasattr(node, "initial_condition"):  # for ExplicitTimeIntegral
-                    node_dict["initial_condition"] = self.default(
-                        node.initial_condition
-                    )
-
-                return node_dict
-
-            if isinstance(node, pybamm.Event):
-                hook = node.to_json()
-                hook.pop("children", None)  # legacy encoder walks expression itself
-                node_dict.update(hook)
-                node_dict["expression"] = self.default(node._expression)
-                return node_dict
-
-            node_dict["json"] = json.JSONEncoder.default(self, node)  # pragma: no cover
-            return node_dict  # pragma: no cover
-
-    class _MeshEncoder(json.JSONEncoder):
-        """Converts PyBaMM meshes into a JSON-serialisable format"""
-
-        def default(self, node: pybamm.Mesh):
-            node_dict = {"py/object": str(type(node))[8:-2], "py/id": id(node)}
-            if isinstance(node, pybamm.Mesh):
-                node_dict.update(node.to_json())
-                # Drop the kernel-only keys; the legacy encoder builds sub_meshes
-                # itself. Removed when _MeshEncoder is retired (later task).
-                node_dict.pop("children", None)
-                node_dict.pop("sub_mesh_domains", None)
-
-                submeshes = {}
-                for k, v in node.items():
-                    if len(k) == 1 and "ghost cell" not in k[0]:
-                        submeshes[k[0]] = self.default(v)
-
-                node_dict["sub_meshes"] = submeshes
-
-                return node_dict
-
-            if isinstance(node, pybamm.SubMesh):
-                node_dict.update(node.to_json())
-                return node_dict
-
-            node_dict["json"] = json.JSONEncoder.default(self, node)  # pragma: no cover
-            return node_dict  # pragma: no cover
-
     class _Empty:
         """A dummy class to aid deserialisation"""
 
@@ -240,35 +184,37 @@ class Serialise:
             model.get_processed_variable(k)
         variables_processed = model.get_processed_variables_dict()
 
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            TAG,
+            _class_path,
+            encode,
+        )
+
         model_json = {
-            "py/object": str(type(model))[8:-2],
-            "py/id": id(model),
+            TAG: _class_path(type(model)),
             "pybamm_version": pybamm.__version__,
             "name": model.name,
             "options": model.options,
             "bounds": [bound.tolist() for bound in model.bounds],  # type: ignore[attr-defined]
-            "concatenated_rhs": self._SymbolEncoder().default(model._concatenated_rhs),
-            "concatenated_algebraic": self._SymbolEncoder().default(
-                model._concatenated_algebraic
-            ),
-            "concatenated_initial_conditions": self._SymbolEncoder().default(
+            "concatenated_rhs": encode(model._concatenated_rhs),
+            "concatenated_algebraic": encode(model._concatenated_algebraic),
+            "concatenated_initial_conditions": encode(
                 model._concatenated_initial_conditions
             ),
-            "events": [self._SymbolEncoder().default(event) for event in model.events],
-            "mass_matrix": self._SymbolEncoder().default(model.mass_matrix),
+            "events": [encode(event) for event in model.events],
+            "mass_matrix": encode(model.mass_matrix),
             "_solution_observable": model._solution_observable.name,
         }
 
         if mesh:
-            model_json["mesh"] = self._MeshEncoder().default(mesh)
+            model_json["mesh"] = encode(mesh)
 
         if variables_processed:
             variables_processed = dict(variables_processed)
             if model._geometry:
                 model_json["geometry"] = self._deconstruct_pybamm_dicts(model._geometry)
             model_json["_variables_processed"] = {
-                k: self._SymbolEncoder().default(v)
-                for k, v in variables_processed.items()
+                k: encode(v) for k, v in variables_processed.items()
             }
 
         return model_json
@@ -1692,13 +1638,14 @@ class Serialise:
 
         Dictionaries which don't contain pybamm symbols are returned unchanged.
         """
+        from pybamm.expression_tree.operations.serialise_kernel import encode
 
         def nested_convert(obj):
             if isinstance(obj, dict):
                 new_dict = {}
                 for k, v in obj.items():
                     if isinstance(k, pybamm.Symbol):
-                        new_k = self._SymbolEncoder().default(k)
+                        new_k = encode(k)
                         new_dict["symbol_" + new_k["name"]] = new_k
                         k = new_k["name"]
                     new_dict[k] = nested_convert(v)

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -2002,6 +2002,11 @@ class Serialise:
         else:
             raise ValueError("Experiment config must have 'steps' or 'cycles'.")
 
+    # Solver __init__ params that are genuinely re-derived on construction or are
+    # non-serialisable transients. Empty today (Task 4.1 audit found no shipped solver
+    # omits anything); anything not listed that fails to serialise raises (safe-or-loud).
+    _SOLVER_DERIVED_PARAMS: frozenset = frozenset()
+
     @staticmethod
     def serialise_solver(solver) -> dict:
         """Convert a :class:`pybamm.BaseSolver` to a JSON-serialisable config dict.
@@ -2022,6 +2027,10 @@ class Serialise:
             Config dict with a ``"type"`` key and one key per serialisable
             init parameter.
         """
+        from pybamm.expression_tree.operations.serialise_kernel import (
+            SerialisationError,
+        )
+
         if solver.__class__.__name__ == "CompositeSolver":
             return {
                 "type": "CompositeSolver",
@@ -2057,13 +2066,16 @@ class Serialise:
             value = Serialise._to_json_safe(value)
             try:
                 json.dumps(value)
-            except (TypeError, ValueError):
-                warnings.warn(
-                    f"Solver parameter '{param_name}' is not JSON-serializable and "
-                    f"will be omitted from the config.",
-                    stacklevel=2,
-                )
-                continue
+            except (TypeError, ValueError) as err:
+                if param_name in Serialise._SOLVER_DERIVED_PARAMS:
+                    continue
+                raise SerialisationError(
+                    f"Solver parameter '{param_name}' on "
+                    f"{solver.__class__.__name__} is not JSON-serialisable. Make it "
+                    f"serialisable (extend _to_json_safe), or -- if it is re-derived on "
+                    f"construction or a non-serialisable transient -- add it to "
+                    f"_SOLVER_DERIVED_PARAMS with a justification."
+                ) from err
 
             config[param_name] = value
 

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -368,7 +368,7 @@ _hook_codec = HookCodec()
 # Bases whose concrete subclasses are serialisable through the kernel. Symbol is
 # the introspection-default home; Event/Mesh define hooks on the base; SubMesh has
 # none at the base -- its concrete subclasses do, and the no-hook guard in
-# _lookup_codec raises loudly if a hookless subclass is ever encoded.
+# _lookup_codec raises loudly if a subclass missing a hook is ever encoded.
 _KNOWN_BASES = (pybamm.Symbol, pybamm.Event, pybamm.Mesh, pybamm.SubMesh)
 
 
@@ -395,10 +395,14 @@ def _lookup_codec(cls: type):
     if _overrides_hooks(cls):
         return _hook_codec
     # DefaultCodec requires a Symbol-shaped __init__ (children/domains); a non-Symbol
-    # known base with no hook is a bug, surfaced loudly rather than mis-introspected.
+    # known base missing a hook cannot round-trip, surfaced loudly rather than
+    # mis-introspected.
     if not issubclass(cls, pybamm.Symbol):
+        missing = " and ".join(
+            h for h in ("to_json", "_from_json") if not hasattr(cls, h)
+        )
         raise SerialisationError(
-            f"{cls.__module__}.{cls.__qualname__} is a registered serialisable "
-            f"base but defines no to_json/_from_json hook."
+            f"{cls.__module__}.{cls.__qualname__} is registered as serialisable "
+            f"but is missing {missing}, so it cannot round-trip."
         )
     return _default_codec

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -262,17 +262,16 @@ _default_codec = DefaultCodec()
 
 
 @functools.cache
-def _guarded_params(cls: type) -> tuple[str, ...]:
-    """Non-child, non-domain __init__ params the HookCodec guard checks.
-
-    Cached per class -- encode walks this for every hooked node.
+def _guarded_params(cls: type) -> tuple[tuple[str, bool], ...]:
+    """(name, has_default) for each non-child, non-domain __init__ param the
+    HookCodec guard checks. Cached per class -- encode walks this per hooked node.
     """
     try:
         params = inspect.signature(cls.__init__).parameters
     except (TypeError, ValueError):
         return ()
     return tuple(
-        name
+        (name, p.default is not inspect.Parameter.empty)
         for name, p in params.items()
         if name not in _SKIP_PARAMS
         and name not in _CHILD_PARAMS
@@ -305,11 +304,16 @@ def _assert_hook_covers_params(obj, node: dict, raw_children: list) -> None:
     cls = type(obj)
     derived = getattr(cls, "_serialise_derived_params", frozenset())
     child_ids = {id(c) for c in raw_children}
-    for name in _guarded_params(cls):
+    for name, has_default in _guarded_params(cls):
         if name in node or name in derived:
             continue
         value = _read_attr(obj, name)
-        if value is not _MISSING and (id(value) in child_ids or _is_structural(value)):
+        if value is _MISSING:
+            # Defaulted and never stored: the constructor recreates it on decode
+            # (parity with DefaultCodec). A missing required param falls through.
+            if has_default:
+                continue
+        elif id(value) in child_ids or _is_structural(value):
             continue
         raise SerialisationError(
             f"{cls.__module__}.{cls.__qualname__}.to_json drops the __init__ "

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -112,24 +112,28 @@ def encode(obj):
         return _encode_ndarray(obj)
     if isinstance(obj, slice):
         return _encode_slice(obj)
+    if isinstance(obj, type):
+        return _encode_class_ref(obj)
+
+    # Codec dispatch precedes containers: registered types (e.g. Mesh) may subclass
+    # dict/list and must not be walked as a plain container.
+    codec = _lookup_codec(type(obj))
+    if codec is not None:
+        node = codec.to_json(obj, encode)
+        node[TAG] = _class_path(type(obj))
+        return node
+
     if isinstance(obj, tuple):
         return {TAG: "builtins.tuple", "items": [encode(x) for x in obj]}
     if isinstance(obj, list):
         return [encode(x) for x in obj]
     if isinstance(obj, dict):
         return {k: encode(v) for k, v in obj.items()}
-    if isinstance(obj, type):
-        return _encode_class_ref(obj)
 
-    codec = _lookup_codec(type(obj))
-    if codec is None:
-        raise SerialisationError(
-            f"Cannot serialise {type(obj).__module__}.{type(obj).__qualname__}: "
-            f"no codec registered. Register the class or add a to_json/_from_json hook."
-        )
-    node = codec.to_json(obj, encode)
-    node[TAG] = _class_path(type(obj))
-    return node
+    raise SerialisationError(
+        f"Cannot serialise {type(obj).__module__}.{type(obj).__qualname__}: "
+        f"no codec registered. Register the class or add a to_json/_from_json hook."
+    )
 
 
 def decode(node):

--- a/src/pybamm/expression_tree/operations/serialise_kernel.py
+++ b/src/pybamm/expression_tree/operations/serialise_kernel.py
@@ -361,8 +361,11 @@ class HookCodec:
 _hook_codec = HookCodec()
 
 
-# Bases whose concrete subclasses are serialisable.
-_KNOWN_BASES = (pybamm.Symbol,)
+# Bases whose concrete subclasses are serialisable through the kernel. Symbol is
+# the introspection-default home; Event/Mesh define hooks on the base; SubMesh has
+# none at the base -- its concrete subclasses do, and the no-hook guard in
+# _lookup_codec raises loudly if a hookless subclass is ever encoded.
+_KNOWN_BASES = (pybamm.Symbol, pybamm.Event, pybamm.Mesh, pybamm.SubMesh)
 
 
 def _overrides_hooks(cls: type) -> bool:
@@ -370,10 +373,16 @@ def _overrides_hooks(cls: type) -> bool:
     # plain function comparable by identity; _from_json is a classmethod, so
     # `cls._from_json` is bound and we compare the underlying `.__func__`. Do not
     # "simplify" either branch to match the other.
-    return (
-        cls.to_json is not pybamm.Symbol.to_json
-        or cls._from_json.__func__ is not pybamm.Symbol._from_json.__func__
-    )
+    # Non-Symbol bases may have no hooks at all; treat absence as "not overriding".
+    if not hasattr(cls, "to_json") or not hasattr(cls, "_from_json"):
+        return False
+    if issubclass(cls, pybamm.Symbol):
+        return (
+            cls.to_json is not pybamm.Symbol.to_json
+            or cls._from_json.__func__ is not pybamm.Symbol._from_json.__func__
+        )
+    # Non-Symbol: any hook present means overriding (no Symbol baseline to compare).
+    return True
 
 
 def _lookup_codec(cls: type):
@@ -381,4 +390,11 @@ def _lookup_codec(cls: type):
         return None
     if _overrides_hooks(cls):
         return _hook_codec
+    # DefaultCodec requires a Symbol-shaped __init__ (children/domains); a non-Symbol
+    # known base with no hook is a bug, surfaced loudly rather than mis-introspected.
+    if not issubclass(cls, pybamm.Symbol):
+        raise SerialisationError(
+            f"{cls.__module__}.{cls.__qualname__} is a registered serialisable "
+            f"base but defines no to_json/_from_json hook."
+        )
     return _default_codec

--- a/src/pybamm/meshes/meshes.py
+++ b/src/pybamm/meshes/meshes.py
@@ -176,21 +176,6 @@ class Mesh(dict):
         # add ghost meshes
         self.add_ghost_meshes()
 
-    @classmethod
-    def _from_json(cls, snippet: dict):
-        instance = cls.__new__(cls)
-        super(Mesh, instance).__init__()
-
-        instance.submesh_pts = snippet["submesh_pts"]
-        instance.base_domains = snippet["base_domains"]
-
-        for k, v in snippet["sub_meshes"].items():
-            instance[k] = v
-
-        # instance.add_ghost_meshes()
-
-        return instance
-
     def __getitem__(self, domains):
         if isinstance(domains, str):
             domains = (domains,)
@@ -409,6 +394,10 @@ class Mesh(dict):
                     + str(submesh.dimension)
                 )
 
+    # geometry/submesh_types/var_pts are construction inputs; a Mesh reconstructs
+    # from submesh_pts/base_domains/sub-meshes, so the coverage guard waives them.
+    _serialise_derived_params = frozenset({"geometry", "submesh_types", "var_pts"})
+
     @property
     def geometry(self):
         return self._geometry
@@ -418,12 +407,28 @@ class Mesh(dict):
         self._geometry = geometry
 
     def to_json(self):
-        json_dict = {
+        # Non-ghost single-domain sub-meshes travel through children (each is a
+        # kernel-serialisable SubMesh); their domain keys ride alongside so
+        # _from_json can re-key them.
+        domains = [k for k in self if len(k) == 1 and "ghost cell" not in k[0]]
+        return {
             "submesh_pts": self.submesh_pts,
             "base_domains": self.base_domains,
+            "sub_mesh_domains": [k[0] for k in domains],
+            "children": [self[k] for k in domains],
         }
 
-        return json_dict
+    @classmethod
+    def _from_json(cls, snippet: dict):
+        instance = cls.__new__(cls)
+        super(Mesh, instance).__init__()
+        instance.submesh_pts = snippet["submesh_pts"]
+        instance.base_domains = snippet["base_domains"]
+        for domain, submesh in zip(
+            snippet["sub_mesh_domains"], snippet["children"], strict=True
+        ):
+            instance[domain] = submesh
+        return instance
 
 
 class SubMesh:

--- a/src/pybamm/meshes/meshes.py
+++ b/src/pybamm/meshes/meshes.py
@@ -433,6 +433,14 @@ class SubMesh:
     (optionally) information about the tab locations.
     """
 
+    # Construction-input params: submeshes are reconstructed from edges/coord_sys
+    # (to_json/_from_json), never from these, so the coverage guard waives them.
+    # `npts` is even stored (self.npts) but never serialised; `lims`/`position` are
+    # processed into edges and not stored. Inherited by all SubMesh subclasses; a
+    # class without a given param is simply never flagged for it. (`tabs` is NOT
+    # here -- it is handled by the missing-defaulted guard grace.)
+    _serialise_derived_params = frozenset({"lims", "npts", "position"})
+
     def __init__(self):
         pass
 

--- a/src/pybamm/meshes/meshes.py
+++ b/src/pybamm/meshes/meshes.py
@@ -433,12 +433,9 @@ class SubMesh:
     (optionally) information about the tab locations.
     """
 
-    # Construction-input params: submeshes are reconstructed from edges/coord_sys
-    # (to_json/_from_json), never from these, so the coverage guard waives them.
-    # `npts` is even stored (self.npts) but never serialised; `lims`/`position` are
-    # processed into edges and not stored. Inherited by all SubMesh subclasses; a
-    # class without a given param is simply never flagged for it. (`tabs` is NOT
-    # here -- it is handled by the missing-defaulted guard grace.)
+    # Construction inputs re-derived from edges/coord_sys on decode, so the coverage
+    # guard waives them. Inherited by all SubMesh subclasses. `tabs` is excluded: it
+    # is handled by the kernel guard's missing-defaulted grace.
     _serialise_derived_params = frozenset({"lims", "npts", "position"})
 
     def __init__(self):

--- a/src/pybamm/models/event.py
+++ b/src/pybamm/models/event.py
@@ -57,19 +57,13 @@ class Event:
 
     @classmethod
     def _from_json(cls: type[E], snippet: dict) -> E:
-        """
-        Reconstructs an Event instance during deserialisation of a JSON file.
-
-        Parameters
-        ----------
-        snippet: dict
-            Contains the information needed to reconstruct a specific instance.
-            Should contain "name", "expression" and "event_type".
-        """
-
+        """Reconstruct an Event. Canonical files carry ``expression`` in
+        ``children[0]``; legacy discretised files carried it as a sibling field."""
+        children = snippet.get("children")
+        expression = children[0] if children else snippet["expression"]
         return cls(
             snippet["name"],
-            snippet["expression"],
+            expression,
             event_type=EventType(snippet["event_type"][1]),
         )
 
@@ -101,19 +95,14 @@ class Event:
         return self._event_type
 
     def to_json(self):
+        """Serialise an Event into the kernel wire shape.
+
+        ``expression`` is a Symbol, so it travels through ``children`` (the kernel
+        only recurses ``children``); ``event_type`` is emitted as ``[name, value]``
+        for readability + reconstruction.
         """
-        Method to serialise an Event object into JSON.
-
-        The expression is written out seperately,
-        See :meth:`pybamm.Serialise._SymbolEncoder.default()`
-        """
-
-        # event_type contains string name, for JSON readability,
-        # and value for deserialisation.
-
-        json_dict = {
+        return {
             "name": self._name,
             "event_type": [str(self._event_type), self._event_type.value],
+            "children": [self._expression],
         }
-
-        return json_dict

--- a/tests/strategies/serialise_values.py
+++ b/tests/strategies/serialise_values.py
@@ -21,6 +21,18 @@ _POSITIVE_TOL = st.floats(
     min_value=1e-12, max_value=1e-2, allow_nan=False, allow_infinity=False
 )
 
+# Concrete BaseSolver subclasses the solver fuzzer (and the coverage meta-test)
+# draw from -- single source of truth so coverage can't drift from the fuzzer.
+_SOLVER_CLASSES = (
+    pybamm.IDAKLUSolver,
+    pybamm.CasadiSolver,
+    pybamm.ScipySolver,
+    pybamm.AlgebraicSolver,
+    pybamm.CasadiAlgebraicSolver,
+    pybamm.NonlinearSolver,
+    pybamm.CompositeSolver,
+)
+
 
 def _root_method() -> st.SearchStrategy:
     """root_method can be a string, None, or a nested BaseSolver (#5497)."""
@@ -36,25 +48,24 @@ def _root_method() -> st.SearchStrategy:
 
 
 def solver_kwargs() -> st.SearchStrategy[dict]:
-    """Pick a concrete solver class and generate valid kwargs for it."""
+    """Pick a concrete solver class and generate valid kwargs for it.
+
+    Each class branch generates only the kwargs its constructor accepts.
+    CompositeSolver wraps two randomly chosen sub-solvers from the simple
+    (non-composite) subset of _SOLVER_CLASSES.
+    """
+
+    _SIMPLE_SOLVER_CLASSES = [
+        c for c in _SOLVER_CLASSES if c is not pybamm.CompositeSolver
+    ]
 
     @st.composite
     def _strategy(draw):
-        cls = draw(
-            st.sampled_from(
-                [
-                    pybamm.IDAKLUSolver,
-                    pybamm.CasadiSolver,
-                    pybamm.ScipySolver,
-                ]
-            )
-        )
-        kwargs: dict = {
-            "_cls": cls,
-            "rtol": draw(_POSITIVE_TOL),
-            "atol": draw(_POSITIVE_TOL),
-        }
+        cls = draw(st.sampled_from(list(_SOLVER_CLASSES)))
+        kwargs: dict = {"_cls": cls}
         if cls is pybamm.IDAKLUSolver:
+            kwargs["rtol"] = draw(_POSITIVE_TOL)
+            kwargs["atol"] = draw(_POSITIVE_TOL)
             kwargs["root_method"] = draw(_root_method())
             kwargs["options"] = draw(
                 st.fixed_dictionaries(
@@ -64,6 +75,28 @@ def solver_kwargs() -> st.SearchStrategy[dict]:
                     }
                 )
             )
+        elif cls in (pybamm.CasadiSolver, pybamm.ScipySolver):
+            kwargs["rtol"] = draw(_POSITIVE_TOL)
+            kwargs["atol"] = draw(_POSITIVE_TOL)
+        elif cls is pybamm.AlgebraicSolver:
+            kwargs["method"] = draw(st.sampled_from(["lm", "hybr"]))
+            kwargs["tol"] = draw(_POSITIVE_TOL)
+        elif cls is pybamm.CasadiAlgebraicSolver:
+            kwargs["tol"] = draw(_POSITIVE_TOL)
+            kwargs["step_tol"] = draw(_POSITIVE_TOL)
+        elif cls is pybamm.NonlinearSolver:
+            kwargs["rtol"] = draw(_POSITIVE_TOL)
+            kwargs["atol"] = draw(_POSITIVE_TOL)
+        elif cls is pybamm.CompositeSolver:
+            # Draw two simple solver classes (possibly the same) for sub_solvers.
+            sub_cls_a, sub_cls_b = draw(
+                st.lists(
+                    st.sampled_from(_SIMPLE_SOLVER_CLASSES),
+                    min_size=2,
+                    max_size=2,
+                )
+            )
+            kwargs["sub_solvers"] = [sub_cls_a(), sub_cls_b()]
         return kwargs
 
     return _strategy()

--- a/tests/unit/test_meshes/test_meshes.py
+++ b/tests/unit/test_meshes/test_meshes.py
@@ -577,12 +577,11 @@ class TestMesh:
 
         mesh_json = mesh.to_json()
 
-        expected_json = {
-            "submesh_pts": {"negative particle": {"r": 20}},
-            "base_domains": ["negative particle"],
-        }
-
-        assert mesh_json == expected_json
+        assert mesh_json["submesh_pts"] == {"negative particle": {"r": 20}}
+        assert mesh_json["base_domains"] == ["negative particle"]
+        assert mesh_json["sub_mesh_domains"] == ["negative particle"]
+        assert len(mesh_json["children"]) == 1
+        assert isinstance(mesh_json["children"][0], pybamm.Uniform1DSubMesh)
 
     def test_compute_var_pts_from_thicknesses_cell_size(self):
         from pybamm.meshes.meshes import compute_var_pts_from_thicknesses

--- a/tests/unit/test_meshes/test_scikit_fem_submesh.py
+++ b/tests/unit/test_meshes/test_scikit_fem_submesh.py
@@ -197,22 +197,31 @@ class TestScikitFiniteElement2DSubMesh:
 
         mesh_json = mesh.to_json()
 
-        expected_json = {
-            "submesh_pts": {
-                "negative electrode": {"x_n": 10},
-                "separator": {"x_s": 7},
-                "positive electrode": {"x_p": 12},
-                "current collector": {"y": 16, "z": 24},
-            },
-            "base_domains": [
-                "negative electrode",
-                "separator",
-                "positive electrode",
-                "current collector",
-            ],
+        # Kernel wire shape: sub-meshes travel through children; their domain keys
+        # ride alongside in sub_mesh_domains.
+        assert mesh_json["submesh_pts"] == {
+            "negative electrode": {"x_n": 10},
+            "separator": {"x_s": 7},
+            "positive electrode": {"x_p": 12},
+            "current collector": {"y": 16, "z": 24},
         }
-
-        assert mesh_json == expected_json
+        assert mesh_json["base_domains"] == [
+            "negative electrode",
+            "separator",
+            "positive electrode",
+            "current collector",
+        ]
+        domains = mesh_json["sub_mesh_domains"]
+        assert set(domains) == {
+            "negative electrode",
+            "separator",
+            "positive electrode",
+            "current collector",
+        }
+        assert len(mesh_json["children"]) == len(domains)
+        # the current collector rides through children as the 2D submesh
+        cc = mesh_json["children"][domains.index("current collector")]
+        assert isinstance(cc, pybamm.ScikitUniform2DSubMesh)
 
         # test Uniform2DSubMesh serialisation
 

--- a/tests/unit/test_meshes/test_submesh_to_json.py
+++ b/tests/unit/test_meshes/test_submesh_to_json.py
@@ -11,11 +11,13 @@ class TestSubMeshToConfig:
     """Tests for SubMesh class to_config and from_config."""
 
     def test_submesh_to_config_returns_class_and_module(self):
-        """SubMesh subclass to_config() returns dict with 'class' and 'module'."""
+        """SubMesh subclass to_config() returns the kernel class_reference shape."""
         data = pybamm.Uniform1DSubMesh.to_config()
         assert isinstance(data, dict)
-        assert data["class"] == "Uniform1DSubMesh"
-        assert "pybamm.meshes" in data["module"]
+        assert data["$type"] == "type"
+        assert (
+            data["class"] == "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh"
+        )
 
     def test_submesh_from_config_returns_same_class(self):
         """SubMesh.from_config(to_config()) returns the same class."""
@@ -27,7 +29,7 @@ class TestSubMeshToConfig:
     def test_submesh_round_trip_submesh0d(self):
         """SubMesh0D round-trips via to_config/from_config."""
         data = pybamm.SubMesh0D.to_config()
-        assert data["class"] == "SubMesh0D"
+        assert data["class"] == "pybamm.meshes.zero_dimensional_submesh.SubMesh0D"
         assert pybamm.SubMesh.from_config(data) is pybamm.SubMesh0D
 
 
@@ -35,11 +37,13 @@ class TestMeshGeneratorToConfig:
     """Tests for MeshGenerator to_config and from_config."""
 
     def test_mesh_generator_to_config_has_class_module(self):
-        """MeshGenerator.to_config() contains class and module."""
+        """MeshGenerator.to_config() contains the kernel class_reference."""
         gen = pybamm.MeshGenerator(pybamm.Uniform1DSubMesh)
         data = gen.to_config()
-        assert data["class"] == "Uniform1DSubMesh"
-        assert "pybamm.meshes" in data["module"]
+        assert data["$type"] == "type"
+        assert (
+            data["class"] == "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh"
+        )
 
     def test_mesh_generator_to_config_includes_submesh_params_when_non_empty(self):
         """MeshGenerator with submesh_params includes them in to_config()."""

--- a/tests/unit/test_models/test_event.py
+++ b/tests/unit/test_models/test_event.py
@@ -51,15 +51,15 @@ class TestEvent:
         expression = pybamm.Scalar(1)
         event = pybamm.Event("my event", expression)
 
+        # Kernel wire shape: expression travels through children[0].
         event_json = {
             "name": "my event",
             "event_type": ["EventType.TERMINATION", 0],
+            "children": [expression],
         }
 
         event_ser_json = event.to_json()
         assert event_ser_json == event_json
-
-        event_json["expression"] = expression
 
         new_event = pybamm.Event._from_json(event_json)
 

--- a/tests/unit/test_serialisation/test_base_strategy_coverage.py
+++ b/tests/unit/test_serialisation/test_base_strategy_coverage.py
@@ -1,0 +1,75 @@
+"""Every concrete serialisable subclass of every known base must be exercised by a
+round-trip strategy or be explicitly exempt -- the Symbol contract, generalised.
+
+A new BaseSolver/SubMesh subclass added to pybamm must register a strategy (or
+fuzzed kwarg producer) for its base, or be added to that base's exemption set with
+a one-line reason. Forgetting is a CI failure.
+"""
+
+from __future__ import annotations
+
+import pybamm
+from tests.strategies.serialise_values import _SOLVER_CLASSES
+from tests.unit.test_serialisation.test_symbol_strategy_coverage import (
+    _all_concrete_subclasses,
+)
+
+
+def _covered_solver_classes() -> set[type]:
+    return set(_SOLVER_CLASSES)
+
+
+# Bases reconstructed but not independently fuzzed (carried inside a model/mesh
+# round-trip) are exempted with a reason rather than given a standalone strategy.
+_SOLVER_EXEMPT: set[type] = {
+    pybamm.DummySolver,  # no numerical config to round-trip
+    pybamm.JaxSolver,  # requires optional jax/jaxlib dep; not installed in CI
+}
+
+# A submesh is round-trippable only if it (or an ancestor below the bare SubMesh
+# base) defines its OWN _from_json. Most SubMesh subclasses inherit to_json but
+# define no _from_json -- they encode but cannot decode, a pre-existing limitation
+# PR2 does not expand. They are NOT silently "covered"; each must be listed here
+# with a reason. POPULATE from the Step-2 failure output, one justified line each.
+_SUBMESH_EXEMPT: set[type] = {
+    pybamm.Chebyshev1DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.Exponential1DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.ScikitChebyshev2DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.ScikitExponential2DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.ScikitSubMesh2D,  # encode-only: inherits to_json, no _from_json
+    pybamm.SpectralVolume1DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.SubMesh1D,  # encode-only: inherits to_json, no _from_json
+    pybamm.SubMesh2D,  # encode-only: inherits to_json, no _from_json
+    pybamm.SymbolicUniform1DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.Uniform2DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.UserSupplied1DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.UserSupplied2DSubMesh,  # encode-only: inherits to_json, no _from_json
+}
+
+
+def _defines_own_from_json(cls: type) -> bool:
+    # An OVERRIDING _from_json, not merely inherited: walk the MRO for _from_json in
+    # a class __dict__.
+    return any("_from_json" in k.__dict__ for k in cls.__mro__)
+
+
+def test_every_concrete_solver_subclass_is_covered_or_exempt():
+    concrete = _all_concrete_subclasses(pybamm.BaseSolver)
+    missing = concrete - _covered_solver_classes() - _SOLVER_EXEMPT
+    assert not missing, (
+        "BaseSolver subclasses with no round-trip coverage and no exemption: "
+        + ", ".join(sorted(c.__name__ for c in missing))
+    )
+
+
+def test_every_concrete_submesh_subclass_round_trips_or_exempt():
+    concrete = _all_concrete_subclasses(pybamm.SubMesh)
+    uncovered = {
+        c
+        for c in concrete - _SUBMESH_EXEMPT
+        if not (_defines_own_from_json(c) and "to_json" in dir(c))
+    }
+    assert not uncovered, (
+        "SubMesh subclasses that are encode-only (no own _from_json) and not in "
+        "_SUBMESH_EXEMPT: " + ", ".join(sorted(c.__name__ for c in uncovered))
+    )

--- a/tests/unit/test_serialisation/test_base_strategy_coverage.py
+++ b/tests/unit/test_serialisation/test_base_strategy_coverage.py
@@ -28,9 +28,8 @@ _SOLVER_EXEMPT: set[type] = {
 
 # A submesh is round-trippable only if it (or an ancestor below the bare SubMesh
 # base) defines its OWN _from_json. Most SubMesh subclasses inherit to_json but
-# define no _from_json -- they encode but cannot decode, a pre-existing limitation
-# PR2 does not expand. They are NOT silently "covered"; each must be listed here
-# with a reason. POPULATE from the Step-2 failure output, one justified line each.
+# define no _from_json -- they encode but cannot decode, a pre-existing limitation.
+# They are NOT silently "covered"; each must be listed here with a reason.
 _SUBMESH_EXEMPT: set[type] = {
     pybamm.Chebyshev1DSubMesh,  # encode-only: inherits to_json, no _from_json
     pybamm.Exponential1DSubMesh,  # encode-only: inherits to_json, no _from_json

--- a/tests/unit/test_serialisation/test_base_strategy_coverage.py
+++ b/tests/unit/test_serialisation/test_base_strategy_coverage.py
@@ -28,21 +28,22 @@ _SOLVER_EXEMPT: set[type] = {
 
 # A submesh is round-trippable only if it (or an ancestor below the bare SubMesh
 # base) defines its OWN _from_json. Most SubMesh subclasses inherit to_json but
-# define no _from_json -- they encode but cannot decode, a pre-existing limitation.
-# They are NOT silently "covered"; each must be listed here with a reason.
+# define no _from_json -- the kernel refuses to encode them, since they could
+# never be decoded. They are NOT silently "covered"; each must be listed here
+# with a reason.
 _SUBMESH_EXEMPT: set[type] = {
-    pybamm.Chebyshev1DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.Exponential1DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.ScikitChebyshev2DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.ScikitExponential2DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.ScikitSubMesh2D,  # encode-only: inherits to_json, no _from_json
-    pybamm.SpectralVolume1DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.SubMesh1D,  # encode-only: inherits to_json, no _from_json
-    pybamm.SubMesh2D,  # encode-only: inherits to_json, no _from_json
-    pybamm.SymbolicUniform1DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.Uniform2DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.UserSupplied1DSubMesh,  # encode-only: inherits to_json, no _from_json
-    pybamm.UserSupplied2DSubMesh,  # encode-only: inherits to_json, no _from_json
+    pybamm.Chebyshev1DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.Exponential1DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.ScikitChebyshev2DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.ScikitExponential2DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.ScikitSubMesh2D,  # cannot serialise (no _from_json)
+    pybamm.SpectralVolume1DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.SubMesh1D,  # cannot serialise (no _from_json)
+    pybamm.SubMesh2D,  # cannot serialise (no _from_json)
+    pybamm.SymbolicUniform1DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.Uniform2DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.UserSupplied1DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.UserSupplied2DSubMesh,  # cannot serialise (no _from_json)
 }
 
 
@@ -69,6 +70,6 @@ def test_every_concrete_submesh_subclass_round_trips_or_exempt():
         if not (_defines_own_from_json(c) and "to_json" in dir(c))
     }
     assert not uncovered, (
-        "SubMesh subclasses that are encode-only (no own _from_json) and not in "
-        "_SUBMESH_EXEMPT: " + ", ".join(sorted(c.__name__ for c in uncovered))
+        "SubMesh subclasses that cannot serialise (no own _from_json) and are not "
+        "in _SUBMESH_EXEMPT: " + ", ".join(sorted(c.__name__ for c in uncovered))
     )

--- a/tests/unit/test_serialisation/test_discretised_model_round_trip.py
+++ b/tests/unit/test_serialisation/test_discretised_model_round_trip.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import pybamm
+from pybamm.expression_tree.operations.serialise import Serialise
+
+
+@pytest.fixture(scope="module")
+def built_spm():
+    model = pybamm.lithium_ion.SPM()
+    sim = pybamm.Simulation(model)
+    sim.build()
+    return sim
+
+
+def test_serialise_model_emits_canonical_tags(built_spm):
+    out = Serialise().serialise_model(built_spm.built_model, mesh=built_spm.mesh)
+    # top-level model identity + every serialised tree uses $type, never py/object
+    assert "$type" in out
+    assert "py/object" not in json.dumps(out)
+    # the symbol trees are real kernel nodes
+    assert out["concatenated_rhs"]["$type"].startswith("pybamm")
+    assert out["mesh"]["$type"].endswith("Mesh")
+    # round-trips as plain JSON text (no non-native leftovers)
+    json.loads(json.dumps(out))

--- a/tests/unit/test_serialisation/test_discretised_model_round_trip.py
+++ b/tests/unit/test_serialisation/test_discretised_model_round_trip.py
@@ -50,3 +50,37 @@ def test_load_model_resolves_class_from_canonical_tag(built_spm):
     model_json = s.serialise_model(built_spm.built_model, mesh=built_spm.mesh)
     reloaded = s.load_model(json.loads(json.dumps(model_json)))
     assert isinstance(reloaded, pybamm.lithium_ion.SPM)
+
+
+@pytest.mark.parametrize(
+    "model_cls",
+    [
+        pybamm.lithium_ion.SPM,
+        pybamm.lithium_ion.SPMe,
+        pybamm.lithium_ion.DFN,
+    ],
+)
+def test_round_trip_model_still_solves(model_cls):
+    import numpy as np
+
+    model = model_cls()
+    sim = pybamm.Simulation(model)
+    sim.build()
+    s = Serialise()
+    data = json.loads(json.dumps(s.serialise_model(sim.built_model, mesh=sim.mesh)))
+    reloaded = s.load_model(data)
+
+    # Use an explicit t_eval so both solutions share the same time grid.
+    t_eval = np.linspace(0, 600, 100)
+
+    # Reference: fresh full-pipeline solve.
+    sol_ref = pybamm.Simulation(model_cls()).solve(t_eval)
+    # Reloaded model is pre-discretised: solve directly (mirrors test_save_load_model).
+    sol = reloaded.default_solver.solve(reloaded, t_eval)
+
+    np.testing.assert_allclose(
+        sol["Terminal voltage [V]"].entries,
+        sol_ref["Terminal voltage [V]"].entries,
+        rtol=1e-6,
+        atol=1e-6,
+    )

--- a/tests/unit/test_serialisation/test_discretised_model_round_trip.py
+++ b/tests/unit/test_serialisation/test_discretised_model_round_trip.py
@@ -26,3 +26,27 @@ def test_serialise_model_emits_canonical_tags(built_spm):
     assert out["mesh"]["$type"].endswith("Mesh")
     # round-trips as plain JSON text (no non-native leftovers)
     json.loads(json.dumps(out))
+
+
+def test_serialise_then_load_round_trips_spm(built_spm, tmp_path):
+    s = Serialise()
+    model_json = s.serialise_model(built_spm.built_model, mesh=built_spm.mesh)
+    # dict in-memory path
+    reloaded = s.load_model(
+        json.loads(json.dumps(model_json)), battery_model=pybamm.lithium_ion.SPM()
+    )
+    assert reloaded.concatenated_rhs.id == built_spm.built_model.concatenated_rhs.id
+    assert reloaded.concatenated_initial_conditions.id == (
+        built_spm.built_model.concatenated_initial_conditions.id
+    )
+    assert len(reloaded.events) == len(built_spm.built_model.events)
+    for a, b in zip(reloaded.events, built_spm.built_model.events, strict=True):
+        assert a.expression.id == b.expression.id
+
+
+def test_load_model_resolves_class_from_canonical_tag(built_spm):
+    # No battery_model passed -> class resolved from the $type tag.
+    s = Serialise()
+    model_json = s.serialise_model(built_spm.built_model, mesh=built_spm.mesh)
+    reloaded = s.load_model(json.loads(json.dumps(model_json)))
+    assert isinstance(reloaded, pybamm.lithium_ion.SPM)

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 import pybamm
@@ -57,3 +59,27 @@ def test_registered_non_symbol_base_without_hook_raises(monkeypatch):
     monkeypatch.setattr(sk, "_KNOWN_BASES", (*sk._KNOWN_BASES, _NoHookBase))
     with pytest.raises(sk.SerialisationError, match="no to_json"):
         sk._lookup_codec(_NoHookBase)
+
+
+def test_event_round_trip_through_kernel():
+    expr = pybamm.Variable(
+        "u", domains={"primary": ["negative electrode"]}
+    ) - pybamm.Scalar(1.0)
+    event = pybamm.Event("my event", expr, pybamm.EventType.TERMINATION)
+    restored = sk.decode(json.loads(json.dumps(sk.encode(event))))
+    assert isinstance(restored, pybamm.Event)
+    assert restored.name == "my event"
+    assert restored.event_type == pybamm.EventType.TERMINATION
+    assert restored.expression.id == expr.id
+
+
+def test_event_from_json_tolerates_legacy_expression_field():
+    # Old discretised files carried "expression" as a sibling, not in children.
+    expr = pybamm.Scalar(2.0)
+    snippet = {
+        "name": "legacy",
+        "event_type": ["EventType.TERMINATION", 0],
+        "expression": expr,
+    }  # decoded expression, legacy shape
+    restored = pybamm.Event._from_json(snippet)
+    assert restored.expression.id == expr.id

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -83,3 +83,22 @@ def test_event_from_json_tolerates_legacy_expression_field():
     }  # decoded expression, legacy shape
     restored = pybamm.Event._from_json(snippet)
     assert restored.expression.id == expr.id
+
+
+def test_concrete_submeshes_round_trip_through_kernel():
+    import numpy as np
+
+    # Uniform1DSubMesh.__init__(lims, npts): lims required+unstored, npts stored
+    # (self.npts) but not serialised -> both need the opt-out (the grace does not
+    # cover them). Each reconstructs via its own _from_json from edges/coord_sys.
+    model = pybamm.lithium_ion.SPM()
+    sim = pybamm.Simulation(model)
+    sim.build()
+    checked = 0
+    for k, v in sim.mesh.items():
+        if len(k) == 1 and "ghost cell" not in k[0]:
+            restored = sk.decode(json.loads(json.dumps(sk.encode(v))))
+            assert type(restored) is type(v), k
+            assert np.array_equal(restored.edges, v.edges), k
+            checked += 1
+    assert checked, "no concrete submesh exercised"

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+import pybamm
 from pybamm.expression_tree.operations import serialise_kernel as sk
 
 
@@ -28,3 +31,29 @@ def test_registered_dict_subclass_dispatches_to_codec_not_dict_branch(monkeypatc
 def test_plain_dict_still_recurses():
     assert sk.encode({"a": [1, 2]}) == {"a": [1, 2]}
     assert sk.decode(sk.encode({"a": [1, 2]})) == {"a": [1, 2]}
+
+
+def test_known_bases_resolve_to_hook_codec():
+    # Event/Mesh/SubMesh all define their own to_json/_from_json -> HookCodec.
+    for cls in (pybamm.Event, pybamm.Mesh, pybamm.Uniform1DSubMesh):
+        assert isinstance(sk._lookup_codec(cls), sk.HookCodec), cls
+
+
+def test_unregistered_non_symbol_returns_none():
+    # An unregistered class is not a known base -> no codec (encode then raises
+    # the generic "no codec registered" message elsewhere).
+    class _NoHookBase:
+        pass
+
+    assert sk._lookup_codec(_NoHookBase) is None
+
+
+def test_registered_non_symbol_base_without_hook_raises(monkeypatch):
+    # A registered non-Symbol base with no hook must raise loudly rather than fall
+    # through to the Symbol-only DefaultCodec.
+    class _NoHookBase:
+        pass
+
+    monkeypatch.setattr(sk, "_KNOWN_BASES", (*sk._KNOWN_BASES, _NoHookBase))
+    with pytest.raises(sk.SerialisationError, match="no to_json"):
+        sk._lookup_codec(_NoHookBase)

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -101,3 +101,20 @@ def test_concrete_submeshes_round_trip_through_kernel():
             assert np.array_equal(restored.edges, v.edges), k
             checked += 1
     assert checked, "no concrete submesh exercised"
+
+
+def test_mesh_round_trip_through_kernel():
+    model = pybamm.lithium_ion.SPM()
+    sim = pybamm.Simulation(model)
+    sim.build()
+    mesh = sim.mesh
+    restored = sk.decode(json.loads(json.dumps(sk.encode(mesh))))
+    assert isinstance(restored, pybamm.Mesh)
+    assert restored.submesh_pts == mesh.submesh_pts
+    assert set(restored.base_domains) == set(mesh.base_domains)
+    # every non-ghost submesh survived with matching edges
+    import numpy as np
+
+    for k, v in mesh.items():
+        if len(k) == 1 and "ghost cell" not in k[0]:
+            assert np.array_equal(restored[k[0]].edges, v.edges), k

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pybamm.expression_tree.operations import serialise_kernel as sk
+
+
+class _DictBacked(dict):
+    """A dict subclass with a hook -- stands in for Mesh in the engine-ordering test."""
+
+    def to_json(self):
+        return {"marker": "kept"}
+
+    @classmethod
+    def _from_json(cls, snippet):
+        inst = cls()
+        inst["marker"] = snippet["marker"]
+        return inst
+
+
+def test_registered_dict_subclass_dispatches_to_codec_not_dict_branch(monkeypatch):
+    # Register _DictBacked as a known base for the duration of the test.
+    monkeypatch.setattr(sk, "_KNOWN_BASES", (*sk._KNOWN_BASES, _DictBacked))
+    obj = _DictBacked()
+    node = sk.encode(obj)
+    assert node[sk.TAG] == sk._class_path(_DictBacked)
+    assert node["marker"] == "kept"
+
+
+def test_plain_dict_still_recurses():
+    assert sk.encode({"a": [1, 2]}) == {"a": [1, 2]}
+    assert sk.decode(sk.encode({"a": [1, 2]})) == {"a": [1, 2]}

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -118,3 +118,81 @@ def test_mesh_round_trip_through_kernel():
     for k, v in mesh.items():
         if len(k) == 1 and "ghost cell" not in k[0]:
             assert np.array_equal(restored[k[0]].edges, v.edges), k
+
+
+def test_relocate_legacy_moves_expression_into_children():
+    from pybamm.expression_tree.operations.serialise import _relocate_legacy_model_tree
+
+    legacy = {
+        "py/object": "pybamm.models.event.Event",
+        "py/id": 1,
+        "name": "e",
+        "event_type": ["EventType.TERMINATION", 0],
+        "expression": {
+            "py/object": "pybamm.Scalar",
+            "py/id": 2,
+            "name": "2.0",
+            "id": 9,
+            "value": 2.0,
+            "children": [],
+        },
+    }
+    out = _relocate_legacy_model_tree(legacy)
+    assert "expression" not in out
+    assert out["children"][0]["name"] == "2.0"
+
+
+def test_relocate_legacy_moves_initial_condition_after_child():
+    from pybamm.expression_tree.operations.serialise import _relocate_legacy_model_tree
+
+    child = {
+        "py/object": "pybamm.Scalar",
+        "py/id": 3,
+        "name": "1.0",
+        "id": 1,
+        "value": 1.0,
+        "children": [],
+    }
+    ic = {
+        "py/object": "pybamm.Scalar",
+        "py/id": 4,
+        "name": "0.0",
+        "id": 2,
+        "value": 0.0,
+        "children": [],
+    }
+    legacy = {
+        "py/object": "pybamm.ExplicitTimeIntegral",
+        "py/id": 5,
+        "name": "x",
+        "id": 7,
+        "domains": {},
+        "children": [child],
+        "initial_condition": ic,
+    }
+    out = _relocate_legacy_model_tree(legacy)
+    assert "initial_condition" not in out
+    assert [c["name"] for c in out["children"]] == ["1.0", "0.0"]
+
+
+def test_relocate_legacy_converts_sub_meshes_dict():
+    from pybamm.expression_tree.operations.serialise import _relocate_legacy_model_tree
+
+    legacy = {
+        "py/object": "pybamm.Mesh",
+        "py/id": 6,
+        "submesh_pts": {},
+        "base_domains": ["negative electrode"],
+        "sub_meshes": {
+            "negative electrode": {
+                "py/object": "pybamm.SubMesh1D",
+                "py/id": 7,
+                "edges": [0.0, 1.0],
+                "coord_sys": "cartesian",
+            }
+        },
+    }
+    out = _relocate_legacy_model_tree(legacy)
+    assert "sub_meshes" not in out
+    assert out["sub_mesh_domains"] == ["negative electrode"]
+    assert out["children"][0]["coord_sys"] == "cartesian"

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -88,9 +88,8 @@ def test_event_from_json_tolerates_legacy_expression_field():
 def test_concrete_submeshes_round_trip_through_kernel():
     import numpy as np
 
-    # Uniform1DSubMesh.__init__(lims, npts): lims required+unstored, npts stored
-    # (self.npts) but not serialised -> both need the opt-out (the grace does not
-    # cover them). Each reconstructs via its own _from_json from edges/coord_sys.
+    # lims/npts are in _serialise_derived_params; each subclass reconstructs from
+    # edges/coord_sys via its own _from_json.
     model = pybamm.lithium_ion.SPM()
     sim = pybamm.Simulation(model)
     sim.build()

--- a/tests/unit/test_serialisation/test_kernel_known_bases.py
+++ b/tests/unit/test_serialisation/test_kernel_known_bases.py
@@ -57,8 +57,15 @@ def test_registered_non_symbol_base_without_hook_raises(monkeypatch):
         pass
 
     monkeypatch.setattr(sk, "_KNOWN_BASES", (*sk._KNOWN_BASES, _NoHookBase))
-    with pytest.raises(sk.SerialisationError, match="no to_json"):
+    with pytest.raises(sk.SerialisationError, match="missing to_json and _from_json"):
         sk._lookup_codec(_NoHookBase)
+
+
+def test_submesh_without_from_json_raises_naming_only_missing_hook():
+    # Exponential1DSubMesh inherits to_json from SubMesh1D but has no _from_json;
+    # the message must name only the hook that is actually missing.
+    with pytest.raises(sk.SerialisationError, match="missing _from_json"):
+        sk._lookup_codec(pybamm.Exponential1DSubMesh)
 
 
 def test_event_round_trip_through_kernel():

--- a/tests/unit/test_serialisation/test_legacy_fixtures.py
+++ b/tests/unit/test_serialisation/test_legacy_fixtures.py
@@ -42,8 +42,9 @@ def test_legacy_discretised_model_loads():
     """The pre-refactor py/object discretised model must still load through the
     kernel-based load_model + legacy relocation.
 
-    The fixture is ~20 MB and git-ignored; regenerate from pre-PR2 code (the legacy
-    writer no longer exists). Skipped when the local fixture is absent (e.g. CI).
+    The fixture is ~20 MB and git-ignored; regenerate from a pre-refactor PyBaMM
+    checkout (the legacy writer no longer exists). Skipped when the local fixture
+    is absent (e.g. CI).
     """
     if not (_FIX / "discretised_model.json").exists():
         pytest.skip("discretised_model.json fixture absent (git-ignored, local-only)")

--- a/tests/unit/test_serialisation/test_legacy_fixtures.py
+++ b/tests/unit/test_serialisation/test_legacy_fixtures.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import pathlib
 
+import pytest
+
 import pybamm
 from pybamm.expression_tree.operations.serialise import (
     Serialise,
@@ -34,3 +36,19 @@ def test_legacy_submesh_types_loads():
     restored = Serialise.load_submesh_types(_load("submesh_types.json"))
     assert isinstance(restored, dict) and restored
     assert all(isinstance(v, pybamm.MeshGenerator) for v in restored.values())
+
+
+def test_legacy_discretised_model_loads():
+    """The pre-refactor py/object discretised model must still load through the
+    kernel-based load_model + legacy relocation.
+
+    The fixture is ~20 MB and git-ignored; regenerate from pre-PR2 code (the legacy
+    writer no longer exists). Skipped when the local fixture is absent (e.g. CI).
+    """
+    if not (_FIX / "discretised_model.json").exists():
+        pytest.skip("discretised_model.json fixture absent (git-ignored, local-only)")
+    data = _load("discretised_model.json")
+    model = Serialise().load_model(data, battery_model=pybamm.lithium_ion.SPM())
+    assert isinstance(model, pybamm.lithium_ion.SPM)
+    assert model.concatenated_rhs is not None
+    assert model.concatenated_initial_conditions is not None

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -1809,6 +1809,34 @@ class TestSubmeshTypesSerialization:
         with pytest.raises(ValueError, match=r"must end with '\.json' extension"):
             Serialise.save_submesh_types(submesh_types, filename="test.txt")
 
+    def test_submesh_item_emits_kernel_class_reference(self):
+        item = Serialise.serialise_submesh_item(pybamm.Uniform1DSubMesh)
+        assert item["$type"] == "type"
+        assert (
+            item["class"] == "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh"
+        )
+
+    def test_submesh_item_reads_both_shapes(self):
+        legacy = {
+            "class": "Uniform1DSubMesh",
+            "module": "pybamm.meshes.one_dimensional_submeshes",
+        }
+        canonical = {
+            "$type": "type",
+            "class": "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh",
+        }
+        for shape in (legacy, canonical):
+            cls = Serialise.deserialise_submesh_item(shape, return_class_only=True)
+            assert cls is pybamm.Uniform1DSubMesh
+
+    def test_submesh_item_round_trips_meshgenerator_with_params(self):
+        gen = pybamm.MeshGenerator(pybamm.Uniform1DSubMesh, {"npts": 7})
+        item = Serialise.serialise_submesh_item(gen)
+        restored = Serialise.deserialise_submesh_item(item, return_class_only=False)
+        assert isinstance(restored, pybamm.MeshGenerator)
+        assert restored.submesh_type is pybamm.Uniform1DSubMesh
+        assert restored.submesh_params == {"npts": 7}
+
 
 class TestSerializationErrorHandling:
     def test_invalid_schema_version_geometry(self):

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -160,120 +160,6 @@ class TestSerialiseModels:
 
 
 class TestSerialise:
-    # test the symbol encoder
-
-    def test_symbol_encoder_symbol(self, mocker):
-        """test basic symbol encoder with & without children"""
-
-        # without children
-        a, a_dict = scalar_var_dict(mocker)
-
-        a_ser_json = Serialise._SymbolEncoder().default(a)
-
-        assert a_ser_json == a_dict
-
-        # with children
-        add = pybamm.Addition(2, 4)
-        add_json = {
-            "py/id": mocker.ANY,
-            "py/object": "pybamm.expression_tree.binary_operators.Addition",
-            "name": "+",
-            "domains": {
-                "primary": [],
-                "secondary": [],
-                "tertiary": [],
-                "quaternary": [],
-            },
-            "children": [
-                {
-                    "py/id": mocker.ANY,
-                    "py/object": "pybamm.expression_tree.scalar.Scalar",
-                    "name": "2.0",
-                    "value": 2.0,
-                    "children": [],
-                },
-                {
-                    "py/id": mocker.ANY,
-                    "py/object": "pybamm.expression_tree.scalar.Scalar",
-                    "name": "4.0",
-                    "value": 4.0,
-                    "children": [],
-                },
-            ],
-        }
-
-        add_ser_json = Serialise._SymbolEncoder().default(add)
-
-        assert add_ser_json == add_json
-
-    def test_symbol_encoder_explicit_time_integral(self, mocker):
-        """test symbol encoder with initial conditions"""
-        expr = pybamm.ExplicitTimeIntegral(pybamm.Scalar(5), pybamm.Scalar(1))
-
-        expr_json = {
-            "py/object": "pybamm.expression_tree.unary_operators.ExplicitTimeIntegral",
-            "py/id": mocker.ANY,
-            "name": "explicit time integral",
-            "domains": {
-                "primary": [],
-                "secondary": [],
-                "tertiary": [],
-                "quaternary": [],
-            },
-            "children": [
-                {
-                    "py/object": "pybamm.expression_tree.scalar.Scalar",
-                    "py/id": mocker.ANY,
-                    "name": "5.0",
-                    "value": 5.0,
-                    "children": [],
-                }
-            ],
-            "initial_condition": {
-                "py/object": "pybamm.expression_tree.scalar.Scalar",
-                "py/id": mocker.ANY,
-                "name": "1.0",
-                "value": 1.0,
-                "children": [],
-            },
-        }
-
-        expr_ser_json = Serialise._SymbolEncoder().default(expr)
-
-        assert expr_json == expr_ser_json
-
-    def test_symbol_encoder_event(self, mocker):
-        """test symbol encoder with event"""
-
-        expression = pybamm.Scalar(1)
-        event = pybamm.Event("my event", expression)
-
-        event_json = {
-            "py/object": "pybamm.models.event.Event",
-            "py/id": mocker.ANY,
-            "name": "my event",
-            "event_type": ["EventType.TERMINATION", 0],
-            "expression": {
-                "py/object": "pybamm.expression_tree.scalar.Scalar",
-                "py/id": mocker.ANY,
-                "name": "1.0",
-                "value": 1.0,
-                "children": [],
-            },
-        }
-
-        event_ser_json = Serialise._SymbolEncoder().default(event)
-        assert event_ser_json == event_json
-
-    # test the mesh encoder
-    def test_mesh_encoder(self, mocker):
-        mesh, mesh_json = mesh_var_dict(mocker)
-
-        # serialise mesh
-        mesh_ser_json = Serialise._MeshEncoder().default(mesh)
-
-        assert mesh_ser_json == mesh_json
-
     def test_deconstruct_pybamm_dicts(self, mocker):
         """tests serialisation of dictionaries with pybamm classes as keys"""
 
@@ -281,11 +167,12 @@ class TestSerialise:
 
         test_dict = {"rod": {x: {"min": 0.0, "max": 2.0}}}
 
+        # Symbol keys now serialise through the kernel: canonical $type tag, no
+        # py/object / py/id / id, and empty children are omitted.
         ser_dict = {
             "rod": {
                 "symbol_x": {
-                    "py/object": "pybamm.expression_tree.independent_variable.SpatialVariable",
-                    "py/id": mocker.ANY,
+                    "$type": "pybamm.expression_tree.independent_variable.SpatialVariable",
                     "name": "x",
                     "domains": {
                         "primary": ["negative electrode"],
@@ -293,7 +180,6 @@ class TestSerialise:
                         "tertiary": [],
                         "quaternary": [],
                     },
-                    "children": [],
                     "coord_sys": None,
                     "direction": None,
                 },

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -13,7 +13,6 @@ from unittest.mock import mock_open, patch
 
 import numpy as np
 import pytest
-from numpy import testing
 
 import pybamm
 import pybamm.expression_tree.operations.serialise_kernel as sk
@@ -26,77 +25,6 @@ from pybamm.expression_tree.operations.serialise import (
 )
 from pybamm.models.full_battery_models.lithium_ion.basic_dfn import BasicDFN
 from pybamm.models.full_battery_models.lithium_ion.basic_spm import BasicSPM
-
-
-def scalar_var_dict(mocker):
-    """variable, json pair for a pybamm.Scalar instance"""
-    a = pybamm.Scalar(5)
-    a_dict = {
-        "py/id": mocker.ANY,
-        "py/object": "pybamm.expression_tree.scalar.Scalar",
-        "name": "5.0",
-        "value": 5.0,
-        "children": [],
-    }
-
-    return a, a_dict
-
-
-def mesh_var_dict(mocker):
-    """mesh, json pair for a pybamm.Mesh instance"""
-
-    r = pybamm.SpatialVariable(
-        "r", domain=["negative particle"], coord_sys="spherical polar"
-    )
-
-    geometry = {
-        "negative particle": {r: {"min": pybamm.Scalar(0), "max": pybamm.Scalar(1)}}
-    }
-
-    submesh_types = {"negative particle": pybamm.Uniform1DSubMesh}
-    var_pts = {r: 20}
-
-    # create mesh
-    mesh = pybamm.Mesh(geometry, submesh_types, var_pts)
-
-    mesh_json = {
-        "py/object": "pybamm.meshes.meshes.Mesh",
-        "py/id": mocker.ANY,
-        "submesh_pts": {"negative particle": {"r": 20}},
-        "base_domains": ["negative particle"],
-        "sub_meshes": {
-            "negative particle": {
-                "py/object": "pybamm.meshes.one_dimensional_submeshes.Uniform1DSubMesh",
-                "py/id": mocker.ANY,
-                "edges": [
-                    0.0,
-                    0.05,
-                    0.1,
-                    0.15000000000000002,
-                    0.2,
-                    0.25,
-                    0.30000000000000004,
-                    0.35000000000000003,
-                    0.4,
-                    0.45,
-                    0.5,
-                    0.55,
-                    0.6000000000000001,
-                    0.65,
-                    0.7000000000000001,
-                    0.75,
-                    0.8,
-                    0.8500000000000001,
-                    0.9,
-                    0.9500000000000001,
-                    1.0,
-                ],
-                "coord_sys": "spherical polar",
-            }
-        },
-    }
-
-    return mesh, mesh_json
 
 
 class TestSerialiseModels:
@@ -188,131 +116,6 @@ class TestSerialise:
         }
 
         assert Serialise()._deconstruct_pybamm_dicts(test_dict) == ser_dict
-
-    def test_get_pybamm_class(self, mocker):
-        # symbol
-        _, scalar_dict = scalar_var_dict(mocker)
-
-        scalar_class = Serialise()._get_pybamm_class(scalar_dict)
-
-        assert isinstance(scalar_class, pybamm.Scalar)
-
-        # mesh
-        _, mesh_dict = mesh_var_dict(mocker)
-
-        mesh_class = Serialise()._get_pybamm_class(mesh_dict)
-
-        assert isinstance(mesh_class, pybamm.Mesh)
-
-        with pytest.raises(AttributeError):
-            unrecognised_symbol = {
-                "py/id": mocker.ANY,
-                "py/object": "pybamm.expression_tree.scalar.Scale",
-                "name": "5.0",
-                "id": mocker.ANY,
-                "value": 5.0,
-                "children": [],
-            }
-            Serialise()._get_pybamm_class(unrecognised_symbol)
-
-    def test_reconstruct_symbol(self, mocker):
-        scalar, scalar_dict = scalar_var_dict(mocker)
-
-        new_scalar = Serialise()._reconstruct_symbol(scalar_dict)
-
-        assert new_scalar == scalar
-
-    def test_reconstruct_expression_tree(self):
-        y = pybamm.StateVector(slice(0, 1))
-        t = pybamm.t
-        equation = 2 * y + t
-
-        equation_json = {
-            "py/object": "pybamm.expression_tree.binary_operators.Addition",
-            "py/id": 139691619709376,
-            "name": "+",
-            "id": -2595875552397011963,
-            "domains": {
-                "primary": [],
-                "secondary": [],
-                "tertiary": [],
-                "quaternary": [],
-            },
-            "children": [
-                {
-                    "py/object": "pybamm.expression_tree.binary_operators.Multiplication",
-                    "py/id": 139691619709232,
-                    "name": "*",
-                    "id": 6094209803352873499,
-                    "domains": {
-                        "primary": [],
-                        "secondary": [],
-                        "tertiary": [],
-                        "quaternary": [],
-                    },
-                    "children": [
-                        {
-                            "py/object": "pybamm.expression_tree.scalar.Scalar",
-                            "py/id": 139691619709040,
-                            "name": "2.0",
-                            "id": 1254626814648295285,
-                            "value": 2.0,
-                            "children": [],
-                        },
-                        {
-                            "py/object": "pybamm.expression_tree.state_vector.StateVector",
-                            "py/id": 139691619589760,
-                            "name": "y[0:1]",
-                            "id": 5063056989669636089,
-                            "domains": {
-                                "primary": [],
-                                "secondary": [],
-                                "tertiary": [],
-                                "quaternary": [],
-                            },
-                            "y_slice": [{"start": 0, "stop": 1, "step": None}],
-                            "evaluation_array": [True],
-                            "children": [],
-                        },
-                    ],
-                },
-                {
-                    "py/object": "pybamm.expression_tree.independent_variable.Time",
-                    "py/id": 139692083289392,
-                    "name": "time",
-                    "id": -3301344124754766351,
-                    "domains": {
-                        "primary": [],
-                        "secondary": [],
-                        "tertiary": [],
-                        "quaternary": [],
-                    },
-                    "children": [],
-                },
-            ],
-        }
-
-        new_equation = Serialise()._reconstruct_expression_tree(equation_json)
-
-        assert new_equation == equation
-
-    def test_reconstruct_mesh(self, mocker):
-        mesh, mesh_dict = mesh_var_dict(mocker)
-
-        new_mesh = Serialise()._reconstruct_mesh(mesh_dict)
-
-        testing.assert_array_equal(
-            new_mesh["negative particle"].edges, mesh["negative particle"].edges
-        )
-        testing.assert_array_equal(
-            new_mesh["negative particle"].nodes, mesh["negative particle"].nodes
-        )
-
-        # reconstructed meshes are only used for plotting, geometry not reconstructed.
-        with pytest.raises(
-            AttributeError, match=r"'Mesh' object has no attribute '_geometry'"
-        ):
-            assert new_mesh.geometry == mesh.geometry
 
     def test_reconstruct_pybamm_dict(self, mocker):
         x = pybamm.SpatialVariable("x", "negative electrode")
@@ -414,7 +217,7 @@ class TestSerialise:
         # Test for error if no model type is provided
         with open("test_model.json") as f:
             model_data = json.load(f)
-            del model_data["py/object"]
+            del model_data["$type"]
 
         with open("test_model.json", "w") as f:
             json.dump(model_data, f)

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -151,6 +151,16 @@ class TestSerialise:
 
         assert test_list == new_list
 
+    def test_reconstruct_pybamm_dict_strips_prefix_only(self):
+        # "y" is made entirely of characters in the set {s,y,m,b,o,l,_}, so a
+        # char-set strip of "symbol_y" over-strips to "" instead of "y".
+        y = pybamm.SpatialVariable("y", "current collector")
+
+        test_dict = {"cc": {y: {"min": 0.0, "max": 1.0}}}
+        ser_dict = Serialise()._deconstruct_pybamm_dicts(test_dict)
+
+        assert Serialise()._reconstruct_pybamm_dict(ser_dict) == test_dict
+
     def test_convert_options(self):
         options_dict = {
             "current collector": "uniform",

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -2885,3 +2885,23 @@ class TestSolverSerialization:
         assert exp2.steps[0].temperature == pytest.approx(298.15)
         assert exp2.steps[1].temperature == pytest.approx(313.15)
         assert exp2.steps[2].temperature is None
+
+    def test_serialise_solver_raises_on_unserialisable_param(self):
+        solver = pybamm.ScipySolver()
+        # inject a non-serialisable value on a real guarded __init__ param
+        object.__setattr__(
+            solver, "method", object()
+        )  # `method` is a ScipySolver param
+        with pytest.raises(sk.SerialisationError, match="method"):
+            Serialise.serialise_solver(solver)
+
+    def test_serialise_solver_round_trips_all_shipped_solvers(self):
+        for solver in (
+            pybamm.IDAKLUSolver(),
+            pybamm.CasadiSolver(),
+            pybamm.ScipySolver(),
+            pybamm.AlgebraicSolver(),
+        ):
+            config = Serialise.serialise_solver(solver)  # must NOT raise
+            restored = Serialise.deserialise_solver(config)
+            assert type(restored) is type(solver)

--- a/tests/unit/test_serialisation/test_serialise_kernel.py
+++ b/tests/unit/test_serialisation/test_serialise_kernel.py
@@ -250,6 +250,29 @@ def test_hook_guard_allows_declared_derived_param():
     sk.encode(_Cached(pybamm.Scalar(1.0)))  # no raise
 
 
+def test_hook_guard_skips_missing_defaulted_param():
+    # Mirrors SubMesh1D.tabs: a defaulted __init__ param the instance never stores
+    # when it is not supplied. Nothing to serialise -> the constructor recreates the
+    # default on decode -> the guard must NOT raise (parity with DefaultCodec).
+    class _OptionalCfg(pybamm.Symbol):
+        def __init__(self, child, opt=None):
+            super().__init__("optcfg", children=[child])
+            if opt is not None:
+                self.opt = opt  # only stored when supplied
+
+        def to_json(self):
+            node = {"name": self.name, "domains": self.domains}
+            if hasattr(self, "opt"):
+                node["opt"] = self.opt
+            return node
+
+        @classmethod
+        def _from_json(cls, snippet):
+            return cls(snippet["children"][0], snippet.get("opt"))
+
+    sk.encode(_OptionalCfg(pybamm.Scalar(1.0)))  # opt unset+defaulted -> no raise
+
+
 # Module-level (not function-local) so decode can resolve it by import path during
 # the round-trip below; a `<locals>` class is not importable.
 class _OwnChildren(pybamm.Symbol):

--- a/tests/unit/test_spatial_methods/test_spatial_method_to_config.py
+++ b/tests/unit/test_spatial_methods/test_spatial_method_to_config.py
@@ -10,15 +10,27 @@ from pybamm.expression_tree.operations.serialise import Serialise
 class TestSpatialMethodToConfig:
     """Tests for SpatialMethod to_config and from_config."""
 
-    def test_spatial_method_to_config_returns_class_module_options(self):
-        """SpatialMethod.to_config() returns dict with 'class', 'module', 'options'."""
+    def test_spatial_method_to_config_returns_class_reference_options(self):
+        """SpatialMethod.to_config() returns a class-reference dict with 'options'."""
         method = pybamm.FiniteVolume()
         data = method.to_config()
         assert isinstance(data, dict)
-        assert data["class"] == "FiniteVolume"
-        assert "pybamm.spatial_methods" in data["module"]
+        assert data["$type"] == "type"
+        assert data["class"] == "pybamm.spatial_methods.finite_volume.FiniteVolume"
         assert "options" in data
         assert isinstance(data["options"], dict)
+
+    def test_spatial_method_from_config_reads_both_shapes(self):
+        """from_config accepts the legacy {'class', 'module'} shape and the canonical one."""
+        legacy = {
+            "class": "FiniteVolume",
+            "module": "pybamm.spatial_methods.finite_volume",
+            "options": None,
+        }
+        canonical = pybamm.FiniteVolume().to_config()
+        for data in (legacy, canonical):
+            restored = pybamm.SpatialMethod.from_config(data)
+            assert type(restored) is pybamm.FiniteVolume
 
     def test_spatial_method_from_config_same_type_and_options(self):
         """SpatialMethod.from_config(to_config()) returns same type with same options."""
@@ -44,7 +56,10 @@ class TestSpatialMethodToConfig:
         """ZeroDimensionalSpatialMethod round-trips via to_config/from_config."""
         method = pybamm.ZeroDimensionalSpatialMethod()
         data = method.to_config()
-        assert data["class"] == "ZeroDimensionalSpatialMethod"
+        assert (
+            data["class"]
+            == "pybamm.spatial_methods.zero_dimensional_method.ZeroDimensionalSpatialMethod"
+        )
         restored = pybamm.SpatialMethod.from_config(data)
         assert type(restored) is type(method)
         assert restored.options == method.options


### PR DESCRIPTION
# Description

Second of the stacked serialisation-kernel PRs, built on #5560. With the kernel and the Symbol surface in place, this PR migrates the remaining serialisation surfaces onto it and removes the bespoke encoders, so every surface shares the same safe-or-loud mechanism and one wire format.

This PR covers:

- **Discretised-model surface**: `serialise_model`/`load_model` now encode and decode through the kernel; `_SymbolEncoder`, `_MeshEncoder`, and the bespoke reconstructors are deleted. `Event`, `Mesh`, and `SubMesh` become kernel known bases with kernel-shaped hooks (expressions and sub-meshes carried via children). A read-only relocation pass maps legacy `py/object` nested fields onto the canonical shape, so pre-refactor discretised model files keep loading (regression-tested against an authentic legacy fixture; the fixture is git-ignored for size and the test skips if absent). SPM, SPMe, and DFN round-trip through save, load, and solve.
- **Solvers**: the warn-and-omit branch is replaced by a `SerialisationError` raise, extending safe-or-loud to solver serialisation. All shipped solver classes verified to round-trip; an audit found no solver currently omits anything.
- **Submesh and spatial-method types**: the bespoke `{class, module}` handling is unified onto the kernel's `class_reference` codec (both legacy shapes still read).
- **Coverage meta-test generalised** beyond Symbol to solver and submesh bases, so a new subclass of any known serialisable base without a strategy or explicit exemption fails CI.
- **Contributor doc** ("making a class serialisable") added to the API docs, plus the CHANGELOG entry for the whole kernel refactor.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works