### PR TITLE
docs: try fail fast on unreachable intersphinx hosts via intersphinx_timeout

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -299,6 +299,10 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
+# If an intersphinx inventory host is unreachable, fail in seconds rather than
+# hanging on the default socket timeout (which can stall the build for minutes).
+intersphinx_timeout = 30
+
 # -- sphinxcontrib-bibtex configuration --------------------------------------
 
 bibtex_bibfiles = ["../src/pybamm/CITATIONS.bib"]


### PR DESCRIPTION
## Context

The `Doctests` CI job builds the docs with `sphinx-build -W` (warnings as errors). When an intersphinx target — in practice `docs.scipy.org` — is briefly unreachable while Sphinx fetches its `objects.inv`, the resulting "failed to reach any of the inventories" warning fails the whole build over a transient network blip (observed on #5558, an empty commit off `main`).

## What the ecosystem actually does

I checked how the major scientific-Python projects handle this. They don't, really:

| Project | Docs build | intersphinx | Flakiness mitigation |
|---|---|---|---|
| numpy | `-W -T --keep-going` | plain remote | none |
| scipy | `-WT --keep-going` | `intersphinx_registry` | none |
| matplotlib | `-W --keep-going` | plain remote | none |
| pandas / astropy / xarray / sklearn | strict | plain remote | none |

All of them run the **same `-W --keep-going` + live remote intersphinx** as PyBaMM and **tolerate the rare transient flake** (cleared by re-running CI). `intersphinx_registry` only keeps URLs current — it explicitly has no cache and points scipy at the same `docs.scipy.org`. The warning is logged with no `type`, so `suppress_warnings` can't target it, and there is no clean Sphinx-config way to make it non-fatal. The only things that *eliminate* the flake are vendoring or caching inventories — which none of these projects bother with.

## This PR

Match the ecosystem: keep the standard strict build and the plain remote mapping, and make the **one** small, idiomatic improvement that exists — set `intersphinx_timeout = 30` so an unreachable host fails in seconds instead of hanging on the default socket timeout for minutes (same thing [pyvista](https://github.com/pyvista/pyvista/pull/3081) does).

A genuinely transient intersphinx timeout can still occasionally fail CI and is resolved by a re-run, exactly as it is for numpy/scipy/matplotlib. Earlier revisions of this PR (a logging filter; vendored fallback inventories) were dropped as more machinery than the problem warrants.

No changelog entry (CI/infra).
