### PR TITLE
Expose per-value parameter serialisation publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Reverted the "voltage as a state" default back to "false", undoing the [v26.7.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.0.0) change to "true". Promoting voltage to an algebraic state turns SPM/SPMe into DAEs and places voltage under solver error control, which caused IDAKLU error-test failures on solves of discontinuous (pulsed) current profiles at the default tolerances, and lowered voltage-output accuracy. The option remains available (`{"voltage as a state": "true"}`) and is still enabled automatically for the "explicit power" and "explicit resistance" operating modes. ([#5670](https://github.com/pybamm-team/PyBaMM/pull/5670))
 
+## Features
+
+- Exposed the per-value parameter serialisation dispatch publicly as `pybamm.serialize_parameter_value`/`pybamm.deserialize_parameter_value`, and `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`), so a raw `{name: value}` mapping can be serialised without constructing a throwaway `ParameterValues`. ([#5663](https://github.com/pybamm-team/PyBaMM/pull/5663))
+
 # [v26.7.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.0.0) - 2026-07-21
 
 ## Breaking changes
@@ -14,7 +18,6 @@
 
 ## Features
 
-- Exposed the per-value parameter serialisation dispatch publicly as `pybamm.serialize_parameter_value`/`pybamm.deserialize_parameter_value`, and `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`), so a raw `{name: value}` mapping can be serialised without constructing a throwaway `ParameterValues`. ([#5663](https://github.com/pybamm-team/PyBaMM/pull/5663))
 - `pybammsolvers` now ships Linux `aarch64` (arm64) wheels, built on `manylinux_2_34` native ARM runners. The libstdc++ `std::string` ABI (`_GLIBCXX_USE_CXX11_ABI`) is now detected from the linked CasADi library instead of hard-coded, resolving the unresolved-symbol failure against CasADi's C++11-ABI aarch64 wheel. ([#5653](https://github.com/pybamm-team/PyBaMM/pull/5653))
 - Added `skip_surface_form_check` option to `EISSimulation` to bypass the surface form validation. ([#5632](https://github.com/pybamm-team/PyBaMM/pull/5632))
 - Added ability to export pybamm.Simulation with experiments to DiffSL format ([#5557](https://github.com/pybamm-team/PyBaMM/pull/5557))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Features
 
-- Exposed the per-value parameter serialisation dispatch publicly as `pybamm.serialize_parameter_value`/`pybamm.deserialize_parameter_value`, and `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`), so a raw `{name: value}` mapping can be serialised without constructing a throwaway `ParameterValues`. ([#5661](https://github.com/pybamm-team/PyBaMM/pull/5661))
+- Exposed the per-value parameter serialisation dispatch publicly as `pybamm.serialize_parameter_value`/`pybamm.deserialize_parameter_value`, and `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`), so a raw `{name: value}` mapping can be serialised without constructing a throwaway `ParameterValues`. ([#5663](https://github.com/pybamm-team/PyBaMM/pull/5663))
 - `pybammsolvers` now ships Linux `aarch64` (arm64) wheels, built on `manylinux_2_34` native ARM runners. The libstdc++ `std::string` ABI (`_GLIBCXX_USE_CXX11_ABI`) is now detected from the linked CasADi library instead of hard-coded, resolving the unresolved-symbol failure against CasADi's C++11-ABI aarch64 wheel. ([#5653](https://github.com/pybamm-team/PyBaMM/pull/5653))
 - Added `skip_surface_form_check` option to `EISSimulation` to bypass the surface form validation. ([#5632](https://github.com/pybamm-team/PyBaMM/pull/5632))
 - Added ability to export pybamm.Simulation with experiments to DiffSL format ([#5557](https://github.com/pybamm-team/PyBaMM/pull/5557))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Features
 
+- Exposed the per-value parameter serialisation dispatch publicly as `pybamm.serialize_parameter_value`/`pybamm.deserialize_parameter_value`, and `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`), so a raw `{name: value}` mapping can be serialised without constructing a throwaway `ParameterValues`. ([#5661](https://github.com/pybamm-team/PyBaMM/pull/5661))
 - `pybammsolvers` now ships Linux `aarch64` (arm64) wheels, built on `manylinux_2_34` native ARM runners. The libstdc++ `std::string` ABI (`_GLIBCXX_USE_CXX11_ABI`) is now detected from the linked CasADi library instead of hard-coded, resolving the unresolved-symbol failure against CasADi's C++11-ABI aarch64 wheel. ([#5653](https://github.com/pybamm-team/PyBaMM/pull/5653))
 - Added `skip_surface_form_check` option to `EISSimulation` to bypass the surface form validation. ([#5632](https://github.com/pybamm-team/PyBaMM/pull/5632))
 - Added ability to export pybamm.Simulation with experiments to DiffSL format ([#5557](https://github.com/pybamm-team/PyBaMM/pull/5557))

--- a/docs/source/api/parameters/parameter_values.rst
+++ b/docs/source/api/parameters/parameter_values.rst
@@ -42,3 +42,7 @@ API Reference
 
 .. autoclass:: pybamm.ParameterValues
   :members:
+
+.. autofunction:: pybamm.serialize_parameter_value
+
+.. autofunction:: pybamm.deserialize_parameter_value

--- a/packages/pybamm/src/pybamm/__init__.py
+++ b/packages/pybamm/src/pybamm/__init__.py
@@ -117,7 +117,13 @@ from .expression_tree.independent_variable import KNOWN_COORD_SYS
 from .geometry import standard_spatial_vars
 
 # Parameter classes and methods
-from .parameters.parameter_values import ParameterValues, scalarize_dict, arrayize_dict
+from .parameters.parameter_values import (
+    ParameterValues,
+    scalarize_dict,
+    arrayize_dict,
+    serialize_parameter_value,
+    deserialize_parameter_value,
+)
 from .parameters import constants
 from .parameters.geometric_parameters import geometric_parameters, GeometricParameters
 from .parameters.electrical_parameters import (

--- a/packages/pybamm/src/pybamm/parameters/parameter_values.py
+++ b/packages/pybamm/src/pybamm/parameters/parameter_values.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
@@ -356,8 +356,7 @@ class ParameterValues:
             raise TypeError("Input must be a filename (str or pathlib.Path) or a dict")
 
         for key, value in parameter_values_dict.items():
-            if isinstance(value, dict):
-                parameter_values_dict[key] = convert_symbol_from_json(value)
+            parameter_values_dict[key] = deserialize_parameter_value(value)
 
         return ParameterValues(parameter_values_dict)
 
@@ -1599,18 +1598,68 @@ def convert_symbols_in_dict(data_dict: dict | None = None) -> dict:
     return data_dict
 
 
+def serialize_parameter_value(name: str, value: Any) -> Any:
+    """
+    Serialize a single parameter value to a JSON-compatible representation.
+
+    The per-value dispatch used by :func:`convert_parameter_values_to_json`:
+    callables are first traced to a symbolic expression, everything else is
+    encoded directly.
+
+    Parameters
+    ----------
+    name : str
+        The parameter name (used only to name a traced callable).
+    value : Any
+        The parameter value: a callable, a :class:`pybamm.Symbol`, or a scalar.
+
+    Returns
+    -------
+    Any
+        The JSON representation: a dict for symbols, a scalar otherwise.
+    """
+    if callable(value):
+        return convert_symbol_to_json(
+            convert_function_to_symbolic_expression(value, name)
+        )
+    return convert_symbol_to_json(value)
+
+
+def deserialize_parameter_value(value: Any) -> Any:
+    """
+    Reconstruct a single parameter value from its JSON representation.
+
+    Inverse of :func:`serialize_parameter_value`: dicts are decoded back to
+    :class:`pybamm.Symbol` objects, scalars pass through unchanged.
+
+    Parameters
+    ----------
+    value : Any
+        The JSON representation of a single parameter value.
+
+    Returns
+    -------
+    Any
+        The reconstructed value.
+    """
+    if isinstance(value, dict):
+        return convert_symbol_from_json(value)
+    return value
+
+
 def convert_parameter_values_to_json(
-    parameter_values: ParameterValues, filename: str | None = None
+    parameter_values: Mapping[str, Any], filename: str | None = None
 ) -> dict:
     """
-    Convert a ParameterValues object to a JSON-serializable dictionary.
+    Convert a mapping of parameter values to a JSON-serializable dictionary.
 
     Optionally saves it to a file.
 
     Parameters
     ----------
-    parameter_values : ParameterValues
-        The ParameterValues object to convert.
+    parameter_values : Mapping
+        The parameter values to convert. Any mapping of ``{name: value}`` is
+        accepted, not only a :class:`ParameterValues` object.
     filename : str, optional
         The filename to save the JSON file to.
 
@@ -1628,15 +1677,9 @@ def convert_parameter_values_to_json(
     >>> convert_parameter_values_to_json(param, "params.json")
     {'Temperature [K]': 298.15}
     """
-    parameter_values_dict = {}
-
-    for k, v in parameter_values.items():
-        if callable(v):
-            parameter_values_dict[k] = convert_symbol_to_json(
-                convert_function_to_symbolic_expression(v, k)
-            )
-        else:
-            parameter_values_dict[k] = convert_symbol_to_json(v)
+    parameter_values_dict = {
+        k: serialize_parameter_value(k, v) for k, v in parameter_values.items()
+    }
 
     if filename is not None:
         with open(filename, "w") as f:

--- a/packages/pybamm/tests/unit/test_parameters/test_parameter_values_serialisation.py
+++ b/packages/pybamm/tests/unit/test_parameters/test_parameter_values_serialisation.py
@@ -703,6 +703,62 @@ class TestConvertParameterValuesToJson:
         assert "p1" in data
         assert "p2" in data
 
+    def test_accepts_plain_mapping(self):
+        """A raw dict serializes identically to a ParameterValues wrapper."""
+
+        def my_function(x):
+            return x * 2
+
+        raw = {"p1": 42, "p2": my_function}
+        from_dict = convert_parameter_values_to_json(raw)
+        from_pv = convert_parameter_values_to_json(pybamm.ParameterValues(raw))
+        assert from_dict == from_pv
+
+
+class TestSerializeParameterValue:
+    """Per-value dispatch exposed publicly (fix for raw-mapping serialisation)."""
+
+    def test_roundtrip_scalar(self):
+        wire = pybamm.serialize_parameter_value("a", 3.14)
+        assert pybamm.deserialize_parameter_value(wire) == 3.14
+
+    def test_roundtrip_symbol(self):
+        expr = 1 + pybamm.Parameter("k")
+        wire = pybamm.serialize_parameter_value("expr", expr)
+        restored = pybamm.deserialize_parameter_value(wire)
+        assert restored == expr
+
+    def test_roundtrip_callable(self):
+        def double(x):
+            return 2 * x
+
+        wire = pybamm.serialize_parameter_value("f", double)
+        restored = pybamm.deserialize_parameter_value(wire)
+        pv = pybamm.ParameterValues({"f": restored})
+        fp = pybamm.FunctionParameter("f", {"x": pybamm.Scalar(5)})
+        assert pv.evaluate(fp) == 10.0
+
+    def test_roundtrip_interpolant(self):
+        x_data = np.linspace(0, 1, 20)
+        y_data = 2 * x_data**2
+
+        def ocp(sto):
+            return pybamm.Interpolant(x_data, y_data, sto, name="ocp")
+
+        wire = pybamm.serialize_parameter_value("OCP [V]", ocp)
+        restored = pybamm.deserialize_parameter_value(wire)
+        pv_orig = pybamm.ParameterValues({"OCP [V]": ocp})
+        pv = pybamm.ParameterValues({"OCP [V]": restored})
+        fp = pybamm.FunctionParameter("OCP [V]", {"sto": pybamm.Scalar(0.5)})
+        np.testing.assert_array_equal(pv.evaluate(fp), pv_orig.evaluate(fp))
+
+    def test_matches_convert_parameter_values_to_json(self):
+        """Per-value dispatch agrees with the whole-mapping entry point."""
+        pv = pybamm.ParameterValues({"a": 42, "expr": 1 + pybamm.Parameter("k")})
+        whole = convert_parameter_values_to_json(pv)
+        per_value = {k: pybamm.serialize_parameter_value(k, v) for k, v in pv.items()}
+        assert per_value == whole
+
 
 # ------------------------------------------------------------------ #
 # Stress tests: every callable across every parameter set


### PR DESCRIPTION
## Description

PyBaMM can currently serialise a parameter set only as a whole `ParameterValues` object: `convert_parameter_values_to_json` iterates the object's items and dispatches per value (callables are traced to a symbolic expression, everything else is encoded directly). The per-value dispatch and a raw-mapping entry point are not public, so serialising a plain `{name: value}` mapping (or a single value) means either re-implementing the dispatch or constructing a throwaway `ParameterValues` (which has construction side effects and cannot hold arbitrary values).

This PR exposes the dispatch:

- New public `pybamm.serialize_parameter_value(name, value)` and `pybamm.deserialize_parameter_value(value)` — the per-value serialise/deserialise dispatch, usable on a single value or a raw mapping.
- `convert_parameter_values_to_json` now accepts any `Mapping` (not just a `ParameterValues`); it only ever needs `.items()`, so `Mapping` is the honest type.
- `ParameterValues.from_json` now delegates its per-value work to `deserialize_parameter_value`, so the dispatch lives in one place (mirroring how `convert_parameter_values_to_json` delegates to `serialize_parameter_value`).

Behaviour is unchanged for existing callers — the new helpers reproduce the exact branch logic that was previously inlined.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Tests

Added round-trip tests for the new helpers (scalar/symbol/callable/interpolant), raw-mapping-vs-`ParameterValues` parity for `convert_parameter_values_to_json`, and per-value-vs-whole-mapping agreement. Full serialisation suite (70 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)