### PR TITLE
Voltage-as-a-state infrastructure: centralised registration and operating-mode fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Features
+
+- The "voltage as a state" option is now registered centrally in `BaseBatteryModel` and supports all operating modes. SPM/SPMe promote "surface form" to "algebraic" automatically when a particle-size distribution is used (previously an error) as well as for non-default kinetics. `CasadiSolver` integrator failures on DAE models solved without algebraic initial-condition perturbation now include an actionable hint. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+
+## Bug fixes
+
+- Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+- Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+
 # [v26.6.0.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.0.0) - 2026-06-04
 
 ## Breaking changes

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -1321,6 +1321,13 @@ class BoundaryGradient(BoundaryOperator):
         super().__init__("boundary flux", child, side)
         self.order = order
 
+    def _sympy_operator(self, child):
+        """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        latex_child = (
+            r"\nabla " + sympy.latex(child) + r"^{" + sympy.latex(self.side) + r"}"
+        )
+        return sympy.Symbol(latex_child)
+
 
 class EvaluateAt(SpatialOperator):
     """

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -274,8 +274,17 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 resistance" is distributed in which case it is automatically set to
                 "true".
             * "voltage as a state" : str
-                Whether to make a state for the voltage and solve an algebraic equation
-                for it. Default is "false".
+                Whether to promote voltage to an algebraic state variable.
+                Can be "false" or "true". Default is "false", unless the
+                operating mode is "explicit power" or "explicit resistance",
+                in which case it is automatically set to "true". When "true",
+                the model is a DAE and requires a DAE-capable solver (e.g. the
+                default IDAKLUSolver). When "false", voltage is computed as an
+                expression. Note that setting this to "false" only removes the
+                voltage algebraic equation; SPM/SPMe with ``surface
+                form="false"`` become pure ODE models, but DFN retains other
+                algebraic states (electrode/electrolyte potentials) regardless
+                of this option.
             * "working electrode" : str
                 Can be "both" (default) for a standard battery or "positive" for a
                 half-cell where the negative electrode is replaced with a lithium metal
@@ -408,7 +417,45 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         }
 
         default_options = {
-            name: options[0] for name, options in self.possible_options.items()
+            "calculate discharge energy": "false",
+            "calculate heat source for isothermal models": "false",
+            "cell geometry": "arbitrary",
+            "contact resistance": "false",
+            "convection": "none",
+            "current collector": "uniform",
+            "diffusivity": "single",
+            "dimensionality": 0,
+            "electrolyte conductivity": "default",
+            "exchange-current density": "single",
+            "heat of mixing": "false",
+            "hydrolysis": "false",
+            "intercalation kinetics": "symmetric Butler-Volmer",
+            "interface utilisation": "full",
+            "lithium plating": "none",
+            "lithium plating porosity change": "false",
+            "loss of active material": "none",
+            "number of MSMR reactions": "none",
+            "open-circuit potential": "single",
+            "operating mode": "current",
+            "particle": "Fickian diffusion",
+            "particle mechanics": "none",
+            "particle phases": "1",
+            "particle shape": "spherical",
+            "particle size": "single",
+            "SEI": "none",
+            "SEI film resistance": "none",
+            "SEI on cracks": "false",
+            "SEI porosity change": "false",
+            "stress-induced diffusion": "false",
+            "surface form": "false",
+            "surface temperature": "ambient",
+            "thermal": "isothermal",
+            "total interfacial current density as a state": "false",
+            "transport efficiency": "Bruggeman",
+            "voltage as a state": "false",
+            "working electrode": "both",
+            "x-average side reactions": "false",
+            "use lumped thermal capacity": "false",
         }
         extra_options = extra_options or {}
 
@@ -540,6 +587,13 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         # The "surface form" option will still be overridden by
         # extra_options if provided
 
+        # Explicit power/resistance control requires voltage as a state:
+        # I = P/V (or I = V/R) is circular when V is an expression that
+        # itself depends on I.
+        mode_option = extra_options.get("operating mode", "current")
+        if mode_option in ("explicit power", "explicit resistance"):
+            default_options["voltage as a state"] = "true"
+
         # Change default SEI model based on which lithium plating option is provided
         # return "none" if option not given
         plating_option = extra_options.get("lithium plating", "none")
@@ -628,6 +682,19 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 raise NotImplementedError(
                     "Contact resistance not yet supported for explicit resistance."
                 )
