### PR TITLE
CI: build Linux aarch64 (arm64) solver wheels

### DIFF
--- a/.github/workflows/_build_solver_wheels.yml
+++ b/.github/workflows/_build_solver_wheels.yml
@@ -142,11 +142,33 @@ jobs:
           if-no-files-found: error
 
   build_manylinux_wheels:
-    name: Wheels (Linux)
+    name: Wheels (Linux ${{ matrix.arch }})
     if: ${{ contains(fromJSON(inputs.platforms), 'linux') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # x86_64 uses the default manylinux2014; CasADi's x86_64 wheel is
+          # built with the legacy libstdc++ ABI (CentOS 7, EPEL disabled).
+          - arch: x86_64
+            runner: ubuntu-latest
+            artifact: wheels_manylinux
+            before_all: >
+              yum -y --disablerepo=epel install openblas-devel lapack-devel &&
+              python install_KLU_Sundials.py
+          # aarch64 needs manylinux_2_34: CasADi's aarch64 wheel is built with
+          # the C++11 ABI and requires a GCC>=11 libstdc++, which manylinux2014
+          # and manylinux_2_28 lack. openblas/lapack live in AlmaLinux 9's CRB.
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            artifact: wheels_manylinux_aarch64
+            before_all: >
+              dnf config-manager --set-enabled crb &&
+              dnf -y install openblas-devel lapack-devel &&
+              python install_KLU_Sundials.py
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -169,18 +191,17 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: packages/pybammsolvers/wheelhouse
-          key: solver-wheels-linux-${{ steps.solverhash.outputs.hash }}
+          key: solver-wheels-linux-${{ matrix.arch }}-${{ steps.solverhash.outputs.hash }}
 
       - name: Build wheels on Linux
         if: ${{ !(inputs.cache_wheels && steps.cache.outputs.cache-hit == 'true') }}
         run: pipx run cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_ARCHS_LINUX: x86_64
-          # openblas-devel/lapack-devel live in PowerTools, not EPEL; disable EPEL
-          # so its periodic metadata-rotation outages can't break the wheel build.
-          CIBW_BEFORE_ALL_LINUX: >
-            yum -y --disablerepo=epel install openblas-devel lapack-devel &&
-            python install_KLU_Sundials.py
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          # aarch64 requires GCC>=11 libstdc++ for CasADi's C++11-ABI wheel;
+          # ignored for the x86_64 build (which uses the default manylinux2014).
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34
+          CIBW_BEFORE_ALL_LINUX: ${{ matrix.before_all }}
           # libcasadi ships as a pip dep (resolved at runtime via $ORIGIN/../casadi).
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libcasadi.so.3.7 -w {dest_dir} {wheel}
           CIBW_TEST_EXTRAS: "dev"
@@ -191,7 +212,7 @@ jobs:
       - name: Upload wheels for Linux
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels_manylinux
+          name: ${{ matrix.artifact }}
           path: packages/pybammsolvers/wheelhouse/*.whl
           if-no-files-found: error
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Features
 
+- `pybammsolvers` now ships Linux `aarch64` (arm64) wheels, built on `manylinux_2_34` native ARM runners. The libstdc++ `std::string` ABI (`_GLIBCXX_USE_CXX11_ABI`) is now detected from the linked CasADi library instead of hard-coded, resolving the unresolved-symbol failure against CasADi's C++11-ABI aarch64 wheel. ([#5653](https://github.com/pybamm-team/PyBaMM/pull/5653))
 - Added `skip_surface_form_check` option to `EISSimulation` to bypass the surface form validation. ([#5632](https://github.com/pybamm-team/PyBaMM/pull/5632))
 - Added ability to export pybamm.Simulation with experiments to DiffSL format ([#5557)](https://github.com/pybamm-team/PyBaMM/pull/5557))
 - PyBaMM and `pybammsolvers` now develop in a single repository — a UV workspace under `packages/` — while continuing to release independently to PyPI. Release tags are namespaced (`pybamm-v*` and `pybammsolvers-v*`), and PyBaMM's CI now tests against the in-repo solver on every platform. The published `pybamm` package and its dependency on `pybammsolvers` are unchanged for users. See `RELEASE.md` for the release model. ([#5512](https://github.com/pybamm-team/PyBaMM/issues/5512))

--- a/packages/pybammsolvers/CMakeLists.txt
+++ b/packages/pybammsolvers/CMakeLists.txt
@@ -76,8 +76,8 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=vla")
 endif ()
 
-# casadi seems to compile without the newer versions of std::string
-add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+# The libstdc++ std::string ABI (_GLIBCXX_USE_CXX11_ABI) is reconciled against
+# the actual libcasadi build further down, once CasADi has been located.
 
 find_package(pybind11 CONFIG REQUIRED)
 
@@ -222,6 +222,46 @@ else ()
     else()
         target_link_libraries(idaklu PRIVATE casadi)
     endif()
+endif ()
+
+# Match idaklu's libstdc++ std::string ABI to the linked libcasadi (GNU only;
+# no-op for MSVC and macOS/libc++). CasADi's PyPI casadi-config.cmake forces
+# `_GLIBCXX_USE_CXX11_ABI=0` on consumers: correct for the x86_64 wheel (legacy
+# ABI) but wrong for the aarch64 wheel (C++11 ABI), leaving casadi's std::string
+# symbols unresolved. Detect libcasadi's real ABI and override CasADi's guess.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # Drop CasADi's hard-coded (and, on aarch64, wrong) ABI interface definition.
+    if (TARGET casadi::casadi)
+        get_target_property(_casadi_defs casadi::casadi INTERFACE_COMPILE_DEFINITIONS)
+        if (_casadi_defs)
+            list(REMOVE_ITEM _casadi_defs
+                "_GLIBCXX_USE_CXX11_ABI=0" "_GLIBCXX_USE_CXX11_ABI=1")
+            set_target_properties(casadi::casadi PROPERTIES
+                INTERFACE_COMPILE_DEFINITIONS "${_casadi_defs}")
+        endif ()
+    endif ()
+
+    # Key off casadi::Function::deserialize(const std::string&): the C++11-ABI
+    # build exports the __cxx11 mangling, the legacy build the `Ss` mangling.
+    # Default to the legacy ABI if the probe cannot run (never worse than before).
+    set(_casadi_cxx11_abi 0)
+    set(_nm "${CMAKE_NM}")
+    if (NOT _nm)
+        find_program(_nm NAMES nm gcc-nm)
+    endif ()
+    file(GLOB _libcasadi "${CASADI_LIB_DIR}/libcasadi.so*")
+    if (_libcasadi AND _nm)
+        list(GET _libcasadi 0 _libcasadi0)
+        execute_process(
+            COMMAND "${_nm}" -D --defined-only "${_libcasadi0}"
+            OUTPUT_VARIABLE _casadi_syms
+            ERROR_QUIET)
+        if (_casadi_syms MATCHES "Function11deserializeERKNSt7__cxx11")
+            set(_casadi_cxx11_abi 1)
+        endif ()
+    endif ()
+    message(STATUS "idaklu: _GLIBCXX_USE_CXX11_ABI=${_casadi_cxx11_abi} (matched to libcasadi)")
+    target_compile_definitions(idaklu PRIVATE _GLIBCXX_USE_CXX11_ABI=${_casadi_cxx11_abi})
 endif ()
 
 # Math flags for the IDAKLU target.


### PR DESCRIPTION
# Description

`pybammsolvers` has no Linux `aarch64` (arm64) wheels, so arm64 users cannot `pip install` it (or `pybamm`, which depends on it). Two things blocked the build, both confirmed against CasADi's actual PyPI wheels: CasADi's aarch64 `libcasadi` is built with the C++11 `std::string` ABI, but its shipped `casadi-config.cmake` forces the legacy ABI on consumers (correct for the x86_64 wheel, wrong for aarch64); and CasADi 3.7.2's aarch64 wheel needs a newer libstdc++ (GCC >= 11) than `manylinux2014`/`manylinux_2_28` provide.

- Build aarch64 wheels on native `ubuntu-24.04-arm` runners with `manylinux_2_34` (AlmaLinux 9, GCC 11); keep x86_64 on the default `manylinux2014`. The Linux job is now a per-arch matrix.
- Detect `libcasadi`'s real `std::string` ABI in CMake (probe `casadi::Function::deserialize` with `nm`) and compile IDAKLU to match, instead of hard-coding `_GLIBCXX_USE_CXX11_ABI=0`; also strip CasADi's incorrect ABI interface definition. GNU/libstdc++ only, so it is a no-op on macOS and Windows.
- Install `openblas`/`lapack-devel` from AlmaLinux 9's CRB repo for the aarch64 job.

Verified end-to-end on native arm64 (`quay.io/pypa/manylinux_2_34_aarch64`): the wheel builds, `auditwheel` repairs it to `manylinux_2_34_aarch64`, imports, and the test suite passes (42 passed, 2 skipped). `pybamm` itself is pure-Python and needs no change.

> This changes only the Linux wheel job, but the `pybammsolvers` source edit cache-misses the Windows wheel build, which fails on `main` until #5650 (the vcpkg Fortran-chain fix) lands. This should therefore merge after #5650.

Fixes #4821

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
