### PR TITLE
Fix RegulariseSqrtAndPower corrupting state-independent bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- `RegulariseSqrtAndPower` no longer regularises state-independent bases, fixing corrupted small rate constants in exchange-current density functions. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+
 ## Breaking changes
 
 - The "voltage as a state" model option now defaults to "true": voltage is solved as an algebraic state, making standard models DAEs. Reading `Voltage [V]` from a solution is now an O(1) state lookup instead of a post-solve expression evaluation (up to 73% faster end-to-end for dense output; 8-24% faster experiment cycling across SPM/SPMe/DFN; up to 48% faster with in-solver `output_variables=["Voltage [V]"]`). The default `IDAKLUSolver`, `CasadiSolver` (all modes), and `JaxSolver(method="BDF")` handle DAEs; ODE-only solvers (`ScipySolver`, `JaxSolver(method="RK45")`) require `{"voltage as a state": "false", "surface form": "false"}` for SPM/SPMe, which remains a supported configuration. Known trade-off: continuous solves of rapidly alternating current profiles (e.g. interpolant drive cycles with more than ~25 current reversals in one solve) can be slower, up to ~2x for SPM in the worst measured case; the legacy configuration above restores previous performance for these workloads. Experiment-driven cycling is unaffected. ([#5573](https://github.com/pybamm-team/PyBaMM/pull/5573))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- `RegulariseSqrtAndPower` no longer regularises state-independent bases, fixing corrupted small rate constants in exchange-current density functions. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+- `RegulariseSqrtAndPower` no longer regularises state-independent bases, fixing corrupted small rate constants in exchange-current density functions. ([#5600](https://github.com/pybamm-team/PyBaMM/pull/5600))
 
 ## Breaking changes
 

--- a/src/pybamm/expression_tree/operations/regularise.py
+++ b/src/pybamm/expression_tree/operations/regularise.py
@@ -11,9 +11,15 @@ class RegulariseSqrtAndPower:
     """
     Callable that replaces Sqrt and Power nodes with RegPower nodes.
 
-    All Sqrt and Power nodes are replaced with RegPower. If the base of the
-    operation matches a symbol in the scales map, that scale is used;
-    otherwise the default scale (None) is used.
+    A Sqrt or Power node is replaced with RegPower when the base of the
+    operation matches a symbol in the scales map (using that scale) or when
+    the base is state-dependent, i.e. contains a variable, state vector or
+    time (using the default scale of 1). Bases that are independent of the
+    state (e.g. ``pybamm.Parameter`` or ``pybamm.InputParameter`` rate
+    constants) are left unchanged: they have no derivative to regularise, and
+    RegPower with the default scale of 1 corrupts values smaller than the
+    regularisation tolerance delta (e.g. a rate constant of ~1e-9 raised to
+    the power 0.5 evaluates ~470x too small).
 
     Parameters
     ----------
@@ -100,19 +106,24 @@ class RegulariseSqrtAndPower:
 
         new_children = [self._process(child, resolved_scales) for child in sym.children]
 
-        if isinstance(sym, pybamm.Sqrt):
-            child = new_children[0]
-            scale = self._get_scale(child, resolved_scales)
-            return pybamm.RegPower(child, 0.5, scale=scale)
-
-        if isinstance(sym, pybamm.Power):
-            base, exponent = new_children
+        if isinstance(sym, pybamm.Sqrt | pybamm.Power):
+            base = new_children[0]
+            exponent = 0.5 if isinstance(sym, pybamm.Sqrt) else new_children[1]
             scale = self._get_scale(base, resolved_scales)
-            return pybamm.RegPower(base, exponent, scale=scale)
+            if scale is not None or self._depends_on_state(base):
+                return pybamm.RegPower(base, exponent, scale=scale)
 
         if any(n is not o for n, o in zip(new_children, sym.children, strict=True)):
             return sym.create_copy(new_children=new_children)
         return sym
+
+    @staticmethod
+    def _depends_on_state(expr):
+        """Whether the expression depends on the state (or time)."""
+        return any(
+            isinstance(node, pybamm.VariableBase | pybamm.StateVectorBase | pybamm.Time)
+            for node in expr.pre_order()
+        )
 
     def _get_scale(self, expr, resolved_scales):
         """Get scale for an expression, defaulting to None.

--- a/tests/unit/test_expression_tree/test_operations/test_regularise.py
+++ b/tests/unit/test_expression_tree/test_operations/test_regularise.py
@@ -2,6 +2,8 @@
 # Tests for the RegulariseSqrtAndPower class
 #
 
+import pytest
+
 import pybamm
 
 
@@ -40,16 +42,16 @@ class TestRegulariseSqrtAndPower:
         expr = c_e**0.5
         result = regulariser(expr, inputs=inputs)
 
-        # The original c_e**0.5 Power node should be replaced
-        # (result will have different Power nodes from reg_power formula)
-        assert result != expr
+        # Matched base: RegPower with the registered scale
+        assert isinstance(result, pybamm.RegPower)
+        assert result.children[2] == pybamm.Scalar(1000.0)
 
-    def test_scale_default_to_one(self):
-        """Test that unrecognized expressions get scale=None."""
+    def test_state_dependent_base_default_scale(self):
+        """State-dependent base with no registered scale: regularised with
+        the default scale of 1."""
         c_e = pybamm.Variable("c_e")
         c_s = pybamm.Variable("c_s")
 
-        # Only c_e has a scale, c_s should get scale=None
         inputs = {"c_e": c_e, "c_s": c_s}
         regulariser = pybamm.RegulariseSqrtAndPower(
             {c_e: pybamm.Scalar(1000.0)},
@@ -59,13 +61,161 @@ class TestRegulariseSqrtAndPower:
         expr = pybamm.sqrt(c_s)
         result = regulariser(expr, inputs=inputs)
 
-        # Should be replaced with RegPower (no Sqrt)
-        has_sqrt = any(isinstance(n, pybamm.Sqrt) for n in result.pre_order())
-        assert not has_sqrt
-        # Check it's a RegPower with scale=1 (default)
         assert isinstance(result, pybamm.RegPower)
-        # Scale is the third child
         assert result.children[2] == pybamm.Scalar(1)
+
+    def test_normalised_state_dependent_base_still_regularised(self):
+        """Normalised base (ORegan2022-style (c_e / c_e_ref) ** (1 - alpha))
+        matches no scale but is still regularised with the default scale."""
+        c_e = pybamm.Variable("c_e")
+        inputs = {"c_e": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+
+        c_e_ref = pybamm.Parameter("Reference concentration")
+        expr = (c_e / c_e_ref) ** 0.208
+        result = regulariser(expr, inputs=inputs)
+
+        assert isinstance(result, pybamm.RegPower)
+        assert result.children[2] == pybamm.Scalar(1)
+
+    def test_parameter_power_not_corrupted(self):
+        """State-independent Parameter base is not regularised: RegPower with
+        the default scale would corrupt a small rate constant."""
+        c_e = pybamm.Variable("c_e")
+        inputs = {"c_e": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+
+        rate_constant = pybamm.Parameter("Rate constant")
+        expr = rate_constant**0.5
+        result = regulariser(expr, inputs=inputs)
+
+        assert isinstance(result, pybamm.Power)
+        assert not any(isinstance(n, pybamm.RegPower) for n in result.pre_order())
+
+        parameter_values = pybamm.ParameterValues({"Rate constant": 5e-9})
+        value = parameter_values.process_symbol(result).evaluate()
+        assert value == pytest.approx(5e-9**0.5, rel=1e-12)
+
+    def test_input_parameter_power_not_corrupted(self):
+        """State-independent InputParameter base is not regularised."""
+        c_e = pybamm.Variable("c_e")
+        inputs = {"c_e": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+
+        rate_constant = pybamm.InputParameter("Rate constant")
+        expr = rate_constant**0.5
+        result = regulariser(expr, inputs=inputs)
+
+        assert isinstance(result, pybamm.Power)
+        value = result.evaluate(inputs={"Rate constant": 5e-9})
+        assert value == pytest.approx(5e-9**0.5, rel=1e-12)
+
+    def test_constant_base_state_dependent_exponent(self):
+        """Constant base, state-dependent exponent: outer Power kept, sqrt in
+        the exponent regularised."""
+        c_e = pybamm.Variable("c_e")
+        inputs = {"c_e": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+
+        base = pybamm.Parameter("Rate constant")
+        expr = base ** pybamm.sqrt(c_e)
+        result = regulariser(expr, inputs=inputs)
+
+        assert isinstance(result, pybamm.Power)
+        assert isinstance(result.children[0], pybamm.Parameter)
+        assert any(isinstance(n, pybamm.RegPower) for n in result.pre_order())
+        assert not any(isinstance(n, pybamm.Sqrt) for n in result.pre_order())
+
+    def test_existing_reg_power_preserved(self):
+        """A manual RegPower node (e.g. MSMR j0_j) is a Function, not a
+        Sqrt/Power, so it is left untouched, even when nested."""
+        c_e = pybamm.Variable("c_e")
+        c_e_ref = pybamm.Parameter("c_e_ref")
+        aj = pybamm.Parameter("aj")
+        inputs = {"c_e": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+
+        expr = pybamm.reg_power(c_e / c_e_ref, 1 - aj)
+        result = regulariser(expr, inputs=inputs)
+        assert result is expr
+
+        # Nested: reg_power preserved, sibling Power regularised
+        nested = pybamm.reg_power(c_e / c_e_ref, 1 - aj) * c_e**0.5
+        result = regulariser(nested, inputs=inputs)
+        n_reg_power = sum(
+            1 for n in result.pre_order() if isinstance(n, pybamm.RegPower)
+        )
+        assert n_reg_power == 2
+        assert not any(isinstance(n, pybamm.Power) for n in result.pre_order())
+        assert not any(isinstance(n, pybamm.Sqrt) for n in result.pre_order())
+
+    @pytest.mark.parametrize("set_name", ["Chen2020", "ORegan2022", "Ecker2015"])
+    def test_j0_pipeline_produces_regpower(self, set_name):
+        """Built-in j0 pipeline regularises all concentration powers,
+        including ORegan2022's unmatched normalised bases."""
+        param = pybamm.LithiumIonParameters()
+        c_e = pybamm.Variable("c_e")
+        c_s_surf = pybamm.Variable("c_s_surf")
+        T = pybamm.Variable("T")
+        j0 = param.n.prim.j0(c_e, c_s_surf, T)
+
+        parameter_values = pybamm.ParameterValues(set_name)
+        processed = parameter_values.process_symbol(j0)
+
+        n_reg_power = sum(
+            1 for n in processed.pre_order() if isinstance(n, pybamm.RegPower)
+        )
+        n_plain_power = sum(
+            1 for n in processed.pre_order() if isinstance(n, pybamm.Power)
+        )
+        assert n_reg_power == 3, f"{set_name}: expected 3 RegPower, got {n_reg_power}"
+        assert n_plain_power == 0, (
+            f"{set_name}: expected no plain Power nodes, got {n_plain_power}"
+        )
+
+    def test_function_parameter_post_processor_small_parameter(self):
+        """Full j0-style path: a FunctionParameter raising a Parameter to a
+        fractional power must evaluate exactly."""
+
+        def exchange_current(c_e):
+            rate_constant = pybamm.Parameter("Rate constant")
+            return rate_constant**0.5 * c_e**0.5
+
+        c_e = pybamm.Variable("c_e")
+        inputs = {"Electrolyte concentration [mol.m-3]": c_e}
+        regulariser = pybamm.RegulariseSqrtAndPower(
+            {c_e: pybamm.Scalar(1000.0)},
+            inputs=inputs,
+        )
+        function_parameter = pybamm.FunctionParameter(
+            "Exchange-current density [A.m-2]",
+            {"Electrolyte concentration [mol.m-3]": pybamm.Scalar(1000.0)},
+            post_processor=regulariser,
+        )
+        parameter_values = pybamm.ParameterValues(
+            {
+                "Exchange-current density [A.m-2]": exchange_current,
+                "Rate constant": 5e-9,
+            }
+        )
+        value = parameter_values.process_symbol(function_parameter).evaluate()
+        expected = 5e-9**0.5 * 1000.0**0.5
+        assert value == pytest.approx(expected, rel=1e-6)
 
     def test_exact_match_only(self):
         """Test that only exact matches are used for scales."""
@@ -85,7 +235,7 @@ class TestRegulariseSqrtAndPower:
         has_sqrt = any(isinstance(n, pybamm.Sqrt) for n in result1.pre_order())
         assert not has_sqrt
 
-        # sqrt(c_s / c_s_max) should also be replaced
+        # sqrt(c_s / c_s_max) should also be replaced (state-dependent base)
         expr2 = pybamm.sqrt(c_s / c_s_max)
         result2 = regulariser(expr2, inputs=inputs)
         has_sqrt = any(isinstance(n, pybamm.Sqrt) for n in result2.pre_order())


### PR DESCRIPTION
## Description

`RegulariseSqrtAndPower` (the exchange-current density post-processor added in #5371) replaced **every** `Sqrt`/`Power` node with `RegPower`, including bases that are independent of the state. With the default `scale=1` and `delta=1e-3`, this corrupts values below the regularisation tolerance: a `pybamm.Parameter` rate constant of ~1e-9 raised to the power 0.5 evaluated **~470x too small** (`6.7e-5` → `1.4e-7`).

The result: solver failures (Newton/IDACalcIC diverges) or silently wrong overpotentials (~0.5 V instead of ~5 mV at C/20) for any user-supplied exchange-current density function that raises a `Parameter`/`InputParameter` to a fractional power — a common pattern for parameterised electrochemistry.

A plain Python float (`4.52e-9 ** 0.5`) is computed eagerly and never becomes a symbolic `Power` node, so this only bit symbolic parameter bases.

## Fix

Only replace a `Sqrt`/`Power` node with `RegPower` when its base **either** matches a registered scale **or** is state-dependent (contains a `Variable`, `StateVector`, or `Time`). State-independent bases have no derivative to regularise and are left unchanged.

This deliberately differs from "only regularise matched-scale bases": built-in parameter sets (`ORegan2022`, sodium-ion `Chayambuka2022`) use **normalised** bases like `(c_e / c_e_ref) ** (1 - alpha)` that match no registered scale. Keying off state-dependence keeps those regularised exactly as before (`RegPower` with default scale 1), so shipped parameter sets are unaffected. Manually-created `reg_power` nodes (MSMR `j0_j`) are `Function`s, not `Sqrt`/`Power`, so they are never touched.

| Base | Before | After |
|---|---|---|
| `Parameter("rka") ** 0.5` (~1e-9) | corrupt 470x | ✓ exact |
| `(c_e / c_e_ref) ** 0.5` (ORegan/Na) | ✓ RegPower s=1 | ✓ RegPower s=1 |
| `c_e ** 0.5` (matched scale) | ✓ RegPower s=c_e_init | ✓ unchanged |
| manual `reg_power(...)` (MSMR) | ✓ preserved | ✓ preserved |

## Testing

- Unit: 7 new tests in `test_regularise.py` (state-independent `Parameter`/`InputParameter` bases left alone; normalised state-dependent bases still regularised; matched-scale wiring pinned; manual `reg_power` preserved; full j0 pipeline produces 3 `RegPower` / 0 plain `Power` for Chen2020/ORegan2022/Ecker2015). Full unit suite: 4194 passed.
- Integration: li-ion `test_dfn` + `test_compare_outputs` + sodium-ion (64 passed). Parameter-based vs float-based DFN agree to ~2e-5 V; ORegan2022 `dj0/dc_e` bounded (0.317) down to `c_e=0`; MSMR DFN solves end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)