### PR TITLE
Release v26.6.1.0 (feature)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+# [v26.6.1.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.1.0) - 2026-06-11
+
 ## Features
 
 - The "voltage as a state" option is now registered centrally in `BaseBatteryModel` and supports all operating modes. SPM/SPMe promote "surface form" to "algebraic" automatically when a particle-size distribution is used (previously an error) as well as for non-default kinetics. `CasadiSolver` integrator failures on DAE models solved without algebraic initial-condition perturbation now include an actionable hint. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
@@ -11,6 +13,8 @@
 - Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 - Fixed unified experiment crash when the ambient-temperature parameter value is a `pybamm.Scalar`. ([#5587](https://github.com/pybamm-team/PyBaMM/pull/5587))
 - Unified experiment `calculate_sensitivities` no longer leaks internal control inputs into the parameter Jacobian. ([#5587](https://github.com/pybamm-team/PyBaMM/pull/5587))
+- Corrected the overflow-clamp threshold in the lithium-ion OCP asymptote helper so the softplus and its linear continuation match exactly. ([#5588](https://github.com/pybamm-team/PyBaMM/pull/5588))
+- Fixed unified experiment building redundant control branches and a dense switching-control Jacobian. ([#5589](https://github.com/pybamm-team/PyBaMM/pull/5589))
 
 # [v26.6.0.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.0.0) - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug fixes
 
+- Fixed CasADi conversion of a differentiated `Interpolant`, which returned the original function. ([#5583](https://github.com/pybamm-team/PyBaMM/pull/5583))
 - Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 - Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Fixed CasADi conversion of a differentiated `Interpolant`, which returned the original function. ([#5583](https://github.com/pybamm-team/PyBaMM/pull/5583))
 - Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
 - Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+- Fixed unified experiment crash when the ambient-temperature parameter value is a `pybamm.Scalar`. ([#5587](https://github.com/pybamm-team/PyBaMM/pull/5587))
+- Unified experiment `calculate_sensitivities` no longer leaks internal control inputs into the parameter Jacobian. ([#5587](https://github.com/pybamm-team/PyBaMM/pull/5587))
 
 # [v26.6.0.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.0.0) - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Features
+
+- The "voltage as a state" option is now registered centrally in `BaseBatteryModel` and supports all operating modes. SPM/SPMe promote "surface form" to "algebraic" automatically when a particle-size distribution is used (previously an error) as well as for non-default kinetics. `CasadiSolver` integrator failures on DAE models solved without algebraic initial-condition perturbation now include an actionable hint. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+
+## Bug fixes
+
+- Fixed the "explicit power" and "explicit resistance" operating modes, which failed to build with a `ModelError`. These modes now default "voltage as a state" to "true", which breaks the circular dependency between current and voltage (I = P/V), and raise a clear `OptionError` if it is explicitly disabled. ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+- Fixed `latexify()` crashing with a `NotImplementedError` for models whose boundary conditions contain `boundary_gradient` nodes (e.g. DFN with `{"surface form": "algebraic"}`). ([#5572](https://github.com/pybamm-team/PyBaMM/pull/5572))
+
 # [v26.6.0.0](https://github.com/pybamm-team/PyBaMM/tree/v26.6.0.0) - 2026-06-04
 
 ## Breaking changes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.6.0.0"
+version: "26.6.1.0"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"

--- a/src/pybamm/experiment/step/base_step.py
+++ b/src/pybamm/experiment/step/base_step.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 import numbers
 from datetime import datetime
+from enum import Enum
 
 import numpy as np
 
 import pybamm
 
 from .step_termination import _read_termination
+
+
+class ControlKind(str, Enum):
+    """The control-law shape of a step (the quantity its residual fixes)."""
+
+    CURRENT = "current"
+    VOLTAGE = "voltage"
+    POWER = "power"
+    RESISTANCE = "resistance"
+
 
 _examples = """
 
@@ -280,6 +291,46 @@ class BaseStep:
     def __hash__(self):
         return hash(self.basic_repr())
 
+    # --- Control law (used to build the unified-experiment switching model) ---
+    #: Control-law shape (a :class:`ControlKind`); steps sharing it and differing only in
+    #: their target value collapse to one unified-mode branch.
+    control_kind = None
+
+    def get_control_residual(self, variables, target=None):
+        """Control residual. ``target`` is the per-step input that collapsible steps
+        share; when it is ``None`` the step falls back to its own ``_default_target``."""
+        if target is None:
+            target = self._default_target(variables)
+        return self._get_control_residual(variables, target)
+
+    def _default_target(self, variables):
+        """The step's own target, used when no per-step ``target`` overrides it."""
+        return self.value
+
+    def _get_control_residual(self, variables, target):
+        """Residual driving the controlled quantity to the resolved ``target``."""
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    def _control_target(self):
+        """The control target as a symbol (the prescribed current, voltage, ...)."""
+        return self.value
+
+    def control_target_value(self, parameter_values):
+        """The control target as a number, or ``None`` if it is not a constant."""
+        return _constant_value(parameter_values, self._control_target)
+
+    def unified_branch_repr(self):
+        """Branch identity in unified mode: control kind and everything but the value."""
+        parts = [self.control_kind or type(self).__name__]
+        if self.termination:
+            parts.append(f"termination={self.termination}")
+        if self.temperature:
+            parts.append(f"temperature={self.temperature}")
+        if self.direction:
+            parts.append(f"direction={self.direction}")
+        return "|".join(parts)
+
     def _default_timespan(self, value):
         """
         Default timespan for the step is one day (24 hours).
@@ -516,14 +567,21 @@ class BaseStep:
 
 
 class BaseStepExplicit(BaseStep):
+    control_kind = ControlKind.CURRENT
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def current_value(self, variables):
         raise NotImplementedError  # pragma: no cover
 
-    def get_control_residual(self, variables):
-        return variables["Current [A]"] - self.current_value(variables)
+    def _default_target(self, variables):
+        # The current may depend on the solution (custom steps), so build it from
+        # ``variables`` rather than the (possibly absent) constant value.
+        return self.current_value(variables)
+
+    def _get_control_residual(self, variables, target):
+        return variables["Current [A]"] - target
 
     def set_up(self, new_model, new_parameter_values):
         new_parameter_values["Current function [A]"] = self.current_value(
@@ -544,9 +602,6 @@ class BaseStepImplicit(BaseStep):
         return {}
 
     def get_submodel(self, model):
-        raise NotImplementedError  # pragma: no cover
-
-    def get_control_residual(self, variables):
         raise NotImplementedError  # pragma: no cover
 
     @staticmethod
@@ -589,6 +644,16 @@ _type_to_units = {
     "power": "[W]",
     "resistance": "[Ohm]",
 }
+
+
+def _constant_value(parameter_values, target):
+    """Numeric value of ``target`` if it is a state/time-independent constant (after
+    parameter substitution), else ``None``. ``target`` may be ``None`` (custom steps),
+    a number, or a symbol (e.g. a drive-cycle interpolant, which is not constant)."""
+    if target is None:
+        return None
+    processed = parameter_values.process_symbol(pybamm.convert_to_symbol(target))
+    return float(processed.evaluate()) if processed.is_constant() else None
 
 
 def get_unit_from(a_string: str) -> str:

--- a/src/pybamm/experiment/step/steps.py
+++ b/src/pybamm/experiment/step/steps.py
@@ -3,6 +3,7 @@ import pybamm
 from .base_step import (
     BaseStepExplicit,
     BaseStepImplicit,
+    ControlKind,
     _convert_electric,
     _examples,
 )
@@ -168,6 +169,11 @@ class CRate(BaseStepExplicit):
     def current_value(self, variables):
         return self.value * pybamm.Parameter("Nominal cell capacity [A.h]")
 
+    @property
+    def _control_target(self):
+        # ``value`` is a C-rate; the controlled quantity is the current it sets.
+        return self.current_value(None)
+
     def _default_timespan(self, value):
         # "value" is C-rate, so duration is "1 / value" hours in seconds
         # with a 2x safety factor
@@ -187,11 +193,13 @@ class Voltage(BaseStepImplicit):
     Voltage should always be positive.
     """
 
+    control_kind = ControlKind.VOLTAGE
+
     def get_parameter_values(self, variables):
         return {"Voltage function [V]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Voltage [V]"] - self.value
+    def _get_control_residual(self, variables, target):
+        return variables["Voltage [V]"] - target
 
     def get_submodel(self, model):
         return pybamm.external_circuit.VoltageFunctionControl(
@@ -219,6 +227,8 @@ class Power(BaseStepImplicit):
         Any other keyword arguments are passed to the step class
     """
 
+    control_kind = ControlKind.POWER
+
     def __init__(self, value, **kwargs):
         self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
@@ -226,8 +236,8 @@ class Power(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Power function [W]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Power [W]"] - self.value
+    def _get_control_residual(self, variables, target):
+        return variables["Power [W]"] - target
 
     def get_submodel(self, model):
         return pybamm.external_circuit.PowerFunctionControl(model.param, model.options)
@@ -253,6 +263,8 @@ class Resistance(BaseStepImplicit):
         Any other keyword arguments are passed to the step class
     """
 
+    control_kind = ControlKind.RESISTANCE
+
     def __init__(self, value, **kwargs):
         self.calculate_charge_or_discharge = True
         super().__init__(value, **kwargs)
@@ -260,8 +272,8 @@ class Resistance(BaseStepImplicit):
     def get_parameter_values(self, variables):
         return {"Resistance function [Ohm]": self.value}
 
-    def get_control_residual(self, variables):
-        return variables["Voltage [V]"] - self.value * variables["Current [A]"]
+    def _get_control_residual(self, variables, target):
+        return variables["Voltage [V]"] - target * variables["Current [A]"]
 
     def get_submodel(self, model):
         return pybamm.external_circuit.ResistanceFunctionControl(
@@ -429,7 +441,9 @@ class CustomStepImplicit(BaseStepImplicit):
         self.control = control
         self.kwargs = kwargs
 
-    def get_control_residual(self, variables):
+    def _get_control_residual(self, variables, target):
+        # Custom control is never collapsible, so ``target`` is unused -- the residual is
+        # fully defined by ``current_rhs_function``.
         if self.control != "algebraic":
             raise NotImplementedError(
                 "Unified experiment control only supports algebraic implicit custom steps"

--- a/src/pybamm/expression_tree/conditional.py
+++ b/src/pybamm/expression_tree/conditional.py
@@ -150,27 +150,35 @@ class Conditional(pybamm.Symbol):
         """See :meth:`pybamm.Symbol._to_casadi()`.
 
         Dispatch to per-branch Functions via a Switch (``casadi.Function.conditional``)
-        so only the active branch runs; an inline ``if_else`` folds them into one.
+        so only the active branch runs.
+
+        A Switch requires every branch (and the default) to share one output
+        sparsity. We use the *union* of the branch sparsities rather than a dense
+        fill: for a scalar control residual this is identical, but when this node
+        carries matrix-valued branch jacobians (the symbolic-jacobian path,
+        ``Conditional._jac``) the union keeps the jacobian sparse instead of
+        full-bandwidth.
         """
         selector = self.selector._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
         shared = [s for s in (t, y, y_dot) if s is not None] + list(inputs.values())
-        branch_functions = []
-        first_branch = None
-        for index, branch in enumerate(self.branches):
-            converted = branch._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
-            if first_branch is None:
-                first_branch = converted
-            # Switch needs all branches and the default to share one sparsity.
-            branch_functions.append(
-                casadi.Function(
-                    f"cond_branch_{index}", shared, [casadi.densify(converted)]
-                )
+        converted_branches = [
+            branch._to_casadi_inner(t, y, y_dot, inputs, casadi_symbols)
+            for branch in self.branches
+        ]
+        union = converted_branches[0].sparsity()
+        for converted in converted_branches[1:]:
+            union = union.unite(converted.sparsity())
+        branch_functions = [
+            casadi.Function(
+                f"cond_branch_{index}", shared, [casadi.project(converted, union)]
             )
-        # No branch matches -> zeros.
+            for index, converted in enumerate(converted_branches)
+        ]
+        # No branch matches -> zeros in the shared (union) sparsity.
         default_function = casadi.Function(
             "cond_default",
             shared,
-            [casadi.densify(casadi.MX.zeros(*first_branch.shape))],
+            [casadi.project(casadi.MX.zeros(union.size1(), union.size2()), union)],
         )
         switch = casadi.Function.conditional(
             "cond_switch", branch_functions, default_function

--- a/src/pybamm/expression_tree/interpolant.py
+++ b/src/pybamm/expression_tree/interpolant.py
@@ -300,7 +300,18 @@ class Interpolant(pybamm.Function):
 
     def _cubic_to_casadi(self, converted_children):
         if self.dimension == 1:
+            # A cubic differentiated three or more times gives a degree-0
+            # (piecewise-constant) spline, which CasADi mis-evaluates at the
+            # knots (returns 0), so refuse rather than return wrong values (#5582).
+            if self._num_derivatives >= 3:
+                raise NotImplementedError(
+                    "CasADi cannot evaluate the degree-0 spline produced by "
+                    "differentiating a 'cubic' interpolant three or more times."
+                )
             bspline = interpolate.make_interp_spline(self.x[0], self.y, k=3)
+            # Differentiate the spline to match scipy's evaluate (#5582)
+            for _ in range(self._num_derivatives):
+                bspline = bspline.derivative()
             c_flat = bspline.c.flatten()
             n_basis = len(bspline.t) - bspline.k - 1
             m = c_flat.size // n_basis
@@ -352,6 +363,15 @@ class Interpolant(pybamm.Function):
         coeffs[:, 3] = (2 * y0 + hd0 - 2 * y1 + hd1) * inv_h**3
         if not uniform:
             coeffs[:, 4, :] = x_np[:-1, np.newaxis]
+
+        # Honour _num_derivatives (#5582): since dx = x - x_lo, d/dx == d/d(dx),
+        # so differentiating just shifts/scales the coeffs (x_lo row untouched).
+        # Each row reads the next one up, so this is safe to do in place.
+        for _ in range(self._num_derivatives):
+            coeffs[:, 0, :] = coeffs[:, 1, :]
+            coeffs[:, 1, :] = 2 * coeffs[:, 2, :]
+            coeffs[:, 2, :] = 3 * coeffs[:, 3, :]
+            coeffs[:, 3, :] = 0.0
 
         coeffs_flat = casadi.MX(coeffs.reshape(n * stride, m))
 

--- a/src/pybamm/expression_tree/operations/_casadi_matmul.py
+++ b/src/pybamm/expression_tree/operations/_casadi_matmul.py
@@ -47,7 +47,12 @@ class MatMulIdenticalRows:
     m: int
 
     def apply(self, converted_right: casadi.MX) -> casadi.MX:
-        return casadi.DM.ones(self.m, 1) * (casadi.DM(self.row).T @ converted_right)
+        # Broadcast the single computed row to all m rows via an outer product. Use
+        # matmul, not element-wise ``*``: the latter only works when ``converted_right``
+        # is a column vector, but it is a matrix when this runs inside a jacobian.
+        return casadi.mtimes(
+            casadi.DM.ones(self.m, 1), casadi.DM(self.row).T @ converted_right
+        )
 
 
 @dataclass
@@ -64,8 +69,9 @@ class MatMulBoundaryDiffers:
         last = self.last_row if self.last_row is not None else self.interior_row
 
         first_result = casadi.DM(first).T @ converted_right
-        interior_result = casadi.DM.ones(self.m - 2, 1) * (
-            casadi.DM(self.interior_row).T @ converted_right
+        interior_result = casadi.mtimes(
+            casadi.DM.ones(self.m - 2, 1),
+            casadi.DM(self.interior_row).T @ converted_right,
         )
         last_result = casadi.DM(last).T @ converted_right
         return casadi.vertcat(first_result, interior_result, last_result)

--- a/src/pybamm/expression_tree/unary_operators.py
+++ b/src/pybamm/expression_tree/unary_operators.py
@@ -1321,6 +1321,13 @@ class BoundaryGradient(BoundaryOperator):
         super().__init__("boundary flux", child, side)
         self.order = order
 
+    def _sympy_operator(self, child):
+        """Override :meth:`pybamm.UnaryOperator._sympy_operator`"""
+        latex_child = (
+            r"\nabla " + sympy.latex(child) + r"^{" + sympy.latex(self.side) + r"}"
+        )
+        return sympy.Symbol(latex_child)
+
 
 class EvaluateAt(SpatialOperator):
     """

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -50,6 +50,28 @@ _BUILTIN_MODULE_NAMES = (
 )
 
 
+def _switch_row_jacobian(expression, y, switch_rows, switch_columns):
+    """Jacobian of a model's switching-control rows.
+
+    Differentiate those rows on their own -- which keeps the ``Switch`` out of the
+    physics sweep, where CasADi reverse-AD would otherwise inflate it -- and restrict them
+    to the state columns the branches reference. The projection turns CasADi's dense
+    ``Switch`` row into its true sparse pattern; it is lossless because the dropped entries
+    are structural zeros.
+    """
+    jacobian = casadi.jacobian(expression[switch_rows, :], y)
+    rows, cols = jacobian.sparsity().get_triplet()
+    kept = [
+        (row, col)
+        for row, col in zip(rows, cols, strict=True)
+        if col in switch_columns[switch_rows[row]]
+    ]
+    pattern = casadi.Sparsity.triplet(
+        len(switch_rows), jacobian.shape[1], [r for r, _ in kept], [c for _, c in kept]
+    )
+    return casadi.project(jacobian, pattern)
+
+
 class BaseModel:
     """
     Base model class for other models to extend.
@@ -126,6 +148,12 @@ class BaseModel:
         self.is_parameterised = False
         self.y_slices = None
         self.len_rhs_and_alg = None
+
+        # Names of variables whose algebraic equation is a switching control residual --
+        # a pybamm.Conditional over per-step control laws, set by the unified-experiment
+        # setup. A structural attribute (like y_slices) that build_casadi_jacobian
+        # consumes to give those rows a sparse treatment; empty for ordinary models.
+        self.switching_control_variables = set()
 
         # Non-lithium ion models shouldn't calculate eSOH parameters
         self._calc_esoh = False
@@ -536,6 +564,73 @@ class BaseModel:
     @jacobian_algebraic.setter
     def jacobian_algebraic(self, jacobian_algebraic):
         self._jacobian_algebraic = jacobian_algebraic
+
+    def build_casadi_jacobian(self, expression, y):
+        """Build the CasADi jacobian of a converted model ``expression`` w.r.t. ``y``.
+
+        The solver calls this for every model in place of a bare ``casadi.jacobian``. It
+        is plain AD, except for the full rhs+algebraic jacobian of a model that has a
+        *switching control* equation -- a :class:`pybamm.Conditional` over per-step
+        control laws, recorded in :attr:`switching_control_variables` by the unified
+        experiment setup. CasADi turns that ``Conditional`` into a ``Switch`` and
+        differentiates it as a dense, full-bandwidth row inside the combined sweep.
+
+        Such a control residual is written against state variables (the current, and --
+        with "voltage as a state" -- the voltage), so its jacobian can only be nonzero in
+        those state columns. We differentiate those rows on their own and restrict them to
+        exactly those columns, and differentiate the physics block-wise (rhs and algebraic
+        separately, which CasADi handles efficiently). The result is identical to plain
+        AD -- only sparse on the control rows and cheaper to evaluate.
+        """
+        if (
+            not self.switching_control_variables
+            or expression.shape[0] != self.len_rhs_and_alg
+        ):
+            return casadi.jacobian(expression, y)
+
+        switch_columns = self._switching_control_columns()
+        switch_rows = sorted(switch_columns)
+        physics_rhs_rows = [r for r in range(self.len_rhs) if r not in switch_columns]
+        physics_alg_rows = [
+            r
+            for r in range(self.len_rhs, self.len_rhs_and_alg)
+            if r not in switch_columns
+        ]
+        physics = casadi.vertcat(
+            casadi.jacobian(expression[physics_rhs_rows, :], y),
+            casadi.jacobian(expression[physics_alg_rows, :], y),
+        )
+        switch = _switch_row_jacobian(expression, y, switch_rows, switch_columns)
+
+        # Reassemble the row-blocks (physics rhs, physics algebraic, switch) into the
+        # original state ordering.
+        stacked = casadi.vertcat(physics, switch)
+        stacked_order = physics_rhs_rows + physics_alg_rows + switch_rows
+        position = {row: i for i, row in enumerate(stacked_order)}
+        return stacked[[position[row] for row in range(self.len_rhs_and_alg)], :]
+
+    def _switching_control_columns(self):
+        """Map each row of a switching control equation (named in
+        :attr:`switching_control_variables`) to the state columns its branches reference
+        -- the only columns its jacobian can be nonzero in.
+
+        Read structurally from the ``StateVector`` slices in the equation (no
+        differentiation, so drive-cycle interpolants are safe); the rows come from the
+        discretised state slices, which is robust to the ordering of ``algebraic``.
+        """
+        switch_columns = {}
+        for variable, equation in self.algebraic.items():
+            if variable.name not in self.switching_control_variables:
+                continue
+            referenced = set()
+            for node in equation.pre_order():
+                if isinstance(node, pybamm.StateVector):
+                    for state_slice in node.y_slices:
+                        referenced.update(range(state_slice.start, state_slice.stop))
+            for row_slice in self.y_slices[variable]:
+                for row in range(row_slice.start, row_slice.stop):
+                    switch_columns[row] = referenced
+        return switch_columns
 
     @property
     def param(self):
@@ -1071,6 +1166,7 @@ class BaseModel:
         new_model._variables_casadi = self._variables_casadi.copy()
         new_model._symbol_processor = self.symbol_processor.copy()
         new_model._solution_observable = self._solution_observable
+        new_model.switching_control_variables = self.switching_control_variables.copy()
         return new_model
 
     def update(self, *submodels):

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -274,8 +274,17 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 resistance" is distributed in which case it is automatically set to
                 "true".
             * "voltage as a state" : str
-                Whether to make a state for the voltage and solve an algebraic equation
-                for it. Default is "false".
+                Whether to promote voltage to an algebraic state variable.
+                Can be "false" or "true". Default is "false", unless the
+                operating mode is "explicit power" or "explicit resistance",
+                in which case it is automatically set to "true". When "true",
+                the model is a DAE and requires a DAE-capable solver (e.g. the
+                default IDAKLUSolver). When "false", voltage is computed as an
+                expression. Note that setting this to "false" only removes the
+                voltage algebraic equation; SPM/SPMe with ``surface
+                form="false"`` become pure ODE models, but DFN retains other
+                algebraic states (electrode/electrolyte potentials) regardless
+                of this option.
             * "working electrode" : str
                 Can be "both" (default) for a standard battery or "positive" for a
                 half-cell where the negative electrode is replaced with a lithium metal
@@ -408,7 +417,45 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         }
 
         default_options = {
-            name: options[0] for name, options in self.possible_options.items()
+            "calculate discharge energy": "false",
+            "calculate heat source for isothermal models": "false",
+            "cell geometry": "arbitrary",
+            "contact resistance": "false",
+            "convection": "none",
+            "current collector": "uniform",
+            "diffusivity": "single",
+            "dimensionality": 0,
+            "electrolyte conductivity": "default",
+            "exchange-current density": "single",
+            "heat of mixing": "false",
+            "hydrolysis": "false",
+            "intercalation kinetics": "symmetric Butler-Volmer",
+            "interface utilisation": "full",
+            "lithium plating": "none",
+            "lithium plating porosity change": "false",
+            "loss of active material": "none",
+            "number of MSMR reactions": "none",
+            "open-circuit potential": "single",
+            "operating mode": "current",
+            "particle": "Fickian diffusion",
+            "particle mechanics": "none",
+            "particle phases": "1",
+            "particle shape": "spherical",
+            "particle size": "single",
+            "SEI": "none",
+            "SEI film resistance": "none",
+            "SEI on cracks": "false",
+            "SEI porosity change": "false",
+            "stress-induced diffusion": "false",
+            "surface form": "false",
+            "surface temperature": "ambient",
+            "thermal": "isothermal",
+            "total interfacial current density as a state": "false",
+            "transport efficiency": "Bruggeman",
+            "voltage as a state": "false",
+            "working electrode": "both",
+            "x-average side reactions": "false",
+            "use lumped thermal capacity": "false",
         }
         extra_options = extra_options or {}
 
@@ -540,6 +587,13 @@ class BatteryModelOptions(pybamm.FuzzyDict):
         # The "surface form" option will still be overridden by
         # extra_options if provided
 
+        # Explicit power/resistance control requires voltage as a state:
+        # I = P/V (or I = V/R) is circular when V is an expression that
+        # itself depends on I.
+        mode_option = extra_options.get("operating mode", "current")
+        if mode_option in ("explicit power", "explicit resistance"):
+            default_options["voltage as a state"] = "true"
+
         # Change default SEI model based on which lithium plating option is provided
         # return "none" if option not given
         plating_option = extra_options.get("lithium plating", "none")
@@ -628,6 +682,19 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 raise NotImplementedError(
                     "Contact resistance not yet supported for explicit resistance."
                 )
+
+        # Explicit power/resistance need voltage as a state variable because
+        # I = P/V (or I = V/R) creates a circular dependency when V is an
+        # expression that itself depends on I.
+        if options["voltage as a state"] == "false" and options["operating mode"] in (
+            "explicit power",
+            "explicit resistance",
+        ):
+            raise pybamm.OptionError(
+                f"Cannot use '{options['operating mode']}' operating mode with "
+                "'voltage as a state' set to 'false'. Explicit power and "
+                "resistance control require voltage as an algebraic state."
+            )
 
         # Options not yet compatible with particle-size distributions
         if options["particle size"] == "distribution":
@@ -1190,6 +1257,32 @@ class BaseBatteryModel(pybamm.BaseModel):
             self.update(submodel)
             self.check_no_repeated_keys()
 
+    def _build_model(self):
+        if self._built:
+            raise pybamm.ModelError(
+                """Model already built. If you are adding a new submodel, try using
+                `model.update` instead."""
+            )
+
+        pybamm.logger.info(f"Start building {self.name}")
+
+        if self._built_fundamental is False:
+            self.build_fundamental()
+
+        # Register the voltage state Variable before coupled variables,
+        # so submodels that need V in get_coupled_variables can find it.
+        if self.options["voltage as a state"] == "true":
+            self._register_voltage_variable()
+
+        self.build_coupled_variables()
+
+        # Now that the expression is available, add the algebraic constraint
+        # before equations are built.
+        if self.options["voltage as a state"] == "true":
+            self._constrain_voltage_to_expression()
+
+        self.build_model_equations()
+
     def build_model(self):
         # Build model variables and equations
         self._build_model()
@@ -1461,6 +1554,21 @@ class BaseBatteryModel(pybamm.BaseModel):
                     self.param, domain, self.options, reaction_loc
                 )
             self.submodels[f"{Domain} interface utilisation"] = submodel
+
+    def _register_voltage_variable(self):
+        V = pybamm.Variable("Voltage [V]")
+        self.variables["Voltage [V]"] = V
+        self.initial_conditions[V] = self.param.ocv_init
+
+    def _constrain_voltage_to_expression(self):
+        V = self.variables["Voltage [V]"]
+        V_expr = self.variables.get("Voltage expression [V]")
+        if V_expr is None:
+            raise pybamm.ModelError(
+                "'voltage as a state' requires the model to define "
+                "'Voltage expression [V]'"
+            )
+        self.algebraic[V] = V - V_expr
 
     def set_voltage_variables(self):
         if self.options.negative["particle phases"] == "1":

--- a/src/pybamm/models/full_battery_models/lead_acid/basic_full.py
+++ b/src/pybamm/models/full_battery_models/lead_acid/basic_full.py
@@ -242,6 +242,7 @@ class BasicFull(BaseModel):
             "Electrolyte potential [V]": phi_e,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Porosity": eps,
         }
         self.events.extend(

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn.py
@@ -264,6 +264,7 @@ class BasicDFN(BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_2d.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_2d.py
@@ -338,6 +338,7 @@ class BasicDFN2D(BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_composite.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_composite.py
@@ -377,6 +377,7 @@ class BasicDFNComposite(BaseModel):
             "Discharge capacity [A.h]": Q,
             "Time [s]": pybamm.t,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Negative electrode primary open-circuit potential [V]": ocp_n_p1,
             "Negative electrode secondary open-circuit potential [V]": ocp_n_p2,

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_dfn_half_cell.py
@@ -314,6 +314,7 @@ class BasicDFNHalfCell(BaseModel):
             "Negative electrode reaction overpotential [V]": eta_Li,
             "Negative electrode potential drop [V]": delta_phis_Li,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Instantaneous power [W.m-2]": i_cell * voltage,
         }

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_spm.py
@@ -174,6 +174,7 @@ class BasicSPM(BaseModel):
                 phi_s_p, "positive electrode"
             ),
             "Voltage [V]": V,
+            "Voltage expression [V]": V,
             "Battery voltage [V]": V * num_cells,
         }
         # Events specify points at which a solution should terminate

--- a/src/pybamm/models/full_battery_models/lithium_ion/basic_spm_with_3d_thermal.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/basic_spm_with_3d_thermal.py
@@ -241,6 +241,7 @@ class Basic3DThermalSPM(BaseModel):
                 phi_s_p, "positive electrode"
             ),
             "Voltage [V]": V,
+            "Voltage expression [V]": V,
             "Battery voltage [V]": V * num_cells,
         }
 

--- a/src/pybamm/models/full_battery_models/lithium_ion/spm.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/spm.py
@@ -21,16 +21,19 @@ class SPM(BaseModel):
     """
 
     def __init__(self, options=None, name="Single Particle Model", build=True):
-        # Use 'algebraic' surface form if non-default kinetics are used
-        options = options or {}
-        kinetics = options.get("intercalation kinetics")
-        surface_form = options.get("surface form")
-        if kinetics is not None and surface_form is None:
-            options["surface form"] = "algebraic"
-
         # For degradation models we use the "x-average", note that for side reactions
         # this is set by "x-average side reactions"
         self.x_average = True
+
+        # Use 'algebraic' surface form when the explicit-current closure is
+        # unavailable: non-default kinetics have no inverse form, and
+        # particle-size distributions require a surface formulation.
+        options = options or {}
+        if options.get("surface form") is None and (
+            options.get("intercalation kinetics") is not None
+            or "distribution" in options.get("particle size", "")
+        ):
+            options["surface form"] = "algebraic"
 
         # Set "x-average side reactions" to "true" if the model is SPM
         x_average_side_reactions = options.get("x-average side reactions")

--- a/src/pybamm/models/full_battery_models/sodium_ion/basic_dfn.py
+++ b/src/pybamm/models/full_battery_models/sodium_ion/basic_dfn.py
@@ -258,6 +258,7 @@ class BasicDFN(pybamm.lithium_ion.BaseModel):
             "Positive electrolyte potential [V]": phi_e_p,
             "Positive electrode potential [V]": phi_s_p,
             "Voltage [V]": voltage,
+            "Voltage expression [V]": voltage,
             "Battery voltage [V]": voltage * num_cells,
             "Time [s]": pybamm.t,
             "Discharge capacity [A.h]": Q,

--- a/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/explicit_control_external_circuit.py
@@ -20,22 +20,8 @@ class ExplicitCurrentControl(BaseModel):
             "Current [A]": I,
             "C-rate": I / self.param.Q,
         }
-        if self.options.get("voltage as a state") == "true":
-            V = pybamm.Variable("Voltage [V]")
-            variables.update({"Voltage [V]": V})
 
         return variables
-
-    def set_initial_conditions(self, variables):
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            self.initial_conditions[V] = self.param.ocv_init
-
-    def set_algebraic(self, variables):
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            V_expression = variables["Voltage expression [V]"]
-            self.algebraic[V] = V - V_expression
 
 
 class ExplicitPowerControl(BaseModel):

--- a/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
+++ b/src/pybamm/models/submodels/external_circuit/function_control_external_circuit.py
@@ -49,9 +49,6 @@ class FunctionControl(BaseModel):
             "Current [A]": I,
             "C-rate": I / self.param.Q,
         }
-        if self.options.get("voltage as a state") == "true":
-            V = pybamm.Variable("Voltage [V]")
-            variables.update({"Voltage [V]": V})
 
         return variables
 
@@ -59,9 +56,6 @@ class FunctionControl(BaseModel):
         # Initial condition as a guess for consistent initial conditions
         i_cell = variables["Current variable [A]"]
         self.initial_conditions[i_cell] = self.param.Q
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            self.initial_conditions[V] = self.param.ocv_init
 
     def set_rhs(self, variables):
         # External circuit submodels are always equations on the current
@@ -78,10 +72,6 @@ class FunctionControl(BaseModel):
         if self.control == "algebraic":
             i_cell = variables["Current variable [A]"]
             self.algebraic[i_cell] = self.external_circuit_function(variables)
-        if self.options.get("voltage as a state") == "true":
-            V = variables["Voltage [V]"]
-            V_expression = variables["Voltage expression [V]"]
-            self.algebraic[V] = V - V_expression
 
 
 class VoltageFunctionControl(FunctionControl):

--- a/src/pybamm/parameters/lithium_ion_parameters.py
+++ b/src/pybamm/parameters/lithium_ion_parameters.py
@@ -2,6 +2,8 @@
 # Standard parameters for lithium-ion battery models
 #
 
+import numpy as np
+
 import pybamm
 
 from .base_parameters import BaseParameters, NullParameters
@@ -960,8 +962,9 @@ def U_asymptote_approaching_zero(sto):
     b = 6910.192179565431
     c = -7.7e-4
 
-    # Clamp sto to avoid exp overflow (float64 max is ~exp(709))
-    max_safe_exp = 700
+    # Smallest exponent for which 1 + exp(z) == exp(z) in float64, so the
+    # linear continuation below is a bit-exact match for the softplus branch
+    max_safe_exp = np.log(2.0 / np.finfo(np.float64).eps)  # = 53*ln2 ~= 36.737
     sto_limit = c - max_safe_exp / b
 
     # For sto >= sto_limit: use log(1 + exp(...))

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import warnings
 from datetime import timedelta
 from numbers import Number
@@ -8,6 +9,7 @@ import numpy as np
 
 import pybamm
 import pybamm.telemetry
+from pybamm.expression_tree.input_parameter import DUMMY_INPUT_PARAMETER_VALUE
 from pybamm.solvers.base_solver import process
 from pybamm.util import import_optional_dependency
 
@@ -37,6 +39,7 @@ class Simulation(BaseSimulation):
     _AMBIENT_TEMPERATURE_INPUT = "Ambient temperature [K]"
     _PADDING_REST_KEY = "Rest for padding"
     _STEP_INDEX_INPUT = "Experiment step index"
+    _STEP_VALUE_INPUT = "Experiment step value"
     _TERMINATION_TIME = "experiment time limit reached"
     _TERMINATION_VOLTAGE = "experiment voltage limit reached"
     _TERMINATION_CAPACITY = "experiment capacity limit reached"
@@ -51,6 +54,7 @@ class Simulation(BaseSimulation):
             _AMBIENT_TEMPERATURE_INPUT,
             _INITIAL_TEMPERATURE_INPUT,
             _STEP_INDEX_INPUT,
+            _STEP_VALUE_INPUT,
         }
     )
 
@@ -113,6 +117,7 @@ class Simulation(BaseSimulation):
         self._experiment_step_indices = []
         self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
+        self._experiment_uses_value_input = False
 
     def __getstate__(self):
         """
@@ -140,6 +145,7 @@ class Simulation(BaseSimulation):
         "_experiment_step_indices": list,
         "_experiment_padding_rest_index": None,
         "_experiment_includes_padding_rest": False,
+        "_experiment_uses_value_input": False,
     }
 
     def __setstate__(self, state):
@@ -241,8 +247,6 @@ class Simulation(BaseSimulation):
             return ["no experiment is attached to the simulation"]
 
         for step in self.experiment.steps:
-            if step.is_drive_cycle:
-                return ["drive-cycle experiment steps are not yet supported"]
             if isinstance(step, pybamm.step.BaseStep) and not isinstance(
                 step,
                 (
@@ -267,16 +271,45 @@ class Simulation(BaseSimulation):
 
         # Branch the switching Conditionals over unique steps, not instances: one
         # branch per instance is O(n_steps) per timestep -> O(n_steps**2) overall.
+        # A step is "collapsible" if its control target is a constant (a fixed current,
+        # voltage, power, ...): such steps are solved with the target supplied as a
+        # shared per-step input, so steps differing only in their value share a single
+        # branch. This keeps the branch count -- and hence compile and runtime cost --
+        # tied to the number of structurally distinct control laws, not to the number of
+        # distinct values or cycles. Drive cycles and solution-dependent custom steps are
+        # not collapsible and keep their own branch.
+        value_input = pybamm.InputParameter(self._STEP_VALUE_INPUT)
+
+        def is_collapsible(step):
+            return step.control_target_value(self._parameter_values) is not None
+
+        def branch_key(step):
+            return (
+                step.unified_branch_repr()
+                if is_collapsible(step)
+                else step.basic_repr()
+            )
+
+        def control_builder(step):
+            # Collapsible steps read their target from the shared per-step input;
+            # the rest bake their own target in.
+            if is_collapsible(step):
+                return functools.partial(step.get_control_residual, target=value_input)
+            return step.get_control_residual
+
         unique_steps = []
         unique_branch_by_repr = {}
         for step in self.experiment.steps:
-            key = step.basic_repr()
+            key = branch_key(step)
             if key not in unique_branch_by_repr:
                 unique_branch_by_repr[key] = len(unique_steps) + 1  # 1-based selector
                 unique_steps.append(step)
         self._experiment_step_indices = [
-            unique_branch_by_repr[step.basic_repr()] for step in self.experiment.steps
+            unique_branch_by_repr[branch_key(step)] for step in self.experiment.steps
         ]
+        self._experiment_uses_value_input = any(
+            is_collapsible(step) for step in unique_steps
+        )
         self._experiment_includes_padding_rest = bool(
             self.experiment.initial_start_time
         )
@@ -290,9 +323,10 @@ class Simulation(BaseSimulation):
         # ambient temperature from step-level inputs instead of baking in one value.
         new_parameter_values[self._AMBIENT_TEMPERATURE_INPUT] = "[input]"
 
-        # Build one conditional control residual that selects the active step's
-        # control law via the experiment step index input.
-        step_control_builders = [step.get_control_residual for step in unique_steps]
+        # One conditional control residual selects the active step's control law via the
+        # experiment step index input; collapsible steps read their target from the
+        # shared per-step value input instead of baking it.
+        step_control_builders = [control_builder(step) for step in unique_steps]
         if self._experiment_includes_padding_rest:
             padding_rest_step = pybamm.step.Rest(duration=1)
             step_control_builders.append(padding_rest_step.get_control_residual)
@@ -309,6 +343,12 @@ class Simulation(BaseSimulation):
             submodel,
             new_parameter_values,
         )
+        # The control submodel owns the one Conditional residual (the switch over the
+        # per-step control laws). Record its variable so the solver builds that row's
+        # jacobian sparsely instead of via CasADi's dense Switch -- see
+        # BaseModel.build_casadi_jacobian. The attribute rides this same model object
+        # (in-place parameter processing and discretisation) through to solver.process.
+        new_model.switching_control_variables = {var.name for var in submodel.algebraic}
 
         # Combine each step's local termination expression into one experiment event,
         # selecting the active branch with the step index input.
@@ -366,6 +406,13 @@ class Simulation(BaseSimulation):
 
         if self._experiment_uses_unified_model:
             inputs[self._STEP_INDEX_INPUT] = active_step_index
+            if self._experiment_uses_value_input:
+                # Collapsible steps read their control target from this shared input;
+                # a non-collapsible active step doesn't read it, so pass the dummy.
+                target = step.control_target_value(self._parameter_values)
+                inputs[self._STEP_VALUE_INPUT] = (
+                    target if target is not None else DUMMY_INPUT_PARAMETER_VALUE
+                )
         return inputs
 
     def _get_built_experiment_model(self, step_or_key):

--- a/src/pybamm/simulation/simulation.py
+++ b/src/pybamm/simulation/simulation.py
@@ -44,6 +44,16 @@ class Simulation(BaseSimulation):
     _TERMINATION_EXPERIMENT_TAG = "[experiment]"
     _COMBINED_TERMINATION_EVENT = "Combined termination [experiment]"
 
+    # Inputs the experiment injects per step; never user sensitivity targets.
+    _INTERNAL_EXPERIMENT_INPUTS = frozenset(
+        {
+            _START_TIME_INPUT,
+            _AMBIENT_TEMPERATURE_INPUT,
+            _INITIAL_TEMPERATURE_INPUT,
+            _STEP_INDEX_INPUT,
+        }
+    )
+
     def __init__(
         self,
         model,
@@ -344,10 +354,15 @@ class Simulation(BaseSimulation):
 
         inputs[self._START_TIME_INPUT] = start_time
         if include_temperature:
-            inputs[self._AMBIENT_TEMPERATURE_INPUT] = (
+            ambient = (
                 step.temperature
                 or self._parameter_values[self._AMBIENT_TEMPERATURE_INPUT]
             )
+            # The unified model reads ambient temperature as a solver input, so it
+            # must be numeric; the parameter value can be a pybamm.Scalar.
+            if isinstance(ambient, pybamm.Scalar):
+                ambient = ambient.value
+            inputs[self._AMBIENT_TEMPERATURE_INPUT] = ambient
 
         if self._experiment_uses_unified_model:
             inputs[self._STEP_INDEX_INPUT] = active_step_index
@@ -773,6 +788,19 @@ class Simulation(BaseSimulation):
             raise pybamm.SolverError(
                 "Solving with a list of input sets is not supported with experiments."
             )
+
+        # Take sensitivities only w.r.t. user inputs, not the control inputs the
+        # experiment injects per step.
+        if "calculate_sensitivities" in kwargs:
+            requested = kwargs["calculate_sensitivities"]
+            if requested is True:
+                kwargs["calculate_sensitivities"] = list((inputs or {}).keys())
+            elif isinstance(requested, list):
+                kwargs["calculate_sensitivities"] = [
+                    name
+                    for name in requested
+                    if name not in self._INTERNAL_EXPERIMENT_INPUTS
+                ]
 
         # Drop the prior solution before build/integration.
         self._solution = starting_solution

--- a/src/pybamm/solvers/base_solver.py
+++ b/src/pybamm/solvers/base_solver.py
@@ -1960,7 +1960,9 @@ def process(
 
         if use_jacobian:
             report(f"Calculating jacobian for {name} using CasADi")
-            jac_casadi = casadi.jacobian(casadi_expression, y_casadi)
+            # The model owns how its jacobian is built (plain CasADi AD unless the model
+            # has a switching control equation it must differentiate structurally).
+            jac_casadi = model.build_casadi_jacobian(casadi_expression, y_casadi)
             jac = casadi.Function(
                 name + "_jac",
                 [t_casadi, y_casadi, p_casadi_stacked],

--- a/src/pybamm/solvers/casadi_solver.py
+++ b/src/pybamm/solvers/casadi_solver.py
@@ -609,6 +609,18 @@ class CasadiSolver(pybamm.BaseSolver):
 
             return integrator
 
+    def _integrator_error(self, error, len_alg):
+        """Wrap an integrator failure, with a hint for DAE models solved
+        without algebraic IC perturbation (e.g. mode="fast")."""
+        message = error.args[0]
+        if len_alg > 0 and not self.perturb_algebraic_initial_conditions:
+            message += (
+                " The algebraic initial conditions may have failed to "
+                "converge; consider CasadiSolver(mode='safe') or "
+                "perturb_algebraic_initial_conditions=True."
+            )
+        return pybamm.SolverError(message)
+
     def _run_integrator(
         self,
         model,
@@ -678,7 +690,7 @@ class CasadiSolver(pybamm.BaseSolver):
             except RuntimeError as error:
                 # If it doesn't work raise error
                 pybamm.logger.debug(f"Casadi integrator failed with error {error}")
-                raise pybamm.SolverError(error.args[0]) from error
+                raise self._integrator_error(error, len_alg) from error
             pybamm.logger.debug("Finished casadi integrator")
             integration_time = timer.time()
             # Manually add initial conditions and concatenate
@@ -716,7 +728,7 @@ class CasadiSolver(pybamm.BaseSolver):
                 except RuntimeError as error:
                     # If it doesn't work raise error
                     pybamm.logger.debug(f"Casadi integrator failed with error {error}")
-                    raise pybamm.SolverError(error.args[0]) from error
+                    raise self._integrator_error(error, len_alg) from error
                 integration_time = timer.time()
                 x = casadi_sol["xf"]
                 z = casadi_sol["zf"]

--- a/tests/integration/test_unified_experiment_performance.py
+++ b/tests/integration/test_unified_experiment_performance.py
@@ -1,0 +1,98 @@
+#
+# Performance and scaling guards for unified experiment mode.
+#
+# The structural guarantees -- branch count constant across cycles, and constant-current
+# steps collapsing to one branch -- are what make compile/runtime cost independent of the
+# number of cycles and distinct values. They are asserted deterministically. The
+# wall-clock ratios vs legacy are environment-dependent, so they only warn (not fail) on
+# a regression, to monitor performance without flaking CI.
+#
+import time
+import warnings
+
+import numpy as np
+
+import pybamm
+
+
+def _cycling_experiment(n_cycles=3):
+    return pybamm.Experiment(
+        [
+            pybamm.step.c_rate(1.0, termination="3.2 V"),
+            pybamm.step.voltage(4.0, duration=300),
+        ]
+        * n_cycles
+    )
+
+
+def _unique_branch_count(experiment):
+    sim = pybamm.Simulation(
+        pybamm.lithium_ion.SPM(),
+        experiment=experiment,
+        solver=pybamm.IDAKLUSolver(),
+        experiment_model_mode="unified",
+    )
+    sim.build_for_experiment()
+    return len(set(sim._experiment_step_indices))
+
+
+def _min_solve_time(sim, samples=9):
+    # Minimum over several warm solves: the least system-contended run, so the most
+    # stable estimate of compute time. Build + compile are excluded by the warm-up solve.
+    sim.solve()
+    times = []
+    for _ in range(samples):
+        start = time.perf_counter()
+        sim.solve()
+        times.append(time.perf_counter() - start)
+    return float(np.min(times))
+
+
+def _warn_if_slow(model_class, limit):
+    model_class()  # warm the process (import/JIT/first compile) before timing
+    sims = {
+        mode: pybamm.Simulation(
+            model_class(),
+            experiment=_cycling_experiment(),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode=mode,
+        )
+        for mode in ("legacy", "unified")
+    }
+    ratio = _min_solve_time(sims["unified"], 9) / _min_solve_time(sims["legacy"], 9)
+    if ratio > limit:
+        warnings.warn(
+            f"{model_class.__name__} unified warm-solve is {ratio:.2f}x legacy "
+            f"(> {limit}x) -- possible performance regression.",
+            stacklevel=2,
+        )
+
+
+class TestUnifiedExperimentPerformance:
+    def test_dfn_warm_solve_close_to_legacy(self):
+        # Requirement: DFN cycling ~<1.1x legacy (measured ~1.0x). Warn-only: wall-clock
+        # is environment-dependent; the sparse control row is guarded deterministically
+        # by test_unified_control_row_jacobian_is_sparse.
+        _warn_if_slow(pybamm.lithium_ion.DFN, 1.15)
+
+    def test_spme_warm_solve_close_to_legacy(self):
+        # Requirement: SPMe cycling ~<1.2x legacy (measured ~1.05x). Warn-only.
+        _warn_if_slow(pybamm.lithium_ion.SPMe, 1.3)
+
+    def test_branch_count_independent_of_cycle_count(self):
+        # Compile cost cannot scale with cycle count: repeated steps reuse one branch.
+        assert [_unique_branch_count(_cycling_experiment(n)) for n in (1, 10, 50)] == [
+            2,
+            2,
+            2,
+        ]
+
+    def test_constant_current_steps_collapse_regardless_of_count(self):
+        # Distinct C-rates collapse to one branch, so compile/runtime cost does not grow
+        # with the number of CC steps (the current is supplied as a per-step input).
+        for n_steps in (5, 20, 50):
+            currents = np.linspace(0.1, 1.0, n_steps)
+            experiment = pybamm.Experiment(
+                [pybamm.step.c_rate(float(c), duration=1) for c in currents]
+            )
+            assert _unique_branch_count(experiment) == 1

--- a/tests/integration/test_voltage_as_state.py
+++ b/tests/integration/test_voltage_as_state.py
@@ -1,0 +1,157 @@
+"""Integration tests for the 'voltage as a state' option.
+
+Voltage promotion is registered centrally in BaseBatteryModel._build_model;
+these tests cover the opt-in behavior, the conditional defaults, and the
+explicit power/resistance operating modes that require it.
+"""
+
+import numpy as np
+import pytest
+
+import pybamm
+
+OPT_IN = {"voltage as a state": "true"}
+LI_ION_MODELS = [
+    pybamm.lithium_ion.SPM,
+    pybamm.lithium_ion.SPMe,
+    pybamm.lithium_ion.DFN,
+]
+
+
+class TestVoltageAsStateOptIn:
+    """With the option enabled, voltage is an algebraic state variable."""
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_voltage_is_algebraic_state(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        algebraic_var_names = [var.name for var in model.algebraic.keys()]
+        assert "Voltage [V]" in algebraic_var_names
+        assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_residuals_reference_variable(self, model_cls):
+        """Algebraic residuals should contain the Variable, not the expression."""
+        model = model_cls(options=OPT_IN)
+        voltage_eqs = [
+            expr for var, expr in model.algebraic.items() if var.name == "Voltage [V]"
+        ]
+        assert len(voltage_eqs) == 1
+        syms = [
+            s
+            for s in voltage_eqs[0].pre_order()
+            if isinstance(s, pybamm.Variable) and s.name == "Voltage [V]"
+        ]
+        assert len(syms) > 0
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_voltage_expression_matches_state(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        sol = pybamm.Simulation(model).solve([0, 3600])
+
+        v = sol["Voltage [V]"].entries
+        v_expr = sol["Voltage expression [V]"].entries
+        np.testing.assert_allclose(v, v_expr, rtol=1e-3, atol=1e-3)
+
+    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
+    def test_default_voltage_is_expression(self, model_cls):
+        """Without the option, voltage remains a computed expression."""
+        model = model_cls()
+        algebraic_var_names = [var.name for var in model.algebraic.keys()]
+        assert "Voltage [V]" not in algebraic_var_names
+        assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+
+    @pytest.mark.parametrize(
+        "model_cls", [pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe]
+    )
+    def test_opt_in_solvable_by_casadi_safe(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="safe"))
+        sol = sim.solve([0, 3600])
+        v = sol["Voltage [V]"].entries
+        assert v[0] > v[-1]  # voltage decreases during discharge
+
+    def test_opt_in_rejects_scipy(self):
+        """Promoting voltage makes SPM a DAE, which ODE solvers reject."""
+        model = pybamm.lithium_ion.SPM(options=OPT_IN)
+        sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
+        with pytest.raises(pybamm.SolverError, match="Cannot use ODE solver"):
+            sim.solve([0, 3600])
+
+
+class TestExplicitPowerResistance:
+    """Explicit power/resistance control needs voltage as a state: I = P/V
+    (or I = V/R) is circular when V is an expression depending on I."""
+
+    @pytest.mark.parametrize(
+        "operating_mode", ["explicit power", "explicit resistance"]
+    )
+    def test_defaults_to_voltage_as_state(self, operating_mode):
+        model = pybamm.lithium_ion.SPM({"operating mode": operating_mode})
+        assert model.options["voltage as a state"] == "true"
+
+    def test_explicit_power_solves(self):
+        model = pybamm.lithium_ion.SPM({"operating mode": "explicit power"})
+        params = model.default_parameter_values
+        params["Power function [W]"] = 2.0
+        sol = pybamm.Simulation(model, parameter_values=params).solve([0, 1800])
+        power = sol["Voltage [V]"].entries * sol["Current [A]"].entries
+        np.testing.assert_allclose(power, 2.0, rtol=1e-4)
+
+    @pytest.mark.parametrize(
+        "operating_mode", ["explicit power", "explicit resistance"]
+    )
+    def test_explicit_false_rejected(self, operating_mode):
+        with pytest.raises(
+            pybamm.OptionError,
+            match=r"Cannot use.*operating mode.*'voltage as a state'.*'false'",
+        ):
+            pybamm.lithium_ion.SPM(
+                options={
+                    "voltage as a state": "false",
+                    "operating mode": operating_mode,
+                }
+            )
+
+
+class TestSurfaceFormConditionalDefaults:
+    """SPM/SPMe promote surface form to 'algebraic' only when the
+    explicit-current closure is unavailable."""
+
+    @pytest.mark.parametrize(
+        "model_cls", [pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe]
+    )
+    def test_plain_models_keep_false_surface_form(self, model_cls):
+        model = model_cls()
+        assert model.options["surface form"] == "false"
+        assert len(model.algebraic) == 0
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            {"intercalation kinetics": "asymmetric Butler-Volmer"},
+            {"particle size": "distribution"},
+        ],
+    )
+    def test_conditional_algebraic_surface_form(self, options):
+        # No inverse kinetics for non-default kinetics; distributions
+        # require a surface formulation
+        model = pybamm.lithium_ion.SPM(options=options)
+        assert model.options["surface form"] == "algebraic"
+
+    def test_dfn_defaults_to_false_surface_form(self):
+        model = pybamm.lithium_ion.DFN()
+        assert model.options["surface form"] == "false"
+
+
+class TestBasicModelsVoltageExpression:
+    """Basic models expose voltage as an expression, not a state."""
+
+    @pytest.mark.parametrize(
+        "model_cls",
+        [pybamm.lithium_ion.BasicSPM, pybamm.lithium_ion.BasicDFN],
+    )
+    def test_basic_models_have_voltage_expression(self, model_cls):
+        model = model_cls()
+        assert "Voltage expression [V]" in model.variables
+        assert "Voltage [V]" in model.variables
+        assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1306,6 +1306,78 @@ class TestSimulationExperiment:
 
         np.testing.assert_allclose(sol["Current [A]"](time), current)
 
+    def test_solve_with_sensitivities_true_excludes_all_internal_inputs(self):
+        # calculate_sensitivities=True must differentiate only w.r.t. user inputs, not
+        # the control inputs the experiment injects per step.
+        input_param_name = "Negative electrode active material volume fraction"
+
+        def make_sim():
+            model = pybamm.lithium_ion.SPM()
+            param = model.default_parameter_values
+            param.update({input_param_name: "[input]"})
+            # A python-function step (current as a function of time) puts "start time"
+            # into the model, so all three internal inputs are present and could leak.
+            experiment = pybamm.Experiment(
+                [
+                    pybamm.step.current(
+                        lambda t: 1.0 + 0.5 * np.sin(t / 100), duration=300
+                    ),
+                    "Charge at 1 A for 10 seconds",
+                ]
+            )
+            return pybamm.Simulation(
+                model,
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                parameter_values=param,
+                experiment_model_mode="unified",
+            )
+
+        input_value = pybamm.ParameterValues("Chen2020")[input_param_name]
+        sol = make_sim().solve(
+            inputs={input_param_name: input_value},
+            calculate_sensitivities=True,
+            calc_esoh=False,
+        )
+
+        internal_inputs = pybamm.Simulation._INTERNAL_EXPERIMENT_INPUTS
+        # "start time" really is one of the model inputs here, so this is a genuine
+        # exclusion, not a vacuous one.
+        assert "start time" in sol.all_inputs[0]
+        sensitivity_keys = set(sol.sensitivities) - {"all"}
+        assert sensitivity_keys == {input_param_name}
+        assert not (sensitivity_keys & internal_inputs)
+
+    def test_unified_ambient_temperature_scalar_value(self):
+        # Unified mode reads ambient temperature as a solver input; a pybamm.Scalar
+        # value (vs a float) must be coerced or it breaks the casadi call.
+        experiment = pybamm.Experiment(
+            ["Discharge at 1C until 3.0 V", "Charge at 1C until 4.2 V"]
+        )
+
+        def solve(ambient_value):
+            pv = pybamm.ParameterValues("Chen2020")
+            pv["Ambient temperature [K]"] = ambient_value
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                parameter_values=pv,
+                experiment=experiment,
+                experiment_model_mode="unified",
+                solver=pybamm.IDAKLUSolver(),
+            )
+            return sim.solve(calc_esoh=False)
+
+        scalar_sol = solve(pybamm.Scalar(298.15))
+        float_sol = solve(298.15)
+
+        np.testing.assert_allclose(scalar_sol.t[-1], float_sol.t[-1], rtol=1e-10)
+        np.testing.assert_allclose(
+            scalar_sol["Voltage [V]"].data[-1],
+            float_sol["Voltage [V]"].data[-1],
+            rtol=1e-8,
+            atol=1e-8,
+        )
+
     def test_run_experiment_breaks_early_infeasible(self):
         experiment = pybamm.Experiment(["Discharge at 2 C for 1 hour"])
         model = pybamm.lithium_ion.SPM()

--- a/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -121,6 +121,43 @@ class TestSimulationExperiment:
             "unsupported experiment step type 'BaseStep'"
         ]
 
+    def test_unified_allows_drive_cycle_and_algebraic_implicit(self):
+        # Drive-cycle steps are explicit current steps with a time-varying value; they
+        # share the generic current residual, so unified mode must accept them. An
+        # algebraic-control implicit step (voltage hold) is also eligible.
+        drive_cycle = np.column_stack([[0, 5, 10], [1.0, 0.5, 1.0]])
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.current(drive_cycle),
+                pybamm.step.voltage(3.8, duration=10),
+            ]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        assert sim._get_unified_experiment_model_blockers() == []
+
+    def test_unified_drive_cycle_matches_legacy(self):
+        # A drive cycle solved in unified mode must match legacy on a common time grid.
+        time = [0, 20, 40, 60, 80, 100]
+        current = [0.5, 0.6, 0.4, 0.5, 0.45, 0.5]
+        drive_cycle = np.column_stack([time, current])
+        experiment = pybamm.Experiment([pybamm.step.current(drive_cycle)])
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=experiment,
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            sol = sim.solve()
+            out[mode] = sol["Voltage [V]"](time)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-4, atol=1e-4)
+
     def test_set_up_unified_preserves_voltage_safety_events(self):
         experiment = pybamm.Experiment(
             [
@@ -225,6 +262,106 @@ class TestSimulationExperiment:
             sim._experiment_unified_model_key
         ]
         assert "Current variable [A]" in unified_model.variables
+
+    def test_unified_builds_exactly_one_model_and_solver(self):
+        # Requirement: unified mode uses exactly one model and one solver instance,
+        # even across many steps and cycles.
+        experiment = pybamm.Experiment(
+            [
+                pybamm.step.c_rate(1.0, duration=60),
+                pybamm.step.voltage(3.8, duration=60),
+            ]
+            * 3
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        assert len({id(m) for m in sim.steps_to_built_models.values()}) == 1
+        assert len({id(s) for s in sim.steps_to_built_solvers.values()}) == 1
+
+    def test_unified_constant_current_steps_collapse_to_one_branch(self):
+        # CC/C-rate steps differing only in current value share one branch: the value
+        # is supplied as a per-step input, so the number of branches (and therefore
+        # compile/runtime cost) does not grow with the number of distinct currents.
+        currents = [0.1, 0.2, 0.5, 1.0]
+        steps = [pybamm.step.c_rate(c, duration=1) for c in currents]
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(steps),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        assert len(set(sim._experiment_step_indices)) == 1
+
+    def test_unified_collapses_every_control_kind_by_value(self):
+        # Value-as-input is general: steps of ANY control kind that differ only in their
+        # target value share one branch, and distinct control kinds get separate branches.
+        steps = [
+            pybamm.step.c_rate(0.5, duration=10),
+            pybamm.step.c_rate(1.0, duration=10),
+            pybamm.step.voltage(4.0, duration=10),
+            pybamm.step.voltage(4.1, duration=10),
+            pybamm.step.power(1.0, duration=10),
+            pybamm.step.power(2.0, duration=10),
+        ]
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(steps),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        # current / voltage / power -> exactly three branches (one per control kind).
+        assert len(set(sim._experiment_step_indices)) == 3
+
+    def test_unified_voltage_per_step_matches_legacy(self):
+        # Generalised value-as-input must be correct for implicit control too: two
+        # voltage holds at distinct targets collapse to one branch but must each hold
+        # their own target and match legacy. Sample settled points (end of each fixed
+        # 300 s window) on a common time grid to avoid transient/grid-alignment noise.
+        steps = [
+            pybamm.step.c_rate(0.5, duration=300),
+            pybamm.step.voltage(3.9, duration=300),
+            pybamm.step.voltage(3.8, duration=300),
+        ]
+        sample_times = [250, 590, 890]
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=pybamm.Experiment(steps),
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            out[mode] = sim.solve()["Voltage [V]"](sample_times)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-3, atol=1e-3)
+        # The two collapsed voltage steps must hold their own distinct targets.
+        np.testing.assert_allclose(out["unified"][1:], [3.9, 3.8], atol=2e-2)
+
+    def test_unified_cc_per_step_current_parses(self):
+        # Steps that collapse to one branch must still each solve to their own current:
+        # the per-step current input is parsed correctly (matches legacy, all distinct).
+        currents = [0.1, 0.3, 0.7, 1.0]
+        steps = [pybamm.step.c_rate(c, duration=1) for c in currents]
+        sample_times = [0.5, 1.5, 2.5, 3.5]
+        out = {}
+        for mode in ("legacy", "unified"):
+            sim = pybamm.Simulation(
+                pybamm.lithium_ion.SPM(),
+                experiment=pybamm.Experiment(steps),
+                solver=pybamm.IDAKLUSolver(),
+                experiment_model_mode=mode,
+            )
+            sol = sim.solve()
+            out[mode] = sol["Current [A]"](sample_times)
+        np.testing.assert_allclose(out["unified"], out["legacy"], rtol=1e-4, atol=1e-6)
+        # Each step's input must be applied distinctly, not a single global current.
+        assert len(set(np.round(out["unified"], 6))) == 4
 
     def test_set_up_all_explicit_defaults_to_legacy_model(self):
         experiment = pybamm.Experiment(
@@ -560,6 +697,77 @@ class TestSimulationExperiment:
             return sim.solution["Voltage [V]"].entries[-1]
 
         assert voltage("unified") == pytest.approx(voltage("legacy"), abs=1e-6)
+
+    def test_unified_control_row_jacobian_is_sparse(self):
+        # CasADi declares a Switch's jacobian structurally dense, so the control
+        # equation would otherwise be a full-bandwidth row and balloon KLU work. The
+        # solver projects it back onto the true (union-of-branches) sparsity; assert no
+        # jacobian row spans the full bandwidth.
+        from collections import Counter
+
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.DFN(),
+            experiment=pybamm.Experiment(
+                [("Discharge at 1C until 3.3 V", "Hold at 3.3 V until C/20")]
+            ),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.solve()
+        sparsity = sim._built_experiment_model.jac_rhs_algebraic_eval.sparsity_out(0)
+        n = sparsity.size2()
+        densest_row_nnz = max(Counter(sparsity.get_triplet()[0]).values())
+        assert densest_row_nnz <= n // 2, (
+            f"a jacobian row has {densest_row_nnz}/{n} nonzeros (near full bandwidth); "
+            "the control-row union-sparsity projection did not take effect"
+        )
+
+    def test_unified_records_switching_control_variable_not_voltage(self):
+        # The unified setup records the control variable (its one Conditional residual) by
+        # name, so build_casadi_jacobian gives only that row the sparse switch treatment.
+        # With "voltage as a state" the algebraic block also holds a "Voltage [V]" row,
+        # which is physics and must NOT be picked up as a switch row. Request the option
+        # explicitly so the test exercises that configuration regardless of the default.
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM({"voltage as a state": "true"}),
+            experiment=pybamm.Experiment(
+                [("Charge at 1 A for 1 min", "Hold at 4.1 V for 1 min")]
+            ),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+        model = sim.experiment_unique_steps_to_model[sim._experiment_unified_model_key]
+        assert model.switching_control_variables == {"Current variable [A]"}
+
+        def rows_for(name):
+            return {
+                r
+                for v, slices in model.y_slices.items()
+                if v.name == name
+                for s in slices
+                for r in range(s.start, s.stop)
+            }
+
+        switch_rows = set(model._switching_control_columns())
+        voltage_rows = rows_for("Voltage [V]")
+        assert voltage_rows, "expected voltage to be a state in this configuration"
+        assert switch_rows == rows_for("Current variable [A]")
+        assert not (switch_rows & voltage_rows)
+
+    def test_non_unified_model_jacobian_is_plain_casadi(self):
+        # An ordinary model records no switching control variable, so build_casadi_jacobian
+        # short-circuits to plain casadi.jacobian -- zero extra work, identical result.
+        import casadi
+
+        model = pybamm.lithium_ion.SPM()
+        assert model.switching_control_variables == set()
+
+        x = casadi.MX.sym("x", 3)
+        expr = casadi.vertcat(x[0] ** 2, x[1] * x[2], x[0] + x[1])
+        assert casadi.is_equal(
+            model.build_casadi_jacobian(expr, x), casadi.jacobian(expr, x), 20
+        )
 
     def test_unified_aot_compile_bounded_in_unique_steps(self):
         # -O3 is superlinear in single-function size, so per-branch dispatch must keep
@@ -1239,17 +1447,21 @@ class TestSimulationExperiment:
             "Ambient temperature [K]",
             "start time",
         }
-        assert len(internal_keys) == 1
-        experiment_input_name = internal_keys.pop()
+        # Unified mode injects the step-index selector and the per-step value input.
+        assert internal_keys == {
+            "Experiment step index",
+            "Experiment step value",
+        }
 
         sol = make_sim().solve(
             inputs={input_param_name: input_param_value},
-            calculate_sensitivities=[input_param_name, experiment_input_name],
+            calculate_sensitivities=[input_param_name, *internal_keys],
         )
 
         sensitivity_keys = set(sol.sensitivities)
         assert input_param_name in sensitivity_keys
-        assert experiment_input_name not in sensitivity_keys
+        for experiment_input_name in internal_keys:
+            assert experiment_input_name not in sensitivity_keys
 
     def test_processed_variable_sensitivities_ignore_experiment_input(self):
         # Regression test for #5517.

--- a/tests/unit/test_expression_tree/test_interpolant.py
+++ b/tests/unit/test_expression_tree/test_interpolant.py
@@ -4,6 +4,7 @@
 
 import re
 
+import casadi
 import numpy as np
 import pytest
 
@@ -358,6 +359,78 @@ class TestInterpolant:
             match=r"differentiation not implemented for functions with more than one child",
         ):
             interp.diff(var1)
+
+    @pytest.fixture
+    def assert_casadi_matches_evaluate(self):
+        def _check(diff_expr, casadi_sym, test_point):
+            f = casadi.Function("f", [casadi_sym], [diff_expr.to_casadi(y=casadi_sym)])
+            np.testing.assert_allclose(
+                np.array(f(test_point)).flatten(),
+                diff_expr.evaluate(y=test_point).flatten(),
+                rtol=1e-6,
+                atol=1e-6,
+            )
+
+        return _check
+
+    @pytest.fixture(params=["uniform", "non_uniform"])
+    def grid(self, request):
+        if request.param == "uniform":
+            return np.linspace(0, 1, 200)
+        return np.sort(
+            np.concatenate([np.linspace(0, 0.5, 50), np.linspace(0.5, 1, 150)[1:]])
+        )
+
+    @pytest.mark.parametrize("interpolator", ["cubic", "pchip"])
+    def test_diff_to_casadi(self, grid, interpolator, assert_casadi_matches_evaluate):
+        # Regression for #5582: the CasADi conversion ignored _num_derivatives
+        # and returned the original, un-differentiated function.
+        y = pybamm.StateVector(slice(0, 2))
+        casadi_y = casadi.MX.sym("y", 2)
+        y_test = np.array([0.4, 0.6])
+        interp = pybamm.Interpolant(grid, grid**2, y, interpolator=interpolator)
+
+        assert_casadi_matches_evaluate(interp.diff(y), casadi_y, y_test)
+        assert_casadi_matches_evaluate(interp.diff(y).diff(y), casadi_y, y_test)
+
+    @pytest.mark.parametrize("interpolator", ["cubic", "pchip"])
+    def test_diff_to_casadi_vector_valued(
+        self, interpolator, assert_casadi_matches_evaluate
+    ):
+        x = np.linspace(0, 1, 200)
+        data = np.column_stack([x**2, x**3])
+        child = pybamm.StateVector(slice(0, 1))
+        casadi_child = casadi.MX.sym("y", 1)
+        interp = pybamm.Interpolant(x, data, child, interpolator=interpolator)
+
+        assert_casadi_matches_evaluate(
+            interp.diff(child), casadi_child, np.array([0.4])
+        )
+
+    def test_diff_to_casadi_pchip_third_derivative(
+        self, assert_casadi_matches_evaluate
+    ):
+        # pchip uses a Horner polynomial, not a b-spline, so its (nonzero,
+        # piecewise-constant) third derivative converts correctly, unlike cubic.
+        x = np.linspace(0, 1, 50)
+        y = pybamm.StateVector(slice(0, 1))
+        casadi_y = casadi.MX.sym("y", 1)
+        third = pybamm.Interpolant(x, x**3, y, interpolator="pchip")
+        for _ in range(3):
+            third = third.diff(y)
+        assert_casadi_matches_evaluate(third, casadi_y, np.array([0.3673]))
+
+    def test_diff_to_casadi_cubic_degree_zero_raises(self):
+        # A cubic differentiated three times is a degree-0 spline that CasADi
+        # mis-evaluates, so it must raise rather than return wrong values (#5582).
+        x = np.linspace(0, 1, 50)
+        y = pybamm.StateVector(slice(0, 1))
+        casadi_y = casadi.MX.sym("y", 1)
+        third = pybamm.Interpolant(x, x**3, y, interpolator="cubic")
+        for _ in range(3):
+            third = third.diff(y)
+        with pytest.raises(NotImplementedError, match="degree-0"):
+            third.to_casadi(y=casadi_y)
 
     def test_processing(self):
         x = np.linspace(0, 1, 200)

--- a/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
+++ b/tests/unit/test_expression_tree/test_operations/test_convert_to_casadi.py
@@ -594,6 +594,34 @@ class TestRepeatedRowMatmulOptimization:
         actual = np.array(f(x)).flatten()
         np.testing.assert_allclose(actual, expected, rtol=1e-14)
 
+    def test_matrix_right_operand(self):
+        """M @ R when R is a matrix (e.g. a jacobian seed), not just a column vector.
+
+        The repeated-row optimization must broadcast with matmul, not element-wise ``*``
+        (which only works for a column vector and otherwise raises a dimension mismatch).
+        """
+        rng = np.random.default_rng(0)
+        n, m, k = 20, 8, 5
+        R = casadi.MX.sym("R", n, k)
+        Rv = rng.random((n, k))
+        row = rng.random(n)
+
+        # all rows identical
+        M = np.tile(row, (m, 1))
+        result = try_repeated_row_matmul(pybamm.Matrix(M), R)
+        assert result is not None
+        f = casadi.Function("f", [R], [result])
+        np.testing.assert_allclose(np.array(f(Rv)), M @ Rv, rtol=1e-12)
+
+        # interior rows identical, boundaries differ
+        M2 = np.tile(row, (m, 1))
+        M2[0, :] = rng.random(n)
+        M2[-1, :] = rng.random(n)
+        result2 = try_repeated_row_matmul(pybamm.Matrix(M2), R)
+        assert result2 is not None
+        f2 = casadi.Function("f2", [R], [result2])
+        np.testing.assert_allclose(np.array(f2(Rv)), M2 @ Rv, rtol=1e-12)
+
     def test_two_rows_identical(self):
         """Test m=2 with identical rows."""
 

--- a/tests/unit/test_expression_tree/test_unary_operators.py
+++ b/tests/unit/test_expression_tree/test_unary_operators.py
@@ -746,6 +746,11 @@ class TestUnaryOperators:
             r"c^{\mathtt{\text{left}}}"
         )
 
+        # Test BoundaryGradient
+        assert pybamm.BoundaryGradient(a, "left").to_equation() == sympy.Symbol(
+            r"\nabla a^{\mathtt{\text{left}}}"
+        )
+
         # Test Integral
         xn = pybamm.SpatialVariable("xn", ["negative electrode"])
         assert pybamm.Integral(d, xn).to_equation() == sympy.Integral(

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -512,12 +512,32 @@ class TestBaseBatteryModel:
         model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
         assert model.options["voltage as a state"] == "true"
         assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+        assert "Voltage [V]" in [v.name for v in model.algebraic.keys()]
 
         model = pybamm.lithium_ion.SPM(
             {"voltage as a state": "true", "operating mode": "voltage"}
         )
         assert model.options["voltage as a state"] == "true"
         assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
+        assert "Voltage [V]" in [v.name for v in model.algebraic.keys()]
+
+    def test_explicit_modes_default_voltage_as_state(self):
+        for mode in ["explicit power", "explicit resistance"]:
+            options = pybamm.BatteryModelOptions({"operating mode": mode})
+            assert options["voltage as a state"] == "true"
+
+    def test_explicit_modes_reject_voltage_as_state_false(self):
+        for mode in ["explicit power", "explicit resistance"]:
+            with pytest.raises(pybamm.OptionError, match="voltage as a state"):
+                pybamm.BatteryModelOptions(
+                    {"operating mode": mode, "voltage as a state": "false"}
+                )
+
+    def test_voltage_as_state_requires_voltage_expression(self):
+        model = pybamm.BaseBatteryModel({"voltage as a state": "true"})
+        model.variables["Voltage [V]"] = pybamm.Variable("Voltage [V]")
+        with pytest.raises(pybamm.ModelError, match="Voltage expression"):
+            model._constrain_voltage_to_expression()
 
 
 class TestOptions:
@@ -608,3 +628,42 @@ class TestOptions:
             )
             == ocp_option[1]
         )
+
+    def test_default_options_independent_of_possible_options_order(self):
+        """Defaults should be set explicitly, not derived from possible_options[0]."""
+        options = pybamm.BatteryModelOptions({})
+        # defaults are set explicitly, not derived from list order
+        assert options["voltage as a state"] == "false"
+        # surface form: possible_options lists "false" first, default is "false"
+        assert options["surface form"] == "false"
+
+    def test_default_options_cover_all_possible_options(self):
+        """Every key in possible_options must have an explicit default."""
+        options = pybamm.BatteryModelOptions({})
+        for key in options.possible_options:
+            assert key in options, f"Missing default for option '{key}'"
+
+
+class TestVaasNormalization:
+    """Test the centralized VAAS + surface form policy."""
+
+    def test_vaas_true_with_surface_form_false_is_valid(self):
+        """VAAS can be true even with surface_form=false (DFN case)."""
+        options = pybamm.BatteryModelOptions(
+            {"voltage as a state": "true", "surface form": "false"}
+        )
+        assert options["voltage as a state"] == "true"
+        assert options["surface form"] == "false"
+
+    def test_vaas_false_with_surface_form_algebraic_is_valid(self):
+        """surface form algebraic without voltage-as-state is valid."""
+        options = pybamm.BatteryModelOptions(
+            {"voltage as a state": "false", "surface form": "algebraic"}
+        )
+        assert options["voltage as a state"] == "false"
+        assert options["surface form"] == "algebraic"
+
+    def test_vaas_false_defaults_surface_form_false(self):
+        """When VAAS is false and surface form not set, surface form stays false."""
+        options = pybamm.BatteryModelOptions({"voltage as a state": "false"})
+        assert options["surface form"] == "false"

--- a/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
+++ b/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_spm.py
@@ -41,8 +41,8 @@ class TestSPM(BaseUnitTestLithiumIon):
             pybamm.lithium_ion.SPM(options)
 
     def test_distribution_options(self):
-        with pytest.raises(pybamm.OptionError, match=r"surface form"):
-            pybamm.lithium_ion.SPM({"particle size": "distribution"})
+        options = {"particle size": "distribution"}
+        self.check_well_posedness(options)
 
     def test_particle_size_distribution(self):
         options = {"surface form": "algebraic", "particle size": "distribution"}

--- a/tests/unit/test_solvers/test_casadi_solver.py
+++ b/tests/unit/test_solvers/test_casadi_solver.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 
@@ -187,7 +189,12 @@ class TestCasadiSolver:
             solver=pybamm.CasadiSolver(mode="fast"),
         )
 
-        with pytest.raises(pybamm.SolverError, match=r"IDA_CONV_FAIL"):
+        # the integrator failure message carries a hint for DAE models solved
+        # without algebraic IC perturbation
+        with pytest.raises(
+            pybamm.SolverError,
+            match=r"(?s)IDA_CONV_FAIL.*perturb_algebraic_initial_conditions",
+        ):
             sim.solve()
 
     def test_model_solver_events(self):
@@ -653,6 +660,16 @@ class TestCasadiSolver:
             match=f"Explicit interpolation times not implemented for {solver.name}",
         ):
             solver.solve(model, t_eval, t_interp=t_interp)
+
+    def test_casadi_fast_solves_dae_without_warning(self):
+        """CasadiSolver(mode='fast') solves a DAE model silently; integrator
+        failures carry an actionable hint instead (see test_solver_error)."""
+        model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
+        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="fast"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", pybamm.SolverWarning)
+            sol = sim.solve([0, 3600])
+        assert sol.termination == "final time"
 
     def test_discontinuous_current(self):
         def car_current(t):


### PR DESCRIPTION
## v26.6.1.0 — second feature release of June 2026

Cut from **v26.6.0.0**. Supersedes #5590 (closed when its head branch was renamed `release/v26.6.0.1` → `release/v26.6.1.0`). Cherry-picked (`-x`) from `main`:

- Voltage-as-a-state infrastructure: centralised registration + operating-mode fixes. (#5572)
- Fixed CasADi conversion of a differentiated `Interpolant`. (#5583)
- Fixed unified experiment scalar ambient temperature + sensitivity leak. (#5587)
- Corrected the lithium-ion OCP asymptote overflow-clamp threshold. (#5588)
- Fixed unified experiment redundant control branches + dense switching-control Jacobian. (#5589)

**Excludes** the breaking `"voltage as a state"` default flip to `"true"` (#5573) — the global default **stays `"false"`**. #5572 is included because #5589 depends on its registration fix (otherwise `"Voltage [V]"` leaks into the switching-control variables).

### Do not merge
Draft, opened **only to run CI** (base is `patch-base/v26.6.0.0` so the merge ref builds cleanly). The release is tagged directly from `release/v26.6.1.0` (`v26.6.1.0`); `main`'s changelog is updated via a separate PR; the `release/*` + `patch-base/*` branches are deleted afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)