### PR TITLE
ci: sparse PR test matrix and consume-only solver wheel builds

### DIFF
--- a/.github/workflows/_build_solver_wheels.yml
+++ b/.github/workflows/_build_solver_wheels.yml
@@ -8,6 +8,9 @@
 #                             against the in-repo solver without rebuilding it
 #                             per cell).
 #
+# Platform selection: callers pass `platforms` / `macos_runners` to build only the
+# wheels their downstream jobs consume; both default to all platforms.
+#
 # Windows is built here via cibuildwheel + vcpkg — the ONLY way this solver has
 # ever been built on Windows. PyBaMM's matrix must not invent a from-source
 # Windows build; it consumes these wheels.
@@ -37,6 +40,16 @@ on:
         default: false
         required: false
         type: boolean
+      platforms:
+        description: 'JSON array of non-macOS targets to build, subset of ["linux", "windows"]. Lets a caller build only the wheels its downstream jobs consume.'
+        default: '["linux", "windows"]'
+        required: false
+        type: string
+      macos_runners:
+        description: 'JSON array of macOS runner labels to build on (e.g. ["macos-latest"]); empty [] skips macOS entirely.'
+        default: '["macos-15-intel", "macos-latest"]'
+        required: false
+        type: string
 
 defaults:
   run:
@@ -51,6 +64,7 @@ env:
 jobs:
   build_windows_wheels:
     name: Wheels (Windows)
+    if: ${{ contains(fromJSON(inputs.platforms), 'windows') }}
     runs-on: windows-2022
     permissions:
       contents: read
@@ -124,6 +138,7 @@ jobs:
 
   build_manylinux_wheels:
     name: Wheels (Linux)
+    if: ${{ contains(fromJSON(inputs.platforms), 'linux') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -177,12 +192,13 @@ jobs:
 
   build_macos_wheels:
     name: Wheels (${{ matrix.os }})
+    if: ${{ inputs.macos_runners != '[]' }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
       matrix:
-        os: [macos-15-intel, macos-latest]
+        os: ${{ fromJSON(inputs.macos_runners) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/run_periodic_tests.yml
+++ b/.github/workflows/run_periodic_tests.yml
@@ -42,9 +42,11 @@ jobs:
 
     strategy:
       fail-fast: false
+      # Full sweep: every OS x Python. Complements test_on_push.yml's sparse PR matrix;
+      # keep the Python list in sync with it.
       matrix:
         os: [ ubuntu-latest, macos-15-intel, macos-latest, windows-latest ]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     env:

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -36,6 +36,9 @@ jobs:
       solver: ${{ steps.filter.outputs.solver }}
       pybamm: ${{ steps.filter.outputs.pybamm }}
       docs: ${{ steps.filter.outputs.docs }}
+      # Solver-wheel platforms each scenario's downstream jobs actually consume.
+      platforms: ${{ steps.route.outputs.platforms }}
+      macos_runners: ${{ steps.route.outputs.macos_runners }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -56,6 +59,29 @@ jobs:
               - '.github/workflows/test_on_push.yml'
             docs:
               - 'docs/**'
+
+      # Map "what changed" to the solver wheels to build: solver PRs validate every
+      # platform; pybamm/push need the sparse matrix's runners; docs-only needs Linux.
+      - id: route
+        env:
+          EVENT: ${{ github.event_name }}
+          SOLVER: ${{ steps.filter.outputs.solver }}
+          PYBAMM: ${{ steps.filter.outputs.pybamm }}
+        run: |
+          if [ "$SOLVER" = true ]; then
+            platforms='["linux", "windows"]'
+            macos='["macos-15-intel", "macos-latest"]'
+          elif [ "$EVENT" = push ] || [ "$PYBAMM" = true ]; then
+            platforms='["linux", "windows"]'
+            macos='["macos-latest"]'
+          else
+            platforms='["linux"]'
+            macos='[]'
+          fi
+          {
+            echo "platforms=$platforms"
+            echo "macos_runners=$macos"
+          } >> "$GITHUB_OUTPUT"
 
   style:
     runs-on: ubuntu-latest
@@ -99,6 +125,9 @@ jobs:
     with:
       cache_wheels: true
       build_sdist: false
+      # Build only the wheels the triggered jobs consume (see the changes job's route step).
+      platforms: ${{ needs.changes.outputs.platforms }}
+      macos_runners: ${{ needs.changes.outputs.macos_runners }}
 
   run_unit_tests:
     needs: [changes, build_solver]
@@ -109,9 +138,20 @@ jobs:
 
     strategy:
       fail-fast: false
+      # PR matrix: full Python on Linux + min/max endpoints on the 10x macOS/Windows
+      # runners; macos-15-intel and interior versions run nightly (run_periodic_tests.yml).
       matrix:
-        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.14"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.14"
     name: Tests (${{ matrix.os }} / Python ${{ matrix.python-version }})
 
     env:


### PR DESCRIPTION
# Description

Cut per-PR CI without losing coverage, now that the monorepo builds the solver once and routes jobs by what changed.

- `test_on_push.yml`: replace the 4x4 OS/Python cross-product with a sparse matrix (full Python on Linux, 3.10/3.14 endpoints on macos-latest and windows-latest, macos-15-intel dropped to nightly).
- `_build_solver_wheels.yml`: add platforms/macos_runners inputs (default to all platforms, so release and nightly callers are unchanged) so a caller builds only the wheels its downstream jobs consume.
- `test_on_push.yml`: derive those inputs in a changes-job route step; push no longer builds the 10x macos-15-intel wheel no PR path consumes.
- add Python 3.10 to both matrices to honour requires-python >=3.10.


Fixes # (issue)

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
