### PR TITLE
Preserve termination provenance in unified experiment mode

### DIFF
--- a/packages/pybamm/src/pybamm/experiment/step/base_step.py
+++ b/packages/pybamm/src/pybamm/experiment/step/base_step.py
@@ -472,7 +472,10 @@ class BaseStep:
         return events
 
     def get_combined_termination_expression(self, variables):
-        events = self.get_termination_events(variables)
+        return self._combine_termination_events(self.get_termination_events(variables))
+
+    @staticmethod
+    def _combine_termination_events(events):
         if not events:
             return pybamm.Scalar(1)
 

--- a/packages/pybamm/src/pybamm/simulation/simulation.py
+++ b/packages/pybamm/src/pybamm/simulation/simulation.py
@@ -470,7 +470,7 @@ class Simulation(BaseSimulation):
         active_step_index = inputs[self._STEP_INDEX_INPUT]
         if isinstance(active_step_index, np.ndarray):
             active_step_index = active_step_index.item()
-        return self._experiment_termination_event_names_by_index.get(active_step_index)
+        return self._experiment_termination_event_names_by_index[active_step_index]
 
     def _get_step_termination_event_candidates(self, step, model, inputs):
         candidates = []
@@ -483,9 +483,6 @@ class Simulation(BaseSimulation):
             return candidates
 
         source_event_names = self._get_unified_termination_event_names(inputs)
