### PR TITLE
Revert "voltage as a state" default to "false"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Breaking changes
+
+- Reverted the "voltage as a state" default back to "false", undoing the [v26.7.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.0.0) change to "true". Promoting voltage to an algebraic state turns SPM/SPMe into DAEs and places voltage under solver error control, which caused IDAKLU error-test failures on solves of discontinuous (pulsed) current profiles at the default tolerances, and lowered voltage-output accuracy. The option remains available (`{"voltage as a state": "true"}`) and is still enabled automatically for the "explicit power" and "explicit resistance" operating modes. ([#5670](https://github.com/pybamm-team/PyBaMM/pull/5670))
+
 # [v26.7.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.0.0) - 2026-07-21
 
 ## Breaking changes

--- a/docs/source/examples/notebooks/change-settings.ipynb
+++ b/docs/source/examples/notebooks/change-settings.ipynb
@@ -620,7 +620,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To change this, simply create a new solver using one of the available classes and use it to solve your discretised model. Note that the default SPM model is a DAE (differential-algebraic equation) system, so you need a DAE-capable solver such as the default `IDAKLUSolver`."
+    "To change this, simply create a new solver using one of the available classes and use it to solve your discretised model. The default `IDAKLUSolver` is recommended for essentially all use cases."
    ]
   },
   {

--- a/packages/pybamm/src/pybamm/models/full_battery_models/base_battery_model.py
+++ b/packages/pybamm/src/pybamm/models/full_battery_models/base_battery_model.py
@@ -299,20 +299,16 @@ class BatteryModelOptions(pybamm.FuzzyDict):
                 "true".
             * "voltage as a state" : str
                 Whether to promote voltage to an algebraic state variable.
-                Can be "true" (default) or "false". When "true", the model is
-                a DAE and requires a DAE-capable solver (e.g. the default
+                Can be "false" (default) or "true", unless the operating mode
+                is "explicit power" or "explicit resistance", in which case it
+                is automatically set to "true". When "true", the model is a DAE
+                and requires a DAE-capable solver (e.g. the default
                 IDAKLUSolver). When "false", voltage is computed as an
-                expression; the "explicit power" and "explicit resistance"
-                operating modes require "true" and raise an error otherwise.
-                Note that setting this to "false" only removes the voltage
-                algebraic equation; SPM/SPMe with ``surface form="false"``
-                become pure ODE models, but DFN retains other algebraic states
-                (electrode/electrolyte potentials) regardless of this option.
-                Continuous solves of rapidly alternating current profiles
-                (e.g. interpolant drive cycles) can be slower with the
-                additional algebraic state; setting this to "false" (with
-                ``surface form="false"`` for SPM/SPMe) restores the previous
-                behaviour for such workloads.
+                expression. Note that setting this to "false" only removes the
+                voltage algebraic equation; SPM/SPMe with ``surface
+                form="false"`` become pure ODE models, but DFN retains other
+                algebraic states (electrode/electrolyte potentials) regardless
+                of this option.
             * "working electrode" : str
                 Can be "both" (default) for a standard battery or "positive" for a
                 half-cell where the negative electrode is replaced with a lithium metal
@@ -480,7 +476,7 @@ class BatteryModelOptions(pybamm.FuzzyDict):
             "thermal": "isothermal",
             "total interfacial current density as a state": "false",
             "transport efficiency": "Bruggeman",
-            "voltage as a state": "true",
+            "voltage as a state": "false",
             "working electrode": "both",
             "x-average side reactions": "false",
             "use lumped thermal capacity": "false",

--- a/packages/pybamm/tests/integration/test_solvers/test_casadi_mode.py
+++ b/packages/pybamm/tests/integration/test_solvers/test_casadi_mode.py
@@ -49,15 +49,14 @@ class TestCasadiModes:
                 solutions[0][var].data, solutions[1][var].data, rtol=1e-6, atol=1e-6
             )
 
-    def test_casadi_fast_matches_safe_legacy_ode(self):
-        # numerical equivalence of "fast" and "safe" on the legacy pure-ODE
-        # configuration, solved over a fixed window ("fast" ignores events)
-        legacy = {"voltage as a state": "false", "surface form": "false"}
+    def test_casadi_fast_matches_safe_default_ode(self):
+        # Numerical equivalence of "fast" and "safe" on the default pure-ODE
+        # configuration, solved over a fixed window ("fast" ignores events).
         t_eval = np.linspace(0, 3600, 100)
 
         solutions = []
         for mode in ["safe", "fast"]:
-            model = pybamm.lithium_ion.SPM(legacy)
+            model = pybamm.lithium_ion.SPM()
             solver = pybamm.CasadiSolver(mode=mode, atol=1e-6, rtol=1e-6)
             sim = pybamm.Simulation(model, solver=solver)
             solutions.append(sim.solve(t_eval))

--- a/packages/pybamm/tests/integration/test_voltage_as_state.py
+++ b/packages/pybamm/tests/integration/test_voltage_as_state.py
@@ -1,9 +1,8 @@
 """Integration tests for the 'voltage as a state' option.
 
-Voltage is promoted to an algebraic state by default; these tests cover the
-default behavior, the 'false' escape hatch that restores pure-ODE SPM/SPMe,
-the conditional surface-form defaults, and the explicit power/resistance
-operating modes.
+Voltage promotion is registered centrally in BaseBatteryModel._build_model;
+these tests cover the opt-in behavior, the conditional defaults, and the
+explicit power/resistance operating modes that require it.
 """
 
 import numpy as np
@@ -11,7 +10,7 @@ import pytest
 
 import pybamm
 
-LEGACY_OPTIONS = {"voltage as a state": "false", "surface form": "false"}
+OPT_IN = {"voltage as a state": "true"}
 LI_ION_MODELS = [
     pybamm.lithium_ion.SPM,
     pybamm.lithium_ion.SPMe,
@@ -20,12 +19,12 @@ LI_ION_MODELS = [
 REDUCED_MODELS = [pybamm.lithium_ion.SPM, pybamm.lithium_ion.SPMe]
 
 
-class TestVoltageAsStateDefault:
-    """By default, voltage is an algebraic state variable."""
+class TestVoltageAsStateOptIn:
+    """With the option enabled, voltage is an algebraic state variable."""
 
     @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
     def test_voltage_is_algebraic_state(self, model_cls):
-        model = model_cls()
+        model = model_cls(options=OPT_IN)
         algebraic_var_names = [var.name for var in model.algebraic.keys()]
         assert "Voltage [V]" in algebraic_var_names
         assert isinstance(model.variables["Voltage [V]"], pybamm.Variable)
@@ -33,7 +32,7 @@ class TestVoltageAsStateDefault:
     @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
     def test_residuals_reference_variable(self, model_cls):
         """Algebraic residuals should contain the Variable, not the expression."""
-        model = model_cls()
+        model = model_cls(options=OPT_IN)
         voltage_eqs = [
             expr for var, expr in model.algebraic.items() if var.name == "Voltage [V]"
         ]
@@ -47,7 +46,7 @@ class TestVoltageAsStateDefault:
 
     @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
     def test_voltage_expression_matches_state(self, model_cls):
-        model = model_cls()
+        model = model_cls(options=OPT_IN)
         sol = pybamm.Simulation(model).solve([0, 3600])
 
         v = sol["Voltage [V]"].entries
@@ -55,23 +54,24 @@ class TestVoltageAsStateDefault:
         np.testing.assert_allclose(v, v_expr, rtol=1e-3, atol=1e-3)
 
     @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
-    def test_false_excludes_algebraic_voltage(self, model_cls):
-        """With the option disabled, voltage remains a computed expression."""
-        model = model_cls(options=LEGACY_OPTIONS)
+    def test_default_voltage_is_expression(self, model_cls):
+        """Without the option, voltage remains a computed expression."""
+        model = model_cls()
         algebraic_var_names = [var.name for var in model.algebraic.keys()]
         assert "Voltage [V]" not in algebraic_var_names
         assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)
 
-    def test_dfn_false_still_has_algebraic_states(self):
-        """DFN with the option disabled retains other algebraic states
-        (electrode/electrolyte potentials), so it is not a pure ODE model."""
-        model = pybamm.lithium_ion.DFN(options=LEGACY_OPTIONS)
-        assert len(model.algebraic) > 0
-        algebraic_var_names = [var.name for var in model.algebraic.keys()]
-        assert "Voltage [V]" not in algebraic_var_names
+    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
+    def test_opt_in_solvable_by_casadi_safe(self, model_cls):
+        model = model_cls(options=OPT_IN)
+        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="safe"))
+        sol = sim.solve([0, 3600])
+        v = sol["Voltage [V]"].entries
+        assert v[0] > v[-1]  # voltage decreases during discharge
 
