### PR TITLE
Release pybamm 26.7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+# [v26.7.1.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.1.0) - 2026-07-22
+
 ## Breaking changes
 
 - Reverted the "voltage as a state" default back to "false", undoing the [v26.7.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.0.0) change to "true". Promoting voltage to an algebraic state turns SPM/SPMe into DAEs and places voltage under solver error control, which caused IDAKLU error-test failures on solves of discontinuous (pulsed) current profiles at the default tolerances, and lowered voltage-output accuracy. The option remains available (`{"voltage as a state": "true"}`) and is still enabled automatically for the "explicit power" and "explicit resistance" operating modes. ([#5670](https://github.com/pybamm-team/PyBaMM/pull/5670))

--- a/packages/pybamm/CITATION.cff
+++ b/packages/pybamm/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.7.0.0"
+version: "26.7.1.0"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"


### PR DESCRIPTION
Second feature release of July 2026 (`pybamm-v26.7.1.0`), following `RELEASE.md`.

Bumps `CITATION.cff` to `26.7.1.0` and moves the `[Unreleased]` changelog entries under a dated `v26.7.1.0` heading.

## Breaking changes

- Reverted the "voltage as a state" default back to "false" ([#5670](https://github.com/pybamm-team/PyBaMM/pull/5670)). This undoes the 26.7.0.0 default change, which turned SPM/SPMe into DAEs and caused IDAKLU error-test failures on discontinuous (pulsed) current profiles. Required regression fix; the option remains available and stays on automatically for "explicit power"/"explicit resistance" modes. Per policy this break in a non-`.0` feature release is the documented "absolutely required" exception, justified in the changelog entry.

## Features

- Exposed the per-value parameter serialisation dispatch publicly (`pybamm.serialize_parameter_value`/`deserialize_parameter_value`), and `convert_parameter_values_to_json` now accepts any `Mapping` ([#5663](https://github.com/pybamm-team/PyBaMM/pull/5663)).

No `pybammsolvers` bump: the dependency pin (`>=0.9.0`) is unchanged and 0.9.0 is already on PyPI.

After merge, a `pybamm-v26.7.1.0` GitHub release will be tagged from `main` to trigger `publish_pypi.yml`.
