### PR TITLE
Fix load_custom_model leaving param inconsistent with restored options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - The "voltage as a state" model option now defaults to "true": voltage is solved as an algebraic state, making standard models DAEs. Reading `Voltage [V]` from a solution is now an O(1) state lookup instead of a post-solve expression evaluation (up to 73% faster end-to-end for dense output; 8-24% faster experiment cycling across SPM/SPMe/DFN; up to 48% faster with in-solver `output_variables=["Voltage [V]"]`). The default `IDAKLUSolver`, `CasadiSolver` (all modes), and `JaxSolver(method="BDF")` handle DAEs; ODE-only solvers (`ScipySolver`, `JaxSolver(method="RK45")`) require `{"voltage as a state": "false", "surface form": "false"}` for SPM/SPMe, which remains a supported configuration. Known trade-off: continuous solves of rapidly alternating current profiles (e.g. interpolant drive cycles with more than ~25 current reversals in one solve) can be slower, up to ~2x for SPM in the worst measured case; the legacy configuration above restores previous performance for these workloads. Experiment-driven cycling is unaffected. ([#5573](https://github.com/pybamm-team/PyBaMM/pull/5573))
 
+## Bug fixes
+
+- Fixed `load_custom_model` leaving a model's `param` inconsistent with its restored `options`, which broke voltage-based initialisation of round-tripped composite custom models with a `ParameterNotFoundError`. ([#5598](https://github.com/pybamm-team/PyBaMM/pull/5598))
+
 # [v26.6.1.1](https://github.com/pybamm-team/PyBaMM/tree/v26.6.1.1) - 2026-06-11
 
 ## Bug fixes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1393,6 +1393,18 @@ class Serialise:
         opts = model_data.get("options", {})
         if opts is not None:
             model.options = Serialise._convert_options(opts)
+            # The options setter only updates the options dict; it does not
+            # rebuild the cached ``param`` object, which ``base_cls()`` built
+            # from the default options. For lithium-ion models this leaves the
+            # parameters inconsistent with the restored options -- e.g. a
+            # composite electrode ("particle phases": ("2", "1")) would keep
+            # the single-phase parameter names ("Negative electrode active
+            # material volume fraction") instead of the phase-prefixed ones
+            # ("Primary: Negative electrode active material volume fraction"),
+            # which breaks downstream electrode-SOH initialisation. Rebuild the
+            # parameter object so it matches the restored options.
+            if isinstance(model, pybamm.lithium_ion.BaseModel):
+                model.param = pybamm.LithiumIonParameters(model.options)
 
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]

--- a/tests/unit/test_serialisation/test_serialisation.py
+++ b/tests/unit/test_serialisation/test_serialisation.py
@@ -728,6 +728,49 @@ class TestSerialise:
         assert "positive particle" in loaded.default_geometry
         assert "positive particle" in loaded.default_spatial_methods
 
+    def test_custom_composite_model_roundtrip_rebuilds_param(self, tmp_path):
+        """A composite custom model must keep its parameters consistent with the
+        restored options after a round-trip. Regression test: previously the
+        reloaded model kept the single-phase ``param`` built from the default
+        options, so ``param.n.prim.epsilon_s_av`` referenced
+        "Negative electrode active material volume fraction" instead of the
+        phase-prefixed "Primary: ..." name, breaking electrode-SOH based
+        initialisation."""
+        from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
+            BaseModel as LiIonBaseModel,
+        )
+
+        model = LiIonBaseModel(options={"particle phases": ("2", "1")})
+        model.name = "CompositeCustom"
+        c = pybamm.Variable(
+            "X-averaged negative primary particle concentration [mol.m-3]",
+            domain="negative primary particle",
+        )
+        model.rhs = {c: -pybamm.div(-pybamm.grad(c))}
+        model.initial_conditions = {c: pybamm.Scalar(0.5)}
+        model.boundary_conditions = {
+            c: {
+                "left": (pybamm.Scalar(0), "Neumann"),
+                "right": (pybamm.Scalar(0), "Neumann"),
+            }
+        }
+        model.variables = {c.name: c}
+
+        # Sanity check: the live model uses the phase-prefixed parameter name.
+        assert "Primary: Negative electrode active material volume fraction" in str(
+            model.param.n.prim.epsilon_s_av
+        )
+
+        file_path = tmp_path / "composite.json"
+        Serialise.save_custom_model(model, filename=str(file_path))
+        loaded = Serialise.load_custom_model(str(file_path))
+
+        assert loaded.options["particle phases"] == ("2", "1")
+        # The reloaded param must match the restored composite options.
+        assert "Primary: Negative electrode active material volume fraction" in str(
+            loaded.param.n.prim.epsilon_s_av
+        )
+
     def test_serialise_records_base_class_mro(self, tmp_path):
         from pybamm.models.full_battery_models.lithium_ion.base_lithium_ion_model import (
             BaseModel as LiIonBaseModel,


### PR DESCRIPTION
## Description

`Serialise.load_custom_model` reconstructs a model by calling `base_cls()` (which builds `param` from the **default** options — a single-phase `LithiumIonParameters`) and then restoring the serialised options. The `options` setter only updates the options dict; it does **not** rebuild the cached `param`. For a composite custom model this leaves `param` and `options` inconsistent:

- `options["particle phases"] == ("2", "1")` → pybamm dispatches to the **composite** electrode-SOH solver, but
- `param.n.prim.epsilon_s_av` still resolves to the **single-phase** name `"Negative electrode active material volume fraction"`.

So voltage-based initial-state setup (`set_initial_state("X V")`) on a round-tripped composite model raises:

```
ParameterNotFoundError: Parameter 'Negative electrode active material volume fraction' not found...
you may need to use Primary: Negative electrode active material volume fraction instead.
```

## Fix

After restoring the options in `load_custom_model`, rebuild `LithiumIonParameters` from those options so `param` matches `options`. Scoped to `pybamm.lithium_ion.BaseModel` (lead-acid `param` is options-independent; generic `BaseModel` has no `param`). Single-phase models are unaffected (rebuild is equivalent).

## Testing

- Added `test_custom_composite_model_roundtrip_rebuilds_param`: round-trips a composite (`"particle phases": ("2", "1")`) custom model through the generic-base-class load path and asserts the reloaded `param.n.prim.epsilon_s_av` uses the phase-prefixed `Primary:` name. Verified it fails without the fix and passes with it.
- Existing custom-model / options round-trip tests still pass.

Made with [Cursor](https://cursor.com)