+
+        # Explicit power/resistance need voltage as a state variable because
+        # I = P/V (or I = V/R) creates a circular dependency when V is an
+        # expression that itself depends on I.
+        if options["voltage as a state"] == "false" and options["operating mode"] in (
+            "explicit power",
+            "explicit resistance",
+        ):
+            raise pybamm.OptionError(
+                f"Cannot use '{options['operating mode']}' operating mode with "
+                "'voltage as a state' set to 'false'. Explicit power and "
+                "resistance control require voltage as an algebraic state."
+            )
 
         # Options not yet compatible with particle-size distributions
         if options["particle size"] == "distribution":
@@ -1190,6 +1257,32 @@ class BaseBatteryModel(pybamm.BaseModel):
             self.update(submodel)
             self.check_no_repeated_keys()
 
+    def _build_model(self):
+        if self._built:
+            raise pybamm.ModelError(
+                """Model already built. If you are adding a new submodel, try using
+                `model.update` instead."""
+            )
+
+        pybamm.logger.info(f"Start building {self.name}")
+
+        if self._built_fundamental is False:
+            self.build_fundamental()
+
+        # Register the voltage state Variable before coupled variables,
+        # so submodels that need V in get_coupled_variables can find it.
+        if self.options["voltage as a state"] == "true":
+            self._register_voltage_variable()
+
+        self.build_coupled_variables()
+
+        # Now that the expression is available, add the algebraic constraint
+        # before equations are built.
+        if self.options["voltage as a state"] == "true":
+            self._constrain_voltage_to_expression()
+
+        self.build_model_equations()
+
     def build_model(self):
         # Build model variables and equations
         self._build_model()
@@ -1461,6 +1554,21 @@ class BaseBatteryModel(pybamm.BaseModel):
                     self.param, domain, self.options, reaction_loc
                 )
             self.submodels[f"{Domain} interface utilisation"] = submodel
+
+    def _register_voltage_variable(self):
+        V = pybamm.Variable("Voltage [V]")
+        self.variables["Voltage [V]"] = V
+        self.initial_conditions[V] = self.param.ocv_init
+
+    def _constrain_voltage_to_expression(self):
+        V = self.variables["Voltage [V]"]
+        V_expr = self.variables.get("Voltage expression [V]")
+        if V_expr is None:
+            raise pybamm.ModelError(
+                "'voltage as a state' requires the model to define "
+                "'Voltage expression [V]'"
+            )
+        self.algebraic[V] = V - V_expr
 
     def set_voltage_variables(self):
         if self.options.negative["particle phases"] == "1":

--- a/src/pybamm/models/full_battery_models/lead_acid/basic_full.py
+++ b/src/pybamm/models/full_battery_models/lead_acid/basic_full.py
@@ -242,6 +242,7 @@ class BasicFull(BaseModel):
             "Electrolyte potential [V]": phi_e,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Porosity": eps,
         }
         self.events.extend(

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
@@ -264,6 +264,7 @@ class BasicDFN(BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_2d.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_2d.py
@@ -338,6 +338,7 @@ class BasicDFN2D(BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_composite.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_composite.py
@@ -377,6 +377,7 @@ class BasicDFNComposite(BaseModel):
             "Discharge capacity [A.h]": Q,
             "Time [s]": pybamm.t,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Negative electrode primary open-circuit potential [V]": ocp_n_p1,
             "Negative electrode secondary open-circuit potential [V]": ocp_n_p2,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -314,6 +314,7 @@ class BasicDFNHalfCell(BaseModel):
             "Negative electrode reaction overpotential [V]": eta_Li,
             "Negative electrode potential drop [V]": delta_phis_Li,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Instantaneous power [W.m-2]": i_cell * voltage,
         }

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
@@ -174,6 +174,7 @@ class BasicSPM(BaseModel):
                 phi_s_p, "positive electrode"
             ),
             "Voltage [V]": V,
+            "Voltage expression [V]": V,
             "Battery voltage [V]": V * num_cells,
         }
         # Events specify points at which a solution should terminate

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_spm_with_3d_thermal.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_spm_with_3d_thermal.py
@@ -241,6 +241,7 @@ class Basic3DThermalSPM(BaseModel):
                 phi_s_p, "positive electrode"
             ),
             "Voltage [V]": V,
+            "Voltage expression [V]": V,
             "Battery voltage [V]": V * num_cells,
         }
 