-        if source_event_names is None or len(source_event_names) != len(candidates):
-            return candidates
-
         # Prefer the names recorded when the unified branch was built; the events
         # below are reconstructed only to evaluate which source termination crossed.
         return [

--- a/packages/pybamm/src/pybamm/simulation/simulation.py
+++ b/packages/pybamm/src/pybamm/simulation/simulation.py
@@ -467,15 +467,9 @@ class Simulation(BaseSimulation):
         return value
 
     def _get_unified_termination_event_names(self, inputs):
-        active_step_index = inputs.get(self._STEP_INDEX_INPUT)
-        if active_step_index is None:
-            return None
-
-        try:
-            active_step_index = int(np.asarray(active_step_index).reshape(-1)[0])
-        except (IndexError, TypeError, ValueError):
-            return None
-
+        active_step_index = inputs[self._STEP_INDEX_INPUT]
+        if isinstance(active_step_index, np.ndarray):
+            active_step_index = active_step_index.item()
         return self._experiment_termination_event_names_by_index.get(active_step_index)
 
     def _get_step_termination_event_candidates(self, step, model, inputs):
@@ -484,6 +478,9 @@ class Simulation(BaseSimulation):
             event = term.get_event(model.variables, step)
             if event is not None:
                 candidates.append((event.name, event, term))
+
+        if not self._experiment_uses_unified_model:
+            return candidates
 
         source_event_names = self._get_unified_termination_event_names(inputs)
         if source_event_names is None or len(source_event_names) != len(candidates):

--- a/packages/pybamm/src/pybamm/simulation/simulation.py
+++ b/packages/pybamm/src/pybamm/simulation/simulation.py
@@ -118,6 +118,7 @@ class Simulation(BaseSimulation):
         self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
         self._experiment_uses_value_input = False
+        self._experiment_termination_event_names_by_index = {}
 
     def __getstate__(self):
         """
@@ -146,6 +147,7 @@ class Simulation(BaseSimulation):
         "_experiment_padding_rest_index": None,
         "_experiment_includes_padding_rest": False,
         "_experiment_uses_value_input": False,
+        "_experiment_termination_event_names_by_index": dict,
     }
 
     def __setstate__(self, state):
@@ -350,13 +352,23 @@ class Simulation(BaseSimulation):
         # (in-place parameter processing and discretisation) through to solver.process.
         new_model.switching_control_variables = {var.name for var in submodel.algebraic}
 
-        # Combine each step's local termination expression into one experiment event,
-        # selecting the active branch with the step index input.
-        termination_branches = [
-            step.get_combined_termination_expression(variables) for step in unique_steps
-        ]
+        # The combined event is a numerical switch. Keep each branch's source
+        # event names beside it so solve can report the original step termination.
+        self._experiment_termination_event_names_by_index = {}
+        termination_branches = []
+        for step_index, step in enumerate(unique_steps, start=1):
+            events = step.get_termination_events(variables)
+            self._experiment_termination_event_names_by_index[step_index] = [
+                event.name for event in events
+            ]
+            termination_branches.append(
+                pybamm.step.BaseStep._combine_termination_events(events)
+            )
         if self._experiment_includes_padding_rest:
             termination_branches.append(pybamm.Scalar(1))
+            self._experiment_termination_event_names_by_index[
+                self._experiment_padding_rest_index
+            ] = []
         combined_termination_expression = pybamm.Conditional(
             pybamm.InputParameter(self._STEP_INDEX_INPUT),
             *termination_branches,
@@ -454,16 +466,46 @@ class Simulation(BaseSimulation):
 
         return value
 
+    def _get_unified_termination_event_names(self, inputs):
+        active_step_index = inputs.get(self._STEP_INDEX_INPUT)
+        if active_step_index is None:
+            return None
+
+        try:
+            active_step_index = int(np.asarray(active_step_index).reshape(-1)[0])
+        except (IndexError, TypeError, ValueError):
+            return None
+
+        return self._experiment_termination_event_names_by_index.get(active_step_index)
+
+    def _get_step_termination_event_candidates(self, step, model, inputs):
+        candidates = []
+        for term in step.termination:
+            event = term.get_event(model.variables, step)
+            if event is not None:
+                candidates.append((event.name, event, term))
+
+        source_event_names = self._get_unified_termination_event_names(inputs)
+        if source_event_names is None or len(source_event_names) != len(candidates):
+            return candidates
+
+        # Prefer the names recorded when the unified branch was built; the events
+        # below are reconstructed only to evaluate which source termination crossed.
+        return [
+            (source_event_name, event, term)
+            for source_event_name, (_event_name, event, term) in zip(
+                source_event_names, candidates, strict=True
+            )
+        ]
+
     def _decode_combined_step_termination(self, step_solution, step, model, inputs):
         if step_solution.termination != f"event: {self._COMBINED_TERMINATION_EVENT}":
             return step_solution.termination
 
         final_event_values = {}
-        for term in step.termination:
-            event = term.get_event(model.variables, step)
-            if event is None:
-                continue
-
+        for event_name, event, term in self._get_step_termination_event_candidates(
+            step, model, inputs
+        ):
             # First try the exact symbolic event expression that the unified model used.
             # This is the closest match to what the solver just triggered.
             t = (
@@ -488,7 +530,7 @@ class Simulation(BaseSimulation):
                 )
 
             if value is not None:
-                final_event_values[event.name] = value
+                final_event_values[event_name] = value
 
         if not final_event_values:
             return step_solution.termination
@@ -585,6 +627,7 @@ class Simulation(BaseSimulation):
         self._experiment_step_indices = []
         self._experiment_padding_rest_index = None
         self._experiment_includes_padding_rest = False
+        self._experiment_termination_event_names_by_index = {}
 
         self.experiment_unique_steps_to_model = {}
         for step in self.experiment.unique_steps:

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -2240,6 +2240,28 @@ class TestSimulationExperiment:
 
         assert decoded == "event: Negative stoichiometry cut-off [experiment]"
 
+    def test_step_termination_event_candidates_legacy_use_reconstructed_events(self):
+        experiment = pybamm.Experiment(
+            [pybamm.step.current(1, duration=3600, termination=["2.5V", "0.05A"])]
+        )
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            experiment_model_mode="legacy",
+        )
+        sim.build_for_experiment()
+        step = sim.experiment.steps[0]
+        model = sim.steps_to_built_models[step.basic_repr()]
+
+        candidates = sim._get_step_termination_event_candidates(step, model, {})
+
+        expected = [
+            "Voltage < 2.5 [V] [experiment]",
+            "abs(Current [A]) < 0.05 [A] [experiment]",
+        ]
+        assert [name for name, _event, _term in candidates] == expected
+        assert [event.name for _name, event, _term in candidates] == expected
+
     def test_decode_combined_step_termination_returns_original_when_no_events_match(
         self,
     ):

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1143,6 +1143,46 @@ class TestSimulationExperiment:
             atol=5e-5,
         )
 
+    def test_unified_solution_termination_uses_concrete_step_event_name(self):
+        experiment = pybamm.Experiment(
+            [
+                (
+                    "Charge at 1 A until 4.1 V",
+                    pybamm.step.Voltage(4.1, termination=["0.5 A", "0.1 A"]),
+                )
+            ]
+        )
+
+        legacy_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="legacy",
+        )
+        unified_sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=experiment,
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+
+        legacy_sol = legacy_sim.solve(calc_esoh=False, initial_soc=0.2)
+        unified_sol = unified_sim.solve(calc_esoh=False, initial_soc=0.2)
+
+        # Unified mode should project the source step event, not the synthetic
+        # combined event used to drive the shared experiment model.
+        expected = "event: abs(Current [A]) < 0.5 [A] [experiment]"
+        combined = f"event: {unified_sim._COMBINED_TERMINATION_EVENT}"
+        legacy_hold = legacy_sol.cycles[0].steps[1]
+        unified_hold = unified_sol.cycles[0].steps[1]
+
+        assert legacy_sol.termination == expected
+        assert unified_sol.termination == expected
+        assert legacy_hold.termination == expected
+        assert unified_hold.termination == expected
+        assert unified_sol.termination != combined
+        assert unified_hold.termination != combined
+
     def test_run_unified_resistance_branch_is_safe_when_inactive_at_zero_current(self):
         experiment = pybamm.Experiment(
             [("Rest for 5 minutes", "Discharge at 4 Ohm for 5 minutes")]

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -2236,11 +2236,15 @@ class TestSimulationExperiment:
             direction="rest",
             termination=[pybamm.step.VoltageTermination(4.2), custom_termination],
         )
+        # Invalid branch provenance should fall back to evaluating the step events.
         decoded = sim._decode_combined_step_termination(
             step_solution,
             step,
             sim._built_experiment_model,
-            step_solution.all_inputs[0],
+            {
+                **step_solution.all_inputs[0],
+                sim._STEP_INDEX_INPUT: "not-an-index",
+            },
         )
 
         assert decoded == "event: Negative stoichiometry cut-off [experiment]"

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -1169,10 +1169,7 @@ class TestSimulationExperiment:
         legacy_sol = legacy_sim.solve(calc_esoh=False, initial_soc=0.2)
         unified_sol = unified_sim.solve(calc_esoh=False, initial_soc=0.2)
 
-        # Unified mode should project the source step event, not the synthetic
-        # combined event used to drive the shared experiment model.
         expected = "event: abs(Current [A]) < 0.5 [A] [experiment]"
-        combined = f"event: {unified_sim._COMBINED_TERMINATION_EVENT}"
         legacy_hold = legacy_sol.cycles[0].steps[1]
         unified_hold = unified_sol.cycles[0].steps[1]
 
@@ -1180,8 +1177,6 @@ class TestSimulationExperiment:
         assert unified_sol.termination == expected
         assert legacy_hold.termination == expected
         assert unified_hold.termination == expected
-        assert unified_sol.termination != combined
-        assert unified_hold.termination != combined
 
     def test_run_unified_resistance_branch_is_safe_when_inactive_at_zero_current(self):
         experiment = pybamm.Experiment(
@@ -2236,15 +2231,11 @@ class TestSimulationExperiment:
             direction="rest",
             termination=[pybamm.step.VoltageTermination(4.2), custom_termination],
         )
-        # Invalid branch provenance should fall back to evaluating the step events.
         decoded = sim._decode_combined_step_termination(
             step_solution,
             step,
             sim._built_experiment_model,
-            {
-                **step_solution.all_inputs[0],
-                sim._STEP_INDEX_INPUT: "not-an-index",
-            },
+            step_solution.all_inputs[0],
         )
 
         assert decoded == "event: Negative stoichiometry cut-off [experiment]"
@@ -2268,7 +2259,7 @@ class TestSimulationExperiment:
             step_solution,
             step,
             sim._built_experiment_model,
-            {},
+            {sim._STEP_INDEX_INPUT: sim._experiment_step_indices[0]},
         )
 
         assert decoded == step_solution.termination


### PR DESCRIPTION
## Summary

This PR preserves termination provenance when running experiments in unified experiment mode.

In the unified path, multiple step controls can be collapsed into a shared model branch to reduce model-building work. That works well for execution, but when termination information is reported back to the user, some of the original experiment step context can be lost. The goal of this change is to keep that context available so termination reporting still reflects the relevant experiment step.

The underlying execution behaviour remains the same.

## What changed

The implementation now carries forward the experiment step context needed for termination reporting in unified mode, while remaining compatible with the existing branch collapsing behaviour. I also added test coverage around unified experiment termination reporting to make sure the original context is preserved.

## Why

Unified mode simplifies some of the internal execution mechanics, but termination reporting is part of the user facing behaviour. Even if different controls share the same execution path internally, the reported termination reason should still be traceable to the experiment step that produced it.

## Behaviour preservation

This is intended to be a behaviour preserving change focused on retaining provenance information.

Experiment execution and solver behaviour should remain unchanged. The only difference is that the termination context is preserved and reported correctly when using the unified path.

## Tests

Added and updated focused unit tests covering termination reporting in experiment simulations.
