### PR TITLE
fix: two arguments silently shadowed by loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Bug fixes
+
+- `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
+- `pybamm.citations.register` now names the citation the caller passed in when a BibTeX string fails to parse, instead of whichever entry the parser had reached. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
+
 # [v26.7.1.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.1.0) - 2026-07-22
 
 ## Breaking changes

--- a/packages/pybamm/src/pybamm/batch_study.py
+++ b/packages/pybamm/src/pybamm/batch_study.py
@@ -136,10 +136,12 @@ class BatchStudy:
             submesh_type,
             var_pt,
             spatial_method,
-            solver,
+            solver_input,
             output_variable,
             C_rate,
         ) in iter_func(self.models.values(), *inp_values):
+            # a solver from `self.solvers` wins; otherwise fall back to the argument
+            sim_solver = solver if solver_input is None else solver_input
             sim = pybamm.Simulation(
                 model,
                 experiment=experiment,
@@ -148,7 +150,7 @@ class BatchStudy:
                 submesh_types=submesh_type,
                 var_pts=var_pt,
                 spatial_methods=spatial_method,
-                solver=solver,
+                solver=sim_solver,
                 output_variables=output_variable,
                 C_rate=C_rate,
             )
@@ -158,7 +160,7 @@ class BatchStudy:
             for _ in range(self.repeats):
                 sol = sim.solve(
                     t_eval,
-                    solver,
+                    sim_solver,
                     save_at_cycles,
                     calc_esoh,
                     starting_solution,

--- a/packages/pybamm/src/pybamm/citations.py
+++ b/packages/pybamm/src/pybamm/citations.py
@@ -152,9 +152,9 @@ class Citations:
                     raise PybtexError("no entries found")
 
                 # Add and register all citations
-                for key, entry in bib_data.entries.items():
-                    self._add_citation(key, entry)
-                    self._papers_to_cite.add(key)
+                for entry_key, entry in bib_data.entries.items():
+                    self._add_citation(entry_key, entry)
+                    self._papers_to_cite.add(entry_key)
                 return
             except PybtexError as error:
                 raise KeyError(

--- a/packages/pybamm/tests/unit/test_batch_study.py
+++ b/packages/pybamm/tests/unit/test_batch_study.py
@@ -90,6 +90,28 @@ class TestBatchStudy:
             ]
             assert output_experiment in experiments_list
 
+    def test_solve_honours_solver_argument(self):
+        spm = pybamm.lithium_ion.SPM()
+        spm_uniform = pybamm.lithium_ion.SPM({"particle": "uniform profile"})
+        argument_solver = pybamm.IDAKLUSolver(rtol=1e-7)
+
+        # with no per-simulation solvers, the argument is used
+        bs = pybamm.BatchStudy(models={"SPM": spm, "SPM uniform": spm_uniform})
+        bs.solve(t_eval=[0, 3600], solver=argument_solver)
+        assert len(bs.sims) == 2
+        for sim in bs.sims:
+            assert sim.solver is argument_solver
+
+        # a solver from `solvers=` still takes precedence over the argument
+        study_solver = pybamm.IDAKLUSolver(rtol=1e-9)
+        bs = pybamm.BatchStudy(
+            models={"SPM": spm, "SPM uniform": spm_uniform},
+            solvers={"idaklu0": study_solver, "idaklu1": study_solver},
+        )
+        bs.solve(t_eval=[0, 3600], solver=argument_solver)
+        for sim in bs.sims:
+            assert sim.solver is study_solver
+
     def test_create_gif(self, tmp_path):
         bs = pybamm.BatchStudy({"spm": pybamm.lithium_ion.SPM()})
         with pytest.raises(

--- a/packages/pybamm/tests/unit/test_citations.py
+++ b/packages/pybamm/tests/unit/test_citations.py
@@ -73,11 +73,11 @@ class TestCitations:
 
         # Overwrite NotACitation
         old_citation = pybamm.citations._all_citations["NotACitation"]
+        new_citation = r"@article{NotACitation, title = {A New Title}}"
+        pybamm.citations.register(new_citation)
+        # the overwrite warning comes from parsing, not from registering
         with pytest.warns(Warning):
-            pybamm.citations.register(r"@article{NotACitation, title = {A New Title}}")
-            pybamm.citations._parse_citation(
-                r"@article{NotACitation, title = {A New Title}}"
-            )
+            pybamm.citations._parse_citation(new_citation)
         assert "NotACitation" in pybamm.citations._papers_to_cite
         assert pybamm.citations._all_citations["NotACitation"] != old_citation
 


### PR DESCRIPTION
# Description

Two places bind a loop variable to the same name as an enclosing argument, so the argument is dropped before it is ever read. Both were surfaced by ruff's PLR1704, but neither depends on the lint bump, so they are split out to be reviewed on their own.

`BatchStudy.solve` unpacked `self.solvers` into `solver`, shadowing its own `solver` argument. A caller-supplied solver was silently ignored and `Simulation` fell back to the model default. A solver from `BatchStudy(solvers=...)` still takes precedence; the argument is now the fallback. Covered by a new test that fails on `main`.

`Citations._parse_citation` reused `key` for its loop variable, so a `KeyError` from a multi-entry BibTeX string named whichever entry the loop had reached rather than the citation the caller passed in.

First of three stacked PRs splitting up #5676. The ruff bump follows on top of this one.

Fixes # (issue)

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
