### PR TITLE
Fix flaky half-cell case in serialisation round-trip param check

### DIFF
--- a/tests/unit/test_serialisation/test_round_trip.py
+++ b/tests/unit/test_serialisation/test_round_trip.py
@@ -566,8 +566,13 @@ def _assert_param_matches_options(model):
         )
         # Symptom-level guard: a two-phase negative electrode names its primary
         # active-material fraction "Primary: ..."; a param left built from
-        # single-phase options would not.
-        if model.options.negative["particle phases"] == "2":
+        # single-phase options would not. Only meaningful on a full cell -- a
+        # half cell's negative electrode is lithium metal with no porous
+        # particle, so ``param.n.prim`` has no ``epsilon_s``.
+        if (
+            model.options["working electrode"] == "both"
+            and model.options.negative["particle phases"] == "2"
+        ):
             epsilon_s_name = model.param.n.prim.epsilon_s.name
             assert epsilon_s_name.startswith("Primary:"), (
                 f"negative primary active material fraction is {epsilon_s_name!r}; "


### PR DESCRIPTION
## Description

Follow-up to #5599. The round-trip test helper `_assert_param_matches_options` fails intermittently in CI with:

```
AttributeError: 'ParticleLithiumIonParameters' object has no attribute 'epsilon_s'
Falsifying example: options={'particle phases': '2', 'working electrode': 'positive'}
```

### Cause

The helper reads `model.param.n.prim.epsilon_s` whenever the negative electrode's `"particle phases"` resolves to `"2"`. A scalar `"particle phases": "2"` applies to **both** electrodes, so combined with `"working electrode": "positive"` (a half cell) the guard fires even though the negative electrode is lithium metal — it has no porous particle, so `param.n.prim` has no `epsilon_s`.

`TestModelOptionsRoundTrip`'s Hypothesis fuzzing only draws this combination occasionally, so #5599's own CI run passed by chance; the failure surfaced on a later run.

### Fix

Gate the symptom-level check to full cells (`working electrode == "both"`), where the negative electrode is a porous insertion electrode. The full-cell composite coverage that actually guards the #5598 regression is unchanged (verified: the symptom branch still runs for full-cell `("2", "1")` models).

Test-only change; no product code touched.

## Type of change

Internal-only (test fix) — no CHANGELOG entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)