### PR TITLE
docs: ignore bot-blocked URLs (Real Python, ACS DOI) in linkcheck and lychee

### DIFF
--- a/.github/workflows/lychee_url_checker.yml
+++ b/.github/workflows/lychee_url_checker.yml
@@ -50,6 +50,7 @@ jobs:
             --exclude https://twitter.com/pybamm_
             --exclude "https://doi\.org|www.sciencedirect\.com/*"
             --exclude https://www.rse.ox.ac.uk
+            --exclude https://realpython\.com
             --accept 200,429
             --exclude-path ./CHANGELOG.md
             --exclude-path ./scripts/update_version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,8 @@ linkcheck_ignore = [
     "https://docs.scipy.org/doc/scipy",  # SciPy docs timeout intermittently
     "https://chemrxiv.org",  # ChemRxiv blocks automated link checking
     "https://pubs.acs.org",  # ACS blocks automated link checking
+    "https://doi.org/10.1021/acsaem.2c02047",  # ACS DOI 403s automated checkers
+    "https://realpython.com",  # Real Python (Cloudflare) blocks automated link checking
 ]
 
 # GitHub prefixes Markdown heading anchors with "user-content-" in the rendered


### PR DESCRIPTION
## What

Add two bot-blocking URLs to the link checkers so they stop failing CI:

- `docs/conf.py` `linkcheck_ignore`: `realpython.com` and `doi.org/10.1021/acsaem.2c02047`
- `lychee_url_checker.yml`: exclude `realpython.com` (`doi.org` is already excluded there)

## Why

Both URLs return 403 to automated checkers (Real Python sits behind Cloudflare; the DOI redirects to ACS, which blocks bots). They are live, valid links for human readers, but they intermittently fail the Read the Docs `sphinx -b linkcheck` pre_build step and the lychee `linkChecker` job on every branch, which is a recurring cause of flaky `docs/readthedocs.org:pybamm` and `linkChecker` failures on PRs.

This follows the existing convention in `linkcheck_ignore` (sciencedirect, wikipedia, scipy, chemrxiv, pubs.acs.org) for sites that block automated link checking.

## Verification

Checked every external link and anchor in the docs tree: no broken (404) pages or missing anchors remain. The only non-200 responses are these two 403s, plus one harmless 302 redirect that linkcheck already treats as OK.