### PR TITLE
Harden serialisation round-trip tests + #5598

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - The "voltage as a state" model option now defaults to "true": voltage is solved as an algebraic state, making standard models DAEs. Reading `Voltage [V]` from a solution is now an O(1) state lookup instead of a post-solve expression evaluation (up to 73% faster end-to-end for dense output; 8-24% faster experiment cycling across SPM/SPMe/DFN; up to 48% faster with in-solver `output_variables=["Voltage [V]"]`). The default `IDAKLUSolver`, `CasadiSolver` (all modes), and `JaxSolver(method="BDF")` handle DAEs; ODE-only solvers (`ScipySolver`, `JaxSolver(method="RK45")`) require `{"voltage as a state": "false", "surface form": "false"}` for SPM/SPMe, which remains a supported configuration. Known trade-off: continuous solves of rapidly alternating current profiles (e.g. interpolant drive cycles with more than ~25 current reversals in one solve) can be slower, up to ~2x for SPM in the worst measured case; the legacy configuration above restores previous performance for these workloads. Experiment-driven cycling is unaffected. ([#5573](https://github.com/pybamm-team/PyBaMM/pull/5573))
 
+## Bug fixes
+
+- Fixed `Serialise.load_custom_model` leaving a loaded lithium-ion model's cached `param` built from default options instead of the restored ones, so a model loaded with non-default options (e.g. composite `"particle phases"`) had parameters inconsistent with its options. ([#5599](https://github.com/pybamm-team/PyBaMM/pull/5599))
+- Fixed `BatteryModelOptions` letting two invalid MSMR option sets pass validation and then crash during parameter construction with `invalid literal for int() with base 10: 'none'`; both now raise a clear `OptionError`. The all-or-nothing MSMR check now detects MSMR inside a per-electrode tuple (e.g. `"open-circuit potential": ("MSMR", "single")`), and an MSMR model must set `"number of MSMR reactions"` to a positive integer rather than the default `"none"`. ([#5599](https://github.com/pybamm-team/PyBaMM/pull/5599))
+
 # [v26.6.1.1](https://github.com/pybamm-team/PyBaMM/tree/v26.6.1.1) - 2026-06-11
 
 ## Bug fixes

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1386,13 +1386,12 @@ class Serialise:
         model = base_cls()
         model.name = model_data["name"]
         model.schema_version = schema_version
-        # Restore options so round-trip serialisation produces an equivalent
-        # model. A JSON round-trip turns tuple-valued options (e.g. "particle
-        # phases": ("2", "1")) into lists, which pybamm's options validation
-        # rejects, so convert lists back to tuples before assigning.
+        # JSON turns tuple-valued options into lists (rejected by validation);
+        # convert back, then rebuild param to match the restored options.
         opts = model_data.get("options", {})
         if opts is not None:
             model.options = Serialise._convert_options(opts)
+            model._rebuild_param()
 
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]

--- a/src/pybamm/expression_tree/operations/serialise.py
+++ b/src/pybamm/expression_tree/operations/serialise.py
@@ -1387,11 +1387,11 @@ class Serialise:
         model.name = model_data["name"]
         model.schema_version = schema_version
         # JSON turns tuple-valued options into lists (rejected by validation);
-        # convert back, then rebuild param to match the restored options.
+        # convert back. Assigning options rebuilds the options-derived param via
+        # the setter, so it matches the restored options.
         opts = model_data.get("options", {})
         if opts is not None:
             model.options = Serialise._convert_options(opts)
-            model._rebuild_param()
 
         all_variable_keys = (
             [lhs_json for lhs_json, _ in model_data["rhs"]]

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -643,8 +643,8 @@ class BaseModel:
 
     def _rebuild_param(self):
         """Rebuild ``param`` from ``self.options``; no-op unless ``param`` is
-        options-derived. Call after assigning options post-construction (the
-        setter leaves ``param`` untouched), e.g. when deserialising.
+        options-derived. Called by the ``options`` setter whenever options are
+        (re)assigned, so subclasses keep ``param`` in sync automatically.
         """
 
     @property

--- a/src/pybamm/models/base_model.py
+++ b/src/pybamm/models/base_model.py
@@ -641,6 +641,12 @@ class BaseModel:
     def param(self, values):
         self._param = values
 
+    def _rebuild_param(self):
+        """Rebuild ``param`` from ``self.options``; no-op unless ``param`` is
+        options-derived. Call after assigning options post-construction (the
+        setter leaves ``param`` untouched), e.g. when deserialising.
+        """
+
     @property
     def options(self):
         """Returns the model options dictionary that allows customization of the model's behavior."""

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -18,6 +18,20 @@ def represents_positive_integer(s):
         return val > 0
 
 
+def _is_msmr(value):
+    """True if an option requests MSMR, including inside a per-electrode tuple."""
+    if isinstance(value, (tuple, list)):
+        return "MSMR" in value
+    return value == "MSMR"
+
+
+def _is_positive_integer_count(value):
+    """True if value is a positive integer, or a per-electrode tuple of them."""
+    if isinstance(value, (tuple, list)):
+        return bool(value) and all(_is_positive_integer_count(v) for v in value)
+    return represents_positive_integer(value)
+
+
 def _rename_option(options_dict, option_name, old_name, new_name):
     if option_name not in options_dict:
         return
@@ -625,13 +639,11 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                         f"Option '{name}' not recognised. Best matches are {options.get_best_matches(name)}"
                     )
 
-        # If any of "open-circuit potential", "particle" or "intercalation kinetics" is
-        # "MSMR" then all of them must be "MSMR".
-        # Note: this check is currently performed on full cells, but is loosened for
-        # half-cells where you must pass a tuple of options to only set MSMR models in
-        # the working electrode
+        # All-or-nothing on full cells: if any of OCP/particle/intercalation
+        # kinetics requests MSMR (incl. inside a per-electrode tuple), all must.
+        # Half-cells are loosened -- a tuple sets MSMR in the working electrode.
         msmr_check_list = [
-            options[opt] == "MSMR"
+            _is_msmr(options[opt])
             for opt in ["open-circuit potential", "particle", "intercalation kinetics"]
         ]
         if (
@@ -642,6 +654,17 @@ class BatteryModelOptions(pybamm.FuzzyDict):
             raise pybamm.OptionError(
                 "If any of 'open-circuit potential', 'particle' or "
                 "'intercalation kinetics' is 'MSMR' then all of them must be 'MSMR'"
+            )
+
+        # MSMR needs an explicit positive-integer count; the registry default
+        # "none" otherwise crashes later in parameter construction (int('none')).
+        msmr_count = options["number of MSMR reactions"]
+        if any(msmr_check_list) and not _is_positive_integer_count(msmr_count):
+            raise pybamm.OptionError(
+                "'number of MSMR reactions' must be a positive integer (or a "
+                "per-electrode tuple of positive integers) when "
+                "'open-circuit potential', 'particle' and 'intercalation "
+                f"kinetics' use 'MSMR' (got {msmr_count!r})"
             )
 
         # If "SEI film resistance" is "distributed" then "total interfacial current

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -660,9 +660,13 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 "'intercalation kinetics' is 'MSMR' then all of them must be 'MSMR'"
             )
 
-        # Validate per electrode so a mixed cell
-        # (MSMR in one electrode, conventional in the other) is accepted.
-        for domain, index in [("negative", 0), ("positive", 1)]:
+        # Validate per electrode so a mixed full cell (MSMR in one electrode,
+        # conventional in the other) is accepted.
+        if options["working electrode"] == "both":
+            electrode_domains = [("negative", 0), ("positive", 1)]
+        else:
+            electrode_domains = [("positive", 1)]
+        for domain, index in electrode_domains:
             domain_uses_msmr = any(
                 _per_electrode(options[opt], index) == "MSMR"
                 for opt in [

--- a/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -25,11 +25,15 @@ def _is_msmr(value):
     return value == "MSMR"
 
 
-def _is_positive_integer_count(value):
-    """True if value is a positive integer, or a per-electrode tuple of them."""
+def _per_electrode(value, index):
+    """Resolve a possibly per-electrode option to one electrode.
+
+    Per-electrode tuples are ``(negative, positive)``; a scalar applies to
+    both. ``index`` is 0 for the negative electrode, 1 for the positive.
+    """
     if isinstance(value, (tuple, list)):
-        return bool(value) and all(_is_positive_integer_count(v) for v in value)
-    return represents_positive_integer(value)
+        return value[index]
+    return value
 
 
 def _rename_option(options_dict, option_name, old_name, new_name):
@@ -656,16 +660,24 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 "'intercalation kinetics' is 'MSMR' then all of them must be 'MSMR'"
             )
 
-        # MSMR needs an explicit positive-integer count; the registry default
-        # "none" otherwise crashes later in parameter construction (int('none')).
-        msmr_count = options["number of MSMR reactions"]
-        if any(msmr_check_list) and not _is_positive_integer_count(msmr_count):
-            raise pybamm.OptionError(
-                "'number of MSMR reactions' must be a positive integer (or a "
-                "per-electrode tuple of positive integers) when "
-                "'open-circuit potential', 'particle' and 'intercalation "
-                f"kinetics' use 'MSMR' (got {msmr_count!r})"
+        # Validate per electrode so a mixed cell
+        # (MSMR in one electrode, conventional in the other) is accepted.
+        for domain, index in [("negative", 0), ("positive", 1)]:
+            domain_uses_msmr = any(
+                _per_electrode(options[opt], index) == "MSMR"
+                for opt in [
+                    "open-circuit potential",
+                    "particle",
+                    "intercalation kinetics",
+                ]
             )
+            domain_count = _per_electrode(options["number of MSMR reactions"], index)
+            if domain_uses_msmr and not represents_positive_integer(domain_count):
+                raise pybamm.OptionError(
+                    "'number of MSMR reactions' must be a positive integer for "
+                    f"the {domain} electrode when it uses 'MSMR' "
+                    f"(got {domain_count!r})"
+                )
 
         # If "SEI film resistance" is "distributed" then "total interfacial current
         # density as a state" must be "true"
@@ -1236,6 +1248,9 @@ class BaseBatteryModel(pybamm.BaseModel):
                 f"must use surface formulation to solve {self!s} with hydrolysis"
             )
         self._options = options
+        # rebuild whenever options are (re)assigned.
+        # No-op unless the subclass overrides ``_rebuild_param``.
+        self._rebuild_param()
 
     def set_standard_output_variables(self):
         # Time

--- a/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -29,12 +29,17 @@ class BaseModel(pybamm.BaseBatteryModel):
 
     def __init__(self, options=None, name="Unnamed lithium-ion model", build=False):
         super().__init__(options, name)
-        self.param = pybamm.LithiumIonParameters(self.options)
+        self._rebuild_param()
 
         self.set_standard_output_variables()
 
         # Li models should calculate esoh by default
         self._calc_esoh = True
+
+    def _rebuild_param(self):
+        # param is options-derived, so rebuild it whenever options are
+        # (re)assigned: at construction and on deserialisation.
+        self.param = pybamm.LithiumIonParameters(self.options)
 
     def set_submodels(self, build):
         self.set_external_circuit_submodel()

--- a/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
+++ b/src/pybamm/models/full_battery_models/lithium_ion/base_lithium_ion_model.py
@@ -29,7 +29,6 @@ class BaseModel(pybamm.BaseBatteryModel):
 
     def __init__(self, options=None, name="Unnamed lithium-ion model", build=False):
         super().__init__(options, name)
-        self._rebuild_param()
 
         self.set_standard_output_variables()
 

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -471,6 +471,34 @@ class TestBaseBatteryModel:
         model = pybamm.BaseBatteryModel(options)
         assert model.options["number of MSMR reactions"] == ("3", "none")
 
+    def test_msmr_half_cell_does_not_validate_counter_electrode(self):
+        # On a half cell the negative electrode is lithium metal, not a porous
+        # MSMR electrode, so a scalar "MSMR" option must not force a reaction
+        # count on it.
+        options = {
+            "working electrode": "positive",
+            "open-circuit potential": "MSMR",
+            "particle": "MSMR",
+            "intercalation kinetics": "MSMR",
+            "number of MSMR reactions": ("none", "6"),
+        }
+        model = pybamm.BaseBatteryModel(options)
+        assert model.options["number of MSMR reactions"] == ("none", "6")
+
+    def test_msmr_half_cell_still_validates_working_electrode(self):
+        # The working electrode is still validated: a "none" count
+        # there must be rejected cleanly rather than slipping through.
+        with pytest.raises(pybamm.OptionError, match=r"positive electrode"):
+            pybamm.BaseBatteryModel(
+                {
+                    "working electrode": "positive",
+                    "open-circuit potential": "MSMR",
+                    "particle": "MSMR",
+                    "intercalation kinetics": "MSMR",
+                    "number of MSMR reactions": ("6", "none"),
+                }
+            )
+
     def test_build_twice(self):
         model = pybamm.lithium_ion.SPM()  # need to pick a model to set vars and build
         with pytest.raises(pybamm.ModelError, match=r"Model already built"):

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -444,6 +444,21 @@ class TestBaseBatteryModel:
                     "number of MSMR reactions": "1.5",
                 }
             )
+        # MSMR inside a per-electrode tuple must be rejected cleanly, not slip
+        # through to crash later as int('none') in parameter construction.
+        with pytest.raises(pybamm.OptionError, match=r"MSMR"):
+            pybamm.BaseBatteryModel({"open-circuit potential": ("MSMR", "single")})
+        with pytest.raises(pybamm.OptionError, match=r"MSMR"):
+            pybamm.BaseBatteryModel({"particle": ("MSMR", "Fickian diffusion")})
+        # MSMR with the default "none" reaction count must also be rejected cleanly.
+        with pytest.raises(pybamm.OptionError, match=r"MSMR"):
+            pybamm.BaseBatteryModel(
+                {
+                    "open-circuit potential": "MSMR",
+                    "particle": "MSMR",
+                    "intercalation kinetics": "MSMR",
+                }
+            )
 
     def test_build_twice(self):
         model = pybamm.lithium_ion.SPM()  # need to pick a model to set vars and build

--- a/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -460,6 +460,17 @@ class TestBaseBatteryModel:
                 }
             )
 
