### PR TITLE
Adjust floating point arthimetic in OCP asymptote softplus

### DIFF
--- a/src/pybamm/parameters/lithium_ion_parameters.py
+++ b/src/pybamm/parameters/lithium_ion_parameters.py
@@ -2,6 +2,8 @@
 # Standard parameters for lithium-ion battery models
 #
 
+import numpy as np
+
 import pybamm
 
 from .base_parameters import BaseParameters, NullParameters
@@ -960,8 +962,9 @@ def U_asymptote_approaching_zero(sto):
     b = 6910.192179565431
     c = -7.7e-4
 
-    # Clamp sto to avoid exp overflow (float64 max is ~exp(709))
-    max_safe_exp = 700
+    # Smallest exponent for which 1 + exp(z) == exp(z) in float64, so the
+    # linear continuation below is a bit-exact match for the softplus branch
+    max_safe_exp = np.log(2.0 / np.finfo(np.float64).eps)  # = 53*ln2 ~= 36.737
     sto_limit = c - max_safe_exp / b
 
     # For sto >= sto_limit: use log(1 + exp(...))


### PR DESCRIPTION
# Description

Previously, this function could've overflowed for large `sto` values with precision under float64. The new, smaller upper bound now supports up float32/bfloat16, but not float16

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