--- a/src/pybamm/models/full_battery_models/lithium_ion/spm.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/spm.py
@@ -21,16 +21,19 @@ class SPM(BaseModel):
     """
 
     def __init__(self, options=None, name="Single Particle Model", build=True):
-        # Use 'algebraic' surface form if non-default kinetics are used
-        options = options or {}
-        kinetics = options.get("intercalation kinetics")
-        surface_form = options.get("surface form")
-        if kinetics is not None and surface_form is None:
-            options["surface form"] = "algebraic"
-
         # For degradation models we use the "x-average", note that for side reactions
         # this is set by "x-average side reactions"
         self.x_average = True
+
+        # Use 'algebraic' surface form when the explicit-current closure is
+        # unavailable: non-default kinetics have no inverse form, and
+        # particle-size distributions require a surface formulation.
+        options = options or {}
+        if options.get("surface form") is None and (
+            options.get("intercalation kinetics") is not None
+            or "distribution" in options.get("particle size", "")
+        ):
+            options["surface form"] = "algebraic"
 
         # Set "x-average side reactions" to "true" if the model is SPM
         x_average_side_reactions = options.get("x-average side reactions")

--- a/src/pybamm/models/full_battery_models/sodium_ion/basic_dfn.py
+++ b/src/pybamm/models/full_battery_models/sodium_ion/basic_dfn.py
@@ -258,6 +258,7 @@ class BasicDFN(pybamm.lithium_ion.BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
@@ -20,22 +20,8 @@ class ExplicitCurrentControl(BaseModel):
             "Current [A]": I,
             "C-rate": I / self.param.Q,
         }
-        if self.options.get("voltage as a state") == "true":
-            V = pybamm.Variable("Voltage [V]")
-            variables.update({"Voltage [V]": V})
 
         return variables
-
-    def set_initial_conditions(self, variables):
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            self.initial_conditions[V] = self.param.ocv_init
-
-    def set_algebraic(self, variables):
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            V_expression = variables["Voltage expression [V]"]
-            self.algebraic[V] = V - V_expression
 
 
 class ExplicitPowerControl(BaseModel):

--- a/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
@@ -49,9 +49,6 @@ class FunctionControl(BaseModel):
             "Current [A]": I,
             "C-rate": I / self.param.Q,
         }
-        if self.options.get("voltage as a state") == "true":
-            V = pybamm.Variable("Voltage [V]")
-            variables.update({"Voltage [V]": V})
 
         return variables
 
@@ -59,9 +56,6 @@ class FunctionControl(BaseModel):
         # Initial condition as a guess for consistent initial conditions
         i_cell = variables["Current variable [A]"]
         self.initial_conditions[i_cell] = self.param.Q
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            self.initial_conditions[V] = self.param.ocv_init
 
     def set_rhs(self, variables):
         # External circuit submodels are always equations on the current
@@ -78,10 +72,6 @@ class FunctionControl(BaseModel):
         if self.control == "algebraic":
             i_cell = variables["Current variable [A]"]
             self.algebraic[i_cell] = self.external_circuit_function(variables)
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            V_expression = variables["Voltage expression [V]"]
-            self.algebraic[V] = V - V_expression
 
 
 class VoltageFunctionControl(FunctionControl):

--- a/src/pybamm/solvers/casadi_solver.py
+++ b/src/pybamm/solvers/casadi_solver.py
@@ -609,6 +609,18 @@ class CasadiSolver(pybamm.BaseSolver):
 
             return integrator
 
+    def _integrator_error(self, error, len_alg):
+        """Wrap an integrator failure, with a hint for DAE models solved
+        without algebraic IC perturbation (e.g. mode="fast")."""
+        message = error.args[0]
+        if len_alg > 0 and not self.perturb_algebraic_initial_conditions:
+            message += (
+                " The algebraic initial conditions may have failed to "
+                "converge; consider CasadiSolver(mode='safe') or "
+                "perturb_algebraic_initial_conditions=True."
+            )
+        return pybamm.SolverError(message)
+
     def _run_integrator(
         self,
         model,
@@ -678,7 +690,7 @@ class CasadiSolver(pybamm.BaseSolver):
             except RuntimeError as error:
                 # If it doesn't work raise error
                 pybamm.logger.debug(f"Casadi integrator failed with error {error}")
-                raise pybamm.SolverError(error.args[0]) from error
+                raise self._integrator_error(error, len_alg) from error
             pybamm.logger.debug("Finished casadi integrator")
             integration_time = timer.time()
             # Manually add initial conditions and concatenate
@@ -716,7 +728,7 @@ class CasadiSolver(pybamm.BaseSolver):
                 except RuntimeError as error:
                     # If it doesn't work raise error
                     pybamm.logger.debug(f"Casadi integrator failed with error {error}")
-                    raise pybamm.SolverError(error.args[0]) from error
+                    raise self._integrator_error(error, len_alg) from error
                 integration_time = timer.time()
                 x = casadi_sol["xf"]
                 z = casadi_sol["zf"]

--- a/tests/integration/test_voltage_as_state.py
+++ b/tests/integration/test_voltage_as_state.py
@@ -1,0 +1,157 @@
+"""Integration tests for the 'voltage as a state' option.
+
+Voltage promotion is registered centrally in BaseBatteryModel._build_model;
+these tests cover the opt-in behavior, the conditional defaults, and the
+explicit power/resistance operating modes that require it.
+"""
+
+import numpy as np
+import pytest
+
+import pybamm
+
+OPT_IN = {"voltage as a state": "true"}
+LI_ION_MODELS = [
+    pybamm.lithium_ion.SPM,
+    pybamm.lithium_ion.SPMe,
+    pybamm.lithium_ion.DFN,
+]
+
+
+class TestVoltageAsStateOptIn:
+    """With the option enabled, voltage is an algebraic state variable."""
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_voltage_is_algebraic_state(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        algebraic_var_names = [var.name for var in model.algebraic.keys()]
+        assert "Voltage [V]" in algebraic_var_names
+        assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_residuals_reference_variable(self, model_cls):
+        """Algebraic residuals should contain the Variable, not the expression."""
+        model = model_cls(options=OPT_IN)
+        voltage_eqs = [
+            expr for var, expr in model.algebraic.items() if var.name == "Voltage [V]"
+        ]
+        assert len(voltage_eqs) == 1
+        syms = [
+            s
+            for s in voltage_eqs[0].pre_order()
+            if isinstance(s, pybamm.Variable) and s.name == "Voltage [V]"
+        ]
+        assert len(syms) > 0
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_voltage_expression_matches_state(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        sol = pybamm.Simulation(model).solve([0, 3600])
+
+        v = sol["Voltage [V]"].entries
+        v_expr = sol["Voltage expression [V]"].entries
+        np.testing.assert_allclose(v, v_expr, rtol=1e-3, atol=1e-3)
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_default_voltage_is_expression(self, model_cls):
+        """Without the option, voltage remains a computed expression."""
+        model = model_cls()
+        algebraic_var_names = [var.name for var in model.algebraic.keys()]
+        assert "Voltage [V]" not in algebraic_var_names
+        assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+
+    @pytest.mark.parametrize(
+        "model_cls", [pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe]
+    )
+    def test_opt_in_solvable_by_casadi_safe(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="safe"))
+        sol = sim.solve([0, 3600])
+        v = sol["Voltage [V]"].entries
+        assert v[0] > v[-1]  # voltage decreases during discharge
+
+    def test_opt_in_rejects_scipy(self):
+        """Promoting voltage makes SPM a DAE, which ODE solvers reject."""
+        model = pybamm.lithium_ion.SPM(options=OPT_IN)
+        sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
+        with pytest.raises(pybamm.SolverError, match="Cannot use ODE solver"):
+            sim.solve([0, 3600])
+
+
+class TestExplicitPowerResistance:
+    """Explicit power/resistance control needs voltage as a state: I = P/V
+    (or I = V/R) is circular when V is an expression depending on I."""
+
+    @pytest.mark.parametrize(
+        "operating_mode", ["explicit power", "explicit resistance"]
+    )
+    def test_defaults_to_voltage_as_state(self, operating_mode):
+        model = pybamm.lithium_ion.SPM({"operating mode": operating_mode})
+        assert model.options["voltage as a state"] == "true"
+
+    def test_explicit_power_solves(self):
+        model = pybamm.lithium_ion.SPM({"operating mode": "explicit power"})
+        params = model.default_parameter_values
+        params["Power function [W]"] = 2.0
+        sol = pybamm.Simulation(model, parameter_values=params).solve([0, 1800])
+        power = sol["Voltage [V]"].entries * sol["Current [A]"].entries
+        np.testing.assert_allclose(power, 2.0, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        "operating_mode", ["explicit power", "explicit resistance"]
+    )
+    def test_explicit_false_rejected(self, operating_mode):
+        with pytest.raises(
+            pybamm.OptionError,
+            match=r"Cannot use.*operating mode.*'voltage as a state'.*'false'",
+        ):
+            pybamm.lithium_ion.SPM(
+                options={
+                    "voltage as a state": "false",
+                    "operating mode": operating_mode,
+                }
+            )
+
+
+class TestSurfaceFormConditionalDefaults:
+    """SPM/SPMe promote surface form to 'algebraic' only when the
+    explicit-current closure is unavailable."""
+
+    @pytest.mark.parametrize(
+        "model_cls", [pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe]
+    )
+    def test_plain_models_keep_false_surface_form(self, model_cls):
+        model = model_cls()
+        assert model.options["surface form"] == "false"
+        assert len(model.algebraic) == 0
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {"intercalation kinetics": "asymmetric Butler-Volmer"},
+            {"particle size": "distribution"},
+        ],
+    )
+    def test_conditional_algebraic_surface_form(self, options):
+        # No inverse kinetics for non-default kinetics; distributions
+        # require a surface formulation
+        model = pybamm.lithium_ion.SPM(options=options)
+        assert model.options["surface form"] == "algebraic"
+
+    def test_dfn_defaults_to_false_surface_form(self):
+        model = pybamm.lithium_ion.DFN()
+        assert model.options["surface form"] == "false"
+
+
+class TestBasicModelsVoltageExpression:
+    """Basic models expose voltage as an expression, not a state."""
+
+    @pytest.mark.parametrize(
+        "model_cls",
+        [pybamm.lithium_ion.BasicSPM, pybamm.lithium_ion.BasicDFN],
+    )
+    def test_basic_models_have_voltage_expression(self, model_cls):
+        model = model_cls()
+        assert "Voltage expression [V]" in model.variables
+        assert "Voltage [V]" in model.variables
+        assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -746,6 +746,11 @@ class TestUnaryOperators:
             r"c^{\mathtt{\text{left}}}"
         )
 
+        # Test BoundaryGradient
+        assert pybamm.BoundaryGradient(a, "left").to_equation() == sympy.Symbol(
+            r"\nabla a^{\mathtt{\text{left}}}"
+        )
+
         # Test Integral
         xn = pybamm.SpatialVariable("xn", ["negative electrode"])
         assert pybamm.Integral(d, xn).to_equation() == sympy.Integral(

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -512,12 +512,32 @@ class TestBaseBatteryModel:
         model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
         assert model.options["voltage as a state"] == "true"
         assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+        assert "Voltage [V]" in [v.name for v in model.algebraic.keys()]
 
         model = pybamm.lithium_ion.SPM(
             {"voltage as a state": "true", "operating mode": "voltage"}
         )
         assert model.options["voltage as a state"] == "true"
         assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+        assert "Voltage [V]" in [v.name for v in model.algebraic.keys()]
+
+    def test_explicit_modes_default_voltage_as_state(self):
+        for mode in ["explicit power", "explicit resistance"]:
+            options = pybamm.BatteryModelOptions({"operating mode": mode})
+            assert options["voltage as a state"] == "true"
+
+    def test_explicit_modes_reject_voltage_as_state_false(self):
+        for mode in ["explicit power", "explicit resistance"]:
+            with pytest.raises(pybamm.OptionError, match="voltage as a state"):
+                pybamm.BatteryModelOptions(
+                    {"operating mode": mode, "voltage as a state": "false"}
+                )
+
+    def test_voltage_as_state_requires_voltage_expression(self):
+        model = pybamm.BaseBatteryModel({"voltage as a state": "true"})
+        model.variables["Voltage [V]"] = pybamm.Variable("Voltage [V]")
+        with pytest.raises(pybamm.ModelError, match="Voltage expression"):
+            model._constrain_voltage_to_expression()
 
 
 class TestOptions:
@@ -608,3 +628,42 @@ class TestOptions:
             )
             == ocp_option[1]
         )
+
+    def test_default_options_independent_of_possible_options_order(self):
+        """Defaults should be set explicitly, not derived from possible_options[0]."""
+        options = pybamm.BatteryModelOptions({})
+        # defaults are set explicitly, not derived from list order
+        assert options["voltage as a state"] == "false"
+        # surface form: possible_options lists "false" first, default is "false"
+        assert options["surface form"] == "false"
+
+    def test_default_options_cover_all_possible_options(self):
+        """Every key in possible_options must have an explicit default."""
+        options = pybamm.BatteryModelOptions({})
+        for key in options.possible_options:
+            assert key in options, f"Missing default for option '{key}'"
+
+
+class TestVaasNormalization:
+    """Test the centralized VAAS + surface form policy."""
+
+    def test_vaas_true_with_surface_form_false_is_valid(self):
+        """VAAS can be true even with surface_form=false (DFN case)."""
+        options = pybamm.BatteryModelOptions(
+            {"voltage as a state": "true", "surface form": "false"}
+        )
+        assert options["voltage as a state"] == "true"
+        assert options["surface form"] == "false"
+
+    def test_vaas_false_with_surface_form_algebraic_is_valid(self):
+        """surface form algebraic without voltage-as-state is valid."""
+        options = pybamm.BatteryModelOptions(
+            {"voltage as a state": "false", "surface form": "algebraic"}
+        )
+        assert options["voltage as a state"] == "false"
+        assert options["surface form"] == "algebraic"
+
+    def test_vaas_false_defaults_surface_form_false(self):
+        """When VAAS is false and surface form not set, surface form stays false."""
+        options = pybamm.BatteryModelOptions({"voltage as a state": "false"})
+        assert options["surface form"] == "false"

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
@@ -41,8 +41,8 @@ class TestSPM(BaseUnitTestLithiumIon):
             pybamm.lithium_ion.SPM(options)
 
     def test_distribution_options(self):
-        with pytest.raises(pybamm.OptionError, match=r"surface form"):
-            pybamm.lithium_ion.SPM({"particle size": "distribution"})
+        options = {"particle size": "distribution"}
+        self.check_well_posedness(options)
 
     def test_particle_size_distribution(self):
         options = {"surface form": "algebraic", "particle size": "distribution"}

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -187,7 +189,12 @@ class TestCasadiSolver:
             solver=pybamm.CasadiSolver(mode="fast"),
         )
 
-        with pytest.raises(pybamm.SolverError, match=r"IDA_CONV_FAIL"):
+        # the integrator failure message carries a hint for DAE models solved
+        # without algebraic IC perturbation
+        with pytest.raises(
+            pybamm.SolverError,
+            match=r"(?s)IDA_CONV_FAIL.*perturb_algebraic_initial_conditions",
+        ):
             sim.solve()
 
     def test_model_solver_events(self):
@@ -653,6 +660,16 @@ class TestCasadiSolver:
             match=f"Explicit interpolation times not implemented for {solver.name}",
         ):
             solver.solve(model, t_eval, t_interp=t_interp)
+
+    def test_casadi_fast_solves_dae_without_warning(self):
+        """CasadiSolver(mode='fast') solves a DAE model silently; integrator
+        failures carry an actionable hint instead (see test_solver_error)."""
+        model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
+        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="fast"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", pybamm.SolverWarning)
+            sol = sim.solve([0, 3600])
+        assert sol.termination == "final time"
 
     def test_discontinuous_current(self):
         def car_current(t):


### PR DESCRIPTION
# Description

Infrastructure for the "voltage as a state" model option, ahead of flipping its default in the stacked follow-up PR. Non-breaking: the default remains "false".

- Centralises voltage-state registration in `BaseBatteryModel._build_model`, removing duplicated logic from the external-circuit submodels
- Fixes the "explicit power" and "explicit resistance" operating modes, which fail on main with a `ModelError` (circular I = P/V); they now default "voltage as a state" to "true" and raise a clear `OptionError` if it is explicitly disabled
- SPM/SPMe promote "surface form" to "algebraic" when a particle-size distribution or non-default kinetics are used (previously an error)
- Fixes `latexify()` crashing with `NotImplementedError` on models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with algebraic surface form)
- `CasadiSolver` integrator failures on DAE models solved without algebraic IC perturbation now include an actionable hint suggesting `mode='safe'` or `perturb_algebraic_initial_conditions=True`

## Type of change

CHANGELOG entries added under Features and Bug fixes.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- [x] No style issues: `nox -s pre-commit`
- [x] All tests pass: `nox -s tests` (affected unit and integration suites verified locally, full matrix in CI)
- [ ] The documentation builds: `nox -s doctests`
- [x] Code is commented for hard-to-understand areas
- [x] Tests added that prove fix is effective or that feature works