### PR TITLE
refactor: catch specific exceptions instead of blind `except Exception`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
 - `pybamm.citations.register` now names the citation the caller passed in when a BibTeX string fails to parse, instead of whichever entry the parser had reached. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
+- Deserialising a parameter set whose interpolant specification is invalid now logs a warning naming the offending parameter, instead of printing the bare exception to stdout with no indication of which parameter fell back to zero. ([#5679](https://github.com/pybamm-team/PyBaMM/pull/5679))
+- A user-specified boundary tag that is absent from a mesh file now raises `GeometryError` instead of degrading to a warning and a mesh with no boundary groups. ([#5679](https://github.com/pybamm-team/PyBaMM/pull/5679))
 
 # [v26.7.1.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.7.1.0) - 2026-07-22
 

--- a/docs/source/examples/notebooks/performance/02-input-parameters.ipynb
+++ b/docs/source/examples/notebooks/performance/02-input-parameters.ipynb
@@ -266,7 +266,7 @@
     "        sim = pybamm.Simulation(model, parameter_values=params)\n",
     "        try:\n",
     "            sim.solve([0, 3600], inputs={param: original_param})\n",
-    "        except Exception as e:\n",
+    "        except Exception as e:  # noqa: BLE001 - report every failing parameter\n",
     "            print(f\"Failed for parameter {param}. Error was {e}\")\n",
     "            tb = traceback.format_exc()\n",
     "            print(tb)"

--- a/packages/pybamm/src/pybamm/citations.py
+++ b/packages/pybamm/src/pybamm/citations.py
@@ -263,7 +263,7 @@ class Citations:
 def print_citations(filename=None, output_format="text", verbose=False):
     """See :meth:`Citations.print`"""
     if verbose and filename is not None:  # pragma: no cover
-        raise Exception(
+        raise ValueError(
             "Verbose output is available only for the terminal and not for printing to files",
         )
     pybamm.citations.print(filename, output_format, verbose)

--- a/packages/pybamm/src/pybamm/codegen/compilation.py
+++ b/packages/pybamm/src/pybamm/codegen/compilation.py
@@ -90,7 +90,7 @@ def aot_compile(fn_or_fns, **kwargs):
     fns = [fn_or_fns] if is_single else list(fn_or_fns)
     try:
         out = _aot_compile(fns, **kwargs)
-    except Exception as e:
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as e:
         names = ", ".join(fn.name() for fn in fns)
         logger.warning(f"Failed to compile [{names}] with error: {e}")
         out = list(fns)

--- a/packages/pybamm/src/pybamm/config.py
+++ b/packages/pybamm/src/pybamm/config.py
@@ -87,9 +87,8 @@ def ask_user_opt_in(timeout=10):
                 input("Do you want to enable telemetry? (Y/n): ").strip().lower()
             )
             answer.append(user_input)
-        except Exception:
-            # Handle any input errors
-            pass
+        except (EOFError, OSError) as err:
+            pybamm.logger.debug(f"Could not read telemetry prompt response: {err}")
 
     time_start = time.time()
 

--- a/packages/pybamm/src/pybamm/expression_tree/symbol.py
+++ b/packages/pybamm/src/pybamm/expression_tree/symbol.py
@@ -1238,5 +1238,5 @@ def convert_to_symbol(value) -> Symbol:
     try:
         # Try to convert the input to a pybamm.Symbol
         return value * pybamm.Scalar(1)
-    except Exception:
+    except (NotImplementedError, TypeError, ValueError):
         raise ValueError("Input cannot be converted to a `pybamm.Symbol`") from None

--- a/packages/pybamm/src/pybamm/meshes/scikit_fem_submeshes_3d.py
+++ b/packages/pybamm/src/pybamm/meshes/scikit_fem_submeshes_3d.py
@@ -642,7 +642,7 @@ class ScikitFemSubMesh3D(pybamm.SubMesh):
                                 f"No boundary facets found for '{name}' with tag {tag}"
                             )
 
-        except Exception as e:
+        except (KeyError, IndexError, AttributeError, TypeError, ValueError) as e:
             pybamm.logger.warning(
                 f"Could not extract boundary information from '{file_path}': {e}"
             )

--- a/packages/pybamm/src/pybamm/models/base_model.py
+++ b/packages/pybamm/src/pybamm/models/base_model.py
@@ -2287,15 +2287,15 @@ class BaseModel:
                     model_config["geometry"] = Serialise.serialise_custom_geometry(
                         self.default_geometry
                     )
-                except Exception:
-                    pass
+                except (pybamm.SerialisationError, ValueError) as err:
+                    pybamm.logger.debug(f"Could not serialise default geometry: {err}")
             if hasattr(self, "default_var_pts"):
                 try:
                     model_config["var_pts"] = Serialise.serialise_var_pts(
                         self.default_var_pts
                     )
-                except Exception:
-                    pass
+                except (pybamm.SerialisationError, ValueError) as err:
+                    pybamm.logger.debug(f"Could not serialise default var_pts: {err}")
             if hasattr(self, "default_spatial_methods"):
                 try:
                     model_config["spatial_methods"] = (
@@ -2303,15 +2303,19 @@ class BaseModel:
                             self.default_spatial_methods
                         )
                     )
-                except Exception:
-                    pass
+                except (pybamm.SerialisationError, ValueError) as err:
+                    pybamm.logger.debug(
+                        f"Could not serialise default spatial methods: {err}"
+                    )
             if hasattr(self, "default_submesh_types"):
                 try:
                     model_config["submesh_types"] = Serialise.serialise_submesh_types(
                         self.default_submesh_types
                     )
-                except Exception:
-                    pass
+                except (pybamm.SerialisationError, ValueError) as err:
+                    pybamm.logger.debug(
+                        f"Could not serialise default submesh types: {err}"
+                    )
 
         if filename is not None:
             self._write_json_to_file(model_config, filename, label="model config")

--- a/packages/pybamm/src/pybamm/parameters/parameter_values.py
+++ b/packages/pybamm/src/pybamm/parameters/parameter_values.py
@@ -1571,11 +1571,14 @@ def convert_symbols_in_dict(data_dict: dict | None = None) -> dict:
             x = value.get("x", [])
             y = value.get("y", [])
 
-            def interpolant_function(sto, x=x, y=y, interpolator=interpolator):
+            def interpolant_function(sto, x=x, y=y, interpolator=interpolator, key=key):
                 try:
                     return pybamm.Interpolant(x, y, sto, interpolator=interpolator)
-                except Exception as e:
-                    print(e)
+                except (ValueError, TypeError, IndexError) as e:
+                    pybamm.logger.warning(
+                        f"Could not build interpolant for '{key}', "
+                        f"falling back to zero: {e}"
+                    )
                     return pybamm.Scalar(0)
 
             data_dict[key] = interpolant_function

--- a/packages/pybamm/src/pybamm/simulation/base_simulation.py
+++ b/packages/pybamm/src/pybamm/simulation/base_simulation.py
@@ -210,7 +210,7 @@ class BaseSimulation:
             evals = pybamm.lithium_ion.compute_esoh_fingerprint(
                 pv, self._model.param, self._model.options, inputs
             )
-        except Exception:
+        except (KeyError, AttributeError, TypeError, ValueError, pybamm.ModelError):
             evals = self._normalize_inputs(inputs) if inputs else ()
 
         return (initial_soc, direction, pv_fp, evals)

--- a/packages/pybamm/src/pybamm/solvers/idaklu_jax.py
+++ b/packages/pybamm/src/pybamm/solvers/idaklu_jax.py
@@ -1004,8 +1004,8 @@ class IDAKLUJax:
                 out = [f_vjp(y_bars, invar, yt, *inputs) for yt in t]
                 return jnp.stack(out), 0
             else:
-                raise Exception(
-                    "Batch mode not supported for batch_axes = ", batch_axes
+                raise pybamm.SolverError(
+                    f"Batch mode not supported for batch_axes = {batch_axes}"
                 )  # pragma: no cover
 
         batching.primitive_batchers[f_vjp_p] = f_vjp_batch

--- a/packages/pybamm/tests/unit/test_meshes/test_scikit_fem_submesh_3d.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_scikit_fem_submesh_3d.py
@@ -290,6 +290,18 @@ class TestUserSuppliedMesh:
                 VALID_MESH_FILE, {}, {}, domain_tag_name="bad_tag"
             )
 
+    def test_bad_user_boundary_tag_name_error(self):
+        with pytest.raises(
+            pybamm.GeometryError,
+            match=r"User-specified boundary tag name 'bad_tag' not found",
+        ):
+            pybamm.ScikitFemSubMesh3D.load_mesh_from_file(
+                VALID_MESH_FILE,
+                {"z_min": 1},
+                {"current collector": 5},
+                boundary_tag_name="bad_tag",
+            )
+
     def test_no_integer_tag_error(self):
         with pytest.raises(
             pybamm.GeometryError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,11 +87,6 @@ ignore = [
     "DTZ",     # Experiment step `start_time`s are naive wall-clock by design
     "N999",    # Parameter-set modules are named after the set (e.g. Chen2020.py)
     "TRY004",  # PyBaMM raises its own exceptions, not TypeError (see AGENTS.md)
-    # The three below travel together: the blind catches they flag are the same
-    # statements, so they are resolved in one follow-up rather than piecemeal.
-    "BLE001",  # Blind `except Exception` on best-effort paths
-    "TRY002",  # Bare `raise Exception`
-    "S110",    # `try`-`except`-`pass`
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
# Description

Drops the `BLE001`, `TRY002` and `S110` ignores parked by the ruff bump, and replaces every blind `except Exception` in `packages/pybamm/src` with the exceptions the guarded call can actually raise, so an unexpected failure propagates instead of being absorbed by a best-effort path. Split out from the bump because this is a behaviour change and deserves review on its own.

Two user-visible effects:

- A user-specified boundary tag absent from a mesh file now raises `GeometryError`. Previously the blind catch in `ScikitFemSubMesh3D.load_mesh_from_file` swallowed it and returned a mesh with no boundary groups behind a warning. New test covers this; it does not raise without the change.
- Deserialising a parameter set with an invalid interpolant specification now logs a warning naming the offending parameter instead of printing the bare exception to stdout. `key` is bound as a closure default so the message reports the right parameter.

Also narrows the catches in `codegen/compilation.py`, `config.py`, `expression_tree/symbol.py`, `models/base_model.py` (serialisation failures now logged at debug rather than dropped, resolving `S110`) and `simulation/base_simulation.py`, and replaces two bare `raise Exception` with `SolverError` and `ValueError` (`TRY002`). Per-call detail is in the commit message.

Third of three stacked PRs splitting up #5676.

Fixes # (issue)

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
