### PR TITLE
Unified experiment mode: branch-collapsing controls + sparse switching-control jacobian

### DIFF
--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 import numbers
 from datetime import datetime
+from enum import Enum
 
 import numpy as np
 
 import pybamm
 
 from .step_termination import _read_termination
+
+
+class ControlKind(str, Enum):
+    """The control-law shape of a step (the quantity its residual fixes)."""
+
+    CURRENT = "current"
+    VOLTAGE = "voltage"
+    POWER = "power"
+    RESISTANCE = "resistance"
+
 
 _examples = """
 
@@ -280,6 +291,46 @@ class BaseStep:
     def __hash__(self):
         return hash(self.basic_repr())
 
+    # --- Control law (used to build the unified-experiment switching model) ---
+    #: Control-law shape (a :class:`ControlKind`); steps sharing it and differing only in
+    #: their target value collapse to one unified-mode branch.
+    control_kind = None
+
+    def get_control_residual(self, variables, target=None):
+        """Control residual. ``target`` is the per-step input that collapsible steps
+        share; when it is ``None`` the step falls back to its own ``_default_target``."""
+        if target is None:
+            target = self._default_target(variables)
+        return self._get_control_residual(variables, target)
+
+    def _default_target(self, variables):
+        """The step's own target, used when no per-step ``target`` overrides it."""
+        return self.value
+
+    def _get_control_residual(self, variables, target):
+        """Residual driving the controlled quantity to the resolved ``target``."""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def _control_target(self):
+        """The control target as a symbol (the prescribed current, voltage, ...)."""
+        return self.value
+
+    def control_target_value(self, parameter_values):
+        """The control target as a number, or ``None`` if it is not a constant."""
+        return _constant_value(parameter_values, self._control_target)
+
+    def unified_branch_repr(self):
+        """Branch identity in unified mode: control kind and everything but the value."""
+        parts = [self.control_kind or type(self).__name__]
+        if self.termination:
+            parts.append(f"termination={self.termination}")
+        if self.temperature:
+            parts.append(f"temperature={self.temperature}")
+        if self.direction:
+            parts.append(f"direction={self.direction}")
+        return "|".join(parts)
+
     def _default_timespan(self, value):
         """
         Default timespan for the step is one day (24 hours).
@@ -516,14 +567,21 @@ class BaseStep:
 
 
 class BaseStepExplicit(BaseStep):
+    control_kind = ControlKind.CURRENT
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def current_value(self, variables):
         raise NotImplementedError  # pragma: no cover
 
-    def get_control_residual(self, variables):
-        return variables["Current [A]"] - self.current_value(variables)
+    def _default_target(self, variables):
+        # The current may depend on the solution (custom steps), so build it from
+        # ``variables`` rather than the (possibly absent) constant value.
+        return self.current_value(variables)
+
+    def _get_control_residual(self, variables, target):
+        return variables["Current [A]"] - target
 
     def set_up(self, new_model, new_parameter_values):
         new_parameter_values["Current function [A]"] = self.current_value(
@@ -544,9 +602,6 @@ class BaseStepImplicit(BaseStep):
         return {}
 
     def get_submodel(self, model):
-        raise NotImplementedError  # pragma: no cover
-
-    def get_control_residual(self, variables):
         raise NotImplementedError  # pragma: no cover
 
     @staticmethod
@@ -589,6 +644,16 @@ _type_to_units = {
     "power": "[W]",
     "resistance": "[Ohm]",
 }
+
+
+def _constant_value(parameter_values, target):
+    """Numeric value of ``target`` if it is a state/time-independent constant (after
+    parameter substitution), else ``None``. ``target`` may be ``None`` (custom steps),
+    a number, or a symbol (e.g. a drive-cycle interpolant, which is not constant)."""
+    if target is None:
+        return None
+    processed = parameter_values.process_symbol(pybamm.convert_to_symbol(target))
+    return float(processed.evaluate()) if processed.is_constant() else None
 
 
 def get_unit_from(a_string: str) -> str:

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -3,6 +3,7 @@ import pybamm
 from .base_step import (
     BaseStepExplicit,
     BaseStepImplicit,
+    ControlKind,
     _convert_electric,
     _examples,
 )
@@ -168,6 +169,11 @@ class CRate(BaseStepExplicit):
     def current_value(self, variables):
         return self.value * pybamm.Parameter("Nominal cell capacity [A.h]")
 
+    @property
+    def _control_target(self):
+        # ``value`` is a C-rate; the controlled quantity is the current it sets.
+        return self.current_value(None)
+
     def _default_timespan(self, value):
         # "value" is C-rate, so duration is "1 / value" hours in seconds
         # with a 2x safety factor
@@ -187,11 +193,13 @@ class Voltage(BaseStepImplicit):
     Voltage should always be positive.
     """
 
+    control_kind = ControlKind.VOLTAGE
+
     def get_parameter_values(self, variables):
         return {"Voltage function [V]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Voltage [V]"] - self.value
