### PR TITLE
Fix incomplete BPX import for interpolated-table OCP branches (#5610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- Fixed BPX import leaving interpolated-table OCP hysteresis branches (`OCP (lithiation) [V]`, `OCP (delithiation) [V]`) as raw data tuples instead of usable expression-tree objects. Remaining `FloatFunctionTable` placeholders are now converted generically, so new BPX table parameters no longer need a hand-maintained conversion list. ([#5610](https://github.com/pybamm-team/PyBaMM/issues/5610))
 - `RegulariseSqrtAndPower` no longer regularises state-independent bases, fixing corrupted small rate constants in exchange-current density functions. ([#5600](https://github.com/pybamm-team/PyBaMM/pull/5600))
 
 ## Breaking changes

--- a/src/pybamm/parameters/bpx.py
+++ b/src/pybamm/parameters/bpx.py
@@ -18,6 +18,12 @@ def _interpolant_func(var, name, x, y):
     return pybamm.Interpolant(x, y, var, name=name, interpolator="linear")
 
 
+def _table_to_interpolant(value):
+    """Wrap a ``(name, (x, y))`` FloatFunctionTable placeholder in an interpolant."""
+    name, (x, y) = value
+    return partial(_interpolant_func, name=name, x=x, y=y)
+
+
 preamble = "from pybamm import exp, tanh, cosh\n\n"
 
 
@@ -308,20 +314,6 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
                 ]
             ) / 3.0
 
-            # ocp
-            U = pybamm_dict[phase_domain_pre_name + "OCP [V]"]
-            if isinstance(U, tuple):
-                pybamm_dict[phase_domain_pre_name + "OCP [V]"] = partial(
-                    _interpolant_func, name=U[0], x=U[1][0], y=U[1][1]
-                )
-
-            # entropic change
-            dUdT = pybamm_dict[phase_domain_pre_name + "OCP entropic change [V.K-1]"]
-            if isinstance(dUdT, tuple):
-                pybamm_dict[phase_domain_pre_name + "OCP entropic change [V.K-1]"] = (
-                    partial(_interpolant_func, name=dUdT[0], x=dUdT[1][0], y=dUdT[1][1])
-                )
-
             # reaction rate
             c_max = pybamm_dict[
                 phase_pre_name
@@ -364,11 +356,7 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
                 )
             elif isinstance(D_ref, tuple):
                 pybamm_dict[phase_domain_pre_name + "diffusivity [m2.s-1]"] = partial(
-                    _diffusivity,
-                    D_ref=partial(
-                        _interpolant_func, name=D_ref[0], x=D_ref[1][0], y=D_ref[1][1]
-                    ),
-                    Ea=Ea_D,
+                    _diffusivity, D_ref=_table_to_interpolant(D_ref), Ea=Ea_D
                 )
             else:
                 pybamm_dict[phase_domain_pre_name + "diffusivity [m2.s-1]"] = partial(
@@ -390,11 +378,7 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
         )
     elif isinstance(D_e_ref, tuple):
         pybamm_dict[electrolyte.pre_name + "diffusivity [m2.s-1]"] = partial(
-            _diffusivity,
-            D_ref=partial(
-                _interpolant_func, name=D_e_ref[0], x=D_e_ref[1][0], y=D_e_ref[1][1]
-            ),
-            Ea=Ea_D_e,
+            _diffusivity, D_ref=_table_to_interpolant(D_e_ref), Ea=Ea_D_e
         )
     else:
         pybamm_dict[electrolyte.pre_name + "diffusivity [m2.s-1]"] = partial(
@@ -416,14 +400,7 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
         )
     elif isinstance(sigma_e_ref, tuple):
         pybamm_dict[electrolyte.pre_name + "conductivity [S.m-1]"] = partial(
-            _conductivity,
-            sigma_ref=partial(
-                _interpolant_func,
-                name=sigma_e_ref[0],
-                x=sigma_e_ref[1][0],
-                y=sigma_e_ref[1][1],
-            ),
-            Ea=Ea_sigma_e,
+            _conductivity, sigma_ref=_table_to_interpolant(sigma_e_ref), Ea=Ea_sigma_e
         )
     else:
         pybamm_dict[electrolyte.pre_name + "conductivity [S.m-1]"] = partial(
@@ -437,12 +414,16 @@ def bpx_to_param_dict(bpx: BPX) -> dict:
             value = process_float_function_table(value, name)
             if callable(value):
                 pybamm_dict[name] = partial(_callable_func, fun=value)
-            elif isinstance(value, tuple):
-                pybamm_dict[name] = partial(
-                    _interpolant_func, name=value[0], x=value[1][0], y=value[1][1]
-                )
             else:
                 pybamm_dict[name] = value
+
+    # The only tuples left in the dict are (name, (x, y)) interpolant placeholders
+    # from process_float_function_table (OCP, entropic change, hysteresis branches);
+    # temperature-dependent params are already wrapped into partials above. Convert
+    # them generically so new 1:1 table params need no hand-maintained list.
+    for key, value in pybamm_dict.items():
+        if isinstance(value, tuple):
+            pybamm_dict[key] = _table_to_interpolant(value)
     return pybamm_dict
 
 

--- a/tests/unit/test_parameters/test_bpx.py
+++ b/tests/unit/test_parameters/test_bpx.py
@@ -564,6 +564,12 @@ class TestBPX:
         for electrode in ("Negative", "Positive"):
             assert f"{electrode} electrode lithiation OCP [V]" in param
             assert f"{electrode} electrode delithiation OCP [V]" in param
+            # interpolated-table OCP branches must be converted to usable
+            # expression-tree builders, not left as raw (name, (x, y)) tuples
+            for branch in ("lithiation", "delithiation"):
+                U = param[f"{electrode} electrode {branch} OCP [V]"]
+                assert not isinstance(U, tuple)
+                assert callable(U)
             assert f"{electrode} particle lithiation hysteresis decay rate" in param
             assert f"{electrode} particle delithiation hysteresis decay rate" in param
             assert f"{electrode} electrode OCP (lithiation) [V]" not in param


### PR DESCRIPTION
Fixes #5610.

## Problem

BPX `FloatFunctionTable` fields are parsed into placeholder tuples `(name, (x, y))` that must be converted back into `pybamm.Interpolant` objects in a final processing stage. As the issue notes, the conversion targets were written manually and were not updated when #5463/#5507 added the new BPX v1.1 branches `OCP (lithiation) [V]` and `OCP (delithiation) [V]`. When supplied as interpolated tables, those parameters were left as raw tuples, making the resulting `ParameterValues` unusable (no expression-tree value).

## Fix

Rather than add two more entries to the hand-maintained list (which is the root cause), this generalises the last stage:

- Extract a small `_table_to_interpolant` helper that names the `(name, (x, y))` placeholder contract.
- Replace the per-parameter conversion blocks (OCP, entropic change, user-defined) with a single catch-all that converts **any** remaining placeholder tuple just before returning.
- Reuse the helper at the temperature-dependent sites (particle/electrolyte diffusivity, electrolyte conductivity), which stay explicit because they wrap the interpolant inside an Arrhenius dependence.

New 1:1 table parameters now need no hand-maintained conversion entry. The only tuples remaining in the dict at that point are interpolant placeholders (temperature-dependent params are already wrapped into partials above); this invariant is documented inline.

## Tests

Strengthened `test_bpx_hysteresis_names` to assert the lithiation/delithiation OCP branches are converted to usable callables rather than left as raw tuples (it previously only checked key presence). Existing `test_table_data` already covers the main OCP and entropic-change table paths. Full BPX suite (24 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)