### PR TITLE
Fix unified branch identity for custom terminations

### DIFF
--- a/packages/pybamm/src/pybamm/experiment/step/base_step.py
+++ b/packages/pybamm/src/pybamm/experiment/step/base_step.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pybamm
 
-from .step_termination import _read_termination
+from .step_termination import CustomTermination, _read_termination
 
 
 class ControlKind(str, Enum):
@@ -320,11 +320,21 @@ class BaseStep:
         """The control target as a number, or ``None`` if it is not a constant."""
         return _constant_value(parameter_values, self._control_target)
 
+    @staticmethod
+    def _unified_branch_termination_identity(term):
+        if isinstance(term, CustomTermination):
+            return repr((type(term).__name__, term.name, id(term.event_function)))
+        return repr(term)
+
     def unified_branch_repr(self):
         """Branch identity in unified mode: control kind and everything but the value."""
         parts = [self.control_kind or type(self).__name__]
         if self.termination:
-            parts.append(f"termination={self.termination}")
+            termination_identities = ", ".join(
+                self._unified_branch_termination_identity(term)
+                for term in self.termination
+            )
+            parts.append(f"termination=[{termination_identities}]")
         if self.temperature:
             parts.append(f"temperature={self.temperature}")
         if self.direction:

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -298,6 +298,36 @@ class TestSimulationExperiment:
         sim.build_for_experiment()
         assert len(set(sim._experiment_step_indices)) == 1
 
+    def test_unified_custom_termination_functions_get_distinct_branches(self):
+        def lower_voltage_limit(variables):
+            return variables["Battery voltage [V]"] - 3.8
+
+        def higher_voltage_limit(variables):
+            return variables["Battery voltage [V]"] - 3.9
+
+        lower_voltage_termination = pybamm.step.CustomTermination(
+            name="shared custom cut-off", event_function=lower_voltage_limit
+        )
+        higher_voltage_termination = pybamm.step.CustomTermination(
+            name="shared custom cut-off", event_function=higher_voltage_limit
+        )
+
+        assert lower_voltage_termination != higher_voltage_termination
+
+        steps = [
+            pybamm.step.c_rate(0.5, duration=10, termination=lower_voltage_termination),
+            pybamm.step.c_rate(1.0, duration=10, termination=higher_voltage_termination),
+        ]
+        sim = pybamm.Simulation(
+            pybamm.lithium_ion.SPM(),
+            experiment=pybamm.Experiment(steps),
+            solver=pybamm.IDAKLUSolver(),
+            experiment_model_mode="unified",
+        )
+        sim.build_for_experiment()
+
+        assert sim._experiment_step_indices[0] != sim._experiment_step_indices[1]
+
     def test_unified_collapses_every_control_kind_by_value(self):
         # Value-as-input is general: steps of ANY control kind that differ only in their
         # target value share one branch, and distinct control kinds get separate branches.

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -316,7 +316,9 @@ class TestSimulationExperiment:
 
         steps = [
             pybamm.step.c_rate(0.5, duration=10, termination=lower_voltage_termination),
-            pybamm.step.c_rate(1.0, duration=10, termination=higher_voltage_termination),
+            pybamm.step.c_rate(
+                1.0, duration=10, termination=higher_voltage_termination
+            ),
         ]
         sim = pybamm.Simulation(
             pybamm.lithium_ion.SPM(),


### PR DESCRIPTION
## Summary

Fixes unified experiment branch identity for same-named `CustomTermination` objects with distinct event functions.

Previously, unified branch identity could collapse two custom terminations that had the same name but different `event_function` objects, because the branch key used representation-shaped termination identity. The fix makes custom termination branch identity include the event function object identity while keeping ordinary termination branch identity on the existing repr-compatible path.

This aligns unified branch selection with `CustomTermination` equality/hash semantics.

Closes #5625.

## Tests

```bash
uv run --group dev pytest packages/pybamm/tests/unit/test_experiments/test_experiment_step_termination.py -q
uv run --group dev pytest packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py -q
uv run nox -s unit
```
