### PR TITLE
Fix wrong display of subscript

### DIFF
--- a/docs/source/examples/notebooks/models/thermal-models.ipynb
+++ b/docs/source/examples/notebooks/models/thermal-models.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "$$ T\\big|_{t=0} = T_0.$$\n",
     "\n",
-    "Here $\\lambda_k$ is the thermal conductivity of component $k$, and the heat transfer coefficients $h_{cn}$ and $h_{cp}$ correspond to heat transfer at the large surface of the pouch on the side of the negative current collector, heat transfer at the large surface of the pouch on the side of the positive current collector, respectively. The heat source term $Q$ is as described in the section on lumped models. The term $Q_cool$ accounts for additional heat losses due to heat transfer at the sides of the pouch, as well as the tabs. This term is computed automatically by PyBaMM based on the cell geometry and heat transfer coefficients on the edges and tabs of the cell.\n",
+    "Here $\\lambda_k$ is the thermal conductivity of component $k$, and the heat transfer coefficients $h_{cn}$ and $h_{cp}$ correspond to heat transfer at the large surface of the pouch on the side of the negative current collector, heat transfer at the large surface of the pouch on the side of the positive current collector, respectively. The heat source term $Q$ is as described in the section on lumped models. The term $Q_{cool}$ accounts for additional heat losses due to heat transfer at the sides of the pouch, as well as the tabs. This term is computed automatically by PyBaMM based on the cell geometry and heat transfer coefficients on the edges and tabs of the cell.\n",
     "\n",
     "The relevant heat transfer parameters are:\n",
     "\"Negative current collector surface heat transfer coefficient [W.m-2.K-1]\"\n",


### PR DESCRIPTION
# Description
Subscript "cool" was not encapsulated correctly.