+    def _get_control_residual(self, variables, target):
+        return variables["Voltage [V]"] - target
 
     def get_submodel(self, model):
         return pybamm.external_circuit.VoltageFunctionControl(
@@ -219,6 +227,8 @@ class Power(BaseStepImplicit):
         Any other keyword arguments are passed to the step class
     """
 
+    control_kind = ControlKind.POWER
+
     def __init__(self, value, **kwargs):
         self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
@@ -226,8 +236,8 @@ class Power(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Power function [W]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Power [W]"] - self.value
+    def _get_control_residual(self, variables, target):
+        return variables["Power [W]"] - target
 
     def get_submodel(self, model):
         return pybamm.external_circuit.PowerFunctionControl(model.param, model.options)
@@ -253,6 +263,8 @@ class Resistance(BaseStepImplicit):
         Any other keyword arguments are passed to the step class
     """
 
+    control_kind = ControlKind.RESISTANCE
+
     def __init__(self, value, **kwargs):
         self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
@@ -260,8 +272,8 @@ class Resistance(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Resistance function [Ohm]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Voltage [V]"] - self.value * variables["Current [A]"]
+    def _get_control_residual(self, variables, target):
+        return variables["Voltage [V]"] - target * variables["Current [A]"]
 
     def get_submodel(self, model):
         return pybamm.external_circuit.ResistanceFunctionControl(
@@ -429,7 +441,9 @@ class CustomStepImplicit(BaseStepImplicit):
         self.control = control
         self.kwargs = kwargs
 
-    def get_control_residual(self, variables):
+    def _get_control_residual(self, variables, target):
+        # Custom control is never collapsible, so ``target`` is unused -- the residual is
+        # fully defined by ``current_rhs_function``.
         if self.control != "algebraic":
             raise NotImplementedError(
                 "Unified experiment control only supports algebraic implicit custom steps"

--- a/src/pybamm/expression_tree/conditional.py
+++ b/src/pybamm/expression_tree/conditional.py
@@ -150,27 +150,35 @@ class Conditional(pybamm.Symbol):
         """See :meth:`pybamm.Symbol._to_casadi()`.
 
         Dispatch to per-branch Functions via a Switch (``casadi.Function.conditional``)
-        so only the active branch runs; an inline ``if_else`` folds them into one.
+        so only the active branch runs.
+
+        A Switch requires every branch (and the default) to share one output
+        sparsity. We use the *union* of the branch sparsities rather than a dense
+        fill: for a scalar control residual this is identical, but when this node
+        carries matrix-valued branch jacobians (the symbolic-jacobian path,
+        ``Conditional._jac``) the union keeps the jacobian sparse instead of
+        full-bandwidth.
         """
         selector = self.selector._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
         shared = [s for s in (t, y, y_dot) if s is not None] + list(inputs.values())
-        branch_functions = []
-        first_branch = None
-        for index, branch in enumerate(self.branches):
-            converted = branch._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
-            if first_branch is None:
-                first_branch = converted
-            # Switch needs all branches and the default to share one sparsity.
-            branch_functions.append(
-                casadi.Function(
-                    f"cond_branch_{index}", shared, [casadi.densify(converted)]
-                )
+        converted_branches = [
+            branch._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
+            for branch in self.branches
+        ]
+        union = converted_branches[0].sparsity()
+        for converted in converted_branches[1:]:
+            union = union.unite(converted.sparsity())
+        branch_functions = [
+            casadi.Function(
+                f"cond_branch_{index}", shared, [casadi.project(converted, union)]
             )
-        # No branch matches -> zeros.
+            for index, converted in enumerate(converted_branches)
+        ]
+        # No branch matches -> zeros in the shared (union) sparsity.
         default_function = casadi.Function(
             "cond_default",
             shared,
-            [casadi.densify(casadi.MX.zeros(*first_branch.shape))],
+            [casadi.project(casadi.MX.zeros(union.size1(), union.size2()), union)],
         )
         switch = casadi.Function.conditional(
             "cond_switch", branch_functions, default_function

--- a/src/pybamm/expression_tree/operations/_casadi_matmul.py
+++ b/src/pybamm/expression_tree/operations/_casadi_matmul.py
@@ -47,7 +47,12 @@ class MatMulIdenticalRows:
     m: int
 
     def apply(self, converted_right: casadi.MX) -> casadi.MX:
-        return casadi.DM.ones(self.m, 1) * (casadi.DM(self.row).T @ converted_right)
+        # Broadcast the single computed row to all m rows via an outer product. Use
+        # matmul, not element-wise ``*``: the latter only works when ``converted_right``
+        # is a column vector, but it is a matrix when this runs inside a jacobian.
+        return casadi.mtimes(
+            casadi.DM.ones(self.m, 1), casadi.DM(self.row).T @ converted_right
+        )
 
 
 @dataclass
@@ -64,8 +69,9 @@ class MatMulBoundaryDiffers:
         last = self.last_row if self.last_row is not None else self.interior_row
 
         first_result = casadi.DM(first).T @ converted_right
-        interior_result = casadi.DM.ones(self.m - 2, 1) * (
-            casadi.DM(self.interior_row).T @ converted_right
+        interior_result = casadi.mtimes(
+            casadi.DM.ones(self.m - 2, 1),
+            casadi.DM(self.interior_row).T @ converted_right,
         )
         last_result = casadi.DM(last).T @ converted_right
         return casadi.vertcat(first_result, interior_result, last_result)

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -50,6 +50,28 @@ _BUILTIN_MODULE_NAMES = (
 )
 
 
+def _switch_row_jacobian(expression, y, switch_rows, switch_columns):
+    """Jacobian of a model's switching-control rows.
+
+    Differentiate those rows on their own -- which keeps the ``Switch`` out of the
+    physics sweep, where CasADi reverse-AD would otherwise inflate it -- and restrict them
+    to the state columns the branches reference. The projection turns CasADi's dense
+    ``Switch`` row into its true sparse pattern; it is lossless because the dropped entries
+    are structural zeros.
+    """
+    jacobian = casadi.jacobian(expression[switch_rows, :], y)
+    rows, cols = jacobian.sparsity().get_triplet()
+    kept = [
+        (row, col)
+        for row, col in zip(rows, cols, strict=True)
+        if col in switch_columns[switch_rows[row]]
+    ]
+    pattern = casadi.Sparsity.triplet(
+        len(switch_rows), jacobian.shape[1], [r for r, _ in kept], [c for _, c in kept]
+    )
+    return casadi.project(jacobian, pattern)
+
+
 class BaseModel:
     """
     Base model class for other models to extend.
@@ -126,6 +148,12 @@ class BaseModel:
         self.is_parameterised = False
         self.y_slices = None
         self.len_rhs_and_alg = None
+
+        # Names of variables whose algebraic equation is a switching control residual --
+        # a pybamm.Conditional over per-step control laws, set by the unified-experiment
+        # setup. A structural attribute (like y_slices) that build_casadi_jacobian
+        # consumes to give those rows a sparse treatment; empty for ordinary models.
+        self.switching_control_variables = set()
 
         # Non-lithium ion models shouldn't calculate eSOH parameters
         self._calc_esoh = False
@@ -536,6 +564,73 @@ class BaseModel:
     @jacobian_algebraic.setter
     def jacobian_algebraic(self, jacobian_algebraic):
         self._jacobian_algebraic = jacobian_algebraic
+
+    def build_casadi_jacobian(self, expression, y):
+        """Build the CasADi jacobian of a converted model ``expression`` w.r.t. ``y``.
+
+        The solver calls this for every model in place of a bare ``casadi.jacobian``. It
+        is plain AD, except for the full rhs+algebraic jacobian of a model that has a
+        *switching control* equation -- a :class:`pybamm.Conditional` over per-step
+        control laws, recorded in :attr:`switching_control_variables` by the unified
+        experiment setup. CasADi turns that ``Conditional`` into a ``Switch`` and
+        differentiates it as a dense, full-bandwidth row inside the combined sweep.
+
+        Such a control residual is written against state variables (the current, and --
+        with "voltage as a state" -- the voltage), so its jacobian can only be nonzero in
+        those state columns. We differentiate those rows on their own and restrict them to
+        exactly those columns, and differentiate the physics block-wise (rhs and algebraic
+        separately, which CasADi handles efficiently). The result is identical to plain
+        AD -- only sparse on the control rows and cheaper to evaluate.
+        """
+        if (
+            not self.switching_control_variables
+            or expression.shape[0] != self.len_rhs_and_alg
+        ):
+            return casadi.jacobian(expression, y)
+
+        switch_columns = self._switching_control_columns()
+        switch_rows = sorted(switch_columns)
+        physics_rhs_rows = [r for r in range(self.len_rhs) if r not in switch_columns]
+        physics_alg_rows = [
+            r
+            for r in range(self.len_rhs, self.len_rhs_and_alg)
+            if r not in switch_columns
+        ]
+        physics = casadi.vertcat(
+            casadi.jacobian(expression[physics_rhs_rows, :], y),
+            casadi.jacobian(expression[physics_alg_rows, :], y),
+        )
+        switch = _switch_row_jacobian(expression, y, switch_rows, switch_columns)
+
+        # Reassemble the row-blocks (physics rhs, physics algebraic, switch) into the
+        # original state ordering.
+        stacked = casadi.vertcat(physics, switch)
+        stacked_order = physics_rhs_rows + physics_alg_rows + switch_rows
+        position = {row: i for i, row in enumerate(stacked_order)}
+        return stacked[[position[row] for row in range(self.len_rhs_and_alg)], :]
+
+    def _switching_control_columns(self):
+        """Map each row of a switching control equation (named in
+        :attr:`switching_control_variables`) to the state columns its branches reference
+        -- the only columns its jacobian can be nonzero in.
+
+        Read structurally from the ``StateVector`` slices in the equation (no
+        differentiation, so drive-cycle interpolants are safe); the rows come from the
+        discretised state slices, which is robust to the ordering of ``algebraic``.
+        """
+        switch_columns = {}
+        for variable, equation in self.algebraic.items():
+            if variable.name not in self.switching_control_variables:
+                continue
+            referenced = set()
+            for node in equation.pre_order():
+                if isinstance(node, pybamm.StateVector):
+                    for state_slice in node.y_slices:
+                        referenced.update(range(state_slice.start, state_slice.stop))
+            for row_slice in self.y_slices[variable]:
+                for row in range(row_slice.start, row_slice.stop):
+                    switch_columns[row] = referenced
+        return switch_columns
 
     @property
     def param(self):
@@ -1071,6 +1166,7 @@ class BaseModel:
         new_model._variables_casadi = self._variables_casadi.copy()
         new_model._symbol_processor = self.symbol_processor.copy()
         new_model._solution_observable = self._solution_observable
+        new_model.switching_control_variables = self.switching_control_variables.copy()
         return new_model
 
     def update(self, *submodels):

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import warnings
 from datetime import timedelta
 from numbers import Number
@@ -8,6 +9,7 @@ import numpy as np
 
 import pybamm
 import pybamm.telemetry
+from pybamm.expression_tree.input_parameter import DUMMY_INPUT_PARAMETER_VALUE
 from pybamm.solvers.base_solver import process
 from pybamm.util import import_optional_dependency
 
@@ -37,6 +39,7 @@ class Simulation(BaseSimulation):
     _AMBIENT_TEMPERATURE_INPUT = "Ambient temperature [K]"
     _PADDING_REST_KEY = "Rest for padding"
     _STEP_INDEX_INPUT = "Experiment step index"
+    _STEP_VALUE_INPUT = "Experiment step value"
     _TERMINATION_TIME = "experiment time limit reached"
     _TERMINATION_VOLTAGE = "experiment voltage limit reached"
     _TERMINATION_CAPACITY = "experiment capacity limit reached"
@@ -51,6 +54,7 @@ class Simulation(BaseSimulation):
             _AMBIENT_TEMPERATURE_INPUT,
             _INITIAL_TEMPERATURE_INPUT,
             _STEP_INDEX_INPUT,
+            _STEP_VALUE_INPUT,
         }
     )
 
@@ -113,6 +117,7 @@ class Simulation(BaseSimulation):
         self._experiment_step_indices = []
         self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
+        self._experiment_uses_value_input = False
 
     def __getstate__(self):
         """
@@ -140,6 +145,7 @@ class Simulation(BaseSimulation):
         "_experiment_step_indices": list,
         "_experiment_padding_rest_index": None,
         "_experiment_includes_padding_rest": False,
+        "_experiment_uses_value_input": False,
     }
 
     def __setstate__(self, state):
@@ -241,8 +247,6 @@ class Simulation(BaseSimulation):
             return ["no experiment is attached to the simulation"]
 
         for step in self.experiment.steps:
-            if step.is_drive_cycle:
-                return ["drive-cycle experiment steps are not yet supported"]
             if isinstance(step, pybamm.step.BaseStep) and not isinstance(
                 step,
                 (
@@ -267,16 +271,45 @@ class Simulation(BaseSimulation):
 
         # Branch the switching Conditionals over unique steps, not instances: one
         # branch per instance is O(n_steps) per timestep -> O(n_steps**2) overall.
+        # A step is "collapsible" if its control target is a constant (a fixed current,
+        # voltage, power, ...): such steps are solved with the target supplied as a
+        # shared per-step input, so steps differing only in their value share a single
+        # branch. This keeps the branch count -- and hence compile and runtime cost --
+        # tied to the number of structurally distinct control laws, not to the number of
+        # distinct values or cycles. Drive cycles and solution-dependent custom steps are
+        # not collapsible and keep their own branch.
+        value_input = pybamm.InputParameter(self._STEP_VALUE_INPUT)
+
+        def is_collapsible(step):
+            return step.control_target_value(self._parameter_values) is not None
+
+        def branch_key(step):
+            return (
+                step.unified_branch_repr()
+                if is_collapsible(step)
+                else step.basic_repr()
+            )
+
+        def control_builder(step):
+            # Collapsible steps read their target from the shared per-step input;
+            # the rest bake their own target in.
+            if is_collapsible(step):
+                return functools.partial(step.get_control_residual, target=value_input)
+            return step.get_control_residual
+
         unique_steps = []
         unique_branch_by_repr = {}
         for step in self.experiment.steps:
-            key = step.basic_repr()
+            key = branch_key(step)
             if key not in unique_branch_by_repr:
                 unique_branch_by_repr[key] = len(unique_steps) + 1  # 1-based selector
                 unique_steps.append(step)
         self._experiment_step_indices = [
-            unique_branch_by_repr[step.basic_repr()] for step in self.experiment.steps
+            unique_branch_by_repr[branch_key(step)] for step in self.experiment.steps
         ]
+        self._experiment_uses_value_input = any(
+            is_collapsible(step) for step in unique_steps
+        )
         self._experiment_includes_padding_rest = bool(
             self.experiment.initial_start_time
         )
@@ -290,9 +323,10 @@ class Simulation(BaseSimulation):
         # ambient temperature from step-level inputs instead of baking in one value.
         new_parameter_values[self._AMBIENT_TEMPERATURE_INPUT] = "[input]"
 
-        # Build one conditional control residual that selects the active step's
-        # control law via the experiment step index input.
-        step_control_builders = [step.get_control_residual for step in unique_steps]
+        # One conditional control residual selects the active step's control law via the
+        # experiment step index input; collapsible steps read their target from the
+        # shared per-step value input instead of baking it.
+        step_control_builders = [control_builder(step) for step in unique_steps]
         if self._experiment_includes_padding_rest:
             padding_rest_step = pybamm.step.Rest(duration=1)
             step_control_builders.append(padding_rest_step.get_control_residual)
@@ -309,6 +343,12 @@ class Simulation(BaseSimulation):
             submodel,
             new_parameter_values,
         )
+        # The control submodel owns the one Conditional residual (the switch over the
+        # per-step control laws). Record its variable so the solver builds that row's
+        # jacobian sparsely instead of via CasADi's dense Switch -- see
+        # BaseModel.build_casadi_jacobian. The attribute rides this same model object
+        # (in-place parameter processing and discretisation) through to solver.process.
+        new_model.switching_control_variables = {var.name for var in submodel.algebraic}
 
         # Combine each step's local termination expression into one experiment event,
         # selecting the active branch with the step index input.
@@ -366,6 +406,13 @@ class Simulation(BaseSimulation):
 
         if self._experiment_uses_unified_model:
             inputs[self._STEP_INDEX_INPUT] = active_step_index
+            if self._experiment_uses_value_input:
+                # Collapsible steps read their control target from this shared input;
+                # a non-collapsible active step doesn't read it, so pass the dummy.
+                target = step.control_target_value(self._parameter_values)
+                inputs[self._STEP_VALUE_INPUT] = (
+                    target if target is not None else DUMMY_INPUT_PARAMETER_VALUE
+                )
         return inputs
 
     def _get_built_experiment_model(self, step_or_key):

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1960,7 +1960,9 @@ def process(
 
         if use_jacobian:
             report(f"Calculating jacobian for {name} using CasADi")
-            jac_casadi = casadi.jacobian(casadi_expression, y_casadi)
+            # The model owns how its jacobian is built (plain CasADi AD unless the model
+            # has a switching control equation it must differentiate structurally).
+            jac_casadi = model.build_casadi_jacobian(casadi_expression, y_casadi)
             jac = casadi.Function(
                 name + "_jac",
                 [t_casadi, y_casadi, p_casadi_stacked],

--- a/tests/integration/test_unified_experiment_performance.py
+++ b/tests/integration/test_unified_experiment_performance.py
@@ -1,0 +1,98 @@
+#
+# Performance and scaling guards for unified experiment mode.
+#
+# The structural guarantees -- branch count constant across cycles, and constant-current
+# steps collapsing to one branch -- are what make compile/runtime cost independent of the
+# number of cycles and distinct values. They are asserted deterministically. The
+# wall-clock ratios vs legacy are environment-dependent, so they only warn (not fail) on
+# a regression, to monitor performance without flaking CI.
+#
+import time
+import warnings
+
+import numpy as np
+
+import pybamm
+
+
+def _cycling_experiment(n_cycles=3):
+    return pybamm.Experiment(
+        [
+            pybamm.step.c_rate(1.0, termination="3.2 V"),
+            pybamm.step.voltage(4.0, duration=300),
+        ]
+        * n_cycles
+    )
+
+
+def _unique_branch_count(experiment):
+    sim = pybamm.Simulation(
+        pybamm.lithium_ion.SPM(),
+        experiment=experiment,
+        solver=pybamm.IDAKLUSolver(),
+        experiment_model_mode="unified",
+    )
+    sim.build_for_experiment()
+    return len(set(sim._experiment_step_indices))
+
+
+def _min_solve_time(sim, samples=9):
+    # Minimum over several warm solves: the least system-contended run, so the most
+    # stable estimate of compute time. Build + compile are excluded by the warm-up solve.
+    sim.solve()
+    times = []
+    for _ in range(samples):
+        start = time.perf_counter()
+        sim.solve()
+        times.append(time.perf_counter() - start)
+    return float(np.min(times))
+
+
+def _warn_if_slow(model_class, limit):
+    model_class()  # warm the process (import/JIT/first compile) before timing
+    sims = {
+        mode: pybamm.Simulation(
+            model_class(),
+            experiment=_cycling_experiment(),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode=mode,
+        )
+        for mode in ("legacy", "unified")
+    }
+    ratio = _min_solve_time(sims["unified"], 9) / _min_solve_time(sims["legacy"], 9)
+    if ratio > limit:
+        warnings.warn(
+            f"{model_class.__name__} unified warm-solve is {ratio:.2f}x legacy "
+            f"(> {limit}x) -- possible performance regression.",
+            stacklevel=2,
+        )
+
+
+class TestUnifiedExperimentPerformance:
+    def test_dfn_warm_solve_close_to_legacy(self):
+        # Requirement: DFN cycling ~<1.1x legacy (measured ~1.0x). Warn-only: wall-clock
+        # is environment-dependent; the sparse control row is guarded deterministically
+        # by test_unified_control_row_jacobian_is_sparse.
+        _warn_if_slow(pybamm.lithium_ion.DFN, 1.15)
+
+    def test_spme_warm_solve_close_to_legacy(self):
+        # Requirement: SPMe cycling ~<1.2x legacy (measured ~1.05x). Warn-only.
+        _warn_if_slow(pybamm.lithium_ion.SPMe, 1.3)
+
+    def test_branch_count_independent_of_cycle_count(self):
+        # Compile cost cannot scale with cycle count: repeated steps reuse one branch.
+        assert [_unique_branch_count(_cycling_experiment(n)) for n in (1, 10, 50)] == [
+            2,
+            2,
+            2,
+        ]
+
+    def test_constant_current_steps_collapse_regardless_of_count(self):
+        # Distinct C-rates collapse to one branch, so compile/runtime cost does not grow
+        # with the number of CC steps (the current is supplied as a per-step input).
+        for n_steps in (5, 20, 50):
+            currents = np.linspace(0.1, 1.0, n_steps)
+            experiment = pybamm.Experiment(
+                [pybamm.step.c_rate(float(c), duration=1) for c in currents]
+            )
+            assert _unique_branch_count(experiment) == 1

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -121,6 +121,43 @@ class TestSimulationExperiment:
             "unsupported experiment step type 'BaseStep'"
         ]
 
+    def test_unified_allows_drive_cycle_and_algebraic_implicit(self):
+        # Drive-cycle steps are explicit current steps with a time-varying value; they
+        # share the generic current residual, so unified mode must accept them. An
+        # algebraic-control implicit step (voltage hold) is also eligible.
+        drive_cycle = np.column_stack([[0, 5, 10], [1.0, 0.5, 1.0]])
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.current(drive_cycle),
+                pybamm.step.voltage(3.8, duration=10),
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        assert sim._get_unified_experiment_model_blockers() == []
+
+    def test_unified_drive_cycle_matches_legacy(self):
+        # A drive cycle solved in unified mode must match legacy on a common time grid.
+        time = [0, 20, 40, 60, 80, 100]
+        current = [0.5, 0.6, 0.4, 0.5, 0.45, 0.5]
+        drive_cycle = np.column_stack([time, current])
+        experiment = pybamm.Experiment([pybamm.step.current(drive_cycle)])
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            sol = sim.solve()
+            out[mode] = sol["Voltage [V]"](time)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-4, atol=1e-4)
+
     def test_set_up_unified_preserves_voltage_safety_events(self):
         experiment = pybamm.Experiment(
             [
@@ -225,6 +262,106 @@ class TestSimulationExperiment:
             sim._experiment_unified_model_key
         ]
         assert "Current variable [A]" in unified_model.variables
+
+    def test_unified_builds_exactly_one_model_and_solver(self):
+        # Requirement: unified mode uses exactly one model and one solver instance,
+        # even across many steps and cycles.
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.c_rate(1.0, duration=60),
+                pybamm.step.voltage(3.8, duration=60),
+            ]
+            * 3
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        assert len({id(m) for m in sim.steps_to_built_models.values()}) == 1
+        assert len({id(s) for s in sim.steps_to_built_solvers.values()}) == 1
+
+    def test_unified_constant_current_steps_collapse_to_one_branch(self):
+        # CC/C-rate steps differing only in current value share one branch: the value
+        # is supplied as a per-step input, so the number of branches (and therefore
+        # compile/runtime cost) does not grow with the number of distinct currents.
+        currents = [0.1, 0.2, 0.5, 1.0]
+        steps = [pybamm.step.c_rate(c, duration=1) for c in currents]
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(steps),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        assert len(set(sim._experiment_step_indices)) == 1
+
+    def test_unified_collapses_every_control_kind_by_value(self):
+        # Value-as-input is general: steps of ANY control kind that differ only in their
+        # target value share one branch, and distinct control kinds get separate branches.
+        steps = [
+            pybamm.step.c_rate(0.5, duration=10),
+            pybamm.step.c_rate(1.0, duration=10),
+            pybamm.step.voltage(4.0, duration=10),
+            pybamm.step.voltage(4.1, duration=10),
+            pybamm.step.power(1.0, duration=10),
+            pybamm.step.power(2.0, duration=10),
+        ]
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(steps),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        # current / voltage / power -> exactly three branches (one per control kind).
+        assert len(set(sim._experiment_step_indices)) == 3
+
+    def test_unified_voltage_per_step_matches_legacy(self):
+        # Generalised value-as-input must be correct for implicit control too: two
+        # voltage holds at distinct targets collapse to one branch but must each hold
+        # their own target and match legacy. Sample settled points (end of each fixed
+        # 300 s window) on a common time grid to avoid transient/grid-alignment noise.
+        steps = [
+            pybamm.step.c_rate(0.5, duration=300),
+            pybamm.step.voltage(3.9, duration=300),
+            pybamm.step.voltage(3.8, duration=300),
+        ]
+        sample_times = [250, 590, 890]
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=pybamm.Experiment(steps),
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            out[mode] = sim.solve()["Voltage [V]"](sample_times)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-3, atol=1e-3)
+        # The two collapsed voltage steps must hold their own distinct targets.
+        np.testing.assert_allclose(out["unified"][1:], [3.9, 3.8], atol=2e-2)
+
+    def test_unified_cc_per_step_current_parses(self):
+        # Steps that collapse to one branch must still each solve to their own current:
+        # the per-step current input is parsed correctly (matches legacy, all distinct).
+        currents = [0.1, 0.3, 0.7, 1.0]
+        steps = [pybamm.step.c_rate(c, duration=1) for c in currents]
+        sample_times = [0.5, 1.5, 2.5, 3.5]
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=pybamm.Experiment(steps),
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            sol = sim.solve()
+            out[mode] = sol["Current [A]"](sample_times)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-4, atol=1e-6)
+        # Each step's input must be applied distinctly, not a single global current.
+        assert len(set(np.round(out["unified"], 6))) == 4
 
     def test_set_up_all_explicit_defaults_to_legacy_model(self):
         experiment = pybamm.Experiment(
@@ -560,6 +697,76 @@ class TestSimulationExperiment:
             return sim.solution["Voltage [V]"].entries[-1]
 
         assert voltage("unified") == pytest.approx(voltage("legacy"), abs=1e-6)
+
+    def test_unified_control_row_jacobian_is_sparse(self):
+        # CasADi declares a Switch's jacobian structurally dense, so the control
+        # equation would otherwise be a full-bandwidth row and balloon KLU work. The
+        # solver projects it back onto the true (union-of-branches) sparsity; assert no
+        # jacobian row spans the full bandwidth.
+        from collections import Counter
+
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.DFN(),
+            experiment=pybamm.Experiment(
+                [("Discharge at 1C until 3.3 V", "Hold at 3.3 V until C/20")]
+            ),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.solve()
+        sparsity = sim._built_experiment_model.jac_rhs_algebraic_eval.sparsity_out(0)
+        n = sparsity.size2()
+        densest_row_nnz = max(Counter(sparsity.get_triplet()[0]).values())
+        assert densest_row_nnz <= n // 2, (
+            f"a jacobian row has {densest_row_nnz}/{n} nonzeros (near full bandwidth); "
+            "the control-row union-sparsity projection did not take effect"
+        )
+
+    def test_unified_records_switching_control_variable_not_voltage(self):
+        # The unified setup records the control variable (its one Conditional residual) by
+        # name, so build_casadi_jacobian gives only that row the sparse switch treatment.
+        # With "voltage as a state" the algebraic block also holds a "Voltage [V]" row,
+        # which is physics and must NOT be picked up as a switch row.
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(
+                [("Charge at 1 A for 1 min", "Hold at 4.1 V for 1 min")]
+            ),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        model = sim.experiment_unique_steps_to_model[sim._experiment_unified_model_key]
+        assert model.switching_control_variables == {"Current variable [A]"}
+
+        def rows_for(name):
+            return {
+                r
+                for v, slices in model.y_slices.items()
+                if v.name == name
+                for s in slices
+                for r in range(s.start, s.stop)
+            }
+
+        switch_rows = set(model._switching_control_columns())
+        voltage_rows = rows_for("Voltage [V]")
+        assert voltage_rows, "expected voltage to be a state in this configuration"
+        assert switch_rows == rows_for("Current variable [A]")
+        assert not (switch_rows & voltage_rows)
+
+    def test_non_unified_model_jacobian_is_plain_casadi(self):
+        # An ordinary model records no switching control variable, so build_casadi_jacobian
+        # short-circuits to plain casadi.jacobian -- zero extra work, identical result.
+        import casadi
+
+        model = pybamm.lithium_ion.SPM()
+        assert model.switching_control_variables == set()
+
+        x = casadi.MX.sym("x", 3)
+        expr = casadi.vertcat(x[0] ** 2, x[1] * x[2], x[0] + x[1])
+        assert casadi.is_equal(
+            model.build_casadi_jacobian(expr, x), casadi.jacobian(expr, x), 20
+        )
 
     def test_unified_aot_compile_bounded_in_unique_steps(self):
         # -O3 is superlinear in single-function size, so per-branch dispatch must keep
@@ -1243,17 +1450,21 @@ class TestSimulationExperiment:
             "Ambient temperature [K]",
             "start time",
         }
-        assert len(internal_keys) == 1
-        experiment_input_name = internal_keys.pop()
+        # Unified mode injects the step-index selector and the per-step value input.
+        assert internal_keys == {
+            "Experiment step index",
+            "Experiment step value",
+        }
 
         sol = make_sim().solve(
             inputs={input_param_name: input_param_value},
-            calculate_sensitivities=[input_param_name, experiment_input_name],
+            calculate_sensitivities=[input_param_name, *internal_keys],
         )
 
         sensitivity_keys = set(sol.sensitivities)
         assert input_param_name in sensitivity_keys
-        assert experiment_input_name not in sensitivity_keys
+        for experiment_input_name in internal_keys:
+            assert experiment_input_name not in sensitivity_keys
 
     def test_processed_variable_sensitivities_ignore_experiment_input(self):
         # Regression test for #5517.

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -594,6 +594,34 @@ class TestRepeatedRowMatmulOptimization:
         actual = np.array(f(x)).flatten()
         np.testing.assert_allclose(actual, expected, rtol=1e-14)
 
+    def test_matrix_right_operand(self):
+        """M @ R when R is a matrix (e.g. a jacobian seed), not just a column vector.
+
+        The repeated-row optimization must broadcast with matmul, not element-wise ``*``
+        (which only works for a column vector and otherwise raises a dimension mismatch).
+        """
+        rng = np.random.default_rng(0)
+        n, m, k = 20, 8, 5
+        R = casadi.MX.sym("R", n, k)
+        Rv = rng.random((n, k))
+        row = rng.random(n)
+
+        # all rows identical
+        M = np.tile(row, (m, 1))
+        result = try_repeated_row_matmul(pybamm.Matrix(M), R)
+        assert result is not None
+        f = casadi.Function("f", [R], [result])
+        np.testing.assert_allclose(np.array(f(Rv)), M @ Rv, rtol=1e-12)
+
+        # interior rows identical, boundaries differ
+        M2 = np.tile(row, (m, 1))
+        M2[0, :] = rng.random(n)
+        M2[-1, :] = rng.random(n)
+        result2 = try_repeated_row_matmul(pybamm.Matrix(M2), R)
+        assert result2 is not None
+        f2 = casadi.Function("f2", [R], [result2])
+        np.testing.assert_allclose(np.array(f2(Rv)), M2 @ Rv, rtol=1e-12)
+
     def test_two_rows_identical(self):
         """Test m=2 with identical rows."""
 


### PR DESCRIPTION
# Description

Advances `experiment_model_mode="unified"` (one switching model for the whole experiment, with the active step selected by an `"Experiment step index"` input, instead of legacy's one model per unique step) along two combined but distinct lines.

**1. Coverage + branch collapse**
- Enable unified mode for all drive cycles and algebraic implicit steps with a defined control residual (previously blocked).
- Route each collapsible step's control target to one shared per-step input (`"Experiment step value"`), so steps that differ only in their value — CC at different C-rates, CV at different voltages, power, resistance — collapse to a **single branch**. Compile and runtime cost then track the number of *structurally distinct control laws*, not the number of distinct values or cycles. Drive cycles and solution-dependent custom steps keep their own branch.
- Generalize value-as-input across every control kind (current/voltage/power/resistance).

**2. Sparse, branching control-row jacobian**
- CasADi declares a `Switch`'s jacobian *structurally dense*, which turned the control equation into a full-bandwidth row and ballooned KLU work. We keep the `Switch` for the value (only the active branch evaluates) and build the jacobian so the control row stays sparse: physics rows are differentiated block-wise (rhs ⟂ algebraic, which keeps the `Switch` out of the physics sweep where reverse-AD would inflate it), and the switching-control rows are differentiated on their own and restricted to exactly the state columns their branches reference (read structurally, so drive-cycle interpolants are safe).
- The model records its switching control variable(s) at the single `Conditional` construction site (`BaseModel.switching_control_variables`); `build_casadi_jacobian` consults that and is plain `casadi.jacobian` for every other model (zero added work, no experiment knowledge in the generic model base).

Result: DFN cycling ≈1.0× legacy solve time, SPMe ≈1.05×; compile time and runtime are flat in the number of cycles and the number of distinct constant-current steps.

**Incidental correctness fix:** `_casadi_matmul.py` `MatMul*.apply` broadcast a repeated row with element-wise `*`, which is only valid for column vectors; switched to `casadi.mtimes` so it is correct for matrix operands (jacobian seeds). This was surfaced by the symbolic-jacobian path here but is a general fix; a regression test is included.

**API cleanups (refactor):** the control-law step API is consolidated to `get_control_residual(variables, target=None)` — defined once on `BaseStep` (resolves `target=None` to the step's `_default_target` and delegates to a per-kind `_get_control_residual`) — plus `control_target_value(...)`; control kinds moved to a `ControlKind` enum.

Fixes # (no dedicated issue — advances the `unified` experiment-model mode)

## Type of change

This is largely a refactor/perf pass on the (experimental) `unified` experiment-model mode plus one general bug fix. I have **not** added a CHANGELOG entry — please advise whether the drive-cycle enablement (`## Features`) and the `_casadi_matmul` fix (`## Bug fixes`) warrant entries given `unified` mode's release status; happy to add them with the PR number.

# Important checks

Verified locally:
- Style: `ruff check` clean on all touched files (full `nox -s pre-commit` not run in this environment).
- Tests: the unit suites for experiments, models, solvers, discretisation, and serialisation pass (2800+ tests), as do the unified-experiment integration guards. Full `nox -s tests` and `nox -s doctests` were not run here.
- New tests added: parity/structure guards for the switching-control jacobian (sparse control row; recorded variable; voltage-row exclusion; non-unified plain-AD path), branch-collapse and per-step-input scaling guards, drive-cycle/voltage matches-legacy, and the `_casadi_matmul` matrix-operand regression test.

**Reviewer note — known limitation (deferred):** unified mode + `calculate_sensitivities=True` can diverge at a current→CV (voltage-hold) step transition on DFN (the `IDACalcIC` consistent-IC solve fails its linesearch and returns a truncated, wrong result). SPM and non-`current→voltage` switches are unaffected, and legacy mode is unaffected. `calculate_sensitivities` is not yet a unified-mode blocker — flagged for a follow-up (guard or root-cause).
