### PR TITLE
Fix internal link errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -912,7 +912,7 @@ package to install PyBaMM with only the required dependencies. ([conda-forge/pyb
 - Removed `get_infinite_nested_dict`, `BaseModel.check_default_variables_dictionaries`, and `Discretisation.create_jacobian` methods, which were not used by any other functionality in the repository ([#2384](https://github.com/pybamm-team/PyBaMM/pull/2384))
 - Dropped support for Python 3.7 after the release of Numpy v1.22.0 ([#2379](https://github.com/pybamm-team/PyBaMM/pull/2379))
 - Removed parameter cli tools (add/edit/remove parameters). Parameter sets can now more easily be added via python scripts. ([#2342](https://github.com/pybamm-team/PyBaMM/pull/2342))
-- Parameter sets should now be provided as single python files containing all parameters and functions. Parameters provided as "data" (e.g. OCP vs SOC) can still be csv files, but must be either in the same folder as the parameter file or in a subfolder called "data/". See for example [Ai2020](https://github.com/pybamm-team/PyBaMM/blob/develop/src/pybamm/input/parameters/lithium_ion/Ai2020.py) ([#2342](https://github.com/pybamm-team/PyBaMM/pull/2342))
+- Parameter sets should now be provided as single python files containing all parameters and functions. Parameters provided as "data" (e.g. OCP vs SOC) can still be csv files, but must be either in the same folder as the parameter file or in a subfolder called "data/". See for example [Ai2020](https://github.com/pybamm-team/PyBaMM/blob/develop/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Ai2020.py) ([#2342](https://github.com/pybamm-team/PyBaMM/pull/2342))
 
 # [v22.9](https://github.com/pybamm-team/PyBaMM/tree/v22.9) - 2022-09-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,7 +440,7 @@ pybamm.print_citations()
 
 to the end of a script will print all citations that were used by that script. This will print BibTeX information to the terminal; passing a filename to `print_citations` will print the BibTeX information to the specified file instead.
 
-When you contribute code to PyBaMM, you can add your own papers that you would like to be cited if that code is used. First, add the BibTeX for your paper to [CITATIONS.bib](https://github.com/pybamm-team/PyBaMM/blob/main/src/pybamm/CITATIONS.bib). Then, add the line
+When you contribute code to PyBaMM, you can add your own papers that you would like to be cited if that code is used. First, add the BibTeX for your paper to [CITATIONS.bib](https://github.com/pybamm-team/PyBaMM/blob/main/packages/pybamm/src/pybamm/CITATIONS.bib). Then, add the line
 
 ```python3
 pybamm.citations.register("your_paper_bibtex_identifier")

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ We would be grateful if you could also cite the relevant papers. These will chan
 pybamm.print_citations()
 ```
 
-to the end of your script. This will print BibTeX information to the terminal; passing a filename to `print_citations` will print the BibTeX information to the specified file instead. A list of all citations can also be found in the [citations file](https://github.com/pybamm-team/PyBaMM/blob/main/src/pybamm/CITATIONS.bib). In particular, PyBaMM relies heavily on [CasADi](https://web.casadi.org/publications/).
+to the end of your script. This will print BibTeX information to the terminal; passing a filename to `print_citations` will print the BibTeX information to the specified file instead. A list of all citations can also be found in the [citations file](https://github.com/pybamm-team/PyBaMM/blob/main/packages/pybamm/src/pybamm/CITATIONS.bib). In particular, PyBaMM relies heavily on [CasADi](https://web.casadi.org/publications/).
 See [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/main/CONTRIBUTING.md#citations) for information on how to add your own citations when you contribute.
 
 ## 🛠️ Contributing to PyBaMM

--- a/docs/source/api/parameters/parameter_sets.rst
+++ b/docs/source/api/parameters/parameter_sets.rst
@@ -33,7 +33,7 @@ package (``cell_parameters``) should consist of the following::
 The actual parameter set is defined within ``cell_alpha.py``, as shown below.
 For an example, see the `Marquis2019`_ parameter sets.
 
-.. _Marquis2019: https://github.com/pybamm-team/PyBaMM/blob/main/src/pybamm/input/parameters/lithium_ion/Marquis2019.py
+.. _Marquis2019: https://github.com/pybamm-team/PyBaMM/blob/main/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Marquis2019.py
 
 .. code-block:: python
     :linenos:

--- a/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
@@ -599,7 +599,7 @@
    "source": [
     "Note how, when we pass a function as a parameter, we pass the object without calling it, i.e. we pass `cube` rather than `cube(t)`. This new `parameter_values` variable could now be passed to a simulation, but note that it is incomplete as it does not include all the parameters that the model needs to run (see the parameters needed by calling `model.print_parameter_info()`, as done above). \n",
     "\n",
-    "It is often convenient to define the parameter set in a separate file, and then call the parameters into your notebook or script. You can find some examples on how to do so in [PyBaMM's parameter library](https://github.com/pybamm-team/PyBaMM/tree/main/src/pybamm/input/parameters/lithium_ion). You can copy one of the parameter sets available into a new file and modify it accordingly for the new parameter set. Then, whenever the set is needed, one can import the `get_parameter_values` method from the corresponding file and call it to obtain a copy of the parameter values."
+    "It is often convenient to define the parameter set in a separate file, and then call the parameters into your notebook or script. You can find some examples on how to do so in [PyBaMM's parameter library](https://github.com/pybamm-team/PyBaMM/tree/main/packages/pybamm/src/pybamm/input/parameters/lithium_ion). You can copy one of the parameter sets available into a new file and modify it accordingly for the new parameter set. Then, whenever the set is needed, one can import the `get_parameter_values` method from the corresponding file and call it to obtain a copy of the parameter values."
    ]
   },
   {
@@ -648,7 +648,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "pybamm-local (3.11.10)",
    "language": "python",
    "name": "python3"
   },
@@ -662,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.11.10"
   },
   "toc": {
    "base_numbering": 1,

--- a/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
+++ b/docs/source/examples/notebooks/getting_started/tutorial-4-setting-parameter-values.ipynb
@@ -648,7 +648,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pybamm-local (3.11.10)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -662,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/packages/pybamm/README.md
+++ b/packages/pybamm/README.md
@@ -171,7 +171,7 @@ We would be grateful if you could also cite the relevant papers. These will chan
 pybamm.print_citations()
 ```
 
-to the end of your script. This will print BibTeX information to the terminal; passing a filename to `print_citations` will print the BibTeX information to the specified file instead. A list of all citations can also be found in the [citations file](https://github.com/pybamm-team/PyBaMM/blob/main/src/pybamm/CITATIONS.bib). In particular, PyBaMM relies heavily on [CasADi](https://web.casadi.org/publications/).
+to the end of your script. This will print BibTeX information to the terminal; passing a filename to `print_citations` will print the BibTeX information to the specified file instead. A list of all citations can also be found in the [citations file](https://github.com/pybamm-team/PyBaMM/blob/main/packages/pybamm/src/pybamm/CITATIONS.bib). In particular, PyBaMM relies heavily on [CasADi](https://web.casadi.org/publications/).
 See [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/main/CONTRIBUTING.md#citations) for information on how to add your own citations when you contribute.
 
 ## 🛠️ Contributing to PyBaMM

--- a/packages/pybamm/README.md
+++ b/packages/pybamm/README.md
@@ -97,9 +97,9 @@ Note that the examples on the `main` branch are tested on the latest commit. If 
 
 PyBaMM uses [CalVer](https://calver.org/). Version numbers take the form `YY.MM.N.P`, where `YY.MM` is the year and month of the release, `N` is the feature release within that month (`0` for the first), and `P` is the patch level (`0` for the feature release itself). For example, `27.1.0.1` is the first patch of the first feature release in January 2027.
 
-Releases ship when there's something worth releasing, not on a fixed schedule. Any release may contain breaking changes; when it does, they appear under a `## Breaking changes` section at the top of [`CHANGELOG.md`](CHANGELOG.md). Public APIs that are removed or renamed ship a `DeprecationWarning` for at least two prior feature releases first, where technically possible.
+Releases ship when there's something worth releasing, not on a fixed schedule. Any release may contain breaking changes; when it does, they appear under a `## Breaking changes` section at the top of [`CHANGELOG.md`](../../CHANGELOG.md). Public APIs that are removed or renamed ship a `DeprecationWarning` for at least two prior feature releases first, where technically possible.
 
-See [`RELEASE.md`](RELEASE.md) for the full release policy, including how we define "public API" and what counts as a breaking change.
+See [`RELEASE.md`](../../RELEASE.md) for the full release policy, including how we define "public API" and what counts as a breaking change.
 
 ## 🚀 Installing PyBaMM
 


### PR DESCRIPTION
Fixes various errors in the [url checker](https://github.com/pybamm-team/PyBaMM/actions/workflows/lychee_url_checker.yml) for internal links which weren't updated during/after the monorepo merge.

The remaining error in `scripts/update_version.py` is because no pybamm-v{version} tags (the new naming convention after the monorepo merge) have been generated yet.