+    def test_msmr_mixed_electrode_accepted(self):
+        # Verify non-MSMR electrode's "none" reaction count is legitimate
+        options = {
+            "open-circuit potential": ("MSMR", "single"),
+            "particle": ("MSMR", "Fickian diffusion"),
+            "intercalation kinetics": ("MSMR", "symmetric Butler-Volmer"),
+            "number of MSMR reactions": ("3", "none"),
+        }
+        model = pybamm.BaseBatteryModel(options)
+        assert model.options["number of MSMR reactions"] == ("3", "none")
+
     def test_build_twice(self):
         model = pybamm.lithium_ion.SPM()  # need to pick a model to set vars and build
         with pytest.raises(pybamm.ModelError, match=r"Model already built"):

--- a/tests/unit/test_serialisation/test_round_trip.py
+++ b/tests/unit/test_serialisation/test_round_trip.py
@@ -564,22 +564,28 @@ def _assert_param_matches_options(model):
             f"param built from {dict(model.param.options)!r} != restored options "
             f"{dict(model.options)!r}; load_custom_model must rebuild param."
         )
+        # Symptom-level guard: a two-phase negative electrode names its primary
+        # active-material fraction "Primary: ..."; a param left built from
+        # single-phase options would not.
+        if model.options.negative["particle phases"] == "2":
+            epsilon_s_name = model.param.n.prim.epsilon_s.name
+            assert epsilon_s_name.startswith("Primary:"), (
+                f"negative primary active material fraction is {epsilon_s_name!r}; "
+                "expected a 'Primary:' prefix for a two-phase electrode -- param "
+                "was not rebuilt from the restored composite options."
+            )
 
 
-def test_rebuild_param_syncs_param_with_reassigned_options():
-    """The ``_rebuild_param`` hook resyncs ``param`` to ``options``.
-
-    Deserialisation assigns ``options`` after construction; the setter leaves
-    ``param`` untouched, so the model-owned hook must rebuild it.
+def test_options_setter_rebuilds_param():
+    """Assigning ``options`` post-construction rebuilds the options-derived
+    ``param`` via the setter, keeping it in sync without an explicit hook call.
     """
     # A complete, valid two-phase options set (as a load path would restore).
     full_opts = dict(pybamm.lithium_ion.SPM({"particle phases": ("2", "1")}).options)
 
     model = pybamm.lithium_ion.SPM(build=False)  # default: single particle phase
     model.options = full_opts
-    # The setter alone leaves param built from the default (single-phase) options.
-    assert dict(model.param.options) != dict(model.options)
-    model._rebuild_param()
+    # The setter rebuilds param, so it tracks the reassigned options.
     assert dict(model.param.options) == dict(model.options)
 
 

--- a/tests/unit/test_serialisation/test_round_trip.py
+++ b/tests/unit/test_serialisation/test_round_trip.py
@@ -11,12 +11,17 @@ Validated to catch the regression shape behind #5495 (bool->int coercion),
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
+import textwrap
 import warnings
 from datetime import datetime
 
 import numpy as np
 import pytest
+from hypothesis import given, reject, settings
+from hypothesis import strategies as st
 
 import pybamm
 from pybamm.expression_tree.operations.serialise import (
@@ -24,6 +29,7 @@ from pybamm.expression_tree.operations.serialise import (
     convert_symbol_from_json,
     convert_symbol_to_json,
 )
+from pybamm.models.full_battery_models.base_battery_model import BatteryModelOptions
 from tests.unit.test_serialisation._helpers import (
     _experiments_equal,
     _solver_init_args_equal,
@@ -500,3 +506,331 @@ class TestSymbolRoundTrip:
             f"{type(symbol).__name__} structural id changed across round-trip: "
             f"{symbol!r} -> {restored!r}"
         )
+
+
+# Generative option round-trip fuzzing. JSON has no tuple type, so a tuple option
+# (e.g. "particle phases": ("2", "1")) deserialises as a list, which validation
+# rejects. Fuzzes the build-free to_json/from_json path; the deterministic
+# fixtures below cover to_config/from_config (which builds the model).
+
+# Option registry, sourced from pybamm so the strategy never hardcodes values.
+_POSSIBLE_OPTIONS = BatteryModelOptions({}).possible_options
+
+_STRING_VALUES = {
+    key: [v for v in values if isinstance(v, str)]
+    for key, values in _POSSIBLE_OPTIONS.items()
+}
+
+# Drawable keys. "dimensionality" (the only int option) is excluded: a non-zero
+# value needs companion geometry options the random strategy can't assemble; its
+# int round-trip is covered by test_int_option_survives_json_round_trip_as_int.
+_STRING_OPTION_KEYS = sorted(
+    key for key, values in _STRING_VALUES.items() if key != "dimensionality" and values
+)
+
+# Options accepting a 2-tuple of strings; mirrors the list in BatteryModelOptions
+# (test_tuple_capable_keys_match_validation_source guards drift).
+_TUPLE_CAPABLE_KEYS = frozenset(
+    {
+        "diffusivity",
+        "exchange-current density",
+        "intercalation kinetics",
+        "interface utilisation",
+        "lithium plating",
+        "loss of active material",
+        "number of MSMR reactions",
+        "open-circuit potential",
+        "particle",
+        "particle mechanics",
+        "particle phases",
+        "particle size",
+        "SEI",
+        "SEI on cracks",
+        "stress-induced diffusion",
+    }
+)
+
+# SPM matches the original regression; DFN has a broader option surface.
+_OPTION_MODEL_CLASSES = [pybamm.lithium_ion.SPM, pybamm.lithium_ion.DFN]
+
+
+def _assert_param_matches_options(model):
+    """Assert a loaded lithium-ion model's ``param`` matches its restored options.
+
+    Guards #5598; lead-acid ``param`` is options-independent, so skip it.
+    """
+    if isinstance(model, pybamm.lithium_ion.BaseModel):
+        assert dict(model.param.options) == dict(model.options), (
+            f"param built from {dict(model.param.options)!r} != restored options "
+            f"{dict(model.options)!r}; load_custom_model must rebuild param."
+        )
+
+
+def test_rebuild_param_syncs_param_with_reassigned_options():
+    """The ``_rebuild_param`` hook resyncs ``param`` to ``options``.
+
+    Deserialisation assigns ``options`` after construction; the setter leaves
+    ``param`` untouched, so the model-owned hook must rebuild it.
+    """
+    # A complete, valid two-phase options set (as a load path would restore).
+    full_opts = dict(pybamm.lithium_ion.SPM({"particle phases": ("2", "1")}).options)
+
+    model = pybamm.lithium_ion.SPM(build=False)  # default: single particle phase
+    model.options = full_opts
+    # The setter alone leaves param built from the default (single-phase) options.
+    assert dict(model.param.options) != dict(model.options)
+    model._rebuild_param()
+    assert dict(model.param.options) == dict(model.options)
+
+
+@st.composite
+def valid_option_dicts(draw):
+    """Draw a small registry-valid option dict, biased to exercise tuples."""
+    keys = draw(
+        st.lists(
+            st.sampled_from(_STRING_OPTION_KEYS),
+            min_size=1,
+            max_size=3,
+            unique=True,
+        )
+    )
+    options = {}
+    for key in keys:
+        choices = _STRING_VALUES[key]
+        if key in _TUPLE_CAPABLE_KEYS and draw(st.booleans()):
+            options[key] = (
+                draw(st.sampled_from(choices)),
+                draw(st.sampled_from(choices)),
+            )
+        else:
+            options[key] = draw(st.sampled_from(choices))
+    return options
+
+
+def test_tuple_capable_keys_match_validation_source():
+    """``_TUPLE_CAPABLE_KEYS`` must match the tuple-capable list in
+    BatteryModelOptions -- AST-extracted so it can't silently drift.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(BatteryModelOptions)))
+    candidates = [
+        {
+            elt.value
+            for elt in node.elts
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+        }
+        for node in ast.walk(tree)
+        if isinstance(node, ast.List)
+    ]
+    # The tuple-capable list is the one literal containing these marker keys.
+    matches = [c for c in candidates if {"particle phases", "SEI on cracks"} <= c]
+    assert len(matches) == 1, (
+        "Could not uniquely locate the tuple-capable option list in "
+        "BatteryModelOptions source; update the extraction in this test."
+    )
+    assert matches[0] == set(_TUPLE_CAPABLE_KEYS), (
+        "Tuple-capable options in pybamm have changed. Update "
+        "_TUPLE_CAPABLE_KEYS so option fuzzing keeps generating tuple values "
+        f"for every such key. Source: {sorted(matches[0])}, "
+        f"test constant: {sorted(_TUPLE_CAPABLE_KEYS)}."
+    )
+    assert _TUPLE_CAPABLE_KEYS <= set(_POSSIBLE_OPTIONS), (
+        "_TUPLE_CAPABLE_KEYS contains keys absent from the option registry."
+    )
+
+
+class TestModelOptionsRoundTrip:
+    """Any valid option dict must survive a JSON round-trip with exact types."""
+
+    @pytest.mark.parametrize(
+        "model_cls", _OPTION_MODEL_CLASSES, ids=lambda c: c.__name__
+    )
+    @settings(max_examples=100, deadline=None)
+    @given(options=valid_option_dicts())
+    def test_options_survive_json_round_trip(self, model_cls, options):
+        try:
+            # Construction is the precondition, not the SUT; pass a copy
+            # (pybamm mutates the dict).
+            model = model_cls(dict(options), build=False)
+        except (pybamm.OptionError, NotImplementedError):
+            # Invalid/unsupported option set -> discard. Any other exception is a
+            # real bug that must surface (a broad except here once hid an MSMR
+            # int('none') crash).
+            reject()
+
+        expected = dict(model.options)
+
+        via_json = pybamm.BaseModel.from_json(
+            json.loads(json.dumps(model.to_json(), default=Serialise._json_encoder))
+        )
+        assert _values_equal(expected, dict(via_json.options)), (
+            f"{model_cls.__name__} options lost or mutated via "
+            f"to_json/from_json for input {options!r}: "
+            f"{expected!r} -> {dict(via_json.options)!r}"
+        )
+        # Options surviving isn't enough -- the derived param must match too.
+        _assert_param_matches_options(via_json)
+
+
+def test_int_option_survives_json_round_trip_as_int():
+    """``dimensionality`` (the only int option) must round-trip as an int, not be
+    coerced to/from bool (the #5495 shape, ``True == 1``). Bool-like options are
+    strings "true"/"false" (pybamm rejects Python bools), already fuzzed; a
+    non-zero value needs companion geometry options to construct.
+    """
+    options = {
+        "dimensionality": 1,
+        "current collector": "potential pair",
+        "cell geometry": "pouch",
+    }
+    model = pybamm.lithium_ion.DFN(dict(options), build=False)
+
+    via_json = pybamm.BaseModel.from_json(
+        json.loads(json.dumps(model.to_json(), default=Serialise._json_encoder))
+    )
+    restored = via_json.options["dimensionality"]
+    assert restored == 1
+    assert isinstance(restored, int) and not isinstance(restored, bool)
+
+
+# Buildable tuple options that must round-trip through both load paths --
+# deterministic, always-run coverage of the bug shape.
+_TUPLE_OPTION_FIXTURES = [
+    (pybamm.lithium_ion.SPM, "particle phases", ("2", "1")),
+    (pybamm.lithium_ion.SPM, "SEI", ("none", "constant")),
+    (pybamm.lithium_ion.DFN, "particle size", ("single", "distribution")),
+    (pybamm.lithium_ion.DFN, "particle", ("Fickian diffusion", "uniform profile")),
+]
+
+
+class TestTupleOptionRoundTripRegression:
+    @pytest.mark.parametrize(
+        "model_cls,key,value",
+        _TUPLE_OPTION_FIXTURES,
+        ids=["SPM-particle phases", "SPM-SEI", "DFN-particle size", "DFN-particle"],
+    )
+    def test_tuple_option_survives_both_paths(self, model_cls, key, value):
+        model = model_cls({key: value}, build=False)
+
+        via_json = pybamm.BaseModel.from_json(
+            json.loads(json.dumps(model.to_json(), default=Serialise._json_encoder))
+        )
+        assert via_json.options[key] == value
+        assert isinstance(via_json.options[key], tuple)
+        # Composite "particle phases" is the case (param stuck single-phase).
+        _assert_param_matches_options(via_json)
+
+        via_config = pybamm.BaseModel.from_config(
+            json.loads(json.dumps(model.to_config()))
+        )
+        assert via_config.options[key] == value
+        assert isinstance(via_config.options[key], tuple)
+
+
+# Discretised-model round-trip (save_model/load_model): previously only checked
+# "load and solve". These verify structural identity and solution equivalence
+# (mesh transitively: same equations + solution => same mesh).
+
+_DISCRETISED_MODEL_CLASSES = [pybamm.lithium_ion.SPM, pybamm.lithium_ion.DFN]
+
+
+def _discretised_model(model_cls, options=None):
+    """Build, parameterise and discretise a model; return it and its mesh
+    (the mesh is needed by ``serialise_model`` for named variables).
+    """
+    model = model_cls(options)
+    geometry = model.default_geometry
+    param = model.default_parameter_values
+    param.process_model(model)
+    param.process_geometry(geometry)
+    mesh = pybamm.Mesh(geometry, model.default_submesh_types, model.default_var_pts)
+    disc = pybamm.Discretisation(mesh, model.default_spatial_methods)
+    disc.process_model(model)
+    return model, mesh
+
+
+def _round_trip_discretised(model, mesh):
+    """Serialise a discretised model and load it back, via dict (no temp file)."""
+    serialised = Serialise().serialise_model(model, mesh)
+    return Serialise().load_model(json.loads(json.dumps(serialised)))
+
+
+@pytest.mark.parametrize(
+    "model_cls", _DISCRETISED_MODEL_CLASSES, ids=lambda c: c.__name__
+)
+class TestDiscretisedModelRoundTrip:
+    def test_derived_state_matches_original(self, model_cls):
+        """Concatenated equations, mass matrix, bounds and options must match."""
+        model, mesh = _discretised_model(model_cls)
+        loaded = _round_trip_discretised(model, mesh)
+
+        for attr in (
+            "concatenated_rhs",
+            "concatenated_algebraic",
+            "concatenated_initial_conditions",
+            "mass_matrix",
+        ):
+            original = getattr(model, attr)
+            restored = getattr(loaded, attr)
+            assert original.id == restored.id, (
+                f"{model_cls.__name__}.{attr} changed across the discretised "
+                f"round-trip: {original.id} != {restored.id}"
+            )
+
+        assert all(
+            np.array_equal(a, b)
+            for a, b in zip(model.bounds, loaded.bounds, strict=True)
+        ), f"{model_cls.__name__} bounds changed across the discretised round-trip"
+        assert dict(model.options) == dict(loaded.options)
+
+        # Events are serialised too -- verify them structurally rather than
+        # relying on the solution check.
+        assert len(model.events) == len(loaded.events)
+        for original_event, restored_event in zip(
+            model.events, loaded.events, strict=True
+        ):
+            assert original_event.name == restored_event.name
+            assert original_event.event_type == restored_event.event_type
+            assert original_event.expression.id == restored_event.expression.id, (
+                f"{model_cls.__name__} event {original_event.name!r} changed "
+                "across the discretised round-trip"
+            )
+
+    def test_solution_matches_original(self, model_cls):
+        """The reloaded model must solve to the same answer as the original."""
+        model, mesh = _discretised_model(model_cls)
+        # Serialise before solving so any solve-time caching cannot leak in.
+        loaded = _round_trip_discretised(model, mesh)
+
+        t_eval = [0, 3600]
+        original_solution = model.default_solver.solve(model, t_eval)
+        loaded_solution = loaded.default_solver.solve(loaded, t_eval)
+
+        assert np.allclose(
+            original_solution.y, loaded_solution.y, rtol=1e-6, atol=1e-8
+        ), (
+            f"{model_cls.__name__} state trajectory diverged after a "
+            "discretised round-trip"
+        )
+        assert np.allclose(
+            original_solution["Voltage [V]"].entries,
+            loaded_solution["Voltage [V]"].entries,
+            rtol=1e-6,
+            atol=1e-8,
+        ), f"{model_cls.__name__} Voltage [V] diverged after a discretised round-trip"
+
+
+def test_nondefault_tuple_option_survives_discretised_round_trip():
+    """A tuple-valued option must survive the discretised save/load path too.
+
+    The parametrised tests above only use default options; this guards
+    ``load_model``'s list->tuple conversion. ``particle`` is used because it
+    discretises with the default parameter set (composite ``particle phases``
+    would need a phase-prefixed one).
+    """
+    options = {"particle": ("Fickian diffusion", "uniform profile")}
+    model, mesh = _discretised_model(pybamm.lithium_ion.DFN, options)
+    loaded = _round_trip_discretised(model, mesh)
+
+    assert loaded.options["particle"] == ("Fickian diffusion", "uniform profile")
+    assert isinstance(loaded.options["particle"], tuple)
+    _assert_param_matches_options(loaded)


