### PR TITLE
Fix CasADi conversion of differentiated Interpolant (#5582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+- Fixed CasADi conversion of a differentiated `Interpolant`, which returned the original function. ([#5582](https://github.com/pybamm-team/PyBaMM/issues/5582))
 - Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 - Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## Bug fixes
 
-- Fixed CasADi conversion of a differentiated `Interpolant`, which returned the original function. ([#5582](https://github.com/pybamm-team/PyBaMM/issues/5582))
+- Fixed CasADi conversion of a differentiated `Interpolant`, which returned the original function. ([#5583](https://github.com/pybamm-team/PyBaMM/pull/5583))
 - Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 - Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -300,17 +300,16 @@ class Interpolant(pybamm.Function):
 
     def _cubic_to_casadi(self, converted_children):
         if self.dimension == 1:
-            # Each derivative lowers the cubic (degree 3) by one; CasADi cannot
-            # reliably evaluate the resulting degree-0 spline (it returns 0 at the
-            # knots), so refuse rather than return wrong values (#5582).
+            # A cubic differentiated three or more times gives a degree-0
+            # (piecewise-constant) spline, which CasADi mis-evaluates at the
+            # knots (returns 0), so refuse rather than return wrong values (#5582).
             if self._num_derivatives >= 3:
                 raise NotImplementedError(
                     "CasADi cannot evaluate the degree-0 spline produced by "
-                    "differentiating a 'cubic' interpolant more than twice; use the "
-                    "'pchip' interpolator for third- and higher-order derivatives."
+                    "differentiating a 'cubic' interpolant three or more times."
                 )
             bspline = interpolate.make_interp_spline(self.x[0], self.y, k=3)
-            # Honour _num_derivatives so the conversion matches scipy (#5582)
+            # Differentiate the spline to match scipy's evaluate (#5582)
             for _ in range(self._num_derivatives):
                 bspline = bspline.derivative()
             c_flat = bspline.c.flatten()

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -365,12 +365,12 @@ class Interpolant(pybamm.Function):
             coeffs[:, 4, :] = x_np[:-1, np.newaxis]
 
         # Honour _num_derivatives (#5582): since dx = x - x_lo, d/dx == d/d(dx),
-        # so differentiating just shifts/scales the coeffs (x_lo row untouched)
+        # so differentiating just shifts/scales the coeffs (x_lo row untouched).
+        # Each row reads the next one up, so this is safe to do in place.
         for _ in range(self._num_derivatives):
-            poly = coeffs[:, 0:4, :].copy()
-            coeffs[:, 0, :] = poly[:, 1, :]
-            coeffs[:, 1, :] = 2 * poly[:, 2, :]
-            coeffs[:, 2, :] = 3 * poly[:, 3, :]
+            coeffs[:, 0, :] = coeffs[:, 1, :]
+            coeffs[:, 1, :] = 2 * coeffs[:, 2, :]
+            coeffs[:, 2, :] = 3 * coeffs[:, 3, :]
             coeffs[:, 3, :] = 0.0
 
         coeffs_flat = casadi.MX(coeffs.reshape(n * stride, m))

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -300,7 +300,19 @@ class Interpolant(pybamm.Function):
 
     def _cubic_to_casadi(self, converted_children):
         if self.dimension == 1:
+            # Each derivative lowers the cubic (degree 3) by one; CasADi cannot
+            # reliably evaluate the resulting degree-0 spline (it returns 0 at the
+            # knots), so refuse rather than return wrong values (#5582).
+            if self._num_derivatives >= 3:
+                raise NotImplementedError(
+                    "CasADi cannot evaluate the degree-0 spline produced by "
+                    "differentiating a 'cubic' interpolant more than twice; use the "
+                    "'pchip' interpolator for third- and higher-order derivatives."
+                )
             bspline = interpolate.make_interp_spline(self.x[0], self.y, k=3)
+            # Honour _num_derivatives so the conversion matches scipy (#5582)
+            for _ in range(self._num_derivatives):
+                bspline = bspline.derivative()
             c_flat = bspline.c.flatten()
             n_basis = len(bspline.t) - bspline.k - 1
             m = c_flat.size // n_basis
@@ -352,6 +364,15 @@ class Interpolant(pybamm.Function):
         coeffs[:, 3] = (2 * y0 + hd0 - 2 * y1 + hd1) * inv_h**3
         if not uniform:
             coeffs[:, 4, :] = x_np[:-1, np.newaxis]
+
+        # Honour _num_derivatives (#5582): since dx = x - x_lo, d/dx == d/d(dx),
+        # so differentiating just shifts/scales the coeffs (x_lo row untouched)
+        for _ in range(self._num_derivatives):
+            poly = coeffs[:, 0:4, :].copy()
+            coeffs[:, 0, :] = poly[:, 1, :]
+            coeffs[:, 1, :] = 2 * poly[:, 2, :]
+            coeffs[:, 2, :] = 3 * poly[:, 3, :]
+            coeffs[:, 3, :] = 0.0
 
         coeffs_flat = casadi.MX(coeffs.reshape(n * stride, m))
 

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -4,6 +4,7 @@
 
 import re
 
+import casadi
 import numpy as np
 import pytest
 
@@ -358,6 +359,77 @@ class TestInterpolant:
             match=r"differentiation not implemented for functions with more than one child",
         ):
             interp.diff(var1)
+
+    @pytest.fixture
+    def assert_casadi_matches_evaluate(self):
+        def _check(diff_expr, casadi_sym, test_point):
+            f = casadi.Function("f", [casadi_sym], [diff_expr.to_casadi(y=casadi_sym)])
+            np.testing.assert_allclose(
+                np.array(f(test_point)).flatten(),
+                diff_expr.evaluate(y=test_point).flatten(),
+                rtol=1e-6,
+                atol=1e-6,
+            )
+
+        return _check
+
+    @pytest.fixture(params=["uniform", "non_uniform"])
+    def grid(self, request):
+        if request.param == "uniform":
+            return np.linspace(0, 1, 200)
+        return np.sort(
+            np.concatenate([np.linspace(0, 0.5, 50), np.linspace(0.5, 1, 150)[1:]])
+        )
+
+    @pytest.mark.parametrize("interpolator", ["cubic", "pchip"])
+    def test_diff_to_casadi(self, grid, interpolator, assert_casadi_matches_evaluate):
+        # Regression for #5582: the CasADi conversion ignored _num_derivatives
+        # and returned the original, un-differentiated function.
+        y = pybamm.StateVector(slice(0, 2))
+        casadi_y = casadi.MX.sym("y", 2)
+        y_test = np.array([0.4, 0.6])
+        interp = pybamm.Interpolant(grid, grid**2, y, interpolator=interpolator)
+
+        assert_casadi_matches_evaluate(interp.diff(y), casadi_y, y_test)
+        assert_casadi_matches_evaluate(interp.diff(y).diff(y), casadi_y, y_test)
+
+    @pytest.mark.parametrize("interpolator", ["cubic", "pchip"])
+    def test_diff_to_casadi_vector_valued(
+        self, interpolator, assert_casadi_matches_evaluate
+    ):
+        x = np.linspace(0, 1, 200)
+        data = np.column_stack([x**2, x**3])
+        child = pybamm.StateVector(slice(0, 1))
+        casadi_child = casadi.MX.sym("y", 1)
+        interp = pybamm.Interpolant(x, data, child, interpolator=interpolator)
+
+        assert_casadi_matches_evaluate(
+            interp.diff(child), casadi_child, np.array([0.4])
+        )
+
+    def test_diff_to_casadi_pchip_third_derivative(
+        self, assert_casadi_matches_evaluate
+    ):
+        x = np.linspace(0, 1, 50)
+        y = pybamm.StateVector(slice(0, 1))
+        casadi_y = casadi.MX.sym("y", 1)
+        third = pybamm.Interpolant(x, x**3, y, interpolator="pchip")
+        for _ in range(3):
+            third = third.diff(y)
+        assert_casadi_matches_evaluate(third, casadi_y, np.array([0.3673]))
+
+    def test_diff_to_casadi_cubic_degree_zero_raises(self):
+        # Differentiating a cubic interpolant three times yields a degree-0 spline
+        # that CasADi mis-evaluates (returns 0) at the knots, so raise instead of
+        # silently returning wrong values (#5582).
+        x = np.linspace(0, 1, 50)
+        y = pybamm.StateVector(slice(0, 1))
+        casadi_y = casadi.MX.sym("y", 1)
+        third = pybamm.Interpolant(x, x**3, y, interpolator="cubic")
+        for _ in range(3):
+            third = third.diff(y)
+        with pytest.raises(NotImplementedError, match="degree-0"):
+            third.to_casadi(y=casadi_y)
 
     def test_processing(self):
         x = np.linspace(0, 1, 200)

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -410,6 +410,8 @@ class TestInterpolant:
     def test_diff_to_casadi_pchip_third_derivative(
         self, assert_casadi_matches_evaluate
     ):
+        # pchip uses a Horner polynomial, not a b-spline, so its (nonzero,
+        # piecewise-constant) third derivative converts correctly, unlike cubic.
         x = np.linspace(0, 1, 50)
         y = pybamm.StateVector(slice(0, 1))
         casadi_y = casadi.MX.sym("y", 1)
@@ -419,9 +421,8 @@ class TestInterpolant:
         assert_casadi_matches_evaluate(third, casadi_y, np.array([0.3673]))
 
     def test_diff_to_casadi_cubic_degree_zero_raises(self):
-        # Differentiating a cubic interpolant three times yields a degree-0 spline
-        # that CasADi mis-evaluates (returns 0) at the knots, so raise instead of
-        # silently returning wrong values (#5582).
+        # A cubic differentiated three times is a degree-0 spline that CasADi
+        # mis-evaluates, so it must raise rather than return wrong values (#5582).
         x = np.linspace(0, 1, 50)
         y = pybamm.StateVector(slice(0, 1))
         casadi_y = casadi.MX.sym("y", 1)


### PR DESCRIPTION
## Description

Fixes #5582.

The CasADi conversion of an `Interpolant` ignored `self._num_derivatives`, so a symbolically-differentiated `cubic`/`pchip` interpolant converted to the **original, un-differentiated** function instead of its derivative. scipy's `evaluate()` returned the correct derivative while the CasADi conversion returned the original — a silent correctness bug.

This produced wrong values wherever a tabulated (data-backed) function is differentiated and then evaluated through a CasADi/IDAKLU solver, e.g. the **heat-of-mixing** term and the **differential-capacity hysteresis OCP** with data-based open-circuit potentials, as well as any manual `interp.diff(...).to_casadi(...)`.

Note: the standard solver Jacobian is unaffected — it applies `casadi.jacobian` (AD) to the 0th-derivative interpolant rather than symbolically differentiating it first.

## Changes

- `_cubic_to_casadi`: differentiate the scipy b-spline `_num_derivatives` times before building the CasADi b-spline. A `cubic` differentiated three or more times yields a degree-0 (piecewise-constant) spline that CasADi mis-evaluates at the knots (returns `0`), so that case now raises a clear `NotImplementedError` rather than returning wrong values.
- `_pchip_to_casadi`: analytically differentiate the per-interval Horner coefficients (the stored `x_lo` is left untouched). Because pchip uses a Horner polynomial rather than a b-spline, its derivatives convert correctly at all orders.

## Testing

Added regression tests in `test_interpolant.py` (pytest fixtures + parametrization):
- `test_diff_to_casadi` — cubic/pchip × uniform/non-uniform grids, 1st and 2nd derivatives
- `test_diff_to_casadi_vector_valued` — vector-valued data
- `test_diff_to_casadi_pchip_third_derivative` — pchip 3rd derivative stays correct
- `test_diff_to_casadi_cubic_degree_zero_raises` — cubic 3rd derivative raises

Full `tests/unit/test_expression_tree/` suite passes (398 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