-    def test_dfn_false_rejects_scipy(self):
-        model = pybamm.lithium_ion.DFN(options=LEGACY_OPTIONS)
+    def test_opt_in_rejects_scipy(self):
+        """Promoting voltage makes SPM a DAE, which ODE solvers reject."""
+        model = pybamm.lithium_ion.SPM(options=OPT_IN)
         sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
         with pytest.raises(pybamm.SolverError, match="Cannot use ODE solver"):
             sim.solve([0, 3600])
@@ -118,11 +118,9 @@ class TestSurfaceFormConditionalDefaults:
 
     @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
     def test_plain_models_keep_false_surface_form(self, model_cls):
-        # Plain SPM/SPMe keep the explicit-current closure; voltage as a
-        # state is the only algebraic equation
         model = model_cls()
         assert model.options["surface form"] == "false"
-        assert len(model.algebraic) == 1
+        assert len(model.algebraic) == 0
 
     @pytest.mark.parametrize(
         "options",
@@ -154,67 +152,3 @@ class TestBasicModelsVoltageExpression:
         assert "Voltage expression [V]" in model.variables
         assert "Voltage [V]" in model.variables
         assert not isinstance(model.variables["Voltage [V]"], pybamm.Variable)
-
-
-class TestLegacyOdeBehavior:
-    """voltage-as-a-state='false' + surface form='false' remains the
-    supported route to pure-ODE SPM/SPMe for ODE-only solvers."""
-
-    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
-    def test_legacy_solvable_by_scipy(self, model_cls):
-        model = model_cls(options=LEGACY_OPTIONS)
-        sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
-        sol = sim.solve([0, 3600])
-        v = sol["Voltage [V]"].entries
-        assert v[0] > v[-1]  # voltage decreases during discharge
-
-    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
-    def test_legacy_solvable_by_casadi_safe(self, model_cls):
-        model = model_cls(options=LEGACY_OPTIONS)
-        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="safe"))
-        sol = sim.solve([0, 3600])
-        assert sol.termination == "final time"
-
-    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
-    def test_legacy_solvable_by_casadi_fast(self, model_cls):
-        model = model_cls(options=LEGACY_OPTIONS)
-        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="fast"))
-        sol = sim.solve([0, 3600])
-        assert sol.termination == "final time"
-
-
-class TestDefaultDaeBehavior:
-    """Default SPM/SPMe (voltage as an algebraic state) works with
-    DAE-capable solvers and rejects ODE-only solvers."""
-
-    @pytest.mark.parametrize("model_cls", LI_ION_MODELS)
-    def test_default_solvable_by_idaklu(self, model_cls):
-        model = model_cls()
-        sim = pybamm.Simulation(model, solver=pybamm.IDAKLUSolver())
-        sol = sim.solve([0, 3600])
-        v = sol["Voltage [V]"].entries
-        assert v[0] > v[-1]
-
-    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
-    def test_default_solvable_by_casadi_safe(self, model_cls):
-        model = model_cls()
-        sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="safe"))
-        sol = sim.solve([0, 3600])
-        assert sol.termination == "final time"
-
-    @pytest.mark.skipif(not pybamm.has_jax(), reason="jax or jaxlib is not installed")
-    def test_default_solvable_by_jax_bdf(self):
-        model = pybamm.lithium_ion.SPM()
-        model.convert_to_format = "jax"
-        model.events = []  # JaxSolver does not support terminate events
-        sim = pybamm.Simulation(model, solver=pybamm.JaxSolver(method="BDF"))
-        sol = sim.solve(np.linspace(0, 3600, 100))
-        v = sol["Voltage [V]"].entries
-        assert v[0] > v[-1]  # voltage decreases during discharge
-
-    @pytest.mark.parametrize("model_cls", REDUCED_MODELS)
-    def test_default_rejects_scipy(self, model_cls):
-        model = model_cls()
-        sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
-        with pytest.raises(pybamm.SolverError, match="Cannot use ODE solver"):
-            sim.solve([0, 3600])