### PR DESCRIPTION
# Description

Harden serialisation round-trip tests; fix param-rebuild altitude and MSMR option gaps

Follow-up to the tuple-options fix, addressing issues found while hardening the serialisation test suite.

Rebuild param at the right altitude. The previous fix rebuilt a loaded lithium-ion model's `param` with an `isinstance` branch inside `load_custom_model`. Replace it with a model-owned `_rebuild_param` hook (no-op on `BaseModel`, overridden by the lithium-ion base model, which now also uses it in `__init__`). `load_custom_model` calls the hook, so the options setter stays free of param concerns and the fix lives where the model owns its derived state (#5598).

Fix two MSMR option-validation gaps surfaced by option fuzzing. Both let an invalid option set crash later in parameter construction with "invalid literal for int() with base 10: 'none'" instead of raising a clean OptionError:
- the all-or-nothing MSMR check missed MSMR inside a per-electrode tuple (`("MSMR", "single")`) because it compared the whole value to "MSMR";
- an all-MSMR model left on the default "number of MSMR reactions" ("none") passed validation, since the registry only lists that placeholder.

Harden the serialisation test suite:
- generative fuzzing of valid option dicts through to_json/from_json, with the construction guard narrowed to (OptionError, NotImplementedError) so real bugs surface instead of being silently rejected;
- deterministic tuple-option and int-dimensionality round-trip coverage;
- discretised round-trip now asserts structural identity, solution equivalence and event preservation, plus a non-default tuple option.

Fixes # (issue)

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
