### PR TITLE
Fix load_custom_model dropping tuple-valued options on JSON round-trip

### DIFF
--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1428,10 +1428,13 @@ class Serialise:
         model = base_cls()
         model.name = model_data["name"]
         model.schema_version = schema_version
-        # Restore options so round-trip serialisation produces an equivalent model
+        # Restore options so round-trip serialisation produces an equivalent
+        # model. A JSON round-trip turns tuple-valued options (e.g. "particle
+        # phases": ("2", "1")) into lists, which pybamm's options validation
+        # rejects, so convert lists back to tuples before assigning.
         opts = model_data.get("options", {})
         if opts is not None:
-            model.options = dict(opts)
+            model.options = Serialise._convert_options(opts)
 
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]
@@ -1753,15 +1756,31 @@ class Serialise:
 
         return recurse(obj)
 
-    def _convert_options(self, d):
-        """
-        Converts a dictionary with nested lists to nested tuples,
-        used to convert model options back into correct format
+    @staticmethod
+    def _convert_options(d):
+        """Convert a JSON-deserialised options structure back to pybamm's format.
+
+        A JSON round-trip turns tuple-valued options (e.g. ``"particle phases":
+        ("2", "1")``) into lists, which pybamm's options validation rejects.
+        This recursively converts lists back to tuples (nested lists become
+        nested tuples) so option values are restored to the form pybamm expects.
+
+        Parameters
+        ----------
+        d : dict, list or Any
+            The options dictionary, a nested list, or a scalar option value to
+            be normalised.
+
+        Returns
+        -------
+        dict, tuple or Any
+            The input with every list converted to a tuple, recursing through
+            nested dicts and lists. Scalars are returned unchanged.
         """
         if isinstance(d, dict):
-            return {k: self._convert_options(v) for k, v in d.items()}
+            return {k: Serialise._convert_options(v) for k, v in d.items()}
         elif isinstance(d, list):
-            return tuple(self._convert_options(item) for item in d)
+            return tuple(Serialise._convert_options(item) for item in d)
         else:
             return d
 

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -2597,6 +2597,25 @@ class TestSerializationEdgeCases:
         assert loaded_model.name == "test_dict_model"
         assert isinstance(loaded_model.rhs, dict)
 
+    def test_custom_model_tuple_options_survive_json_round_trip(self):
+        """Tuple-valued options must survive a serialise -> JSON -> load round trip.
+
+        JSON has no tuple type, so a tuple option such as
+        ``"particle phases": ("2", "1")`` is turned into a list by
+        ``json.dumps``/``json.loads``. pybamm's options validation rejects
+        lists, so ``load_custom_model`` must convert lists back to tuples
+        before assigning ``model.options``.
+        """
+        model = pybamm.lithium_ion.SPM({"particle phases": ("2", "1")}, build=False)
+
+        serialised = Serialise.serialise_custom_model(model)
+        round_tripped = json.loads(json.dumps(serialised))
+
+        loaded = Serialise.load_custom_model(round_tripped)
+
+        assert loaded.options["particle phases"] == ("2", "1")
+        assert isinstance(loaded.options["particle phases"], tuple)
+
     def test_expression_function_parameter_evaluate(self):
         """Test _unary_evaluate method of ExpressionFunctionParameter."""
         x = pybamm.Variable("x")


### PR DESCRIPTION
## Description

`Serialise.load_custom_model` restored model options with `model.options = dict(opts)`. After a `serialise_custom_model` → JSON → `load_custom_model` round-trip, tuple-valued options such as `"particle phases": ("2", "1")` come back as **lists** (JSON has no tuple type). pybamm's options validation rejects lists:

> `'['2', '1']' is not recognized in option 'particle phases'. Values must be strings or (in some cases) 2-tuples of strings`

So a custom (symbolic) model using composite particle phases — or any tuple-valued option — could not be round-tripped through `save_custom_model` / `load_custom_model`.

## Fix

Reuse the existing `_convert_options` helper (already used by the discretised `load_model` path) to recursively convert lists back to tuples before assigning `model.options`. Made it a `@staticmethod` since it never used `self`, and expanded its docstring.

## Reproduction

```python
import json, pybamm
from pybamm.expression_tree.operations.serialise import Serialise

model = pybamm.lithium_ion.SPM({"particle phases": ("2", "1")}, build=False)
data = json.loads(json.dumps(Serialise.serialise_custom_model(model)))
loaded = Serialise.load_custom_model(data)   # raised OptionError before this fix
assert loaded.options["particle phases"] == ("2", "1")
```

## Testing

Added `test_custom_model_tuple_options_survive_json_round_trip` in `tests/unit/test_serialisation/test_serialisation.py` asserting the `particle phases` tuple option survives the full round-trip and is a `tuple`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)