--- a/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
+++ b/packages/pybamm/tests/unit/test_experiments/test_simulation_with_experiment.py
@@ -728,7 +728,7 @@ class TestSimulationExperiment:
         # With "voltage as a state" the algebraic block also holds a "Voltage [V]" row,
         # which is physics and must NOT be picked up as a switch row.
         sim = pybamm.Simulation(
-            pybamm.lithium_ion.SPM(),
+            pybamm.lithium_ion.SPM({"voltage as a state": "true"}),
             experiment=pybamm.Experiment(
                 [("Charge at 1 A for 1 min", "Hold at 4.1 V for 1 min")]
             ),

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_base_battery_model.py
@@ -53,7 +53,7 @@ PRINT_OPTIONS_OUTPUT = """\
 'thermal': 'x-full' (possible: ['isothermal', 'lumped', 'x-lumped', 'x-full'])
 'total interfacial current density as a state': 'false' (possible: ['false', 'true'])
 'transport efficiency': 'Bruggeman' (possible: ['Bruggeman', 'ordered packing', 'hyperbola of revolution', 'overlapping spheres', 'tortuosity factor', 'random overlapping cylinders', 'heterogeneous catalyst', 'cation-exchange membrane'])
-'voltage as a state': 'true' (possible: ['false', 'true'])
+'voltage as a state': 'false' (possible: ['false', 'true'])
 'working electrode': 'both' (possible: ['both', 'positive'])
 'x-average side reactions': 'false' (possible: ['false', 'true'])
 'use lumped thermal capacity': 'false' (possible: ['false', 'true'])
@@ -686,9 +686,8 @@ class TestOptions:
     def test_default_options_independent_of_possible_options_order(self):
         """Defaults should be set explicitly, not derived from possible_options[0]."""
         options = pybamm.BatteryModelOptions({})
-        # voltage as a state defaults to "true" although possible_options
-        # lists "false" first: defaults are explicit, not derived from order
-        assert options["voltage as a state"] == "true"
+        # defaults are set explicitly, not derived from list order
+        assert options["voltage as a state"] == "false"
         # surface form: possible_options lists "false" first, default is "false"
         assert options["surface form"] == "false"
 

--- a/packages/pybamm/tests/unit/test_solvers/test_casadi_solver.py
+++ b/packages/pybamm/tests/unit/test_solvers/test_casadi_solver.py
@@ -662,9 +662,9 @@ class TestCasadiSolver:
             solver.solve(model, t_eval, t_interp=t_interp)
 
     def test_casadi_fast_solves_dae_without_warning(self):
-        """CasadiSolver(mode='fast') solves the default DAE model silently;
-        integrator failures carry an actionable hint (see test_solver_error)."""
-        model = pybamm.lithium_ion.SPM()
+        """CasadiSolver(mode='fast') solves a DAE model silently; integrator
+        failures carry an actionable hint instead (see test_solver_error)."""
+        model = pybamm.lithium_ion.SPM({"voltage as a state": "true"})
         sim = pybamm.Simulation(model, solver=pybamm.CasadiSolver(mode="fast"))
         with warnings.catch_warnings():
             warnings.simplefilter("error", pybamm.SolverWarning)

--- a/packages/pybamm/tests/unit/test_solvers/test_scipy_solver.py
+++ b/packages/pybamm/tests/unit/test_solvers/test_scipy_solver.py
@@ -24,8 +24,8 @@ class TestScipySolver:
             solver.solve(model, [0, 1], inputs={"p": 1}, calculate_sensitivities=True)
 
     def test_scipy_rejects_dae_spm(self):
-        """ScipySolver is an ODE solver and cannot solve the default SPM (now a DAE)."""
-        model = pybamm.lithium_ion.SPM()
+        """ScipySolver is an ODE solver and cannot solve a DAE model."""
+        model = pybamm.lithium_ion.SPM(options={"voltage as a state": "true"})
         sim = pybamm.Simulation(model, solver=pybamm.ScipySolver())
         with pytest.raises(
             pybamm.SolverError,


### PR DESCRIPTION
# Description

The v26.7.0.0 default of "true" promotes voltage to an algebraic state, turning SPM/SPMe into DAEs and placing voltage under IDAKLU error control. This causes error-test failures (IDA_ERR_FAIL) on solves of discontinuous (pulsed) current profiles at the default tolerances, and lowers voltage-output accuracy.

Revert the default to "false". The option remains available and is still auto-enabled for the "explicit power" and "explicit resistance" operating modes. Tests that assert DAE-specific behaviour now opt in explicitly.


Fixes #5669 

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
