### PR TITLE
Speed up the coverage CI job with the sys.monitoring core

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -105,6 +105,8 @@ def install_locked(session, *, extras=None, groups=None):
 def run_coverage(session):
     """Run the coverage tests and generate an XML report."""
     set_environment_variables(PYBAMM_ENV, session=session)
+    # sys.monitoring core (Python 3.12+) slashes coverage tracing overhead.
+    session.env["COVERAGE_CORE"] = "sysmon"
     install_locked(session, extras=["all", "jax"], groups=["dev"])
     # Using plugin here since coverage runs unit tests on linux with latest python version.
     if "CI" in os.environ:


### PR DESCRIPTION
The `coverage` nox session runs the same unit suite as `unit` but takes roughly 2x as long. The gap is coverage.py's default C trace core, which fires on nearly every executed line and heavily taxes PyBaMM's pure-Python symbolic tree construction.

Set `COVERAGE_CORE=sysmon` in the coverage session so it uses the `sys.monitoring` core (PEP 669, Python 3.12+), which has far lower per-line overhead. CI runs this job on Python 3.13 and locally via `nox -s coverage`, so both benefit from one source of truth.

Verified locally: sysmon is the active core, tests pass, and coverage totals are identical under xdist vs serial (worker data combines correctly).