### PR TITLE
Add unstructured mesh infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains. ([#5687](https://github.com/pybamm-team/PyBaMM/pull/5687))
+- Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains. Hexahedra must have planar faces (warped hexes raise a `GeometryError`), and `UserSuppliedUnstructuredMesh` accepts tetrahedral, triangular, and quadrilateral cells only. ([#5687](https://github.com/pybamm-team/PyBaMM/pull/5687))
 
 ## Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+## Features
+
+- Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains.
+
 ## Bug fixes
 
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains.
+- Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains. ([#5687](https://github.com/pybamm-team/PyBaMM/pull/5687))
 
 ## Bug fixes
 

--- a/docs/source/api/meshes/index.rst
+++ b/docs/source/api/meshes/index.rst
@@ -8,3 +8,4 @@ Meshes
   one_dimensional_submeshes
   two_dimensional_submeshes
   three_dimensional_submeshes
+  unstructured_submeshes

--- a/docs/source/api/meshes/unstructured_submeshes.rst
+++ b/docs/source/api/meshes/unstructured_submeshes.rst
@@ -1,0 +1,16 @@
+Unstructured Sub Meshes
+=======================
+
+.. autoclass:: pybamm.UnstructuredSubMesh
+    :members:
+
+.. autoclass:: pybamm.UnstructuredMeshGenerator
+    :members:
+
+.. autoclass:: pybamm.UserSuppliedUnstructuredMesh
+    :members:
+
+.. autoclass:: pybamm.TaggedSubMeshGenerator
+    :members:
+
+.. autofunction:: pybamm.compute_interface_data

--- a/packages/pybamm/src/pybamm/__init__.py
+++ b/packages/pybamm/src/pybamm/__init__.py
@@ -168,6 +168,15 @@ from .meshes.scikit_fem_submeshes_3d import (
     UserSuppliedSubmesh3D,
 )
 
+
+from .meshes.unstructured_submesh import (
+    UnstructuredSubMesh,
+    UnstructuredMeshGenerator,
+    UserSuppliedUnstructuredMesh,
+    TaggedSubMeshGenerator,
+    compute_interface_data,
+)
+
 # Serialisation
 from .models.base_model import load_model
 

--- a/packages/pybamm/src/pybamm/meshes/__init__.py
+++ b/packages/pybamm/src/pybamm/meshes/__init__.py
@@ -1,2 +1,3 @@
 __all__ = ['meshes', 'one_dimensional_submeshes', 'scikit_fem_submeshes',
-           'zero_dimensional_submesh', 'scikit_fem_submeshes_3d']
+           'zero_dimensional_submesh', 'scikit_fem_submeshes_3d',
+           'unstructured_submesh']

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -362,21 +362,37 @@ class Mesh(dict):
         """
         For adjacent domains backed by :class:`UnstructuredSubMesh`, compute
         and store interface coupling data.
+
+        Adjacency is derived from the geometry, not from the order domains
+        appear in the geometry dict: two domains abut when the plane of one's
+        ``"right"`` boundary faces coincides with the other's ``"left"``.
         """
         unstructured_domains = [
             d
             for d in self.base_domains
             if isinstance(self[d], pybamm.UnstructuredSubMesh)
         ]
-        for i in range(len(unstructured_domains) - 1):
-            left_name = unstructured_domains[i]
-            right_name = unstructured_domains[i + 1]
+        for left_name in unstructured_domains:
             left_mesh = self[left_name]
-            right_mesh = self[right_name]
-            if (
-                "right" in left_mesh.boundary_faces
-                and "left" in right_mesh.boundary_faces
-            ):
+            if "right" not in left_mesh.boundary_faces:
+                continue
+            right_x = left_mesh.face_centroids[
+                left_mesh.boundary_faces["right"], 0
+            ].mean()
+            for right_name in unstructured_domains:
+                if right_name == left_name:
+                    continue
+                right_mesh = self[right_name]
+                if "left" not in right_mesh.boundary_faces:
+                    continue
+                left_x = right_mesh.face_centroids[
+                    right_mesh.boundary_faces["left"], 0
+                ].mean()
+                span = max(
+                    np.ptp(left_mesh.nodes[:, 0]), np.ptp(right_mesh.nodes[:, 0])
+                )
+                if abs(right_x - left_x) > 1e-8 * span:
+                    continue
                 try:
                     pybamm.compute_interface_data(
                         left_mesh,

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -388,10 +388,11 @@ class Mesh(dict):
                 left_x = right_mesh.face_centroids[
                     right_mesh.boundary_faces["left"], 0
                 ].mean()
-                span = max(
-                    np.ptp(left_mesh.nodes[:, 0]), np.ptp(right_mesh.nodes[:, 0])
-                )
-                if abs(right_x - left_x) > 1e-8 * span:
+                from pybamm.meshes.unstructured_submesh import _geometric_tolerance
+
+                if abs(right_x - left_x) > _geometric_tolerance(
+                    [left_mesh, right_mesh]
+                ):
                     continue
                 try:
                     pybamm.compute_interface_data(

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -170,6 +170,9 @@ class Mesh(dict):
             self[domain] = submesh_types[domain](geometry[domain], submesh_pts[domain])
             self.base_domains.append(domain)
 
+        # compute interface data for unstructured meshes
+        self._compute_unstructured_interfaces()
+
         # add ghost meshes
         self.add_ghost_meshes()
 
@@ -214,6 +217,8 @@ class Mesh(dict):
                 raise pybamm.GeometryError(
                     "Cannot combine submeshes of different dimensions"
                 )
+            elif isinstance(self[submeshnames[i]], pybamm.UnstructuredSubMesh):
+                pass
             elif self[submeshnames[i]].dimension == 2:
                 if "left" in submeshnames[i] or "right" in submeshnames[i + 1]:
                     # Make sure that the lr edges are aligned
@@ -264,7 +269,12 @@ class Mesh(dict):
                 )
 
         coord_sys = self[submeshnames[0]].coord_sys
-        if self[submeshnames[0]].dimension == 1:
+        if isinstance(self[submeshnames[0]], pybamm.UnstructuredSubMesh):
+            submesh = _combine_unstructured_submeshes(
+                [self[name] for name in submeshnames]
+            )
+            return submesh
+        elif self[submeshnames[0]].dimension == 1:
             combined_submesh_edges = np.concatenate(
                 [self[submeshnames[0]].edges]
                 + [self[submeshname].edges[1:] for submeshname in submeshnames[1:]]
@@ -349,6 +359,37 @@ class Mesh(dict):
                 submesh.internal_boundaries.append(self[submeshname].edges_lr[0] + min)
         return submesh
 
+    def _compute_unstructured_interfaces(self):
+        """
+        For adjacent domains backed by :class:`UnstructuredSubMesh`, compute
+        and store interface coupling data.
+        """
+        from .unstructured_submesh import compute_interface_data
+
+        unstructured_domains = [
+            d
+            for d in self.base_domains
+            if isinstance(self[d], pybamm.UnstructuredSubMesh)
+        ]
+        for i in range(len(unstructured_domains) - 1):
+            left_name = unstructured_domains[i]
+            right_name = unstructured_domains[i + 1]
+            left_mesh = self[left_name]
+            right_mesh = self[right_name]
+            if (
+                "right" in left_mesh.boundary_faces
+                and "left" in right_mesh.boundary_faces
+            ):
+                try:
+                    compute_interface_data(
+                        left_mesh,
+                        right_mesh,
+                        left_name=left_name,
+                        right_name=right_name,
+                    )
+                except ValueError:
+                    pass
+
     def add_ghost_meshes(self):
         """
         Create meshes for potential ghost nodes on either side of each submesh, using
@@ -365,7 +406,8 @@ class Mesh(dict):
                     submesh,
                     pybamm.SubMesh0D
                     | pybamm.ScikitSubMesh2D
-                    | pybamm.ScikitFemSubMesh3D,
+                    | pybamm.ScikitFemSubMesh3D
+                    | pybamm.UnstructuredSubMesh,
                 )
             )
         ]
@@ -425,6 +467,117 @@ class Mesh(dict):
         ):
             instance[domain] = submesh
         return instance
+
+
+def _combine_unstructured_submeshes(submeshes):
+    """
+    Create a lightweight combined mesh from a list of
+    :class:`UnstructuredSubMesh` objects.  Coincident boundary nodes
+    at domain interfaces are merged so that face-connectivity spans
+    across domains.
+    """
+    from .unstructured_submesh import UnstructuredSubMesh, _hex_to_tet
+
+    # For 3D tet meshes generated from hex grids, regenerate with
+    # cumulative i_offset so that alternating-parity face triangulations
+    # match across domain boundaries.
+    if all(hasattr(sm, "_hex_gen_params") and sm.dimension == 3 for sm in submeshes):
+        cumulative_offset = 0
+        fixed = []
+        for sm in submeshes:
+            p = sm._hex_gen_params
+            if cumulative_offset > 0:
+                nodes, elements = _hex_to_tet(
+                    p["x_edges"],
+                    p["y_edges"],
+                    p["z_edges"],
+                    i_offset=cumulative_offset,
+                )
+                new_sm = UnstructuredSubMesh(
+                    nodes,
+                    elements,
+                    coord_sys=sm.coord_sys,
+                )
+                new_sm._hex_gen_params = p
+                fixed.append(new_sm)
+            else:
+                fixed.append(sm)
+            cumulative_offset += p["nx"]
+        submeshes = fixed
+
+    # Weld coincident nodes across submeshes regardless of which face tag
+    # they belong to.  This generalises the original 1D-stack
+    # ``"right"↔"left"`` welding to arbitrary topology (star, tree, graph)
+    # so that body↔tab interfaces produced by ``FiniteVolumeUnstructured``'s
+    # auto-pairing become internal faces in the combined mesh and TPFA
+    # handles cross-region flux without internal Neumann book-keeping.
+    from scipy.spatial import cKDTree
+
+    tol = 1e-9
+    all_nodes = list(submeshes[0].nodes)
+    global_maps = [{i: i for i in range(submeshes[0].nodes.shape[0])}]
+    next_id = len(all_nodes)
+
+    for k in range(1, len(submeshes)):
+        curr = submeshes[k]
+        tree = cKDTree(np.asarray(all_nodes))
+        d, j = tree.query(curr.nodes)
+        local_to_global = {}
+        for nid in range(curr.nodes.shape[0]):
+            if d[nid] < tol:
+                local_to_global[nid] = int(j[nid])
+            else:
+                local_to_global[nid] = next_id
+                all_nodes.append(curr.nodes[nid])
+                next_id += 1
+        global_maps.append(local_to_global)
+
+    all_elements = [submeshes[0].elements.copy()]
+    for k in range(1, len(submeshes)):
+        gm = global_maps[k]
+        remapped = np.array(
+            [[gm[v] for v in row] for row in submeshes[k].elements],
+            dtype=int,
+        )
+        all_elements.append(remapped)
+
+    combined_nodes = np.array(all_nodes)
+    combined_elements = np.concatenate(all_elements, axis=0)
+    combined = pybamm.UnstructuredSubMesh(
+        combined_nodes,
+        combined_elements,
+        coord_sys=submeshes[0].coord_sys,
+    )
+
+    # Propagate custom boundary tags from component submeshes.
+    # The combined mesh auto-detects only standard tags (left/right/top/bottom/
+    # front/back). Custom tags like "tab_top" are lost. Recover them by
+    # matching boundary face centroids.
+    standard_tags = {"left", "right", "top", "bottom", "front", "back"}
+    custom_centroids = {}  # tag -> list of centroid arrays
+    for sm in submeshes:
+        for tag, face_indices in sm.boundary_faces.items():
+            if tag not in standard_tags:
+                custom_centroids.setdefault(tag, []).append(
+                    sm.face_centroids[face_indices]
+                )
+
+    if custom_centroids:
+        from scipy.spatial import cKDTree
+
+        bnd_start = combined._boundary_face_start
+        bnd_centroids = combined.face_centroids[bnd_start:]
+        if len(bnd_centroids) > 0:
+            tree = cKDTree(bnd_centroids)
+            match_tol = 1e-10 * max(np.ptp(combined_nodes, axis=0).max(), 1.0)
+            for tag, centroid_list in custom_centroids.items():
+                all_src = np.concatenate(centroid_list, axis=0)
+                dists, idxs = tree.query(all_src)
+                matched = idxs[dists < match_tol]
+                if len(matched) > 0:
+                    combined.boundary_faces[tag] = np.unique(matched) + bnd_start
+
+    return combined
 
 
 class SubMesh:

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -384,7 +384,7 @@ class Mesh(dict):
                         left_name=left_name,
                         right_name=right_name,
                     )
-                except ValueError:
+                except pybamm.GeometryError:
                     pass
 
     def add_ghost_meshes(self):

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -270,10 +270,9 @@ class Mesh(dict):
 
         coord_sys = self[submeshnames[0]].coord_sys
         if isinstance(self[submeshnames[0]], pybamm.UnstructuredSubMesh):
-            submesh = _combine_unstructured_submeshes(
+            return pybamm.UnstructuredSubMesh.combine(
                 [self[name] for name in submeshnames]
             )
-            return submesh
         elif self[submeshnames[0]].dimension == 1:
             combined_submesh_edges = np.concatenate(
                 [self[submeshnames[0]].edges]
@@ -364,8 +363,6 @@ class Mesh(dict):
         For adjacent domains backed by :class:`UnstructuredSubMesh`, compute
         and store interface coupling data.
         """
-        from .unstructured_submesh import compute_interface_data
-
         unstructured_domains = [
             d
             for d in self.base_domains
@@ -381,7 +378,7 @@ class Mesh(dict):
                 and "left" in right_mesh.boundary_faces
             ):
                 try:
-                    compute_interface_data(
+                    pybamm.compute_interface_data(
                         left_mesh,
                         right_mesh,
                         left_name=left_name,
@@ -467,117 +464,6 @@ class Mesh(dict):
         ):
             instance[domain] = submesh
         return instance
-
-
-def _combine_unstructured_submeshes(submeshes):
-    """
-    Create a lightweight combined mesh from a list of
-    :class:`UnstructuredSubMesh` objects.  Coincident boundary nodes
-    at domain interfaces are merged so that face-connectivity spans
-    across domains.
-    """
-    from .unstructured_submesh import UnstructuredSubMesh, _hex_to_tet
-
-    # For 3D tet meshes generated from hex grids, regenerate with
-    # cumulative i_offset so that alternating-parity face triangulations
-    # match across domain boundaries.
-    if all(hasattr(sm, "_hex_gen_params") and sm.dimension == 3 for sm in submeshes):
-        cumulative_offset = 0
-        fixed = []
-        for sm in submeshes:
-            p = sm._hex_gen_params
-            if cumulative_offset > 0:
-                nodes, elements = _hex_to_tet(
-                    p["x_edges"],
-                    p["y_edges"],
-                    p["z_edges"],
-                    i_offset=cumulative_offset,
-                )
-                new_sm = UnstructuredSubMesh(
-                    nodes,
-                    elements,
-                    coord_sys=sm.coord_sys,
-                )
-                new_sm._hex_gen_params = p
-                fixed.append(new_sm)
-            else:
-                fixed.append(sm)
-            cumulative_offset += p["nx"]
-        submeshes = fixed
-
-    # Weld coincident nodes across submeshes regardless of which face tag
-    # they belong to.  This generalises the original 1D-stack
-    # ``"right"↔"left"`` welding to arbitrary topology (star, tree, graph)
-    # so that body↔tab interfaces produced by ``FiniteVolumeUnstructured``'s
-    # auto-pairing become internal faces in the combined mesh and TPFA
-    # handles cross-region flux without internal Neumann book-keeping.
-    from scipy.spatial import cKDTree
-
-    tol = 1e-9
-    all_nodes = list(submeshes[0].nodes)
-    global_maps = [{i: i for i in range(submeshes[0].nodes.shape[0])}]
-    next_id = len(all_nodes)
-
-    for k in range(1, len(submeshes)):
-        curr = submeshes[k]
-        tree = cKDTree(np.asarray(all_nodes))
-        d, j = tree.query(curr.nodes)
-        local_to_global = {}
-        for nid in range(curr.nodes.shape[0]):
-            if d[nid] < tol:
-                local_to_global[nid] = int(j[nid])
-            else:
-                local_to_global[nid] = next_id
-                all_nodes.append(curr.nodes[nid])
-                next_id += 1
-        global_maps.append(local_to_global)
-
-    all_elements = [submeshes[0].elements.copy()]
-    for k in range(1, len(submeshes)):
-        gm = global_maps[k]
-        remapped = np.array(
-            [[gm[v] for v in row] for row in submeshes[k].elements],
-            dtype=int,
-        )
-        all_elements.append(remapped)
-
-    combined_nodes = np.array(all_nodes)
-    combined_elements = np.concatenate(all_elements, axis=0)
-    combined = pybamm.UnstructuredSubMesh(
-        combined_nodes,
-        combined_elements,
-        coord_sys=submeshes[0].coord_sys,
-    )
-
-    # Propagate custom boundary tags from component submeshes.
-    # The combined mesh auto-detects only standard tags (left/right/top/bottom/
-    # front/back). Custom tags like "tab_top" are lost. Recover them by
-    # matching boundary face centroids.
-    standard_tags = {"left", "right", "top", "bottom", "front", "back"}
-    custom_centroids = {}  # tag -> list of centroid arrays
-    for sm in submeshes:
-        for tag, face_indices in sm.boundary_faces.items():
-            if tag not in standard_tags:
-                custom_centroids.setdefault(tag, []).append(
-                    sm.face_centroids[face_indices]
-                )
-
-    if custom_centroids:
-        from scipy.spatial import cKDTree
-
-        bnd_start = combined._boundary_face_start
-        bnd_centroids = combined.face_centroids[bnd_start:]
-        if len(bnd_centroids) > 0:
-            tree = cKDTree(bnd_centroids)
-            match_tol = 1e-10 * max(np.ptp(combined_nodes, axis=0).max(), 1.0)
-            for tag, centroid_list in custom_centroids.items():
-                all_src = np.concatenate(centroid_list, axis=0)
-                dists, idxs = tree.query(all_src)
-                matched = idxs[dists < match_tol]
-                if len(matched) > 0:
-                    combined.boundary_faces[tag] = np.unique(matched) + bnd_start
-
-    return combined
 
 
 class SubMesh:

--- a/packages/pybamm/src/pybamm/meshes/meshes.py
+++ b/packages/pybamm/src/pybamm/meshes/meshes.py
@@ -384,8 +384,14 @@ class Mesh(dict):
                         left_name=left_name,
                         right_name=right_name,
                     )
-                except pybamm.GeometryError:
-                    pass
+                except pybamm.GeometryError as error:
+                    # No exception during Mesh.__init__: the model may never
+                    # couple these domains. But a skipped interface carries no
+                    # flux, so it must be visible rather than silent.
+                    pybamm.logger.warning(
+                        f"No interface coupling between {left_name!r} and "
+                        f"{right_name!r}: {error}"
+                    )
 
     def add_ghost_meshes(self):
         """

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -401,6 +401,14 @@ class UnstructuredSubMesh(SubMesh):
         """
         from scipy.spatial import cKDTree
 
+        element_types = {sm.element_type for sm in submeshes}
+        if len(element_types) > 1:
+            raise pybamm.GeometryError(
+                f"Cannot combine unstructured submeshes of different element "
+                f"types: {sorted(element_types)}. All domains must use the "
+                f"same element type."
+            )
+
         # Weld coincident nodes across submeshes regardless of which face tag
         # they belong to, so that interfaces of arbitrary topology (star, tree,
         # graph) become internal faces and TPFA handles cross-region flux

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -1293,19 +1293,11 @@ def _make_quad_grid(x_edges, z_edges):
     xx, zz = np.meshgrid(x_edges, z_edges, indexing="ij")
     nodes = np.column_stack([xx.ravel(), zz.ravel()])
 
-    def node_id(i, j):
-        return i * (nz + 1) + j
+    i, j = np.meshgrid(np.arange(nx), np.arange(nz), indexing="ij")
+    n0 = (i * (nz + 1) + j).ravel()
+    elements = np.column_stack([n0, n0 + (nz + 1), n0 + (nz + 2), n0 + 1])
 
-    elements = []
-    for i in range(nx):
-        for j in range(nz):
-            n0 = node_id(i, j)
-            n1 = node_id(i + 1, j)
-            n2 = node_id(i + 1, j + 1)
-            n3 = node_id(i, j + 1)
-            elements.append([n0, n1, n2, n3])
-
-    return nodes, np.array(elements, dtype=int)
+    return nodes, elements
 
 
 def _quad_to_tri(x_edges, z_edges):
@@ -1326,20 +1318,13 @@ def _quad_to_tri(x_edges, z_edges):
     xx, zz = np.meshgrid(x_edges, z_edges, indexing="ij")
     nodes = np.column_stack([xx.ravel(), zz.ravel()])
 
-    def node_id(i, j):
-        return i * (nz + 1) + j
+    i, j = np.meshgrid(np.arange(nx), np.arange(nz), indexing="ij")
+    n0 = (i * (nz + 1) + j).ravel()
+    elements = np.empty((2 * len(n0), 3), dtype=int)
+    elements[0::2] = np.column_stack([n0, n0 + (nz + 1), n0 + (nz + 2)])
+    elements[1::2] = np.column_stack([n0, n0 + (nz + 2), n0 + 1])
 
-    elements = []
-    for i in range(nx):
-        for j in range(nz):
-            n0 = node_id(i, j)
-            n1 = node_id(i + 1, j)
-            n2 = node_id(i + 1, j + 1)
-            n3 = node_id(i, j + 1)
-            elements.append([n0, n1, n2])
-            elements.append([n0, n2, n3])
-
-    return nodes, np.array(elements, dtype=int)
+    return nodes, elements
 
 
 def _hex_grid(x_edges, y_edges, z_edges):
@@ -1368,34 +1353,22 @@ def _hex_grid(x_edges, y_edges, z_edges):
     xx, yy, zz = np.meshgrid(x_edges, y_edges, z_edges, indexing="ij")
     nodes = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
 
-    def node_id(i, j, k):
-        return i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
-
     # Loop order determines cell numbering and hence Jacobian bandwidth.
     # Bandwidth = product of the two fastest-varying dimension sizes.
     # Minimise by putting the largest dimension outermost (slowest).
     dims = sorted([(nx, "x"), (ny, "y"), (nz, "z")], key=lambda d: d[0], reverse=True)
+    grids = np.meshgrid(*(np.arange(n) for n, _ in dims), indexing="ij")
+    idx = {name: grid.ravel() for (_, name), grid in zip(dims, grids, strict=True)}
+    i, j, k = idx["x"], idx["y"], idx["z"]
 
-    elements = []
-    for a in range(dims[0][0]):
-        for b in range(dims[1][0]):
-            for c in range(dims[2][0]):
-                idx = {dims[0][1]: a, dims[1][1]: b, dims[2][1]: c}
-                i, j, k = idx["x"], idx["y"], idx["z"]
-                elements.append(
-                    [
-                        node_id(i, j, k),
-                        node_id(i + 1, j, k),
-                        node_id(i + 1, j + 1, k),
-                        node_id(i, j + 1, k),
-                        node_id(i, j, k + 1),
-                        node_id(i + 1, j, k + 1),
-                        node_id(i + 1, j + 1, k + 1),
-                        node_id(i, j + 1, k + 1),
-                    ]
-                )
+    n0 = i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
+    p = (ny + 1) * (nz + 1)
+    q = nz + 1
+    elements = np.column_stack(
+        [n0, n0 + p, n0 + p + q, n0 + q, n0 + 1, n0 + p + 1, n0 + p + q + 1, n0 + q + 1]
+    )
 
-    return nodes, np.array(elements, dtype=int)
+    return nodes, elements
 
 
 def _hex_to_tet(x_edges, y_edges, z_edges):
@@ -1422,9 +1395,6 @@ def _hex_to_tet(x_edges, y_edges, z_edges):
     xx, yy, zz = np.meshgrid(x_edges, y_edges, z_edges, indexing="ij")
     nodes = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
 
-    def node_id(i, j, k):
-        return i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
-
     # Hex vertices numbered:
     #   0 = (i,   j,   k  )   4 = (i,   j,   k+1)
     #   1 = (i+1, j,   k  )   5 = (i+1, j,   k+1)
@@ -1433,30 +1403,29 @@ def _hex_to_tet(x_edges, y_edges, z_edges):
     #
     # One tet per monotone path 0 -> 6, stepping +x/+y/+z in each of the
     # 6 possible orders (xyz, xzy, yxz, yzx, zxy, zyx).
-    kuhn_tets = [
-        (0, 1, 2, 6),
-        (0, 1, 5, 6),
-        (0, 3, 2, 6),
-        (0, 3, 7, 6),
-        (0, 4, 5, 6),
-        (0, 4, 7, 6),
-    ]
+    kuhn_tets = np.array(
+        [
+            (0, 1, 2, 6),
+            (0, 1, 5, 6),
+            (0, 3, 2, 6),
+            (0, 3, 7, 6),
+            (0, 4, 5, 6),
+            (0, 4, 7, 6),
+        ]
+    )
 
-    elements = []
-    for i in range(nx):
-        for j in range(ny):
-            for k in range(nz):
-                hex_verts = [
-                    node_id(i, j, k),
-                    node_id(i + 1, j, k),
-                    node_id(i + 1, j + 1, k),
-                    node_id(i, j + 1, k),
-                    node_id(i, j, k + 1),
-                    node_id(i + 1, j, k + 1),
-                    node_id(i + 1, j + 1, k + 1),
-                    node_id(i, j + 1, k + 1),
-                ]
-                for tet in kuhn_tets:
-                    elements.append([hex_verts[v] for v in tet])
+    i, j, k = (
+        grid.ravel()
+        for grid in np.meshgrid(
+            np.arange(nx), np.arange(ny), np.arange(nz), indexing="ij"
+        )
+    )
+    n0 = i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
+    p = (ny + 1) * (nz + 1)
+    q = nz + 1
+    hex_verts = np.column_stack(
+        [n0, n0 + p, n0 + p + q, n0 + q, n0 + 1, n0 + p + 1, n0 + p + q + 1, n0 + q + 1]
+    )
+    elements = hex_verts[:, kuhn_tets].reshape(-1, 4)
 
-    return nodes, np.array(elements, dtype=int)
+    return nodes, elements

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -1133,6 +1133,9 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
     of *right_mesh*, matches them by face centroid position, and records
     cell indices, face areas, and centroid-to-centroid distances.
 
+    Domains are assumed to be stacked along x: faces are paired by their
+    transverse (non-x) centroid coordinates.
+
     Parameters
     ----------
     left_mesh : UnstructuredSubMesh
@@ -1175,6 +1178,18 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
         raise pybamm.GeometryError(
             f"Interface faces do not match: max transverse mismatch = {dists.max():.2e}. "
             "Ensure both meshes have the same transverse grid."
+        )
+
+    # The nearest-neighbour query is one-directional: without this check a
+    # surplus right face silently loses its flux, and a doubly-claimed one
+    # double-counts it.
+    if len(left_bnd) != len(right_bnd) or len(np.unique(right_indices)) != len(
+        right_indices
+    ):
+        raise pybamm.GeometryError(
+            f"Interface face pairing is not one-to-one: {len(left_bnd)} 'right' "
+            f"faces on the left mesh vs {len(right_bnd)} 'left' faces on the "
+            f"right mesh. Both sides must expose the same interface faces."
         )
 
     left_cells = left_mesh.face_owner[left_bnd]

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -1,8 +1,23 @@
+from enum import Enum
+
 import numpy as np
 
 import pybamm
 
 from .meshes import MeshGenerator, SubMesh
+
+
+class ElementType(str, Enum):
+    """Element types supported by :class:`UnstructuredSubMesh`.
+
+    The ``str`` mixin keeps plain strings (``element_type="quad"``)
+    working everywhere an ``ElementType`` is expected.
+    """
+
+    TRIANGLE = "triangle"
+    QUAD = "quad"
+    TETRAHEDRON = "tetrahedron"
+    HEXAHEDRON = "hexahedron"
 
 
 class UnstructuredSubMesh(SubMesh):
@@ -48,13 +63,13 @@ class UnstructuredSubMesh(SubMesh):
 
         verts_per_cell = self.elements.shape[1]
         if self.dimension == 2 and verts_per_cell == 4:
-            self.element_type = "quad"
+            self.element_type = ElementType.QUAD
         elif self.dimension == 2 and verts_per_cell == 3:
-            self.element_type = "triangle"
+            self.element_type = ElementType.TRIANGLE
         elif self.dimension == 3 and verts_per_cell == 4:
-            self.element_type = "tetrahedron"
+            self.element_type = ElementType.TETRAHEDRON
         elif self.dimension == 3 and verts_per_cell == 8:
-            self.element_type = "hexahedron"
+            self.element_type = ElementType.HEXAHEDRON
         else:
             raise pybamm.GeometryError(
                 f"Unsupported: {verts_per_cell} vertices per cell in {self.dimension}D"
@@ -82,13 +97,13 @@ class UnstructuredSubMesh(SubMesh):
         # quads and hexes overwrite it with the true area/volume centroid.
         self.cell_centroids = verts.mean(axis=1)
 
-        if self.element_type == "triangle":
+        if self.element_type == ElementType.TRIANGLE:
             v0, v1, v2 = verts[:, 0], verts[:, 1], verts[:, 2]
             cross = (v1[:, 0] - v0[:, 0]) * (v2[:, 1] - v0[:, 1]) - (
                 v1[:, 1] - v0[:, 1]
             ) * (v2[:, 0] - v0[:, 0])
             self.cell_volumes = 0.5 * np.abs(cross)
-        elif self.element_type == "quad":
+        elif self.element_type == ElementType.QUAD:
             # Shoelace formula for arbitrary simple quadrilaterals
             # Vertices ordered: v0, v1, v2, v3 (counterclockwise or clockwise)
             x = verts[:, :, 0]  # (n_cells, 4)
@@ -104,7 +119,7 @@ class UnstructuredSubMesh(SubMesh):
             cx = np.sum((x + x_next) * cross, axis=1) / (6.0 * signed_area)
             cy = np.sum((y + y_next) * cross, axis=1) / (6.0 * signed_area)
             self.cell_centroids = np.column_stack([cx, cy])
-        elif self.element_type == "tetrahedron":
+        elif self.element_type == ElementType.TETRAHEDRON:
             v0, v1, v2, v3 = verts[:, 0], verts[:, 1], verts[:, 2], verts[:, 3]
             d1 = v1 - v0
             d2 = v2 - v0
@@ -115,7 +130,7 @@ class UnstructuredSubMesh(SubMesh):
                 + d1[:, 2] * (d2[:, 0] * d3[:, 1] - d2[:, 1] * d3[:, 0])
             )
             self.cell_volumes = np.abs(det) / 6.0
-        elif self.element_type == "hexahedron":
+        elif self.element_type == ElementType.HEXAHEDRON:
             # 5-tet decomposition, exact only for planar-faced hexes (warped
             # faces are rejected in _compute_face_geometry). Tet volumes are
             # summed signed so a degenerate or inverted cell cannot cancel
@@ -142,7 +157,7 @@ class UnstructuredSubMesh(SubMesh):
 
     def _build_face_connectivity(self):
         """Extract faces, identify internal / boundary, record owner-neighbor."""
-        if self.element_type == "hexahedron":
+        if self.element_type == ElementType.HEXAHEDRON:
             n_verts_per_face = 4
         else:
             n_verts_per_face = self.dimension
@@ -151,14 +166,14 @@ class UnstructuredSubMesh(SubMesh):
         n_cells = len(elems)
 
         # Build all faces at once using local face definitions
-        if self.element_type == "quad":
+        if self.element_type == ElementType.QUAD:
             idx = np.arange(4)
             local = np.stack([idx, (idx + 1) % 4], axis=1)  # (4, 2)
-        elif self.element_type == "triangle":
+        elif self.element_type == ElementType.TRIANGLE:
             local = np.array([[1, 2], [0, 2], [0, 1]])  # skip vertex 0, 1, 2
-        elif self.element_type == "tetrahedron":
+        elif self.element_type == ElementType.TETRAHEDRON:
             local = np.array([[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]])
-        elif self.element_type == "hexahedron":
+        elif self.element_type == ElementType.HEXAHEDRON:
             local = np.array(self._HEX_FACES)
         n_fpc = len(local)
 
@@ -251,7 +266,7 @@ class UnstructuredSubMesh(SubMesh):
             edge = v1 - v0
             self.face_areas = np.linalg.norm(edge, axis=1)
             normals = np.column_stack([edge[:, 1], -edge[:, 0]])
-        elif self.element_type == "hexahedron":
+        elif self.element_type == ElementType.HEXAHEDRON:
             # Face = quad: 4 vertices. Area via cross product of diagonals.
             v0 = face_verts[:, 0]
             v1 = face_verts[:, 1]
@@ -397,8 +412,8 @@ class UnstructuredSubMesh(SubMesh):
         if len(element_types) > 1:
             raise pybamm.GeometryError(
                 f"Cannot combine unstructured submeshes of different element "
-                f"types: {sorted(element_types)}. All domains must use the "
-                f"same element type."
+                f"types: {sorted(t.value for t in element_types)}. All domains "
+                f"must use the same element type."
             )
 
         # Weld coincident nodes across submeshes regardless of which face tag
@@ -743,10 +758,10 @@ class UnstructuredMeshGenerator(MeshGenerator):
         x_edges = np.linspace(lim_x["min"], lim_x["max"], nx + 1)
         z_edges = np.linspace(lim_z["min"], lim_z["max"], nz + 1)
 
-        etype = self._element_type or "triangle"
-        if etype == "quad":
+        etype = self._element_type or ElementType.TRIANGLE
+        if etype == ElementType.QUAD:
             nodes, elements = _make_quad_grid(x_edges, z_edges)
-        elif etype == "triangle":
+        elif etype == ElementType.TRIANGLE:
             nodes, elements = _quad_to_tri(x_edges, z_edges)
         else:
             raise pybamm.GeometryError(f"Unsupported 2D element_type: {etype!r}")
@@ -770,10 +785,10 @@ class UnstructuredMeshGenerator(MeshGenerator):
         y_edges = np.linspace(lim_y["min"], lim_y["max"], ny + 1)
         z_edges = np.linspace(lim_z["min"], lim_z["max"], nz + 1)
 
-        etype = self._element_type or "hexahedron"
-        if etype == "hexahedron":
+        etype = self._element_type or ElementType.HEXAHEDRON
+        if etype == ElementType.HEXAHEDRON:
             nodes, elements = _hex_grid(x_edges, y_edges, z_edges)
-        elif etype == "tetrahedron":
+        elif etype == ElementType.TETRAHEDRON:
             nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
         else:
             raise pybamm.GeometryError(f"Unsupported 3D element_type: {etype!r}")

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -1,0 +1,1091 @@
+import numpy as np
+
+import pybamm
+
+from .meshes import MeshGenerator, SubMesh
+
+
+class UnstructuredSubMesh(SubMesh):
+    """
+    Cell-centered finite volume submesh on polygonal/polyhedral elements.
+
+    Supported element types:
+
+    * **2D**: triangles (3 vertices) or quadrilaterals (4 vertices)
+    * **3D**: tetrahedra (4 vertices) or hexahedra (8 vertices)
+
+    All operators are dimension-agnostic: the same code path handles
+    both 2D and 3D, with dimension inferred from ``nodes.shape[1]``.
+
+    Parameters
+    ----------
+    nodes : numpy.ndarray
+        Vertex coordinates, of shape ``(n_nodes, d)`` (d = 2 or 3).
+    elements : numpy.ndarray
+        Element vertex indices, of shape ``(n_cells, n_verts_per_cell)``.
+        For 2D: 3 (triangles) or 4 (quads).
+        For 3D: 4 (tetrahedra) or 8 (hexahedra).
+    coord_sys : str, optional
+        Coordinate system, default ``"cartesian"``.
+    boundary_faces : dict[str, numpy.ndarray] or None, optional
+        Maps boundary name to face indices.  If ``None``, boundaries
+        are auto-detected from face centroid positions.
+    """
+
+    def __init__(self, nodes, elements, coord_sys="cartesian", boundary_faces=None):
+        super().__init__()
+        self.nodes = np.asarray(nodes, dtype=float)
+        self.elements = np.asarray(elements, dtype=int)
+        self.dimension = self.nodes.shape[1]
+        self.coord_sys = coord_sys
+
+        verts_per_cell = self.elements.shape[1]
+        if self.dimension == 2 and verts_per_cell == 4:
+            self.element_type = "quad"
+        elif self.dimension == 2 and verts_per_cell == 3:
+            self.element_type = "triangle"
+        elif self.dimension == 3 and verts_per_cell == 4:
+            self.element_type = "tetrahedron"
+        elif self.dimension == 3 and verts_per_cell == 8:
+            self.element_type = "hexahedron"
+        else:
+            raise ValueError(
+                f"Unsupported: {verts_per_cell} vertices per cell in {self.dimension}D"
+            )
+
+        self._compute_cell_geometry()
+        self._build_face_connectivity()
+        self._compute_face_geometry()
+
+        if boundary_faces is not None:
+            self.boundary_faces = boundary_faces
+        else:
+            self._identify_boundary_faces()
+
+        self.npts = len(self.elements)
+        self.npts_lr = self.npts
+        self.npts_tb = 1
+        self.internal_boundaries = []
+        self.interface_data = {}
+
+    # ------------------------------------------------------------------
+    # Cell geometry
+    # ------------------------------------------------------------------
+
+    def _compute_cell_geometry(self):
+        verts = self.nodes[self.elements]  # (n_cells, n_verts, d)
+        self.cell_centroids = verts.mean(axis=1)
+
+        if self.element_type == "triangle":
+            v0, v1, v2 = verts[:, 0], verts[:, 1], verts[:, 2]
+            cross = (v1[:, 0] - v0[:, 0]) * (v2[:, 1] - v0[:, 1]) - (
+                v1[:, 1] - v0[:, 1]
+            ) * (v2[:, 0] - v0[:, 0])
+            self.cell_volumes = 0.5 * np.abs(cross)
+        elif self.element_type == "quad":
+            # Shoelace formula for arbitrary (convex) quadrilaterals
+            # Vertices ordered: v0, v1, v2, v3 (counterclockwise or clockwise)
+            x = verts[:, :, 0]  # (n_cells, 4)
+            y = verts[:, :, 1]  # (n_cells, 4)
+            # shoelace: sum_i (x_i * y_{i+1} - x_{i+1} * y_i)
+            x_next = np.roll(x, -1, axis=1)
+            y_next = np.roll(y, -1, axis=1)
+            self.cell_volumes = 0.5 * np.abs(np.sum(x * y_next - x_next * y, axis=1))
+        elif self.element_type == "tetrahedron":
+            v0, v1, v2, v3 = verts[:, 0], verts[:, 1], verts[:, 2], verts[:, 3]
+            d1 = v1 - v0
+            d2 = v2 - v0
+            d3 = v3 - v0
+            det = (
+                d1[:, 0] * (d2[:, 1] * d3[:, 2] - d2[:, 2] * d3[:, 1])
+                - d1[:, 1] * (d2[:, 0] * d3[:, 2] - d2[:, 2] * d3[:, 0])
+                + d1[:, 2] * (d2[:, 0] * d3[:, 1] - d2[:, 1] * d3[:, 0])
+            )
+            self.cell_volumes = np.abs(det) / 6.0
+        elif self.element_type == "hexahedron":
+            # Volume via divergence theorem: V = (1/3) sum_faces (centroid . normal * area)
+            # For axis-aligned hexes this simplifies, but we use the general approach
+            # by splitting each hex into 5 tets for volume computation only.
+            self.cell_volumes = np.zeros(len(self.elements))
+            for i, cell in enumerate(self.elements):
+                cv = self.nodes[cell]
+                vol = 0.0
+                # Split hex into 5 tets using pattern A
+                for tet_local in [
+                    (0, 1, 2, 5),
+                    (0, 2, 3, 7),
+                    (0, 5, 7, 4),
+                    (2, 5, 7, 6),
+                    (0, 2, 5, 7),
+                ]:
+                    t = cv[list(tet_local)]
+                    d1 = t[1] - t[0]
+                    d2 = t[2] - t[0]
+                    d3 = t[3] - t[0]
+                    vol += abs(np.dot(d1, np.cross(d2, d3))) / 6.0
+                self.cell_volumes[i] = vol
+
+    # ------------------------------------------------------------------
+    # Face-cell connectivity
+    # ------------------------------------------------------------------
+
+    def _build_face_connectivity(self):
+        """Extract faces, identify internal / boundary, record owner-neighbor."""
+        if self.element_type == "hexahedron":
+            n_verts_per_face = 4
+        else:
+            n_verts_per_face = self.dimension
+
+        elems = self.elements
+        n_cells = len(elems)
+
+        # Build all faces at once using local face definitions
+        if self.element_type == "quad":
+            n_fpc = 4  # faces per cell
+            idx = np.arange(4)
+            local = np.stack([idx, (idx + 1) % 4], axis=1)  # (4, 2)
+        elif self.element_type == "triangle":
+            local = np.array([[1, 2], [0, 2], [0, 1]])  # skip vertex 0, 1, 2
+        elif self.element_type == "tetrahedron":
+            local = np.array([[1, 2, 3], [0, 2, 3], [0, 1, 3], [0, 1, 2]])
+        elif self.element_type == "hexahedron":
+            local = np.array(self._HEX_FACES)
+        n_fpc = len(local)
+
+        all_faces = elems[:, local].reshape(-1, n_verts_per_face)
+        cell_ids = np.repeat(np.arange(n_cells), n_fpc)
+
+        # Canonical keys: sort vertex indices within each face
+        sorted_faces = np.sort(all_faces, axis=1)
+
+        # Find unique faces and which are shared (internal) vs single (boundary)
+        _, inverse, counts = np.unique(
+            sorted_faces, axis=0, return_inverse=True, return_counts=True
+        )
+
+        is_internal = counts[inverse] == 2
+        is_boundary = counts[inverse] == 1
+
+        # For internal faces, we need owner/neighbor pairs.
+        # Group by unique face index; first occurrence is owner, second is neighbor.
+        internal_mask = is_internal
+        int_inv = inverse[internal_mask]
+        int_cells = cell_ids[internal_mask]
+        int_faces_raw = all_faces[internal_mask]
+
+        # Sort by unique-face-id to pair them up: [owner0, neighbor0, owner1, neighbor1, ...]
+        order = np.argsort(int_inv, kind="stable")
+        int_cells_sorted = int_cells[order]
+        int_faces_sorted = int_faces_raw[order]
+
+        internal_owner = int_cells_sorted[0::2]
+        internal_neighbor = int_cells_sorted[1::2]
+        internal_face_verts = int_faces_sorted[0::2]
+
+        # Boundary faces
+        bnd_face_verts = all_faces[is_boundary]
+        bnd_owners = cell_ids[is_boundary]
+
+        n_internal = len(internal_owner)
+        n_boundary = len(bnd_owners)
+
+        self.faces = np.concatenate([internal_face_verts, bnd_face_verts], axis=0)
+        self.face_owner = np.concatenate([internal_owner, bnd_owners])
+        self.face_neighbor = internal_neighbor
+        self.n_internal_faces = n_internal
+        self._n_boundary_faces = n_boundary
+        self._boundary_face_start = n_internal
+
+    # Standard hex vertex ordering:
+    #   0=(i,j,k)   1=(i+1,j,k)   2=(i+1,j+1,k)   3=(i,j+1,k)
+    #   4=(i,j,k+1) 5=(i+1,j,k+1) 6=(i+1,j+1,k+1) 7=(i,j+1,k+1)
+    _HEX_FACES = [
+        (0, 3, 7, 4),  # x- (left)
+        (1, 2, 6, 5),  # x+ (right)
+        (0, 1, 5, 4),  # y- (front)
+        (3, 2, 6, 7),  # y+ (back)
+        (0, 1, 2, 3),  # z- (bottom)
+        (4, 5, 6, 7),  # z+ (top)
+    ]
+
+    def _cell_faces(self, cell_verts):
+        """Yield face vertex tuples for a single cell."""
+        n = len(cell_verts)
+        if self.element_type == "quad":
+            for i in range(n):
+                yield (cell_verts[i], cell_verts[(i + 1) % n])
+        elif self.element_type == "hexahedron":
+            for local_face in self._HEX_FACES:
+                yield tuple(cell_verts[v] for v in local_face)
+        else:
+            # Simplex: d+1 faces, face i omits vertex i
+            for skip in range(n):
+                yield tuple(cell_verts[j] for j in range(n) if j != skip)
+
+    # ------------------------------------------------------------------
+    # Face geometry
+    # ------------------------------------------------------------------
+
+    def _compute_face_geometry(self):
+        face_verts = self.nodes[self.faces]
+
+        self.face_centroids = face_verts.mean(axis=1)
+
+        if self.dimension == 2:
+            v0, v1 = face_verts[:, 0], face_verts[:, 1]
+            edge = v1 - v0
+            self.face_areas = np.linalg.norm(edge, axis=1)
+            normals = np.column_stack([edge[:, 1], -edge[:, 0]])
+        elif self.element_type == "hexahedron":
+            # Face = quad: 4 vertices. Area via cross product of diagonals.
+            v0 = face_verts[:, 0]
+            v1 = face_verts[:, 1]
+            v2 = face_verts[:, 2]
+            v3 = face_verts[:, 3]
+            diag1 = v2 - v0
+            diag2 = v3 - v1
+            cross = np.cross(diag1, diag2)
+            self.face_areas = 0.5 * np.linalg.norm(cross, axis=1)
+            normals = cross
+        else:
+            # Face = triangle: 3 vertices
+            v0, v1, v2 = face_verts[:, 0], face_verts[:, 1], face_verts[:, 2]
+            cross = np.cross(v1 - v0, v2 - v0)
+            self.face_areas = 0.5 * np.linalg.norm(cross, axis=1)
+            normals = cross
+
+        # Normalize
+        norms = np.linalg.norm(normals, axis=1, keepdims=True)
+        norms = np.where(norms < 1e-30, 1.0, norms)
+        normals = normals / norms
+
+        # Orient outward from owner cell: if the normal points from the
+        # owner centroid toward the face centroid, keep it; otherwise flip.
+        owner_centroids = self.cell_centroids[self.face_owner]
+        to_face = self.face_centroids - owner_centroids
+        dot = np.sum(normals * to_face, axis=1)
+        flip = dot < 0
+        normals[flip] *= -1
+
+        self.face_normals = normals
+
+    # ------------------------------------------------------------------
+    # Boundary identification
+    # ------------------------------------------------------------------
+
+    def _identify_boundary_faces(self):
+        bnd_start = self._boundary_face_start
+        bnd_centroids = self.face_centroids[bnd_start:]
+
+        if len(bnd_centroids) == 0:
+            self.boundary_faces = {}
+            return
+
+        # Classify every external face by its outward normal direction so all
+        # protrusions (e.g., tabs) get assigned a BC bucket.
+        bnd_normals = self.face_normals[bnd_start:]
+        dominant_axis = np.argmax(np.abs(bnd_normals), axis=1)
+
+        tag_map = {
+            "left": np.zeros(len(bnd_centroids), dtype=bool),
+            "right": np.zeros(len(bnd_centroids), dtype=bool),
+            "bottom": np.zeros(len(bnd_centroids), dtype=bool),
+            "top": np.zeros(len(bnd_centroids), dtype=bool),
+        }
+        if self.dimension == 3:
+            tag_map["front"] = np.zeros(len(bnd_centroids), dtype=bool)
+            tag_map["back"] = np.zeros(len(bnd_centroids), dtype=bool)
+
+        for i, axis in enumerate(dominant_axis):
+            sign = bnd_normals[i, axis]
+            if axis == 0:
+                tag_map["left" if sign < 0 else "right"][i] = True
+            elif self.dimension == 3 and axis == 1:
+                tag_map["front" if sign < 0 else "back"][i] = True
+            else:
+                tag_map["bottom" if sign < 0 else "top"][i] = True
+
+        self.boundary_faces = {}
+        for name, mask in tag_map.items():
+            indices = np.nonzero(mask)[0] + bnd_start
+            if len(indices) > 0:
+                self.boundary_faces[name] = indices
+
+    def optimize_ordering(self):
+        """Reorder cells using Reverse Cuthill-McKee to reduce Jacobian bandwidth.
+
+        Permutes all cell-indexed arrays (elements, centroids, volumes,
+        face_owner, face_neighbor, interface_data) so that adjacent cells
+        have nearby indices, minimising the bandwidth of the FVM
+        connectivity matrix.
+        """
+        from scipy.sparse import csr_matrix
+        from scipy.sparse.csgraph import reverse_cuthill_mckee
+
+        n = self.npts
+        if n <= 1:
+            return
+
+        n_int = self._boundary_face_start
+        owners = self.face_owner[:n_int]
+        neighbors = self.face_neighbor
+
+        rows = np.concatenate([owners, neighbors])
+        cols = np.concatenate([neighbors, owners])
+        data = np.ones(len(rows), dtype=np.float64)
+        adj = csr_matrix((data, (rows, cols)), shape=(n, n))
+
+        perm = reverse_cuthill_mckee(adj)
+        inv_perm = np.empty(n, dtype=int)
+        inv_perm[perm] = np.arange(n)
+
+        self.elements = self.elements[perm]
+        self.cell_centroids = self.cell_centroids[perm]
+        self.cell_volumes = self.cell_volumes[perm]
+
+        self.face_owner = inv_perm[self.face_owner]
+        self.face_neighbor = inv_perm[self.face_neighbor]
+
+        for data_dict in self.interface_data.values():
+            if "left_cells" in data_dict:
+                data_dict["left_cells"] = inv_perm[data_dict["left_cells"]]
+            if "right_cells" in data_dict:
+                data_dict["right_cells"] = inv_perm[data_dict["right_cells"]]
+
+    def boundary_loops(self):
+        """Return boundary loops as a list of ``matplotlib.path.Path`` (2D only).
+
+        Walks boundary edges to extract one or more closed loops.  The first
+        path is the outer boundary (largest area); subsequent paths are holes.
+        Use this to test containment: a point is in the domain if it is inside
+        the outer loop and outside all hole loops.
+        """
+        if self.dimension != 2:
+            return None
+
+        from matplotlib.path import Path
+
+        bnd_start = self._boundary_face_start
+        bnd_edges = self.faces[bnd_start:]
+        if len(bnd_edges) == 0:
+            return None
+
+        adj: dict[int, list[tuple[int, int]]] = {}
+        for i, edge in enumerate(bnd_edges):
+            v0, v1 = int(edge[0]), int(edge[1])
+            adj.setdefault(v0, []).append((i, v1))
+            adj.setdefault(v1, []).append((i, v0))
+
+        visited: set[int] = set()
+        loops: list[list[int]] = []
+
+        for start_edge_idx in range(len(bnd_edges)):
+            if start_edge_idx in visited:
+                continue
+            start_v = int(bnd_edges[start_edge_idx][0])
+            loop = [start_v]
+            current = start_v
+            while True:
+                found = False
+                for edge_idx, next_v in adj[current]:
+                    if edge_idx not in visited:
+                        visited.add(edge_idx)
+                        loop.append(next_v)
+                        current = next_v
+                        found = True
+                        break
+                if not found:
+                    break
+            loops.append(loop)
+
+        def signed_area(pts):
+            x, y = pts[:, 0], pts[:, 1]
+            return 0.5 * np.sum(x[:-1] * y[1:] - x[1:] * y[:-1])
+
+        loop_data = []
+        for loop in loops:
+            pts = self.nodes[loop]
+            sa = signed_area(pts)
+            loop_data.append((abs(sa), pts))
+
+        loop_data.sort(key=lambda t: t[0], reverse=True)
+
+        paths = []
+        for pts in (ld[1] for ld in loop_data):
+            codes = [Path.LINETO] * len(pts)
+            codes[0] = Path.MOVETO
+            codes[-1] = Path.CLOSEPOLY
+            paths.append(Path(pts, codes))
+        return paths
+
+    def contains_points_3d(self, query_pts):
+        """Test whether 3D points lie inside the mesh domain.
+
+        Uses the generalized winding number (Van Oosterom--Strackee signed
+        solid angle sum over all boundary triangles).  Points inside the
+        domain return ``True``; points outside or inside internal cavities
+        return ``False``.
+        """
+        query_pts = np.asarray(query_pts, dtype=np.float64)
+        bnd_start = self._boundary_face_start
+        bnd_fv = self.faces[bnd_start:]
+        bnd_normals = self.face_normals[bnd_start:]
+        n_vpf = bnd_fv.shape[1]
+
+        if n_vpf == 3:
+            tri_idx = bnd_fv
+            tri_normals = bnd_normals
+        elif n_vpf == 4:
+            tri_idx = np.concatenate(
+                [bnd_fv[:, [0, 1, 2]], bnd_fv[:, [0, 2, 3]]], axis=0
+            )
+            tri_normals = np.concatenate([bnd_normals, bnd_normals], axis=0)
+        else:
+            raise ValueError(
+                f"contains_points_3d: unsupported face with {n_vpf} vertices"
+            )
+
+        v0 = self.nodes[tri_idx[:, 0]]
+        v1 = self.nodes[tri_idx[:, 1]]
+        v2 = self.nodes[tri_idx[:, 2]]
+
+        # Ensure consistent CCW orientation from outside (matching outward normals)
+        cross = np.cross(v1 - v0, v2 - v0)
+        flip = np.sum(cross * tri_normals, axis=1) < 0
+        v1_fixed = v1.copy()
+        v2_fixed = v2.copy()
+        v1_fixed[flip] = v2[flip]
+        v2_fixed[flip] = v1[flip]
+
+        n_query = len(query_pts)
+        winding = np.zeros(n_query)
+
+        for i in range(len(tri_idx)):
+            a = v0[i] - query_pts
+            b = v1_fixed[i] - query_pts
+            c = v2_fixed[i] - query_pts
+
+            an = np.linalg.norm(a, axis=1)
+            bn = np.linalg.norm(b, axis=1)
+            cn = np.linalg.norm(c, axis=1)
+
+            num = np.einsum("ij,ij->i", a, np.cross(b, c))
+            den = (
+                an * bn * cn
+                + np.einsum("ij,ij->i", a, b) * cn
+                + np.einsum("ij,ij->i", a, c) * bn
+                + np.einsum("ij,ij->i", b, c) * an
+            )
+
+            winding += 2.0 * np.arctan2(num, den)
+
+        return winding > 2.0 * np.pi
+
+
+# ======================================================================
+# Mesh generators
+# ======================================================================
+
+
+class UnstructuredMeshGenerator(MeshGenerator):
+    """
+    Built-in generator that creates meshes from structured grids.
+
+    * **2D**: rectangular domain meshed as quads or triangulated by
+      splitting each quad into 2 triangles.
+    * **3D**: rectangular prism meshed by splitting each hex into 5
+      tetrahedra.
+
+    Parameters
+    ----------
+    coord_sys : str, optional
+        Coordinate system, default ``"cartesian"``.
+    element_type : str, optional
+        ``"quad"`` for quadrilateral cells (2D only, TPFA-orthogonal),
+        ``"triangle"`` for triangular cells (2D default),
+        ``"tetrahedron"`` for tetrahedral cells (3D default).
+        If ``None``, defaults to ``"triangle"`` in 2D and
+        ``"tetrahedron"`` in 3D.
+    """
+
+    def __init__(self, coord_sys="cartesian", element_type=None):
+        self.submesh_type = UnstructuredSubMesh
+        self.submesh_params = {}
+        self.coord_sys = coord_sys
+        self._element_type = element_type
+
+    def __call__(self, lims, npts):
+        spatial_vars, spatial_lims = self._parse_lims(lims)
+        dim = len(spatial_vars)
+        if dim == 2:
+            return self._generate_2d(spatial_vars, spatial_lims, npts)
+        elif dim == 3:
+            return self._generate_3d(spatial_vars, spatial_lims, npts)
+        else:
+            raise ValueError(
+                f"UnstructuredMeshGenerator supports 2D and 3D, got {dim} spatial variables"
+            )
+
+    def __repr__(self):
+        return "Generator for UnstructuredSubMesh"
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_lims(lims):
+        spatial_vars = []
+        spatial_lims = []
+        for var, var_lims in lims.items():
+            if var == "tabs":
+                continue
+            if isinstance(var, str):
+                var = getattr(pybamm.standard_spatial_vars, var)
+            spatial_vars.append(var)
+            spatial_lims.append(var_lims)
+        return spatial_vars, spatial_lims
+
+    # ------------------------------------------------------------------
+    # 2D
+    # ------------------------------------------------------------------
+
+    def _generate_2d(self, spatial_vars, spatial_lims, npts):
+        var_x, var_z = spatial_vars
+        lim_x, lim_z = spatial_lims
+        nx = npts[var_x.name]
+        nz = npts[var_z.name]
+
+        x_edges = np.linspace(lim_x["min"], lim_x["max"], nx + 1)
+        z_edges = np.linspace(lim_z["min"], lim_z["max"], nz + 1)
+
+        etype = self._element_type or "triangle"
+        if etype == "quad":
+            nodes, elements = _make_quad_grid(x_edges, z_edges)
+        elif etype == "triangle":
+            nodes, elements = _quad_to_tri(x_edges, z_edges)
+        else:
+            raise ValueError(f"Unsupported 2D element_type: {etype!r}")
+        return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+
+    # ------------------------------------------------------------------
+    # 3D: hex -> 5 tets
+    # ------------------------------------------------------------------
+
+    def _generate_3d(self, spatial_vars, spatial_lims, npts):
+        var_x, var_y, var_z = spatial_vars
+        lim_x, lim_y, lim_z = spatial_lims
+        nx = npts[var_x.name]
+        ny = npts[var_y.name]
+        nz = npts[var_z.name]
+
+        x_edges = np.linspace(lim_x["min"], lim_x["max"], nx + 1)
+        y_edges = np.linspace(lim_y["min"], lim_y["max"], ny + 1)
+        z_edges = np.linspace(lim_z["min"], lim_z["max"], nz + 1)
+
+        nodes, elements = _hex_grid(x_edges, y_edges, z_edges)
+        return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+
+
+class UserSuppliedUnstructuredMesh(MeshGenerator):
+    """
+    Load an unstructured mesh from an external file via *meshio*.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the mesh file (GMSH ``.msh``, VTK ``.vtu``, etc.).
+    subdomain_mapping : dict[str, int] or None
+        Maps PyBaMM domain name to physical group / cell-data tag.
+    boundary_mapping : dict[str, int] or None
+        Maps boundary name to physical group / facet tag.
+    coord_sys : str, optional
+        Coordinate system, default ``"cartesian"``.
+    """
+
+    def __init__(
+        self,
+        filepath,
+        subdomain_mapping=None,
+        boundary_mapping=None,
+        coord_sys="cartesian",
+        merge_tolerance=1e-12,
+    ):
+        self.submesh_type = UnstructuredSubMesh
+        self.submesh_params = {}
+        self.filepath = filepath
+        self.subdomain_mapping = subdomain_mapping or {}
+        self.boundary_mapping = boundary_mapping or {}
+        self.coord_sys = coord_sys
+        self.merge_tolerance = merge_tolerance
+        self._cached_mesh = None
+
+    def __call__(self, lims, npts):
+        import meshio
+
+        if self._cached_mesh is None:
+            self._cached_mesh = meshio.read(self.filepath)
+
+        mesh = self._cached_mesh
+        nodes = mesh.points
+
+        # Determine which domain is being requested from the lims keys
+        domain_name = self._domain_name_from_lims(lims)
+
+        # Extract supported cells (triangles/quads or tets/hexes)
+        cells, cell_type = self._extract_supported_cells(mesh)
+
+        if domain_name and domain_name in self.subdomain_mapping:
+            tag_value = self.subdomain_mapping[domain_name]
+            cell_mask = self._get_cell_mask(mesh, cell_type, tag_value)
+            elements = cells[cell_mask]
+        else:
+            elements = cells
+
+        # Weld coincident nodes across cell blocks so touching regions
+        # (e.g. body-tab interfaces) are thermally connected.
+        if self.merge_tolerance is not None and self.merge_tolerance > 0:
+            scale = 1.0 / self.merge_tolerance
+            quantized = np.round(nodes * scale).astype(np.int64)
+            _, unique_idx, inverse = np.unique(
+                quantized, axis=0, return_index=True, return_inverse=True
+            )
+            nodes = nodes[unique_idx]
+            elements = inverse[elements]
+
+        # Re-index nodes to compact numbering
+        unique_nodes = np.unique(elements)
+        node_map = np.full(nodes.shape[0], -1, dtype=int)
+        node_map[unique_nodes] = np.arange(len(unique_nodes))
+        compact_nodes = nodes[unique_nodes]
+        compact_elements = node_map[elements]
+
+        # Trim to 2D if all z-coordinates are zero
+        if compact_nodes.shape[1] == 3 and np.allclose(compact_nodes[:, 2], 0):
+            compact_nodes = compact_nodes[:, :2]
+
+        return UnstructuredSubMesh(
+            compact_nodes, compact_elements, coord_sys=self.coord_sys
+        )
+
+    def __repr__(self):
+        return f"UserSuppliedUnstructuredMesh({self.filepath})"
+
+    @staticmethod
+    def _domain_name_from_lims(lims):
+        for var in lims:
+            if var == "tabs":
+                continue
+            if isinstance(var, str):
+                name = var
+            else:
+                name = var.name
+            for prefix in ("x_n", "x_s", "x_p"):
+                if name.startswith(prefix):
+                    domain_map = {
+                        "x_n": "negative electrode",
+                        "x_s": "separator",
+                        "x_p": "positive electrode",
+                    }
+                    return domain_map.get(prefix)
+        return None
+
+    @staticmethod
+    def _extract_supported_cells(mesh):
+        # Prefer 3D cells when present, otherwise fall back to 2D.
+        for cell_type in ("tetra", "hexahedron", "triangle", "quad"):
+            blocks = [block.data for block in mesh.cells if block.type == cell_type]
+            if blocks:
+                if len(blocks) == 1:
+                    return blocks[0], cell_type
+                return np.concatenate(blocks, axis=0), cell_type
+        raise ValueError(
+            "No supported cells found in mesh file "
+            "(expected tetra/hexahedron/triangle/quad)"
+        )
+
+    @staticmethod
+    def _get_cell_mask(mesh, cell_type, tag_value):
+        for data_list in mesh.cell_data.values():
+            matching = [
+                data
+                for block, data in zip(mesh.cells, data_list, strict=False)
+                if block.type == cell_type
+            ]
+            if matching:
+                if len(matching) == 1:
+                    return matching[0] == tag_value
+                return np.concatenate(matching, axis=0) == tag_value
+        raise ValueError(
+            f"Could not find cell data tag {tag_value} for cell type '{cell_type}'"
+        )
+
+
+# ======================================================================
+# Tagged-region mesh generator
+# ======================================================================
+
+
+class TaggedSubMeshGenerator(MeshGenerator):
+    """
+    Build an :class:`UnstructuredSubMesh` from cells of a single Gmsh
+    physical group in a ``.msh`` file.
+
+    Use one instance per region in a multi-domain pybamm model — the
+    region name doubles as the pybamm domain name. Compare to
+    :class:`UserSuppliedUnstructuredMesh`, which routes multiple regions
+    through one generator by introspecting ``lims``; ``TaggedSubMeshGenerator``
+    is simpler when the model already supplies one mesh generator per
+    domain.
+
+    Parameters
+    ----------
+    region : str
+        Gmsh physical-group name (key in ``meshio.read(...).field_data``).
+    mesh_path : str or pathlib.Path
+        Path to the ``.msh`` file.
+    scale : float, optional
+        Multiplier applied to mesh node coordinates (e.g. ``1e-3`` to
+        convert mm to m). Default ``1.0``.
+    coord_sys : str, optional
+        Coordinate system label, default ``"cartesian"``.
+    """
+
+    _mesh_cache: dict = {}
+
+    def __init__(self, region, mesh_path, scale=1.0, coord_sys="cartesian"):
+        self.submesh_type = UnstructuredSubMesh
+        self.submesh_params = {}
+        self._mesh_path = mesh_path
+        self._region = region
+        self._scale = float(scale)
+        self.coord_sys = coord_sys
+
+    @classmethod
+    def _read(cls, path):
+        if path not in cls._mesh_cache:
+            import meshio
+
+            cls._mesh_cache[path] = meshio.read(str(path))
+        return cls._mesh_cache[path]
+
+    def __call__(self, lims, npts):
+        m = self._read(self._mesh_path)
+        if self._region not in m.field_data:
+            raise KeyError(
+                f"region {self._region!r} not in mesh field_data; "
+                f"available: {list(m.field_data)}"
+            )
+        tag_id = int(m.field_data[self._region][0])
+
+        tet_blocks = []
+        for block, tags in zip(
+            m.cells, m.cell_data.get("gmsh:physical", []), strict=False
+        ):
+            if block.type != "tetra":
+                continue
+            mask = np.asarray(tags, dtype=np.int32) == tag_id
+            if mask.any():
+                tet_blocks.append(block.data[mask])
+        if not tet_blocks:
+            raise RuntimeError(f"no tets for region {self._region!r}")
+
+        elements = np.concatenate(tet_blocks, axis=0)
+        unique_nodes = np.unique(elements)
+        node_map = np.full(m.points.shape[0], -1, dtype=np.int64)
+        node_map[unique_nodes] = np.arange(len(unique_nodes))
+        nodes = m.points[unique_nodes] * self._scale
+        return UnstructuredSubMesh(nodes, node_map[elements], coord_sys=self.coord_sys)
+
+
+# ======================================================================
+# Interface data
+# ======================================================================
+
+
+def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=None):
+    """
+    Compute coupling data for the interface between two adjacent
+    :class:`UnstructuredSubMesh` objects.
+
+    Finds "right" boundary faces of *left_mesh* and "left" boundary faces
+    of *right_mesh*, matches them by face centroid position, and records
+    cell indices, face areas, and centroid-to-centroid distances.
+
+    Parameters
+    ----------
+    left_mesh : UnstructuredSubMesh
+    right_mesh : UnstructuredSubMesh
+    left_name : str or None
+        Domain name of the left mesh (stored as key in ``interface_data``).
+    right_name : str or None
+        Domain name of the right mesh (stored as key in ``interface_data``).
+
+    Returns
+    -------
+    dict
+        Keys: ``"left_cells"``, ``"right_cells"``, ``"face_areas"``,
+        ``"cell_distances"``.
+    """
+    left_bnd = left_mesh.boundary_faces.get("right", np.array([], dtype=int))
+    right_bnd = right_mesh.boundary_faces.get("left", np.array([], dtype=int))
+
+    if len(left_bnd) == 0 or len(right_bnd) == 0:
+        raise ValueError(
+            "Cannot compute interface data: one or both meshes have no "
+            "matching boundary faces ('right' on left_mesh, 'left' on right_mesh)."
+        )
+
+    left_centroids = left_mesh.face_centroids[left_bnd]
+    right_centroids = right_mesh.face_centroids[right_bnd]
+
+    # Match faces by transverse coordinates (all coords except x)
+    left_transverse = left_centroids[:, 1:]
+    right_transverse = right_centroids[:, 1:]
+
+    # Build a mapping by closest transverse match
+    from scipy.spatial import cKDTree
+
+    tree = cKDTree(right_transverse)
+    dists, right_indices = tree.query(left_transverse)
+
+    tol = 1e-8 * max(
+        np.ptp(left_transverse, axis=0).max(),
+        np.ptp(right_transverse, axis=0).max(),
+        1.0,
+    )
+    if np.any(dists > tol):
+        raise ValueError(
+            f"Interface faces do not match: max transverse mismatch = {dists.max():.2e}. "
+            "Ensure both meshes have the same transverse grid."
+        )
+
+    left_cells = left_mesh.face_owner[left_bnd]
+    right_cells = right_mesh.face_owner[right_bnd[right_indices]]
+    face_areas = left_mesh.face_areas[left_bnd]
+
+    left_cell_centroids = left_mesh.cell_centroids[left_cells]
+    right_cell_centroids = right_mesh.cell_centroids[right_cells]
+    cell_distances = np.linalg.norm(right_cell_centroids - left_cell_centroids, axis=1)
+
+    result = {
+        "left_cells": left_cells,
+        "right_cells": right_cells,
+        "face_areas": face_areas,
+        "cell_distances": cell_distances,
+        "other_mesh": right_mesh,
+    }
+
+    if right_name is not None:
+        left_mesh.interface_data[right_name] = result
+    if left_name is not None:
+        right_mesh.interface_data[left_name] = {
+            "left_cells": right_cells,
+            "right_cells": left_cells,
+            "face_areas": face_areas,
+            "cell_distances": cell_distances,
+            "other_mesh": left_mesh,
+        }
+
+    return result
+
+
+# ======================================================================
+# Grid-to-simplex helpers
+# ======================================================================
+
+
+def _make_quad_grid(x_edges, z_edges):
+    """
+    Build a structured quadrilateral mesh on a rectangle.
+
+    Vertices are ordered counterclockwise so that the shoelace formula
+    gives a positive area and consecutive-edge face enumeration is
+    consistent.
+
+    Returns
+    -------
+    nodes : (n_nodes, 2)
+    elements : (n_cells, 4)
+    """
+    nx = len(x_edges) - 1
+    nz = len(z_edges) - 1
+    xx, zz = np.meshgrid(x_edges, z_edges, indexing="ij")
+    nodes = np.column_stack([xx.ravel(), zz.ravel()])
+
+    def node_id(i, j):
+        return i * (nz + 1) + j
+
+    elements = []
+    for i in range(nx):
+        for j in range(nz):
+            n0 = node_id(i, j)
+            n1 = node_id(i + 1, j)
+            n2 = node_id(i + 1, j + 1)
+            n3 = node_id(i, j + 1)
+            elements.append([n0, n1, n2, n3])
+
+    return nodes, np.array(elements, dtype=int)
+
+
+def _quad_to_tri(x_edges, z_edges):
+    """
+    Triangulate a rectangle defined by ``x_edges`` and ``z_edges``.
+
+    Each quad cell is split into 2 triangles using the lower-left to
+    upper-right diagonal (consistent across all cells for interface
+    conformity).
+
+    Returns
+    -------
+    nodes : (n_nodes, 2)
+    elements : (n_cells, 3)
+    """
+    nx = len(x_edges) - 1
+    nz = len(z_edges) - 1
+    xx, zz = np.meshgrid(x_edges, z_edges, indexing="ij")
+    nodes = np.column_stack([xx.ravel(), zz.ravel()])
+
+    def node_id(i, j):
+        return i * (nz + 1) + j
+
+    elements = []
+    for i in range(nx):
+        for j in range(nz):
+            n0 = node_id(i, j)
+            n1 = node_id(i + 1, j)
+            n2 = node_id(i + 1, j + 1)
+            n3 = node_id(i, j + 1)
+            elements.append([n0, n1, n2])
+            elements.append([n0, n2, n3])
+
+    return nodes, np.array(elements, dtype=int)
+
+
+def _hex_grid(x_edges, y_edges, z_edges):
+    """
+    Create a hexahedral grid from edge arrays.
+
+    Returns nodes and 8-vertex hex elements suitable for
+    :class:`UnstructuredSubMesh` with ``element_type="hexahedron"``.
+
+    Vertex ordering per hex matches :attr:`UnstructuredSubMesh._HEX_FACES`:
+
+    ::
+
+        0=(i,j,k)   1=(i+1,j,k)   2=(i+1,j+1,k)   3=(i,j+1,k)
+        4=(i,j,k+1) 5=(i+1,j,k+1) 6=(i+1,j+1,k+1) 7=(i,j+1,k+1)
+
+    Returns
+    -------
+    nodes : (n_nodes, 3)
+    elements : (n_cells, 8)
+    """
+    nx = len(x_edges) - 1
+    ny = len(y_edges) - 1
+    nz = len(z_edges) - 1
+
+    xx, yy, zz = np.meshgrid(x_edges, y_edges, z_edges, indexing="ij")
+    nodes = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
+
+    def node_id(i, j, k):
+        return i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
+
+    # Loop order determines cell numbering and hence Jacobian bandwidth.
+    # Bandwidth = product of the two fastest-varying dimension sizes.
+    # Minimise by putting the largest dimension outermost (slowest).
+    dims = sorted([(nx, "x"), (ny, "y"), (nz, "z")], key=lambda d: d[0], reverse=True)
+
+    elements = []
+    for a in range(dims[0][0]):
+        for b in range(dims[1][0]):
+            for c in range(dims[2][0]):
+                idx = {dims[0][1]: a, dims[1][1]: b, dims[2][1]: c}
+                i, j, k = idx["x"], idx["y"], idx["z"]
+                elements.append(
+                    [
+                        node_id(i, j, k),
+                        node_id(i + 1, j, k),
+                        node_id(i + 1, j + 1, k),
+                        node_id(i, j + 1, k),
+                        node_id(i, j, k + 1),
+                        node_id(i + 1, j, k + 1),
+                        node_id(i + 1, j + 1, k + 1),
+                        node_id(i, j + 1, k + 1),
+                    ]
+                )
+
+    return nodes, np.array(elements, dtype=int)
+
+
+def _hex_to_tet(x_edges, y_edges, z_edges, i_offset=0):
+    """
+    Tetrahedralise a rectangular prism defined by edge arrays.
+
+    Each hex cell is split into 5 tetrahedra using a consistent
+    decomposition that guarantees matching triangular faces on
+    axis-aligned planes (required for interface conformity).
+
+    The decomposition alternates orientation based on the parity of
+    (i + i_offset + j + k) so that shared faces between adjacent hexes
+    are triangulated identically, including across domain boundaries
+    when ``i_offset`` equals the cumulative hex count from preceding
+    domains.
+
+    Returns
+    -------
+    nodes : (n_nodes, 3)
+    elements : (n_cells, 4)
+    """
+    nx = len(x_edges) - 1
+    ny = len(y_edges) - 1
+    nz = len(z_edges) - 1
+
+    xx, yy, zz = np.meshgrid(x_edges, y_edges, z_edges, indexing="ij")
+    nodes = np.column_stack([xx.ravel(), yy.ravel(), zz.ravel()])
+
+    def node_id(i, j, k):
+        return i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
+
+    # Two 5-tet decomposition patterns that share identical face diagonals
+    # on every axis-aligned interface.
+    # Hex vertices numbered:
+    #   0 = (i,   j,   k  )   4 = (i,   j,   k+1)
+    #   1 = (i+1, j,   k  )   5 = (i+1, j,   k+1)
+    #   2 = (i+1, j+1, k  )   6 = (i+1, j+1, k+1)
+    #   3 = (i,   j+1, k  )   7 = (i,   j+1, k+1)
+    #
+    # Pattern A (even parity): diagonal from vertex 0 to 6
+    pattern_a = [
+        (0, 1, 2, 5),
+        (0, 2, 3, 7),
+        (0, 5, 7, 4),
+        (2, 5, 7, 6),
+        (0, 2, 5, 7),
+    ]
+    # Pattern B (odd parity): diagonal from vertex 1 to 7
+    pattern_b = [
+        (1, 0, 3, 4),
+        (1, 2, 3, 6),
+        (1, 6, 4, 5),
+        (3, 4, 6, 7),
+        (1, 3, 4, 6),
+    ]
+
+    elements = []
+    for i in range(nx):
+        for j in range(ny):
+            for k in range(nz):
+                hex_verts = [
+                    node_id(i, j, k),
+                    node_id(i + 1, j, k),
+                    node_id(i + 1, j + 1, k),
+                    node_id(i, j + 1, k),
+                    node_id(i, j, k + 1),
+                    node_id(i + 1, j, k + 1),
+                    node_id(i + 1, j + 1, k + 1),
+                    node_id(i, j + 1, k + 1),
+                ]
+                pattern = pattern_a if (i + i_offset + j + k) % 2 == 0 else pattern_b
+                for tet in pattern:
+                    elements.append([hex_verts[v] for v in tet])
+
+    return nodes, np.array(elements, dtype=int)

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -424,6 +424,34 @@ class UnstructuredSubMesh(SubMesh):
                     if len(matched) > 0:
                         combined.boundary_faces[tag] = np.unique(matched) + bnd_start
 
+        # Welding only produces internal faces where interface nodes coincide.
+        # If a region shares no interface with the rest (mismatched transverse
+        # grids, wrong units, or a non-conforming input mesh) it stays a
+        # separate connected component and no flux can cross into it, which
+        # otherwise solves silently to a wrong answer. Reuse the integer face
+        # connectivity (no distance tolerance) to require a single component.
+        if len(submeshes) > 1 and combined.npts > 1:
+            from scipy.sparse import csr_matrix
+            from scipy.sparse.csgraph import connected_components
+
+            n_int = combined._boundary_face_start
+            rows = np.concatenate([combined.face_owner[:n_int], combined.face_neighbor])
+            cols = np.concatenate([combined.face_neighbor, combined.face_owner[:n_int]])
+            adjacency = csr_matrix(
+                (np.ones(len(rows)), (rows, cols)),
+                shape=(combined.npts, combined.npts),
+            )
+            n_components, _ = connected_components(adjacency, directed=False)
+            if n_components > 1:
+                raise pybamm.GeometryError(
+                    f"Combined unstructured mesh has {n_components} disconnected "
+                    f"regions: welding produced no interface between some domains, "
+                    f"so no flux could cross and the solve would be silently wrong. "
+                    f"Adjacent domains must share a conforming interface — matching "
+                    f"transverse grids and coordinate units, or a fragmented "
+                    f"(node-shared) mesh from the mesh generator."
+                )
+
         return combined
 
     def optimize_ordering(self):
@@ -711,6 +739,14 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
     """
     Load an unstructured mesh from an external file via *meshio*.
 
+    The interface between adjacent domains must be **conforming**: the two
+    sides must share the same interface nodes, so that welding in
+    :meth:`UnstructuredSubMesh.combine` turns the interface into internal
+    faces. In gmsh, build the regions from one geometry or fragment the parts
+    (``BooleanFragments`` / ``Coherence``) so the shared surface is meshed
+    once. A non-conforming interface raises a :class:`pybamm.GeometryError`
+    when the domains are combined.
+
     Parameters
     ----------
     filepath : str
@@ -857,6 +893,12 @@ class TaggedSubMeshGenerator(MeshGenerator):
     through one generator by introspecting ``lims``; ``TaggedSubMeshGenerator``
     is simpler when the model already supplies one mesh generator per
     domain.
+
+    Regions that share an interface must be conforming across it (the shared
+    surface meshed once, so both regions reference the same interface nodes),
+    or combining the domains raises a :class:`pybamm.GeometryError`. Fragment
+    the geometry in gmsh (``BooleanFragments`` / ``Coherence``) to guarantee
+    this.
 
     Parameters
     ----------

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -120,33 +120,21 @@ class UnstructuredSubMesh(SubMesh):
             # faces are rejected in _compute_face_geometry). Tet volumes are
             # summed signed so a degenerate or inverted cell cannot cancel
             # into a plausible positive volume.
-            self.cell_volumes = np.zeros(len(self.elements))
-            for i, cell in enumerate(self.elements):
-                cv = self.vertices[cell]
-                vol = 0.0
-                moment = np.zeros(3)
-                # Split hex into 5 consistently-oriented tets (each signed
-                # volume is positive for a right-handed hex, so the signed
-                # sum is the true volume and flips sign for an inverted cell)
-                for tet_local in [
-                    (0, 1, 2, 5),
-                    (0, 2, 3, 7),
-                    (0, 5, 7, 4),
-                    (2, 7, 5, 6),
-                    (0, 5, 2, 7),
-                ]:
-                    t = cv[list(tet_local)]
-                    d1 = t[1] - t[0]
-                    d2 = t[2] - t[0]
-                    d3 = t[3] - t[0]
-                    tet_vol = np.dot(d1, np.cross(d2, d3)) / 6.0
-                    vol += tet_vol
-                    moment += tet_vol * t.mean(axis=0)
-                self.cell_volumes[i] = abs(vol)
-                # Volume-weighted tet centroids: exact for planar-faced hexes
-                # such as frusta, where the vertex mean is not
-                if vol != 0.0:
-                    self.cell_centroids[i] = moment / vol
+            t = verts[:, self._HEX_TETS]  # (n_cells, 5, 4, d)
+            d1 = t[:, :, 1] - t[:, :, 0]
+            d2 = t[:, :, 2] - t[:, :, 0]
+            d3 = t[:, :, 3] - t[:, :, 0]
+            tet_vols = np.einsum("ijk,ijk->ij", d1, np.cross(d2, d3)) / 6.0
+            vol = tet_vols.sum(axis=1)
+            self.cell_volumes = np.abs(vol)
+            # Volume-weighted tet centroids: exact for planar-faced hexes
+            # such as frusta, where the vertex mean is not
+            moment = np.einsum("ij,ijk->ik", tet_vols, t.mean(axis=2))
+            safe_vol = np.where(vol == 0.0, 1.0, vol)
+            nonzero = (vol != 0.0)[:, None]
+            self.cell_centroids = np.where(
+                nonzero, moment / safe_vol[:, None], self.cell_centroids
+            )
 
     # ------------------------------------------------------------------
     # Face-cell connectivity
@@ -242,6 +230,12 @@ class UnstructuredSubMesh(SubMesh):
         (0, 1, 2, 3),  # z- (bottom)
         (4, 5, 6, 7),  # z+ (top)
     ]
+
+    # 5-tet split for volume/centroid computation, each tet ordered so its
+    # signed volume is positive for a right-handed hex
+    _HEX_TETS = np.array(
+        [(0, 1, 2, 5), (0, 2, 3, 7), (0, 5, 7, 4), (2, 7, 5, 6), (0, 5, 2, 7)]
+    )
 
     # ------------------------------------------------------------------
     # Face geometry

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -311,6 +311,121 @@ class UnstructuredSubMesh(SubMesh):
             if len(indices) > 0:
                 self.boundary_faces[name] = indices
 
+    # ------------------------------------------------------------------
+    # Combining domains
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def combine(cls, submeshes):
+        """
+        Weld a list of :class:`UnstructuredSubMesh` objects into one mesh.
+
+        Coincident boundary nodes at domain interfaces are merged so that
+        face connectivity spans across domains.
+
+        Parameters
+        ----------
+        submeshes : list of UnstructuredSubMesh
+            The submeshes to combine, in order.
+
+        Returns
+        -------
+        UnstructuredSubMesh
+            A single mesh covering the union of the input domains.
+        """
+        from scipy.spatial import cKDTree
+
+        # For 3D tet meshes generated from hex grids, regenerate with
+        # cumulative i_offset so that alternating-parity face triangulations
+        # match across domain boundaries.
+        if all(
+            hasattr(sm, "_hex_gen_params") and sm.dimension == 3 for sm in submeshes
+        ):
+            cumulative_offset = 0
+            fixed = []
+            for sm in submeshes:
+                p = sm._hex_gen_params
+                if cumulative_offset > 0:
+                    nodes, elements = _hex_to_tet(
+                        p["x_edges"],
+                        p["y_edges"],
+                        p["z_edges"],
+                        i_offset=cumulative_offset,
+                    )
+                    new_sm = cls(nodes, elements, coord_sys=sm.coord_sys)
+                    new_sm._hex_gen_params = p
+                    fixed.append(new_sm)
+                else:
+                    fixed.append(sm)
+                cumulative_offset += p["nx"]
+            submeshes = fixed
+
+        # Weld coincident nodes across submeshes regardless of which face tag
+        # they belong to, so that interfaces of arbitrary topology (star, tree,
+        # graph) become internal faces and TPFA handles cross-region flux
+        # without internal Neumann book-keeping.
+        tol = 1e-9
+        all_nodes = list(submeshes[0].nodes)
+        global_maps = [{i: i for i in range(submeshes[0].nodes.shape[0])}]
+        next_id = len(all_nodes)
+
+        for k in range(1, len(submeshes)):
+            curr = submeshes[k]
+            tree = cKDTree(np.asarray(all_nodes))
+            d, j = tree.query(curr.nodes)
+            local_to_global = {}
+            for nid in range(curr.nodes.shape[0]):
+                if d[nid] < tol:
+                    local_to_global[nid] = int(j[nid])
+                else:
+                    local_to_global[nid] = next_id
+                    all_nodes.append(curr.nodes[nid])
+                    next_id += 1
+            global_maps.append(local_to_global)
+
+        all_elements = [submeshes[0].elements.copy()]
+        for k in range(1, len(submeshes)):
+            gm = global_maps[k]
+            remapped = np.array(
+                [[gm[v] for v in row] for row in submeshes[k].elements],
+                dtype=int,
+            )
+            all_elements.append(remapped)
+
+        combined_nodes = np.array(all_nodes)
+        combined_elements = np.concatenate(all_elements, axis=0)
+        combined = cls(
+            combined_nodes,
+            combined_elements,
+            coord_sys=submeshes[0].coord_sys,
+        )
+
+        # The combined mesh auto-detects only standard tags, so custom tags
+        # like "tab_top" are recovered by matching boundary face centroids.
+        standard_tags = {"left", "right", "top", "bottom", "front", "back"}
+        custom_centroids = {}  # tag -> list of centroid arrays
+        for sm in submeshes:
+            for tag, face_indices in sm.boundary_faces.items():
+                if tag not in standard_tags:
+                    custom_centroids.setdefault(tag, []).append(
+                        sm.face_centroids[face_indices]
+                    )
+
+        if custom_centroids:
+            bnd_start = combined._boundary_face_start
+            bnd_centroids = combined.face_centroids[bnd_start:]
+            if len(bnd_centroids) > 0:
+                tree = cKDTree(bnd_centroids)
+                match_tol = 1e-10 * max(np.ptp(combined_nodes, axis=0).max(), 1.0)
+                for tag, centroid_list in custom_centroids.items():
+                    all_src = np.concatenate(centroid_list, axis=0)
+                    dists, idxs = tree.query(all_src)
+                    matched = idxs[dists < match_tol]
+                    if len(matched) > 0:
+                        combined.boundary_faces[tag] = np.unique(matched) + bnd_start
+
+        return combined
+
     def optimize_ordering(self):
         """Reorder cells using Reverse Cuthill-McKee to reduce Jacobian bandwidth.
 

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -461,11 +461,18 @@ class UnstructuredSubMesh(SubMesh):
         self.face_owner = inv_perm[self.face_owner]
         self.face_neighbor = inv_perm[self.face_neighbor]
 
+        # In interface_data, "left_cells" indexes this mesh and "right_cells"
+        # indexes the neighbour, so only the former is permuted. The neighbour
+        # holds a mirrored view of the same pairing and is updated with it.
         for data_dict in self.interface_data.values():
-            if "left_cells" in data_dict:
-                data_dict["left_cells"] = inv_perm[data_dict["left_cells"]]
-            if "right_cells" in data_dict:
-                data_dict["right_cells"] = inv_perm[data_dict["right_cells"]]
+            permuted = inv_perm[data_dict["left_cells"]]
+            data_dict["left_cells"] = permuted
+            other = data_dict.get("other_mesh")
+            if other is None:
+                continue
+            for mirror in other.interface_data.values():
+                if mirror.get("other_mesh") is self:
+                    mirror["right_cells"] = permuted
 
     def boundary_loops(self):
         """Return boundary loops as a list of ``matplotlib.path.Path`` (2D only).

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -78,6 +78,8 @@ class UnstructuredSubMesh(SubMesh):
 
     def _compute_cell_geometry(self):
         verts = self.nodes[self.elements]  # (n_cells, n_verts, d)
+        # Vertex mean is the exact centroid for simplices (triangles, tets);
+        # quads and hexes overwrite it with the true area/volume centroid.
         self.cell_centroids = verts.mean(axis=1)
 
         if self.element_type == "triangle":
@@ -87,14 +89,21 @@ class UnstructuredSubMesh(SubMesh):
             ) * (v2[:, 0] - v0[:, 0])
             self.cell_volumes = 0.5 * np.abs(cross)
         elif self.element_type == "quad":
-            # Shoelace formula for arbitrary (convex) quadrilaterals
+            # Shoelace formula for arbitrary simple quadrilaterals
             # Vertices ordered: v0, v1, v2, v3 (counterclockwise or clockwise)
             x = verts[:, :, 0]  # (n_cells, 4)
             y = verts[:, :, 1]  # (n_cells, 4)
             # shoelace: sum_i (x_i * y_{i+1} - x_{i+1} * y_i)
             x_next = np.roll(x, -1, axis=1)
             y_next = np.roll(y, -1, axis=1)
-            self.cell_volumes = 0.5 * np.abs(np.sum(x * y_next - x_next * y, axis=1))
+            cross = x * y_next - x_next * y
+            signed_area = 0.5 * np.sum(cross, axis=1)
+            self.cell_volumes = np.abs(signed_area)
+            # Polygon centroid (exact for non-parallelogram quads, where the
+            # vertex mean is not)
+            cx = np.sum((x + x_next) * cross, axis=1) / (6.0 * signed_area)
+            cy = np.sum((y + y_next) * cross, axis=1) / (6.0 * signed_area)
+            self.cell_centroids = np.column_stack([cx, cy])
         elif self.element_type == "tetrahedron":
             v0, v1, v2, v3 = verts[:, 0], verts[:, 1], verts[:, 2], verts[:, 3]
             d1 = v1 - v0
@@ -115,6 +124,7 @@ class UnstructuredSubMesh(SubMesh):
             for i, cell in enumerate(self.elements):
                 cv = self.nodes[cell]
                 vol = 0.0
+                moment = np.zeros(3)
                 # Split hex into 5 consistently-oriented tets (each signed
                 # volume is positive for a right-handed hex, so the signed
                 # sum is the true volume and flips sign for an inverted cell)
@@ -129,8 +139,14 @@ class UnstructuredSubMesh(SubMesh):
                     d1 = t[1] - t[0]
                     d2 = t[2] - t[0]
                     d3 = t[3] - t[0]
-                    vol += np.dot(d1, np.cross(d2, d3)) / 6.0
+                    tet_vol = np.dot(d1, np.cross(d2, d3)) / 6.0
+                    vol += tet_vol
+                    moment += tet_vol * t.mean(axis=0)
                 self.cell_volumes[i] = abs(vol)
+                # Volume-weighted tet centroids: exact for planar-faced hexes
+                # such as frusta, where the vertex mean is not
+                if vol != 0.0:
+                    self.cell_centroids[i] = moment / vol
 
     # ------------------------------------------------------------------
     # Face-cell connectivity
@@ -272,6 +288,21 @@ class UnstructuredSubMesh(SubMesh):
             cross = np.cross(diag1, diag2)
             self.face_areas = 0.5 * np.linalg.norm(cross, axis=1)
             normals = cross
+
+            # Area-weighted centroid over the (0,1,2)/(0,2,3) triangle split:
+            # exact for planar non-parallelogram quads (e.g. trapezoids),
+            # where the vertex mean is not. Signed areas taken along the face
+            # normal keep non-convex planar quads exact too.
+            n_hat = plane_normal / safe_norm[:, None]
+            area1 = 0.5 * np.einsum("ij,ij->i", np.cross(v1 - v0, v2 - v0), n_hat)
+            area2 = 0.5 * np.einsum("ij,ij->i", np.cross(v2 - v0, v3 - v0), n_hat)
+            total = area1 + area2
+            safe_total = np.where(np.abs(total) < 1e-30, 1.0, total)
+            weighted = (
+                area1[:, None] * (v0 + v1 + v2) + area2[:, None] * (v0 + v2 + v3)
+            ) / (3.0 * safe_total[:, None])
+            nonzero = np.abs(total) >= 1e-30
+            self.face_centroids[nonzero] = weighted[nonzero]
         else:
             # Face = triangle: 3 vertices
             v0, v1, v2 = face_verts[:, 0], face_verts[:, 1], face_verts[:, 2]

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -408,35 +408,21 @@ class UnstructuredSubMesh(SubMesh):
         # graph) become internal faces and TPFA handles cross-region flux
         # without internal Neumann book-keeping.
         tol = _geometric_tolerance(submeshes)
-        all_nodes = list(submeshes[0].vertices)
-        global_maps = [{i: i for i in range(submeshes[0].vertices.shape[0])}]
-        next_id = len(all_nodes)
+        combined_nodes = np.asarray(submeshes[0].vertices, dtype=float)
+        global_maps = [np.arange(len(combined_nodes))]
 
-        for k in range(1, len(submeshes)):
-            curr = submeshes[k]
-            tree = cKDTree(np.asarray(all_nodes))
-            d, j = tree.query(curr.vertices)
-            local_to_global = {}
-            for nid in range(curr.vertices.shape[0]):
-                if d[nid] < tol:
-                    local_to_global[nid] = int(j[nid])
-                else:
-                    local_to_global[nid] = next_id
-                    all_nodes.append(curr.vertices[nid])
-                    next_id += 1
-            global_maps.append(local_to_global)
-
-        all_elements = [submeshes[0].elements.copy()]
-        for k in range(1, len(submeshes)):
-            gm = global_maps[k]
-            remapped = np.array(
-                [[gm[v] for v in row] for row in submeshes[k].elements],
-                dtype=int,
+        for sm in submeshes[1:]:
+            d, j = cKDTree(combined_nodes).query(sm.vertices)
+            new = d >= tol
+            global_maps.append(
+                np.where(new, np.cumsum(new) - 1 + len(combined_nodes), j)
             )
-            all_elements.append(remapped)
+            combined_nodes = np.vstack([combined_nodes, sm.vertices[new]])
 
-        combined_nodes = np.array(all_nodes)
-        combined_elements = np.concatenate(all_elements, axis=0)
+        combined_elements = np.concatenate(
+            [gm[sm.elements] for gm, sm in zip(global_maps, submeshes, strict=True)],
+            axis=0,
+        )
         combined = cls(
             combined_nodes,
             combined_elements,

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -32,8 +32,11 @@ class UnstructuredSubMesh(SubMesh):
     coord_sys : str, optional
         Coordinate system, default ``"cartesian"``.
     boundary_faces : dict[str, numpy.ndarray] or None, optional
-        Maps boundary name to face indices.  If ``None``, boundaries
-        are auto-detected from face centroid positions.
+        Maps boundary name to face indices.  If ``None``, no boundary
+        tags are assigned: tags must come from the mesh source (the
+        built-in generator tags its own box output, file generators use
+        the mesh file's boundary names), or call
+        :meth:`detect_box_boundaries` for a hand-built axis-aligned box.
     """
 
     def __init__(self, nodes, elements, coord_sys="cartesian", boundary_faces=None):
@@ -61,10 +64,7 @@ class UnstructuredSubMesh(SubMesh):
         self._build_face_connectivity()
         self._compute_face_geometry()
 
-        if boundary_faces is not None:
-            self.boundary_faces = boundary_faces
-        else:
-            self._identify_boundary_faces()
+        self.boundary_faces = boundary_faces if boundary_faces is not None else {}
 
         self.npts = len(self.elements)
         self.npts_lr = self.npts
@@ -329,7 +329,17 @@ class UnstructuredSubMesh(SubMesh):
     # Boundary identification
     # ------------------------------------------------------------------
 
-    def _identify_boundary_faces(self):
+    def detect_box_boundaries(self):
+        """Tag boundary faces of an axis-aligned box by outward normal.
+
+        Assigns ``left``/``right`` (x), ``front``/``back`` (y, 3D only),
+        and ``bottom``/``top`` (z) by each exterior face's dominant normal
+        direction, overwriting ``boundary_faces``. Only meaningful for
+        axis-aligned box domains (each face genuinely normal to one axis);
+        on curved geometry the buckets are not surfaces. The built-in
+        generator calls this on its output; meshes from files should carry
+        their own boundary names instead.
+        """
         bnd_start = self._boundary_face_start
         bnd_centroids = self.face_centroids[bnd_start:]
 
@@ -431,24 +441,24 @@ class UnstructuredSubMesh(SubMesh):
             coord_sys=submeshes[0].coord_sys,
         )
 
-        # The combined mesh auto-detects only standard tags, so custom tags
-        # like "tab_top" are recovered by matching boundary face centroids.
-        standard_tags = {"left", "right", "top", "bottom", "front", "back"}
-        custom_centroids = {}  # tag -> list of centroid arrays
+        # The combined mesh starts with no tags: every tag is propagated from
+        # the input submeshes by matching boundary face centroids. Faces that
+        # welding turned internal (interface faces) match no combined boundary
+        # face and drop out naturally.
+        tag_centroids = {}  # tag -> list of centroid arrays
         for sm in submeshes:
             for tag, face_indices in sm.boundary_faces.items():
-                if tag not in standard_tags:
-                    custom_centroids.setdefault(tag, []).append(
-                        sm.face_centroids[face_indices]
-                    )
+                tag_centroids.setdefault(tag, []).append(
+                    sm.face_centroids[face_indices]
+                )
 
-        if custom_centroids:
+        if tag_centroids:
             bnd_start = combined._boundary_face_start
             bnd_centroids = combined.face_centroids[bnd_start:]
             if len(bnd_centroids) > 0:
                 tree = cKDTree(bnd_centroids)
                 match_tol = 1e-10 * max(np.ptp(combined_nodes, axis=0).max(), 1.0)
-                for tag, centroid_list in custom_centroids.items():
+                for tag, centroid_list in tag_centroids.items():
                     all_src = np.concatenate(centroid_list, axis=0)
                     dists, idxs = tree.query(all_src)
                     matched = idxs[dists < match_tol]
@@ -749,7 +759,10 @@ class UnstructuredMeshGenerator(MeshGenerator):
             nodes, elements = _quad_to_tri(x_edges, z_edges)
         else:
             raise pybamm.GeometryError(f"Unsupported 2D element_type: {etype!r}")
-        return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+        submesh = UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+        # The generator's output is an axis-aligned box by construction
+        submesh.detect_box_boundaries()
+        return submesh
 
     # ------------------------------------------------------------------
     # 3D
@@ -769,12 +782,14 @@ class UnstructuredMeshGenerator(MeshGenerator):
         etype = self._element_type or "hexahedron"
         if etype == "hexahedron":
             nodes, elements = _hex_grid(x_edges, y_edges, z_edges)
-            return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
         elif etype == "tetrahedron":
             nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
-            return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
         else:
             raise pybamm.GeometryError(f"Unsupported 3D element_type: {etype!r}")
+        submesh = UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+        # The generator's output is an axis-aligned box by construction
+        submesh.detect_box_boundaries()
+        return submesh
 
 
 class UserSuppliedUnstructuredMesh(MeshGenerator):

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -49,7 +49,7 @@ class UnstructuredSubMesh(SubMesh):
         elif self.dimension == 3 and verts_per_cell == 8:
             self.element_type = "hexahedron"
         else:
-            raise ValueError(
+            raise pybamm.GeometryError(
                 f"Unsupported: {verts_per_cell} vertices per cell in {self.dimension}D"
             )
 
@@ -141,7 +141,6 @@ class UnstructuredSubMesh(SubMesh):
 
         # Build all faces at once using local face definitions
         if self.element_type == "quad":
-            n_fpc = 4  # faces per cell
             idx = np.arange(4)
             local = np.stack([idx, (idx + 1) % 4], axis=1)  # (4, 2)
         elif self.element_type == "triangle":
@@ -162,6 +161,16 @@ class UnstructuredSubMesh(SubMesh):
         _, inverse, counts = np.unique(
             sorted_faces, axis=0, return_inverse=True, return_counts=True
         )
+
+        # A manifold mesh shares each face between at most two cells. A count of
+        # three or more means overlapping or non-conforming elements; such faces
+        # match neither branch below and would silently vanish, so reject them.
+        if (counts > 2).any():
+            raise pybamm.GeometryError(
+                "Unstructured mesh is non-manifold: at least one face is shared "
+                "by more than two cells. Check for overlapping or duplicated "
+                "elements in the input mesh."
+            )
 
         is_internal = counts[inverse] == 2
         is_boundary = counts[inverse] == 1
@@ -207,20 +216,6 @@ class UnstructuredSubMesh(SubMesh):
         (0, 1, 2, 3),  # z- (bottom)
         (4, 5, 6, 7),  # z+ (top)
     ]
-
-    def _cell_faces(self, cell_verts):
-        """Yield face vertex tuples for a single cell."""
-        n = len(cell_verts)
-        if self.element_type == "quad":
-            for i in range(n):
-                yield (cell_verts[i], cell_verts[(i + 1) % n])
-        elif self.element_type == "hexahedron":
-            for local_face in self._HEX_FACES:
-                yield tuple(cell_verts[v] for v in local_face)
-        else:
-            # Simplex: d+1 faces, face i omits vertex i
-            for skip in range(n):
-                yield tuple(cell_verts[j] for j in range(n) if j != skip)
 
     # ------------------------------------------------------------------
     # Face geometry
@@ -591,7 +586,7 @@ class UnstructuredSubMesh(SubMesh):
             )
             tri_normals = np.concatenate([bnd_normals, bnd_normals], axis=0)
         else:
-            raise ValueError(
+            raise pybamm.GeometryError(
                 f"contains_points_3d: unsupported face with {n_vpf} vertices"
             )
 
@@ -641,21 +636,19 @@ class UnstructuredMeshGenerator(MeshGenerator):
     """
     Built-in generator that creates meshes from structured grids.
 
-    * **2D**: rectangular domain meshed as quads or triangulated by
+    * **2D**: rectangular domain meshed as quads, or triangulated by
       splitting each quad into 2 triangles.
-    * **3D**: rectangular prism meshed by splitting each hex into 5
-      tetrahedra.
+    * **3D**: rectangular prism meshed as hexahedra, or split into 5
+      tetrahedra per hex.
 
     Parameters
     ----------
     coord_sys : str, optional
         Coordinate system, default ``"cartesian"``.
     element_type : str, optional
-        ``"quad"`` for quadrilateral cells (2D only, TPFA-orthogonal),
-        ``"triangle"`` for triangular cells (2D default),
-        ``"tetrahedron"`` for tetrahedral cells (3D default).
-        If ``None``, defaults to ``"triangle"`` in 2D and
-        ``"tetrahedron"`` in 3D.
+        ``"quad"`` or ``"triangle"`` in 2D; ``"hexahedron"`` or
+        ``"tetrahedron"`` in 3D. If ``None``, defaults to ``"triangle"``
+        in 2D and ``"hexahedron"`` in 3D.
     """
 
     def __init__(self, coord_sys="cartesian", element_type=None):
@@ -672,7 +665,7 @@ class UnstructuredMeshGenerator(MeshGenerator):
         elif dim == 3:
             return self._generate_3d(spatial_vars, spatial_lims, npts)
         else:
-            raise ValueError(
+            raise pybamm.GeometryError(
                 f"UnstructuredMeshGenerator supports 2D and 3D, got {dim} spatial variables"
             )
 
@@ -713,11 +706,11 @@ class UnstructuredMeshGenerator(MeshGenerator):
         elif etype == "triangle":
             nodes, elements = _quad_to_tri(x_edges, z_edges)
         else:
-            raise ValueError(f"Unsupported 2D element_type: {etype!r}")
+            raise pybamm.GeometryError(f"Unsupported 2D element_type: {etype!r}")
         return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
 
     # ------------------------------------------------------------------
-    # 3D: hex -> 5 tets
+    # 3D
     # ------------------------------------------------------------------
 
     def _generate_3d(self, spatial_vars, spatial_lims, npts):
@@ -731,8 +724,25 @@ class UnstructuredMeshGenerator(MeshGenerator):
         y_edges = np.linspace(lim_y["min"], lim_y["max"], ny + 1)
         z_edges = np.linspace(lim_z["min"], lim_z["max"], nz + 1)
 
-        nodes, elements = _hex_grid(x_edges, y_edges, z_edges)
-        return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+        etype = self._element_type or "hexahedron"
+        if etype == "hexahedron":
+            nodes, elements = _hex_grid(x_edges, y_edges, z_edges)
+            return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+        elif etype == "tetrahedron":
+            nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
+            submesh = UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
+            # Record the source grid so that combining tet domains can rebuild
+            # each with a cumulative offset, keeping face triangulations
+            # conforming across domain interfaces (see combine()).
+            submesh._hex_gen_params = {
+                "x_edges": x_edges,
+                "y_edges": y_edges,
+                "z_edges": z_edges,
+                "nx": nx,
+            }
+            return submesh
+        else:
+            raise pybamm.GeometryError(f"Unsupported 3D element_type: {etype!r}")
 
 
 class UserSuppliedUnstructuredMesh(MeshGenerator):
@@ -777,7 +787,7 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
         self._cached_mesh = None
 
     def __call__(self, lims, npts):
-        import meshio
+        meshio = pybamm.import_optional_dependency("meshio")
 
         if self._cached_mesh is None:
             self._cached_mesh = meshio.read(self.filepath)
@@ -855,7 +865,7 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
                 if len(blocks) == 1:
                     return blocks[0], cell_type
                 return np.concatenate(blocks, axis=0), cell_type
-        raise ValueError(
+        raise pybamm.GeometryError(
             "No supported cells found in mesh file "
             "(expected tetra/hexahedron/triangle/quad)"
         )
@@ -872,7 +882,7 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
                 if len(matching) == 1:
                     return matching[0] == tag_value
                 return np.concatenate(matching, axis=0) == tag_value
-        raise ValueError(
+        raise pybamm.GeometryError(
             f"Could not find cell data tag {tag_value} for cell type '{cell_type}'"
         )
 
@@ -926,15 +936,14 @@ class TaggedSubMeshGenerator(MeshGenerator):
     @classmethod
     def _read(cls, path):
         if path not in cls._mesh_cache:
-            import meshio
-
+            meshio = pybamm.import_optional_dependency("meshio")
             cls._mesh_cache[path] = meshio.read(str(path))
         return cls._mesh_cache[path]
 
     def __call__(self, lims, npts):
         m = self._read(self._mesh_path)
         if self._region not in m.field_data:
-            raise KeyError(
+            raise pybamm.GeometryError(
                 f"region {self._region!r} not in mesh field_data; "
                 f"available: {list(m.field_data)}"
             )
@@ -950,7 +959,7 @@ class TaggedSubMeshGenerator(MeshGenerator):
             if mask.any():
                 tet_blocks.append(block.data[mask])
         if not tet_blocks:
-            raise RuntimeError(f"no tets for region {self._region!r}")
+            raise pybamm.GeometryError(f"no tets for region {self._region!r}")
 
         elements = np.concatenate(tet_blocks, axis=0)
         unique_nodes = np.unique(elements)
@@ -993,7 +1002,7 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
     right_bnd = right_mesh.boundary_faces.get("left", np.array([], dtype=int))
 
     if len(left_bnd) == 0 or len(right_bnd) == 0:
-        raise ValueError(
+        raise pybamm.GeometryError(
             "Cannot compute interface data: one or both meshes have no "
             "matching boundary faces ('right' on left_mesh, 'left' on right_mesh)."
         )
@@ -1017,7 +1026,7 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
         1.0,
     )
     if np.any(dists > tol):
-        raise ValueError(
+        raise pybamm.GeometryError(
             f"Interface faces do not match: max transverse mismatch = {dists.max():.2e}. "
             "Ensure both meshes have the same transverse grid."
         )

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -19,12 +19,12 @@ class UnstructuredSubMesh(SubMesh):
     raises a :class:`pybamm.GeometryError` for them.
 
     All operators are dimension-agnostic: the same code path handles
-    both 2D and 3D, with dimension inferred from ``nodes.shape[1]``.
+    both 2D and 3D, with dimension inferred from ``vertices.shape[1]``.
 
     Parameters
     ----------
-    nodes : numpy.ndarray
-        Vertex coordinates, of shape ``(n_nodes, d)`` (d = 2 or 3).
+    vertices : numpy.ndarray
+        Vertex coordinates, of shape ``(n_vertices, d)`` (d = 2 or 3).
     elements : numpy.ndarray
         Element vertex indices, of shape ``(n_cells, n_verts_per_cell)``.
         For 2D: 3 (triangles) or 4 (quads).
@@ -39,11 +39,11 @@ class UnstructuredSubMesh(SubMesh):
         :meth:`detect_box_boundaries` for a hand-built axis-aligned box.
     """
 
-    def __init__(self, nodes, elements, coord_sys="cartesian", boundary_faces=None):
+    def __init__(self, vertices, elements, coord_sys="cartesian", boundary_faces=None):
         super().__init__()
-        self.nodes = np.asarray(nodes, dtype=float)
+        self.vertices = np.asarray(vertices, dtype=float)
         self.elements = np.asarray(elements, dtype=int)
-        self.dimension = self.nodes.shape[1]
+        self.dimension = self.vertices.shape[1]
         self.coord_sys = coord_sys
 
         verts_per_cell = self.elements.shape[1]
@@ -77,7 +77,7 @@ class UnstructuredSubMesh(SubMesh):
     # ------------------------------------------------------------------
 
     def _compute_cell_geometry(self):
-        verts = self.nodes[self.elements]  # (n_cells, n_verts, d)
+        verts = self.vertices[self.elements]  # (n_cells, n_verts, d)
         # Vertex mean is the exact centroid for simplices (triangles, tets);
         # quads and hexes overwrite it with the true area/volume centroid.
         self.cell_centroids = verts.mean(axis=1)
@@ -122,7 +122,7 @@ class UnstructuredSubMesh(SubMesh):
             # into a plausible positive volume.
             self.cell_volumes = np.zeros(len(self.elements))
             for i, cell in enumerate(self.elements):
-                cv = self.nodes[cell]
+                cv = self.vertices[cell]
                 vol = 0.0
                 moment = np.zeros(3)
                 # Split hex into 5 consistently-oriented tets (each signed
@@ -248,7 +248,7 @@ class UnstructuredSubMesh(SubMesh):
     # ------------------------------------------------------------------
 
     def _compute_face_geometry(self):
-        face_verts = self.nodes[self.faces]
+        face_verts = self.vertices[self.faces]
 
         self.face_centroids = face_verts.mean(axis=1)
 
@@ -414,21 +414,21 @@ class UnstructuredSubMesh(SubMesh):
         # graph) become internal faces and TPFA handles cross-region flux
         # without internal Neumann book-keeping.
         tol = _geometric_tolerance(submeshes)
-        all_nodes = list(submeshes[0].nodes)
-        global_maps = [{i: i for i in range(submeshes[0].nodes.shape[0])}]
+        all_nodes = list(submeshes[0].vertices)
+        global_maps = [{i: i for i in range(submeshes[0].vertices.shape[0])}]
         next_id = len(all_nodes)
 
         for k in range(1, len(submeshes)):
             curr = submeshes[k]
             tree = cKDTree(np.asarray(all_nodes))
-            d, j = tree.query(curr.nodes)
+            d, j = tree.query(curr.vertices)
             local_to_global = {}
-            for nid in range(curr.nodes.shape[0]):
+            for nid in range(curr.vertices.shape[0]):
                 if d[nid] < tol:
                     local_to_global[nid] = int(j[nid])
                 else:
                     local_to_global[nid] = next_id
-                    all_nodes.append(curr.nodes[nid])
+                    all_nodes.append(curr.vertices[nid])
                     next_id += 1
             global_maps.append(local_to_global)
 
@@ -605,7 +605,7 @@ class UnstructuredSubMesh(SubMesh):
 
         loop_data = []
         for loop in loops:
-            pts = self.nodes[loop]
+            pts = self.vertices[loop]
             sa = signed_area(pts)
             loop_data.append((abs(sa), pts))
 
@@ -646,9 +646,9 @@ class UnstructuredSubMesh(SubMesh):
                 f"contains_points_3d: unsupported face with {n_vpf} vertices"
             )
 
-        v0 = self.nodes[tri_idx[:, 0]]
-        v1 = self.nodes[tri_idx[:, 1]]
-        v2 = self.nodes[tri_idx[:, 2]]
+        v0 = self.vertices[tri_idx[:, 0]]
+        v1 = self.vertices[tri_idx[:, 1]]
+        v2 = self.vertices[tri_idx[:, 2]]
 
         # Ensure consistent CCW orientation from outside (matching outward normals)
         cross = np.cross(v1 - v0, v2 - v0)
@@ -1240,7 +1240,7 @@ def _geometric_tolerance(submeshes, rel=1e-3):
     min_edge = min(
         float(
             np.linalg.norm(
-                sm.nodes[sm.elements[:, 1]] - sm.nodes[sm.elements[:, 0]], axis=1
+                sm.vertices[sm.elements[:, 1]] - sm.vertices[sm.elements[:, 0]], axis=1
             ).min()
         )
         for sm in submeshes

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -14,6 +14,10 @@ class UnstructuredSubMesh(SubMesh):
     * **2D**: triangles (3 vertices) or quadrilaterals (4 vertices)
     * **3D**: tetrahedra (4 vertices) or hexahedra (8 vertices)
 
+    Hexahedra must have planar faces: volumes and face fluxes are
+    ill-defined on warped (non-planar-faced) hexes, so construction
+    raises a :class:`pybamm.GeometryError` for them.
+
     All operators are dimension-agnostic: the same code path handles
     both 2D and 3D, with dimension inferred from ``nodes.shape[1]``.
 
@@ -103,27 +107,30 @@ class UnstructuredSubMesh(SubMesh):
             )
             self.cell_volumes = np.abs(det) / 6.0
         elif self.element_type == "hexahedron":
-            # Volume via divergence theorem: V = (1/3) sum_faces (centroid . normal * area)
-            # For axis-aligned hexes this simplifies, but we use the general approach
-            # by splitting each hex into 5 tets for volume computation only.
+            # 5-tet decomposition, exact only for planar-faced hexes (warped
+            # faces are rejected in _compute_face_geometry). Tet volumes are
+            # summed signed so a degenerate or inverted cell cannot cancel
+            # into a plausible positive volume.
             self.cell_volumes = np.zeros(len(self.elements))
             for i, cell in enumerate(self.elements):
                 cv = self.nodes[cell]
                 vol = 0.0
-                # Split hex into 5 tets using pattern A
+                # Split hex into 5 consistently-oriented tets (each signed
+                # volume is positive for a right-handed hex, so the signed
+                # sum is the true volume and flips sign for an inverted cell)
                 for tet_local in [
                     (0, 1, 2, 5),
                     (0, 2, 3, 7),
                     (0, 5, 7, 4),
-                    (2, 5, 7, 6),
-                    (0, 2, 5, 7),
+                    (2, 7, 5, 6),
+                    (0, 5, 2, 7),
                 ]:
                     t = cv[list(tet_local)]
                     d1 = t[1] - t[0]
                     d2 = t[2] - t[0]
                     d3 = t[3] - t[0]
-                    vol += abs(np.dot(d1, np.cross(d2, d3))) / 6.0
-                self.cell_volumes[i] = vol
+                    vol += np.dot(d1, np.cross(d2, d3)) / 6.0
+                self.cell_volumes[i] = abs(vol)
 
     # ------------------------------------------------------------------
     # Face-cell connectivity
@@ -237,6 +244,26 @@ class UnstructuredSubMesh(SubMesh):
             v1 = face_verts[:, 1]
             v2 = face_verts[:, 2]
             v3 = face_verts[:, 3]
+
+            # Quad areas, normals, and the 5-tet cell volumes are only
+            # well-defined when all four vertices of a face are coplanar,
+            # so warped (non-planar) faces are rejected outright.
+            plane_normal = np.cross(v1 - v0, v2 - v0)
+            plane_norm = np.linalg.norm(plane_normal, axis=1)
+            safe_norm = np.where(plane_norm < 1e-30, 1.0, plane_norm)
+            offset = np.abs(
+                np.einsum("ij,ij->i", v3 - v0, plane_normal / safe_norm[:, None])
+            )
+            diag_len = np.linalg.norm(v2 - v0, axis=1)
+            warped = offset > 1e-8 * np.maximum(diag_len, 1e-30)
+            if warped.any():
+                raise pybamm.GeometryError(
+                    f"{int(warped.sum())} hexahedral face(s) are non-planar "
+                    "(warped): the fourth vertex does not lie in the plane of "
+                    "the other three. Volumes and face fluxes are ill-defined "
+                    "on warped hexahedra. Fix the mesh, or use tetrahedra."
+                )
+
             diag1 = v2 - v0
             diag2 = v3 - v1
             cross = np.cross(diag1, diag2)
@@ -749,6 +776,11 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
     """
     Load an unstructured mesh from an external file via *meshio*.
 
+    Supported cell types are tetrahedra (3D) and triangles or quadrilaterals
+    (2D). Hexahedral file meshes are rejected: file meshes commonly contain
+    warped (non-planar-faced) hexes, whose volumes and face fluxes are
+    ill-defined. Convert such meshes to tetrahedra before loading.
+
     The interface between adjacent domains must be **conforming**: the two
     sides must share the same interface nodes, so that welding in
     :meth:`UnstructuredSubMesh.combine` turns the interface into internal
@@ -858,16 +890,27 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
 
     @staticmethod
     def _extract_supported_cells(mesh):
+        # Hexahedra from files are rejected outright rather than silently
+        # dropped: file meshes commonly contain warped (non-planar-faced)
+        # hexes, for which cell volumes and face fluxes are ill-defined.
+        if any(block.type == "hexahedron" for block in mesh.cells):
+            raise pybamm.GeometryError(
+                "Hexahedral cells in mesh files are not supported: warped "
+                "(non-planar-faced) hexahedra have ill-defined volumes and "
+                "face fluxes. Convert the mesh to tetrahedra (e.g. with "
+                "gmsh or meshio) and reload. Hexahedral meshes are still "
+                "available through pybamm.UnstructuredMeshGenerator, whose "
+                "axis-aligned cells are always well-defined."
+            )
         # Prefer 3D cells when present, otherwise fall back to 2D.
-        for cell_type in ("tetra", "hexahedron", "triangle", "quad"):
+        for cell_type in ("tetra", "triangle", "quad"):
             blocks = [block.data for block in mesh.cells if block.type == cell_type]
             if blocks:
                 if len(blocks) == 1:
                     return blocks[0], cell_type
                 return np.concatenate(blocks, axis=0), cell_type
         raise pybamm.GeometryError(
-            "No supported cells found in mesh file "
-            "(expected tetra/hexahedron/triangle/quad)"
+            "No supported cells found in mesh file (expected tetra/triangle/quad)"
         )
 
     @staticmethod

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -884,9 +884,38 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
         if compact_nodes.shape[1] == 3 and np.allclose(compact_nodes[:, 2], 0):
             compact_nodes = compact_nodes[:, :2]
 
-        return UnstructuredSubMesh(
+        submesh = UnstructuredSubMesh(
             compact_nodes, compact_elements, coord_sys=self.coord_sys
         )
+
+        if self.boundary_mapping:
+            facet_type = "triangle" if cell_type == "tetra" else "line"
+            facets, facet_tags = _extract_tagged_facets(mesh, facet_type)
+            if facets is None:
+                pybamm.logger.warning(
+                    f"boundary_mapping given but no tagged '{facet_type}' "
+                    f"facets found in {self.filepath}; no boundary tags set"
+                )
+            else:
+                if self.merge_tolerance is not None and self.merge_tolerance > 0:
+                    facets = inverse[facets]
+                facets = node_map[facets]
+                # Facets of other subdomains reference nodes outside this
+                # submesh and cannot match
+                in_domain = (facets >= 0).all(axis=1)
+                for name, tag in self.boundary_mapping.items():
+                    matched = _match_facets_to_boundary_faces(
+                        facets[in_domain & (facet_tags == tag)], submesh
+                    )
+                    if len(matched) > 0:
+                        submesh.boundary_faces[name] = matched
+                    else:
+                        pybamm.logger.warning(
+                            f"boundary_mapping entry {name!r} (tag {tag}) "
+                            f"matched no boundary faces of this submesh"
+                        )
+
+        return submesh
 
     def __repr__(self):
         return f"UserSuppliedUnstructuredMesh({self.filepath})"
@@ -986,17 +1015,25 @@ class TaggedSubMeshGenerator(MeshGenerator):
         convert mm to m). Default ``1.0``.
     coord_sys : str, optional
         Coordinate system label, default ``"cartesian"``.
+    boundary_mapping : dict[str, str or int] or None, optional
+        Maps boundary name to a gmsh physical *surface* group, given as
+        its ``field_data`` name or integer tag. Matching tagged surface
+        triangles become the named entries in ``boundary_faces``. Without
+        it the submesh carries no boundary tags.
     """
 
     _mesh_cache: dict = {}
 
-    def __init__(self, region, mesh_path, scale=1.0, coord_sys="cartesian"):
+    def __init__(
+        self, region, mesh_path, scale=1.0, coord_sys="cartesian", boundary_mapping=None
+    ):
         self.submesh_type = UnstructuredSubMesh
         self.submesh_params = {}
         self._mesh_path = mesh_path
         self._region = region
         self._scale = float(scale)
         self.coord_sys = coord_sys
+        self.boundary_mapping = boundary_mapping or {}
 
     @classmethod
     def _read(cls, path):
@@ -1031,7 +1068,40 @@ class TaggedSubMeshGenerator(MeshGenerator):
         node_map = np.full(m.points.shape[0], -1, dtype=np.int64)
         node_map[unique_nodes] = np.arange(len(unique_nodes))
         nodes = m.points[unique_nodes] * self._scale
-        return UnstructuredSubMesh(nodes, node_map[elements], coord_sys=self.coord_sys)
+        submesh = UnstructuredSubMesh(
+            nodes, node_map[elements], coord_sys=self.coord_sys
+        )
+
+        if self.boundary_mapping:
+            facets, facet_tags = _extract_tagged_facets(m, "triangle")
+            if facets is None:
+                pybamm.logger.warning(
+                    f"boundary_mapping given but no tagged surface triangles "
+                    f"found in {self._mesh_path}; no boundary tags set"
+                )
+            else:
+                facets = node_map[facets]
+                in_domain = (facets >= 0).all(axis=1)
+                for name, group in self.boundary_mapping.items():
+                    if isinstance(group, str):
+                        if group not in m.field_data:
+                            raise pybamm.GeometryError(
+                                f"boundary group {group!r} not in mesh "
+                                f"field_data; available: {list(m.field_data)}"
+                            )
+                        group = int(m.field_data[group][0])
+                    matched = _match_facets_to_boundary_faces(
+                        facets[in_domain & (facet_tags == group)], submesh
+                    )
+                    if len(matched) > 0:
+                        submesh.boundary_faces[name] = matched
+                    else:
+                        pybamm.logger.warning(
+                            f"boundary_mapping entry {name!r} matched no "
+                            f"boundary faces of region {self._region!r}"
+                        )
+
+        return submesh
 
 
 # ======================================================================
@@ -1124,6 +1194,47 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
         }
 
     return result
+
+
+# ======================================================================
+# Boundary facet tagging helpers
+# ======================================================================
+
+
+def _extract_tagged_facets(mesh, facet_type):
+    """Concatenate a meshio mesh's facet blocks and their integer tags.
+
+    Returns ``(facets, tags)`` arrays, or ``(None, None)`` if the mesh has
+    no facet blocks of ``facet_type`` or no cell data to tag them with.
+    Prefers the ``gmsh:physical`` cell-data key, falling back to the first
+    available key.
+    """
+    block_ids = [i for i, b in enumerate(mesh.cells) if b.type == facet_type]
+    if not block_ids:
+        return None, None
+    data_lists = mesh.cell_data.get("gmsh:physical")
+    if data_lists is None:
+        data_lists = next(iter(mesh.cell_data.values()), None)
+    if data_lists is None:
+        return None, None
+    facets = np.concatenate([mesh.cells[i].data for i in block_ids], axis=0)
+    tags = np.concatenate([np.asarray(data_lists[i]) for i in block_ids])
+    return facets, tags
+
+
+def _match_facets_to_boundary_faces(facets, submesh):
+    """Return submesh boundary-face indices whose vertex sets match ``facets``."""
+    bnd_start = submesh._boundary_face_start
+    lookup = {
+        tuple(face): bnd_start + i
+        for i, face in enumerate(np.sort(submesh.faces[bnd_start:], axis=1).tolist())
+    }
+    matched = {
+        lookup[key]
+        for key in map(tuple, np.sort(facets, axis=1).tolist())
+        if key in lookup
+    }
+    return np.array(sorted(matched), dtype=int)
 
 
 # ======================================================================

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -360,31 +360,6 @@ class UnstructuredSubMesh(SubMesh):
         """
         from scipy.spatial import cKDTree
 
-        # For 3D tet meshes generated from hex grids, regenerate with
-        # cumulative i_offset so that alternating-parity face triangulations
-        # match across domain boundaries.
-        if all(
-            hasattr(sm, "_hex_gen_params") and sm.dimension == 3 for sm in submeshes
-        ):
-            cumulative_offset = 0
-            fixed = []
-            for sm in submeshes:
-                p = sm._hex_gen_params
-                if cumulative_offset > 0:
-                    nodes, elements = _hex_to_tet(
-                        p["x_edges"],
-                        p["y_edges"],
-                        p["z_edges"],
-                        i_offset=cumulative_offset,
-                    )
-                    new_sm = cls(nodes, elements, coord_sys=sm.coord_sys)
-                    new_sm._hex_gen_params = p
-                    fixed.append(new_sm)
-                else:
-                    fixed.append(sm)
-                cumulative_offset += p["nx"]
-            submeshes = fixed
-
         # Weld coincident nodes across submeshes regardless of which face tag
         # they belong to, so that interfaces of arbitrary topology (star, tree,
         # graph) become internal faces and TPFA handles cross-region flux
@@ -668,8 +643,14 @@ class UnstructuredMeshGenerator(MeshGenerator):
 
     * **2D**: rectangular domain meshed as quads, or triangulated by
       splitting each quad into 2 triangles.
-    * **3D**: rectangular prism meshed as hexahedra, or split into 5
-      tetrahedra per hex.
+    * **3D**: rectangular prism meshed as hexahedra, or split into 6
+      tetrahedra per hex (Kuhn decomposition).
+
+    On box domains, hexahedra (the 3D default) are preferred for real
+    simulations: same resolution with 6x fewer cells and ideal face
+    orthogonality. The simplex element types chiefly exercise the same
+    code paths as user-supplied (e.g. gmsh) meshes without needing a
+    mesh file, which is useful for testing and validation.
 
     Parameters
     ----------
@@ -760,17 +741,7 @@ class UnstructuredMeshGenerator(MeshGenerator):
             return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
         elif etype == "tetrahedron":
             nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
-            submesh = UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
-            # Record the source grid so that combining tet domains can rebuild
-            # each with a cumulative offset, keeping face triangulations
-            # conforming across domain interfaces (see combine()).
-            submesh._hex_gen_params = {
-                "x_edges": x_edges,
-                "y_edges": y_edges,
-                "z_edges": z_edges,
-                "nx": nx,
-            }
-            return submesh
+            return UnstructuredSubMesh(nodes, elements, coord_sys=self.coord_sys)
         else:
             raise pybamm.GeometryError(f"Unsupported 3D element_type: {etype!r}")
 
@@ -1237,19 +1208,17 @@ def _hex_grid(x_edges, y_edges, z_edges):
     return nodes, np.array(elements, dtype=int)
 
 
-def _hex_to_tet(x_edges, y_edges, z_edges, i_offset=0):
+def _hex_to_tet(x_edges, y_edges, z_edges):
     """
     Tetrahedralise a rectangular prism defined by edge arrays.
 
-    Each hex cell is split into 5 tetrahedra using a consistent
-    decomposition that guarantees matching triangular faces on
-    axis-aligned planes (required for interface conformity).
-
-    The decomposition alternates orientation based on the parity of
-    (i + i_offset + j + k) so that shared faces between adjacent hexes
-    are triangulated identically, including across domain boundaries
-    when ``i_offset`` equals the cumulative hex count from preceding
-    domains.
+    Each hex cell is split into 6 tetrahedra with the Kuhn (Freudenthal)
+    decomposition: every tet shares the main diagonal from vertex 0 to
+    vertex 6, one tet per monotone vertex path between them. The split
+    is identical for every cell and puts the same face-local diagonal on
+    opposite faces of each hex, so any two grids that share a boundary
+    plane and transverse edges triangulate it identically — including
+    across domain boundaries — with no cell-parity bookkeeping.
 
     Returns
     -------
@@ -1266,29 +1235,21 @@ def _hex_to_tet(x_edges, y_edges, z_edges, i_offset=0):
     def node_id(i, j, k):
         return i * (ny + 1) * (nz + 1) + j * (nz + 1) + k
 
-    # Two 5-tet decomposition patterns that share identical face diagonals
-    # on every axis-aligned interface.
     # Hex vertices numbered:
     #   0 = (i,   j,   k  )   4 = (i,   j,   k+1)
     #   1 = (i+1, j,   k  )   5 = (i+1, j,   k+1)
     #   2 = (i+1, j+1, k  )   6 = (i+1, j+1, k+1)
     #   3 = (i,   j+1, k  )   7 = (i,   j+1, k+1)
     #
-    # Pattern A (even parity): diagonal from vertex 0 to 6
-    pattern_a = [
-        (0, 1, 2, 5),
-        (0, 2, 3, 7),
-        (0, 5, 7, 4),
-        (2, 5, 7, 6),
-        (0, 2, 5, 7),
-    ]
-    # Pattern B (odd parity): diagonal from vertex 1 to 7
-    pattern_b = [
-        (1, 0, 3, 4),
-        (1, 2, 3, 6),
-        (1, 6, 4, 5),
-        (3, 4, 6, 7),
-        (1, 3, 4, 6),
+    # One tet per monotone path 0 -> 6, stepping +x/+y/+z in each of the
+    # 6 possible orders (xyz, xzy, yxz, yzx, zxy, zyx).
+    kuhn_tets = [
+        (0, 1, 2, 6),
+        (0, 1, 5, 6),
+        (0, 3, 2, 6),
+        (0, 3, 7, 6),
+        (0, 4, 5, 6),
+        (0, 4, 7, 6),
     ]
 
     elements = []
@@ -1305,8 +1266,7 @@ def _hex_to_tet(x_edges, y_edges, z_edges, i_offset=0):
                     node_id(i + 1, j + 1, k + 1),
                     node_id(i, j + 1, k + 1),
                 ]
-                pattern = pattern_a if (i + i_offset + j + k) % 2 == 0 else pattern_b
-                for tet in pattern:
+                for tet in kuhn_tets:
                     elements.append([hex_verts[v] for v in tet])
 
     return nodes, np.array(elements, dtype=int)

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -413,7 +413,7 @@ class UnstructuredSubMesh(SubMesh):
         # they belong to, so that interfaces of arbitrary topology (star, tree,
         # graph) become internal faces and TPFA handles cross-region flux
         # without internal Neumann book-keeping.
-        tol = 1e-9
+        tol = _geometric_tolerance(submeshes)
         all_nodes = list(submeshes[0].nodes)
         global_maps = [{i: i for i in range(submeshes[0].nodes.shape[0])}]
         next_id = len(all_nodes)
@@ -465,7 +465,9 @@ class UnstructuredSubMesh(SubMesh):
             bnd_centroids = combined.face_centroids[bnd_start:]
             if len(bnd_centroids) > 0:
                 tree = cKDTree(bnd_centroids)
-                match_tol = 1e-10 * max(np.ptp(combined_nodes, axis=0).max(), 1.0)
+                # Welding may move nodes (and so centroids) by up to the weld
+                # tolerance, so tag matching must never be tighter than it
+                match_tol = tol
                 for tag, centroid_list in tag_centroids.items():
                     all_src = np.concatenate(centroid_list, axis=0)
                     dists, idxs = tree.query(all_src)
@@ -827,6 +829,11 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
         Maps boundary name to physical group / facet tag.
     coord_sys : str, optional
         Coordinate system, default ``"cartesian"``.
+    merge_tolerance : float or None, optional
+        Absolute length (in the mesh file's units) below which coincident
+        nodes across cell blocks are welded, by quantising coordinates to
+        a grid of this spacing. Default ``1e-12``; pass ``None`` or ``0``
+        to disable welding.
     """
 
     def __init__(
@@ -1163,11 +1170,7 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
     tree = cKDTree(right_transverse)
     dists, right_indices = tree.query(left_transverse)
 
-    tol = 1e-8 * max(
-        np.ptp(left_transverse, axis=0).max(),
-        np.ptp(right_transverse, axis=0).max(),
-        1.0,
-    )
+    tol = _geometric_tolerance([left_mesh, right_mesh])
     if np.any(dists > tol):
         raise pybamm.GeometryError(
             f"Interface faces do not match: max transverse mismatch = {dists.max():.2e}. "
@@ -1202,6 +1205,32 @@ def compute_interface_data(left_mesh, right_mesh, left_name=None, right_name=Non
         }
 
     return result
+
+
+# ======================================================================
+# Geometric tolerance
+# ======================================================================
+
+
+def _geometric_tolerance(submeshes, rel=1e-3):
+    """Distance below which two points of these meshes are the same point.
+
+    Scaled to the smallest sampled element edge: distinct nodes (and face
+    centroids) are at least one edge length apart, so a small fraction of
+    it can never merge genuinely distinct entities, while absorbing the
+    interface jitter that reduced-precision mesh files and unit
+    conversions produce. An absolute tolerance cannot do both across mesh
+    scales — battery meshes in SI units are ~1e-4 m across.
+    """
+    min_edge = min(
+        float(
+            np.linalg.norm(
+                sm.nodes[sm.elements[:, 1]] - sm.nodes[sm.elements[:, 0]], axis=1
+            ).min()
+        )
+        for sm in submeshes
+    )
+    return rel * min_edge
 
 
 # ======================================================================

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -344,30 +344,28 @@ class UnstructuredSubMesh(SubMesh):
         # Classify every external face by its outward normal direction so all
         # protrusions (e.g., tabs) get assigned a BC bucket.
         bnd_normals = self.face_normals[bnd_start:]
-        dominant_axis = np.argmax(np.abs(bnd_normals), axis=1)
+        n_bnd = len(bnd_normals)
 
-        tag_map = {
-            "left": np.zeros(len(bnd_centroids), dtype=bool),
-            "right": np.zeros(len(bnd_centroids), dtype=bool),
-            "bottom": np.zeros(len(bnd_centroids), dtype=bool),
-            "top": np.zeros(len(bnd_centroids), dtype=bool),
-        }
+        # A zero-area face has no normal direction and would land in an
+        # arbitrary bucket; surface it instead.
+        if np.any(self.face_areas[bnd_start:] < 1e-30):
+            raise pybamm.GeometryError(
+                "Mesh has degenerate (zero-area) boundary faces; boundary "
+                "detection cannot classify them."
+            )
+
+        axis = np.argmax(np.abs(bnd_normals), axis=1)
+        positive = (bnd_normals[np.arange(n_bnd), axis] >= 0).astype(int)
         if self.dimension == 3:
-            tag_map["front"] = np.zeros(len(bnd_centroids), dtype=bool)
-            tag_map["back"] = np.zeros(len(bnd_centroids), dtype=bool)
-
-        for i, axis in enumerate(dominant_axis):
-            sign = bnd_normals[i, axis]
-            if axis == 0:
-                tag_map["left" if sign < 0 else "right"][i] = True
-            elif self.dimension == 3 and axis == 1:
-                tag_map["front" if sign < 0 else "back"][i] = True
-            else:
-                tag_map["bottom" if sign < 0 else "top"][i] = True
+            names = ["left", "right", "front", "back", "bottom", "top"]
+            slot = axis * 2 + positive
+        else:
+            names = ["left", "right", "bottom", "top"]
+            slot = np.where(axis == 0, positive, 2 + positive)
 
         self.boundary_faces = {}
-        for name, mask in tag_map.items():
-            indices = np.nonzero(mask)[0] + bnd_start
+        for k, name in enumerate(names):
+            indices = np.nonzero(slot == k)[0] + bnd_start
             if len(indices) > 0:
                 self.boundary_faces[name] = indices
 

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -655,10 +655,13 @@ class UnstructuredSubMesh(SubMesh):
         n_query = len(query_pts)
         winding = np.zeros(n_query)
 
-        for i in range(len(tri_idx)):
-            a = v0[i] - query_pts
-            b = v1_fixed[i] - query_pts
-            c = v2_fixed[i] - query_pts
+        # Loop over query points (usually few), vectorised over the many
+        # boundary triangles — the reverse nesting costs O(n_triangles)
+        # per point regardless of how few points are asked about.
+        for i in range(n_query):
+            a = v0 - query_pts[i]
+            b = v1_fixed - query_pts[i]
+            c = v2_fixed - query_pts[i]
 
             an = np.linalg.norm(a, axis=1)
             bn = np.linalg.norm(b, axis=1)
@@ -672,7 +675,7 @@ class UnstructuredSubMesh(SubMesh):
                 + np.einsum("ij,ij->i", b, c) * an
             )
 
-            winding += 2.0 * np.arctan2(num, den)
+            winding[i] = 2.0 * np.arctan2(num, den).sum()
 
         return winding > 2.0 * np.pi
 

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -168,6 +168,9 @@ class UnstructuredSubMesh(SubMesh):
         _, inverse, counts = np.unique(
             sorted_faces, axis=0, return_inverse=True, return_counts=True
         )
+        # numpy 2.0.0 (the declared floor) returns inverse with shape (n, 1);
+        # 2.0.1+ returns (n,). Flatten so masks below stay 1-D everywhere.
+        inverse = inverse.reshape(-1)
 
         # A manifold mesh shares each face between at most two cells. A count of
         # three or more means overlapping or non-conforming elements; such faces
@@ -848,6 +851,8 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
             _, unique_idx, inverse = np.unique(
                 quantized, axis=0, return_index=True, return_inverse=True
             )
+            # numpy 2.0.0 returns inverse with shape (n, 1); 2.0.1+ (n,)
+            inverse = inverse.reshape(-1)
             nodes = nodes[unique_idx]
             elements = inverse[elements]
 

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -19,6 +19,11 @@ class ElementType(str, Enum):
     TETRAHEDRON = "tetrahedron"
     HEXAHEDRON = "hexahedron"
 
+    @property
+    def meshio_name(self):
+        """This element type's cell-type name in meshio's vocabulary."""
+        return "tetra" if self is ElementType.TETRAHEDRON else self.value
+
 
 class UnstructuredSubMesh(SubMesh):
     """
@@ -900,7 +905,7 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
         )
 
         if self.boundary_mapping:
-            facet_type = "triangle" if cell_type == "tetra" else "line"
+            facet_type = "triangle" if cell_type == ElementType.TETRAHEDRON else "line"
             facets, facet_tags = _extract_tagged_facets(mesh, facet_type)
             if facets is None:
                 pybamm.logger.warning(
@@ -955,7 +960,9 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
         # Hexahedra from files are rejected outright rather than silently
         # dropped: file meshes commonly contain warped (non-planar-faced)
         # hexes, for which cell volumes and face fluxes are ill-defined.
-        if any(block.type == "hexahedron" for block in mesh.cells):
+        if any(
+            block.type == ElementType.HEXAHEDRON.meshio_name for block in mesh.cells
+        ):
             raise pybamm.GeometryError(
                 "Hexahedral cells in mesh files are not supported: warped "
                 "(non-planar-faced) hexahedra have ill-defined volumes and "
@@ -965,8 +972,16 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
                 "axis-aligned cells are always well-defined."
             )
         # Prefer 3D cells when present, otherwise fall back to 2D.
-        for cell_type in ("tetra", "triangle", "quad"):
-            blocks = [block.data for block in mesh.cells if block.type == cell_type]
+        for cell_type in (
+            ElementType.TETRAHEDRON,
+            ElementType.TRIANGLE,
+            ElementType.QUAD,
+        ):
+            blocks = [
+                block.data
+                for block in mesh.cells
+                if block.type == cell_type.meshio_name
+            ]
             if blocks:
                 if len(blocks) == 1:
                     return blocks[0], cell_type
@@ -981,7 +996,7 @@ class UserSuppliedUnstructuredMesh(MeshGenerator):
             matching = [
                 data
                 for block, data in zip(mesh.cells, data_list, strict=False)
-                if block.type == cell_type
+                if block.type == cell_type.meshio_name
             ]
             if matching:
                 if len(matching) == 1:
@@ -1066,7 +1081,7 @@ class TaggedSubMeshGenerator(MeshGenerator):
         for block, tags in zip(
             m.cells, m.cell_data.get("gmsh:physical", []), strict=False
         ):
-            if block.type != "tetra":
+            if block.type != ElementType.TETRAHEDRON.meshio_name:
                 continue
             mask = np.asarray(tags, dtype=np.int32) == tag_id
             if mask.any():

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -730,6 +730,39 @@ class TestMeshIntegration:
         combined = mesh[("negative electrode", "separator", "positive electrode")]
         assert combined.npts == n_neg + n_sep + n_pos
 
+    def test_combine_conforming_interface_welds_into_internal_faces(self):
+        """A matching interface welds, so the combined mesh is one component."""
+        ye = np.linspace(0, 1, 3)
+        ze = np.linspace(0, 1, 4)
+        left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 1, 3), ye, ze))
+        right = UnstructuredSubMesh(*_hex_grid(np.linspace(1, 2, 3), ye, ze))
+
+        combined = UnstructuredSubMesh.combine([left, right])
+
+        assert combined.npts == left.npts + right.npts
+        # coincident interface nodes are welded, not duplicated
+        assert combined.nodes.shape[0] < left.nodes.shape[0] + right.nodes.shape[0]
+        # the x=1 seam is now internal, so flux can cross it
+        n_int = combined._boundary_face_start
+        on_seam = np.abs(combined.face_centroids[:n_int, 0] - 1.0) < 1e-12
+        assert on_seam.sum() > 0
+
+    def test_combine_disconnected_domains_raises(self):
+        """A non-conforming interface must raise, not solve silently to garbage."""
+        import pytest
+
+        ye = np.linspace(0, 1, 3)
+        left = UnstructuredSubMesh(
+            *_hex_grid(np.linspace(0, 1, 3), ye, np.linspace(0, 1, 4))
+        )
+        # mismatched transverse (z) grid: no interface node coincides
+        right = UnstructuredSubMesh(
+            *_hex_grid(np.linspace(1, 2, 3), ye, np.linspace(0, 1, 5))
+        )
+
+        with pytest.raises(pybamm.GeometryError, match=r"disconnected regions"):
+            UnstructuredSubMesh.combine([left, right])
+
     def test_interface_data_computed_automatically(self):
         """Mesh.__init__ should compute interface data between adjacent domains."""
         x_n = pybamm.SpatialVariable(

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -271,6 +271,38 @@ class TestUnstructuredSubMesh:
         assert mesh._n_boundary_faces == 6
         np.testing.assert_allclose(mesh.face_areas, np.ones(6))
 
+    def test_warped_hexahedron_raises(self):
+        """A hex with a non-planar face is rejected at construction.
+
+        Volumes of warped hexes depend on an arbitrary choice of face
+        triangulation (the two diagonal splits of a warped unit-cube face
+        differ by ~20%), so they are disallowed rather than approximated.
+        """
+        import pytest
+
+        nodes = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1.6, 1.6, 1.6],
+                [0, 1, 1],
+            ],
+            dtype=float,
+        )
+        elements = np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int)
+        with pytest.raises(pybamm.GeometryError, match=r"non-planar"):
+            UnstructuredSubMesh(nodes, elements)
+
+        # Sub-tolerance jitter (well below 1e-8 relative) must still pass
+        nodes_jitter = nodes.copy()
+        nodes_jitter[6] = [1, 1, 1 + 1e-12]
+        mesh = UnstructuredSubMesh(nodes_jitter, elements)
+        np.testing.assert_allclose(mesh.cell_volumes, [1.0], rtol=1e-9)
+
     def test_2d_boundary_loops(self):
         """boundary_loops returns a matplotlib Path around the outer edge."""
         nodes, elements = _unit_square_two_triangles()
@@ -667,6 +699,38 @@ class TestFileGenerators:
         )
         with pytest.raises(pybamm.GeometryError, match="No supported cells"):
             gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+    def test_user_supplied_hexahedron_cells_raise(self):
+        """Hexahedral file meshes are rejected, even alongside tets."""
+        import pytest
+
+        meshio = pytest.importorskip("meshio")
+        points = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+            ],
+            dtype=float,
+        )
+        hex_cells = ("hexahedron", np.array([[0, 1, 2, 3, 4, 5, 6, 7]]))
+        tet_cells = ("tetra", np.array([[0, 1, 2, 4]]))
+
+        gen = UserSuppliedUnstructuredMesh("unused.vtu")
+        gen._cached_mesh = meshio.Mesh(points, [hex_cells])
+        with pytest.raises(pybamm.GeometryError, match="Hexahedral cells"):
+            gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+        # Mixed tet+hex must also raise, not silently drop the hex cells
+        gen_mixed = UserSuppliedUnstructuredMesh("unused.vtu")
+        gen_mixed._cached_mesh = meshio.Mesh(points, [tet_cells, hex_cells])
+        with pytest.raises(pybamm.GeometryError, match="Hexahedral cells"):
+            gen_mixed({"x_n": {"min": 0.0, "max": 1.0}}, {})
 
     def test_domain_name_from_lims(self):
         """String and SpatialVariable keys map to electrode domains; 'tabs' skipped."""

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1287,6 +1287,21 @@ class TestMeshIntegration:
         assert "No interface coupling between 'negative electrode'" in caplog.text
         assert "separator" in caplog.text
 
+    def test_combine_mixed_element_types_raises(self):
+        """Combining domains of different element types names both types."""
+        import pytest
+
+        tri_nodes, tri_elems = _unit_square_two_triangles()
+        quad_nodes = np.array([[1, 0], [2, 0], [2, 1], [1, 1]], dtype=float)
+        quad_elems = np.array([[0, 1, 2, 3]], dtype=int)
+        tri = UnstructuredSubMesh(tri_nodes, tri_elems)
+        quad = UnstructuredSubMesh(quad_nodes, quad_elems)
+
+        with pytest.raises(
+            pybamm.GeometryError, match=r"quad.*triangle|triangle.*quad"
+        ):
+            UnstructuredSubMesh.combine([tri, quad])
+
     def test_combine_disconnected_domains_raises(self):
         """A non-conforming interface must raise, not solve silently to garbage."""
         import pytest

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -401,7 +401,7 @@ class TestUnstructuredSubMesh:
 
         tet_mesh = UnstructuredMeshGenerator(element_type="tetrahedron")(lims, npts)
         assert tet_mesh.element_type == "tetrahedron"
-        assert tet_mesh.npts == 8 * 5  # 5 tets per hex
+        assert tet_mesh.npts == 8 * 6  # 6 tets per hex (Kuhn split)
         np.testing.assert_allclose(tet_mesh.cell_volumes.sum(), 1.0, atol=1e-14)
 
     def test_generator_unknown_3d_element_type_raises(self):
@@ -1034,8 +1034,11 @@ class TestMeshIntegration:
     def test_combine_tetrahedron_domains_conforming(self):
         """Tet domains from the generator combine into one connected mesh.
 
-        Exercises the cumulative-offset regeneration in ``combine`` that keeps
-        the alternating tet triangulation conforming across the interface.
+        Uses an odd left nx so the cumulative-offset regeneration in
+        ``combine`` actually fires (an even offset leaves the parity of
+        ``(i + i_offset + j + k)`` unchanged and the branch is a no-op).
+        The combined mesh must describe the same cells as the per-domain
+        meshes: PyBaMM reads both views of the same region.
         """
         x_n = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
         x_s = pybamm.SpatialVariable("x_s", domain=["separator"])
@@ -1048,7 +1051,7 @@ class TestMeshIntegration:
                 y: {"min": 0, "max": 1},
                 z: {"min": 0, "max": 1},
             },
-            {"x_n": 2, "y": 2, "z": 2},
+            {"x_n": 3, "y": 2, "z": 2},
         )
         right = gen(
             {
@@ -1062,6 +1065,16 @@ class TestMeshIntegration:
         combined = UnstructuredSubMesh.combine([left, right])
         assert combined.element_type == "tetrahedron"
         assert combined.npts == left.npts + right.npts
+
+        # Both views of each domain must agree cell-for-cell
+        n_left = left.npts
+        np.testing.assert_allclose(
+            combined.cell_centroids[:n_left], left.cell_centroids
+        )
+        np.testing.assert_allclose(
+            combined.cell_centroids[n_left:], right.cell_centroids
+        )
+        np.testing.assert_allclose(combined.cell_volumes[n_left:], right.cell_volumes)
 
     def test_combine_propagates_custom_boundary_tags(self):
         """Non-standard boundary tags survive combining via centroid matching."""

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1207,6 +1207,50 @@ class TestMeshIntegration:
         np.testing.assert_allclose(tab_centroids[:, 2], 1.0)
         assert tab_centroids[:, 0].max() <= 1.0
 
+    def test_mesh_pairs_interfaces_by_geometry_not_dict_order(self):
+        """Adjacency comes from boundary-plane positions, not insertion order.
+
+        The separator (x: 1-2) is declared before the negative electrode
+        (x: 0-1); consecutive-order pairing would try sep.right vs neg.left
+        (planes x=2 vs x=0), find nothing, and drop the coupling.
+        """
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        z_a = pybamm.SpatialVariable(
+            "z_2d", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z_b = pybamm.SpatialVariable(
+            "z_2d", domain=["separator"], coord_sys="cartesian"
+        )
+
+        geometry = {
+            "separator": {x_s: {"min": 1, "max": 2}, z_b: {"min": 0, "max": 1}},
+            "negative electrode": {
+                x_n: {"min": 0, "max": 1},
+                z_a: {"min": 0, "max": 1},
+            },
+        }
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen, "separator": gen},
+            {x_n: 3, x_s: 3, z_a: 4, z_b: 4},
+        )
+
+        assert "separator" in mesh["negative electrode"].interface_data
+        assert "negative electrode" in mesh["separator"].interface_data
+        # The coupling must join abutting cells across x=1, not staple the
+        # far edges (x=0 and x=2) together. For the default triangle cells
+        # the abutting centroids sit dx/3 from the interface with a dz/3
+        # vertical offset, so the distance is one cell scale — not the
+        # geometry's full span
+        iface = mesh["negative electrode"].interface_data["separator"]
+        np.testing.assert_allclose(
+            iface["cell_distances"], np.hypot(2.0 / 9.0, 1.0 / 12.0)
+        )
+
     def test_mesh_skips_interface_for_mismatched_grids(self, caplog):
         """Mesh.__init__ leaves interface_data empty when pairing fails,
         and says so: a skipped interface means no flux couples the domains,

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -110,6 +110,7 @@ class TestUnstructuredSubMesh:
         z_edges = np.linspace(0, 1, 4)
         nodes, elements = _quad_to_tri(x_edges, z_edges)
         mesh = UnstructuredSubMesh(nodes, elements)
+        mesh.detect_box_boundaries()
 
         assert "left" in mesh.boundary_faces
         assert "right" in mesh.boundary_faces
@@ -188,6 +189,7 @@ class TestUnstructuredSubMesh:
         z_edges = np.linspace(0, 1, 3)
         nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
         mesh = UnstructuredSubMesh(nodes, elements)
+        mesh.detect_box_boundaries()
 
         for tag in ("left", "right", "front", "back", "bottom", "top"):
             assert tag in mesh.boundary_faces, f"Missing boundary tag '{tag}'"
@@ -225,6 +227,7 @@ class TestUnstructuredSubMesh:
         nodes = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
         elements = np.array([[0, 1, 2, 3]], dtype=int)
         mesh = UnstructuredSubMesh(nodes, elements)
+        mesh.detect_box_boundaries()
 
         assert mesh.element_type == "quad"
         np.testing.assert_allclose(mesh.cell_volumes, [1.0])
@@ -279,12 +282,12 @@ class TestUnstructuredSubMesh:
             mesh.cell_centroids, [[0.0, 0.0, 11.0 / 28.0]], atol=1e-14
         )
 
-        # Side face (dominant -y normal, tagged "front") is a trapezoid in
-        # the plane y = -1 + z/2: exact centroid (0, -7/9, 4/9)
-        front = mesh.boundary_faces["front"]
-        assert len(front) == 1
+        # Side face (outward normal toward -y) is a trapezoid in the plane
+        # y = -1 + z/2: exact centroid (0, -7/9, 4/9)
+        bnd_start = mesh._boundary_face_start
+        front = bnd_start + int(np.argmin(mesh.face_normals[bnd_start:, 1]))
         np.testing.assert_allclose(
-            mesh.face_centroids[front[0]],
+            mesh.face_centroids[front],
             [0.0, -7.0 / 9.0, 4.0 / 9.0],
             atol=1e-14,
         )
@@ -711,6 +714,9 @@ class TestFileGenerators:
         assert sub.npts == 2
         np.testing.assert_allclose(sub.cell_volumes.sum(), 1.0)
         assert "square.vtu" in repr(gen)
+        # File meshes get no guessed tags: boundary names must come from the
+        # mesh file (boundary_mapping) or be set explicitly
+        assert sub.boundary_faces == {}
 
     def test_user_supplied_subdomain_filtering(self, tmp_path):
         """subdomain_mapping selects only the cells with the matching tag."""
@@ -985,10 +991,12 @@ class TestComputeInterfaceData:
         left = UnstructuredSubMesh(
             *_hex_grid(np.linspace(0, 1, 3), np.linspace(0, 1, 3), ze)
         )
+        left.detect_box_boundaries()
         # y grid shifted by 0.37: same face count, wrong transverse positions
         right = UnstructuredSubMesh(
             *_hex_grid(np.linspace(1, 2, 3), np.linspace(0.37, 1.37, 3), ze)
         )
+        right.detect_box_boundaries()
 
         with pytest.raises(pybamm.GeometryError, match="do not match"):
             compute_interface_data(left, right)
@@ -1134,6 +1142,8 @@ class TestMeshIntegration:
         ze = np.linspace(0, 1, 3)
         left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 1, 3), ye, ze))
         right = UnstructuredSubMesh(*_hex_grid(np.linspace(1, 2, 3), ye, ze))
+        left.detect_box_boundaries()
+        right.detect_box_boundaries()
         left.boundary_faces["tab_top"] = left.boundary_faces.pop("top")
 
         combined = UnstructuredSubMesh.combine([left, right])
@@ -1286,8 +1296,10 @@ class TestBandwidthOptimization:
         ze = np.linspace(0, 1, 4)
         nodes_l, elems_l = _hex_grid(np.linspace(0, 1, 4), ye, ze)
         mesh_l = UnstructuredSubMesh(nodes_l, elems_l, coord_sys="cartesian")
+        mesh_l.detect_box_boundaries()
         nodes_r, elems_r = _hex_grid(np.linspace(1, 2, 4), ye, ze)
         mesh_r = UnstructuredSubMesh(nodes_r, elems_r, coord_sys="cartesian")
+        mesh_r.detect_box_boundaries()
         compute_interface_data(mesh_l, mesh_r, "left", "right")
 
         iface = mesh_l.interface_data["right"]
@@ -1307,8 +1319,10 @@ class TestBandwidthOptimization:
         # mesh's permutation would run off the end of the neighbour.
         nodes_l, elems_l = _hex_grid(np.linspace(0, 1, 4), ye, ze)
         mesh_l = UnstructuredSubMesh(nodes_l, elems_l, coord_sys="cartesian")
+        mesh_l.detect_box_boundaries()
         nodes_r, elems_r = _hex_grid(np.linspace(1, 2, 3), ye, ze)
         mesh_r = UnstructuredSubMesh(nodes_r, elems_r, coord_sys="cartesian")
+        mesh_r.detect_box_boundaries()
         assert mesh_l.npts > mesh_r.npts
         compute_interface_data(mesh_l, mesh_r, "left", "right")
 

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -878,7 +878,7 @@ class TestFileGenerators:
             assert isinstance(sub, UnstructuredSubMesh)
             assert sub.npts == 3  # cells tagged 1
             # scale multiplies coordinates: unit cube -> side 2
-            np.testing.assert_allclose(sub.nodes.max(axis=0), [2.0, 2.0, 2.0])
+            np.testing.assert_allclose(sub.vertices.max(axis=0), [2.0, 2.0, 2.0])
         finally:
             TaggedSubMeshGenerator._mesh_cache.pop(fake_path, None)
 
@@ -1160,7 +1160,10 @@ class TestMeshIntegration:
 
         assert combined.npts == left.npts + right.npts
         # coincident interface nodes are welded, not duplicated
-        assert combined.nodes.shape[0] < left.nodes.shape[0] + right.nodes.shape[0]
+        assert (
+            combined.vertices.shape[0]
+            < left.vertices.shape[0] + right.vertices.shape[0]
+        )
         # the x=1 seam is now internal, so flux can cross it
         n_int = combined._boundary_face_start
         on_seam = np.abs(combined.face_centroids[:n_int, 0] - 1.0) < 1e-12

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1036,6 +1036,28 @@ class TestComputeInterfaceData:
         with pytest.raises(pybamm.GeometryError, match="matching boundary faces"):
             compute_interface_data(left, right)
 
+    def test_non_bijective_pairing_raises(self):
+        """Surplus faces on one side of an interface must not vanish silently.
+
+        Every left face matches a right face exactly, but the right mesh
+        exposes one extra 'left' face — its flux would silently disappear
+        from the coupling.
+        """
+        import pytest
+
+        ye = np.linspace(0, 1, 3)
+        ze = np.linspace(0, 1, 3)
+        left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 1, 3), ye, ze))
+        right = UnstructuredSubMesh(*_hex_grid(np.linspace(1, 2, 3), ye, ze))
+        left.detect_box_boundaries()
+        right.detect_box_boundaries()
+        right.boundary_faces["left"] = np.append(
+            right.boundary_faces["left"], right.boundary_faces["top"][0]
+        )
+
+        with pytest.raises(pybamm.GeometryError, match=r"one-to-one"):
+            compute_interface_data(left, right)
+
     def test_transverse_mismatch_raises(self):
         """Interface faces at different transverse positions cannot be paired."""
         import pytest

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1207,8 +1207,10 @@ class TestMeshIntegration:
         np.testing.assert_allclose(tab_centroids[:, 2], 1.0)
         assert tab_centroids[:, 0].max() <= 1.0
 
-    def test_mesh_skips_interface_for_mismatched_grids(self):
-        """Mesh.__init__ leaves interface_data empty when pairing fails."""
+    def test_mesh_skips_interface_for_mismatched_grids(self, caplog):
+        """Mesh.__init__ leaves interface_data empty when pairing fails,
+        and says so: a skipped interface means no flux couples the domains,
+        which must be visible rather than silent."""
         x_n = pybamm.SpatialVariable(
             "x_n", domain=["negative electrode"], coord_sys="cartesian"
         )
@@ -1229,14 +1231,17 @@ class TestMeshIntegration:
             "separator": {x_s: {"min": 1, "max": 2}, z_b: {"min": 0, "max": 2}},
         }
         gen = UnstructuredMeshGenerator()
-        mesh = pybamm.Mesh(
-            geometry,
-            {"negative electrode": gen, "separator": gen},
-            {x_n: 3, x_s: 3, z_a: 4, z_b: 4},
-        )
+        with caplog.at_level("WARNING", logger="pybamm"):
+            mesh = pybamm.Mesh(
+                geometry,
+                {"negative electrode": gen, "separator": gen},
+                {x_n: 3, x_s: 3, z_a: 4, z_b: 4},
+            )
 
         assert mesh["negative electrode"].interface_data == {}
         assert mesh["separator"].interface_data == {}
+        assert "No interface coupling between 'negative electrode'" in caplog.text
+        assert "separator" in caplog.text
 
     def test_combine_disconnected_domains_raises(self):
         """A non-conforming interface must raise, not solve silently to garbage."""

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -237,6 +237,58 @@ class TestUnstructuredSubMesh:
         assert "top" in mesh.boundary_faces
         assert "bottom" in mesh.boundary_faces
 
+    def test_2d_quad_trapezoid_centroid_exact(self):
+        """Quad centroids are geometric centroids, not vertex means.
+
+        Symmetric trapezoid: the vertex mean gives y = 0.5, the true
+        area centroid is y = 4/9.
+        """
+        nodes = np.array([[0, 0], [4, 0], [3, 1], [1, 1]], dtype=float)
+        elements = np.array([[0, 1, 2, 3]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        np.testing.assert_allclose(mesh.cell_volumes, [3.0])
+        np.testing.assert_allclose(mesh.cell_centroids, [[2.0, 4.0 / 9.0]])
+
+    def test_3d_hex_frustum_centroid_exact(self):
+        """Planar-faced but non-parallelogram hexes get exact centroids.
+
+        Square frustum, base side 2 at z=0, top side 1 at z=1: all six
+        faces planar (passes the warp check), volume 7/3, and the true
+        centroid height is 11/28 — the vertex mean would give 1/2.
+        The trapezoidal side faces likewise have exact area centroids.
+        """
+        nodes = np.array(
+            [
+                [-1, -1, 0],
+                [1, -1, 0],
+                [1, 1, 0],
+                [-1, 1, 0],
+                [-0.5, -0.5, 1],
+                [0.5, -0.5, 1],
+                [0.5, 0.5, 1],
+                [-0.5, 0.5, 1],
+            ],
+            dtype=float,
+        )
+        elements = np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        np.testing.assert_allclose(mesh.cell_volumes, [7.0 / 3.0])
+        np.testing.assert_allclose(
+            mesh.cell_centroids, [[0.0, 0.0, 11.0 / 28.0]], atol=1e-14
+        )
+
+        # Side face (dominant -y normal, tagged "front") is a trapezoid in
+        # the plane y = -1 + z/2: exact centroid (0, -7/9, 4/9)
+        front = mesh.boundary_faces["front"]
+        assert len(front) == 1
+        np.testing.assert_allclose(
+            mesh.face_centroids[front[0]],
+            [0.0, -7.0 / 9.0, 4.0 / 9.0],
+            atol=1e-14,
+        )
+
     def test_2d_quad_grid_two_cells(self):
         """Two adjacent quads share 1 internal face."""
         nodes = np.array([[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]], dtype=float)

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1,0 +1,839 @@
+import numpy as np
+
+import pybamm
+from pybamm.meshes.unstructured_submesh import (
+    UnstructuredMeshGenerator,
+    UnstructuredSubMesh,
+    _hex_grid,
+    _hex_to_tet,
+    _quad_to_tri,
+    compute_interface_data,
+)
+
+# ======================================================================
+# Helpers
+# ======================================================================
+
+
+def _unit_square_two_triangles():
+    """Unit square [0,1]x[0,1] split into 2 triangles."""
+    nodes = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+    elements = np.array([[0, 1, 2], [0, 2, 3]], dtype=int)
+    return nodes, elements
+
+
+def _unit_cube_five_tets():
+    """Unit cube [0,1]^3 split into 5 tets (pattern A)."""
+    nodes = np.array(
+        [
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [1, 0, 1],
+            [1, 1, 1],
+            [0, 1, 1],
+        ],
+        dtype=float,
+    )
+    elements = np.array(
+        [
+            [0, 1, 2, 5],
+            [0, 2, 3, 7],
+            [0, 5, 7, 4],
+            [2, 5, 7, 6],
+            [0, 2, 5, 7],
+        ],
+        dtype=int,
+    )
+    return nodes, elements
+
+
+# ======================================================================
+# TestUnstructuredSubMesh
+# ======================================================================
+
+
+class TestUnstructuredSubMesh:
+    def test_2d_single_triangle(self):
+        nodes = np.array([[0, 0], [1, 0], [0, 1]], dtype=float)
+        elements = np.array([[0, 1, 2]], dtype=int)
+
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.npts == 1
+        assert mesh.dimension == 2
+        np.testing.assert_allclose(mesh.cell_volumes, [0.5])
+        np.testing.assert_allclose(mesh.cell_centroids, [[1 / 3, 1 / 3]])
+        assert mesh.n_internal_faces == 0
+        assert len(mesh.faces) == 3
+
+    def test_2d_two_triangles(self):
+        nodes, elements = _unit_square_two_triangles()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.npts == 2
+        assert mesh.dimension == 2
+        assert mesh.n_internal_faces == 1
+        # 4 boundary edges + 1 internal = 5 total
+        assert len(mesh.faces) == 5
+
+        # Owner and neighbor of internal face
+        owner = mesh.face_owner[0]
+        neighbor = mesh.face_neighbor[0]
+        assert owner != neighbor
+        assert {owner, neighbor} == {0, 1}
+
+    def test_2d_cell_volumes(self):
+        nodes, elements = _unit_square_two_triangles()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        np.testing.assert_allclose(mesh.cell_volumes, [0.5, 0.5])
+        np.testing.assert_allclose(mesh.cell_volumes.sum(), 1.0)
+
+    def test_2d_face_normals_orientation(self):
+        """All normals should point outward from the owner cell."""
+        nodes, elements = _unit_square_two_triangles()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        for f in range(len(mesh.faces)):
+            owner_centroid = mesh.cell_centroids[mesh.face_owner[f]]
+            to_face = mesh.face_centroids[f] - owner_centroid
+            dot = np.dot(mesh.face_normals[f], to_face)
+            assert dot >= -1e-14, f"Face {f}: normal not outward (dot={dot})"
+
+    def test_2d_boundary_face_identification(self):
+        x_edges = np.linspace(0, 2, 5)
+        z_edges = np.linspace(0, 1, 4)
+        nodes, elements = _quad_to_tri(x_edges, z_edges)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert "left" in mesh.boundary_faces
+        assert "right" in mesh.boundary_faces
+        assert "bottom" in mesh.boundary_faces
+        assert "top" in mesh.boundary_faces
+
+        # All left boundary faces should have face centroid x ≈ 0
+        left_centroids = mesh.face_centroids[mesh.boundary_faces["left"]]
+        np.testing.assert_allclose(left_centroids[:, 0], 0.0, atol=1e-14)
+
+        # All right boundary faces should have face centroid x ≈ 2
+        right_centroids = mesh.face_centroids[mesh.boundary_faces["right"]]
+        np.testing.assert_allclose(right_centroids[:, 0], 2.0, atol=1e-14)
+
+    def test_3d_single_tet(self):
+        nodes = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        elements = np.array([[0, 1, 2, 3]], dtype=int)
+
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.npts == 1
+        assert mesh.dimension == 3
+        np.testing.assert_allclose(mesh.cell_volumes, [1 / 6])
+        np.testing.assert_allclose(mesh.cell_centroids, [[0.25, 0.25, 0.25]])
+        assert mesh.n_internal_faces == 0
+        assert len(mesh.faces) == 4
+
+    def test_3d_two_tets(self):
+        # Two tets sharing a triangular face
+        nodes = np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 1]], dtype=float
+        )
+        elements = np.array([[0, 1, 2, 3], [1, 2, 3, 4]], dtype=int)
+
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.npts == 2
+        assert mesh.dimension == 3
+        assert mesh.n_internal_faces == 1
+
+        owner = mesh.face_owner[0]
+        neighbor = mesh.face_neighbor[0]
+        assert {owner, neighbor} == {0, 1}
+
+    def test_3d_cell_volumes(self):
+        nodes, elements = _unit_cube_five_tets()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        np.testing.assert_allclose(mesh.cell_volumes.sum(), 1.0, atol=1e-14)
+
+    def test_3d_face_areas(self):
+        # Regular tet with edge length 1
+        nodes = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float)
+        elements = np.array([[0, 1, 2, 3]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        # 3 axis-aligned faces with area 0.5
+        # 1 hypotenuse face with area sqrt(3)/2
+        areas = np.sort(mesh.face_areas)
+        np.testing.assert_allclose(areas[:3], 0.5, atol=1e-14)
+        np.testing.assert_allclose(areas[3], np.sqrt(3) / 2, atol=1e-14)
+
+    def test_3d_face_normals_orientation(self):
+        nodes, elements = _unit_cube_five_tets()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        for f in range(len(mesh.faces)):
+            owner_centroid = mesh.cell_centroids[mesh.face_owner[f]]
+            to_face = mesh.face_centroids[f] - owner_centroid
+            dot = np.dot(mesh.face_normals[f], to_face)
+            assert dot >= -1e-14, f"Face {f}: normal not outward (dot={dot})"
+
+    def test_3d_boundary_face_identification(self):
+        x_edges = np.linspace(0, 1, 3)
+        y_edges = np.linspace(0, 1, 3)
+        z_edges = np.linspace(0, 1, 3)
+        nodes, elements = _hex_to_tet(x_edges, y_edges, z_edges)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        for tag in ("left", "right", "front", "back", "bottom", "top"):
+            assert tag in mesh.boundary_faces, f"Missing boundary tag '{tag}'"
+            assert len(mesh.boundary_faces[tag]) > 0
+
+    def test_custom_boundary_faces(self):
+        nodes, elements = _unit_square_two_triangles()
+        custom_bnd = {"my_boundary": np.array([3, 4])}
+        mesh = UnstructuredSubMesh(nodes, elements, boundary_faces=custom_bnd)
+
+        assert "my_boundary" in mesh.boundary_faces
+        np.testing.assert_array_equal(mesh.boundary_faces["my_boundary"], [3, 4])
+
+    def test_unsupported_element_raises(self):
+        """2D cell with 5 verts, or 3D cell with 5 verts, should raise."""
+        nodes = np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0.5, 0.5]], dtype=float)
+        elements = np.array([[0, 1, 2, 3, 4]], dtype=int)
+        import pytest
+
+        with pytest.raises(ValueError, match="Unsupported"):
+            UnstructuredSubMesh(nodes, elements)
+
+    def test_2d_quad_mesh_basic(self):
+        """Quadrilateral element type: geometry and connectivity."""
+        nodes = np.array([[0, 0], [1, 0], [1, 1], [0, 1]], dtype=float)
+        elements = np.array([[0, 1, 2, 3]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.element_type == "quad"
+        np.testing.assert_allclose(mesh.cell_volumes, [1.0])
+        # 4 boundary edges, no internal faces
+        assert mesh.n_internal_faces == 0
+        assert mesh._n_boundary_faces == 4
+        # Standard boundary tags should be present
+        assert "left" in mesh.boundary_faces
+        assert "right" in mesh.boundary_faces
+        assert "top" in mesh.boundary_faces
+        assert "bottom" in mesh.boundary_faces
+
+    def test_2d_quad_grid_two_cells(self):
+        """Two adjacent quads share 1 internal face."""
+        nodes = np.array([[0, 0], [1, 0], [2, 0], [0, 1], [1, 1], [2, 1]], dtype=float)
+        elements = np.array([[0, 1, 4, 3], [1, 2, 5, 4]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.element_type == "quad"
+        assert mesh.n_internal_faces == 1
+        np.testing.assert_allclose(mesh.cell_volumes, [1.0, 1.0])
+
+    def test_3d_hex_mesh_basic(self):
+        """Hexahedron element type: unit-cube volume and 6 boundary faces."""
+        nodes = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+            ],
+            dtype=float,
+        )
+        elements = np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.element_type == "hexahedron"
+        np.testing.assert_allclose(mesh.cell_volumes, [1.0])
+        assert mesh.n_internal_faces == 0
+        assert mesh._n_boundary_faces == 6
+        np.testing.assert_allclose(mesh.face_areas, np.ones(6))
+
+    def test_2d_boundary_loops(self):
+        """boundary_loops returns a matplotlib Path around the outer edge."""
+        nodes, elements = _unit_square_two_triangles()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        paths = mesh.boundary_loops()
+        assert paths is not None
+        assert len(paths) >= 1
+        # Outer loop should contain the centre of the unit square
+        assert paths[0].contains_point((0.5, 0.5))
+        assert not paths[0].contains_point((-0.5, 0.5))
+
+    def test_3d_boundary_loops_returns_none(self):
+        """boundary_loops is 2D-only; 3D mesh returns None."""
+        nodes, elements = _unit_cube_five_tets()
+        mesh = UnstructuredSubMesh(nodes, elements)
+        assert mesh.boundary_loops() is None
+
+    def test_contains_points_3d_unit_cube(self):
+        nodes, elements = _unit_cube_five_tets()
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        inside = np.array([[0.5, 0.5, 0.5]])
+        outside = np.array([[2.0, 2.0, 2.0]])
+        assert mesh.contains_points_3d(inside)[0]
+        assert not mesh.contains_points_3d(outside)[0]
+
+    def test_contains_points_3d_hex_mesh(self):
+        """contains_points_3d on a hex mesh exercises the quad-face branch."""
+        nodes = np.array(
+            [
+                [0, 0, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+                [0, 1, 1],
+            ],
+            dtype=float,
+        )
+        elements = np.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+
+        assert mesh.contains_points_3d(np.array([[0.5, 0.5, 0.5]]))[0]
+        assert not mesh.contains_points_3d(np.array([[2.0, 2.0, 2.0]]))[0]
+
+    def test_optimize_ordering_single_cell_noop(self):
+        """optimize_ordering with 1 cell returns without permuting."""
+        nodes = np.array([[0, 0], [1, 0], [0, 1]], dtype=float)
+        elements = np.array([[0, 1, 2]], dtype=int)
+        mesh = UnstructuredSubMesh(nodes, elements)
+        mesh.optimize_ordering()
+        assert mesh.npts == 1
+
+    def test_generator_wrong_dimension_raises(self):
+        """UnstructuredMeshGenerator rejects non-2D/3D lims."""
+        import pytest
+
+        gen = UnstructuredMeshGenerator()
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        lims = {x: {"min": 0.0, "max": 1.0}}
+        with pytest.raises(ValueError, match="supports 2D and 3D"):
+            gen(lims, {"x_n": 3})
+
+    def test_generator_unknown_element_type_raises(self):
+        """UnstructuredMeshGenerator rejects bogus element_type."""
+        import pytest
+
+        gen = UnstructuredMeshGenerator(element_type="pentagon")
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode"],
+            direction="tb",
+        )
+        lims = {x: {"min": 0.0, "max": 1.0}, z: {"min": 0.0, "max": 1.0}}
+        with pytest.raises(ValueError, match="Unsupported 2D element_type"):
+            gen(lims, {"x_n": 2, "z_2d": 2})
+
+    def test_generator_quad_element_type(self):
+        """Generator with element_type='quad' produces quad submesh."""
+        gen = UnstructuredMeshGenerator(element_type="quad")
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode"],
+            direction="tb",
+        )
+        lims = {x: {"min": 0.0, "max": 1.0}, z: {"min": 0.0, "max": 1.0}}
+        sub = gen(lims, {"x_n": 2, "z_2d": 2})
+        assert sub.element_type == "quad"
+        assert sub.npts == 4
+
+    def test_generator_parse_lims_with_string_var(self):
+        """_parse_lims accepts string variable names and skips 'tabs'."""
+        gen = UnstructuredMeshGenerator()
+        spatial_vars, spatial_lims = gen._parse_lims(
+            {
+                "r_n": {"min": 0.0, "max": 1.0},
+                "r_p": {"min": 0.0, "max": 1.0},
+                "tabs": {},
+            }
+        )
+        assert len(spatial_vars) == 2
+        assert len(spatial_lims) == 2
+
+
+# ======================================================================
+# TestUnstructuredMeshGenerator
+# ======================================================================
+
+
+class TestUnstructuredMeshGenerator:
+    def test_2d_generator_basic(self):
+        x = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator", "positive electrode"],
+            coord_sys="cartesian",
+            direction="tb",
+        )
+
+        lims = {x: {"min": 0.0, "max": 1.0}, z: {"min": 0.0, "max": 1.0}}
+        npts = {"x_n": 4, "z_2d": 3}
+
+        gen = UnstructuredMeshGenerator()
+        mesh = gen(lims, npts)
+
+        assert isinstance(mesh, UnstructuredSubMesh)
+        assert mesh.dimension == 2
+        assert mesh.npts == 4 * 3 * 2  # 4*3 quads, 2 tris each
+        np.testing.assert_allclose(mesh.cell_volumes.sum(), 1.0, atol=1e-14)
+
+    def test_2d_generator_mesh_integration(self):
+        x = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode"],
+            coord_sys="cartesian",
+        )
+        geometry = {
+            "negative electrode": {
+                x: {"min": 0.0, "max": 1.0},
+                z: {"min": 0.0, "max": 2.0},
+            }
+        }
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen},
+            {x: 3, z: 4},
+        )
+        submesh = mesh["negative electrode"]
+        assert isinstance(submesh, UnstructuredSubMesh)
+        assert submesh.dimension == 2
+        assert submesh.npts == 3 * 4 * 2
+
+    def test_3d_generator_basic(self):
+        x = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        y = pybamm.SpatialVariable(
+            "y", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z", domain=["negative electrode"], coord_sys="cartesian"
+        )
+
+        lims = {
+            x: {"min": 0.0, "max": 1.0},
+            y: {"min": 0.0, "max": 1.0},
+            z: {"min": 0.0, "max": 1.0},
+        }
+        npts = {"x_n": 2, "y": 2, "z": 2}
+
+        gen = UnstructuredMeshGenerator()
+        mesh = gen(lims, npts)
+
+        assert isinstance(mesh, UnstructuredSubMesh)
+        assert mesh.dimension == 3
+        assert mesh.npts == 2 * 2 * 2  # 8 hex cells
+        np.testing.assert_allclose(mesh.cell_volumes.sum(), 1.0, atol=1e-14)
+
+    def test_3d_generator_mesh_integration(self):
+        x = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        y = pybamm.SpatialVariable(
+            "y", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z", domain=["negative electrode"], coord_sys="cartesian"
+        )
+
+        geometry = {
+            "negative electrode": {
+                x: {"min": 0.0, "max": 1.0},
+                y: {"min": 0.0, "max": 1.0},
+                z: {"min": 0.0, "max": 1.0},
+            }
+        }
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen},
+            {x: 2, y: 2, z: 2},
+        )
+        submesh = mesh["negative electrode"]
+        assert isinstance(submesh, UnstructuredSubMesh)
+        assert submesh.dimension == 3
+        assert submesh.npts == 2 * 2 * 2  # 8 hex cells
+
+    def test_interface_conformity_2d(self):
+        """Adjacent domains with the same z grid produce matching interface faces."""
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator"],
+            coord_sys="cartesian",
+        )
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+
+        gen = UnstructuredMeshGenerator()
+        left = gen(
+            {x_n: {"min": 0.0, "max": 1.0}, z: {"min": 0.0, "max": 1.0}},
+            {"x_n": 3, "z_2d": 4},
+        )
+        right = gen(
+            {x_s: {"min": 1.0, "max": 2.0}, z: {"min": 0.0, "max": 1.0}},
+            {"x_s": 3, "z_2d": 4},
+        )
+
+        # The right boundary of left and left boundary of right should match
+        left_right_bnd = left.boundary_faces["right"]
+        right_left_bnd = right.boundary_faces["left"]
+
+        assert len(left_right_bnd) == len(right_left_bnd)
+
+        left_transverse = np.sort(left.face_centroids[left_right_bnd, 1])
+        right_transverse = np.sort(right.face_centroids[right_left_bnd, 1])
+        np.testing.assert_allclose(left_transverse, right_transverse, atol=1e-14)
+
+    def test_interface_conformity_3d(self):
+        """Adjacent 3D domains with the same y,z grid produce matching interface faces."""
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        y = pybamm.SpatialVariable(
+            "y", domain=["negative electrode", "separator"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z", domain=["negative electrode", "separator"], coord_sys="cartesian"
+        )
+
+        gen = UnstructuredMeshGenerator()
+        left = gen(
+            {
+                x_n: {"min": 0, "max": 1},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_n": 2, "y": 2, "z": 2},
+        )
+        right = gen(
+            {
+                x_s: {"min": 1, "max": 2},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_s": 2, "y": 2, "z": 2},
+        )
+
+        left_right_bnd = left.boundary_faces["right"]
+        right_left_bnd = right.boundary_faces["left"]
+
+        assert len(left_right_bnd) == len(right_left_bnd)
+        assert len(left_right_bnd) > 0
+
+
+# ======================================================================
+# TestComputeInterfaceData
+# ======================================================================
+
+
+class TestComputeInterfaceData:
+    def test_2d_interface_matching(self):
+        gen = UnstructuredMeshGenerator()
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator"],
+            coord_sys="cartesian",
+        )
+
+        left = gen(
+            {x_n: {"min": 0, "max": 1}, z: {"min": 0, "max": 1}},
+            {"x_n": 3, "z_2d": 3},
+        )
+        right = gen(
+            {x_s: {"min": 1, "max": 2}, z: {"min": 0, "max": 1}},
+            {"x_s": 3, "z_2d": 3},
+        )
+
+        result = compute_interface_data(left, right)
+
+        assert len(result["left_cells"]) == len(result["right_cells"])
+        assert len(result["face_areas"]) == len(result["left_cells"])
+        assert len(result["cell_distances"]) == len(result["left_cells"])
+        assert np.all(result["cell_distances"] > 0)
+        assert np.all(result["face_areas"] > 0)
+
+    def test_3d_interface_matching(self):
+        gen = UnstructuredMeshGenerator()
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        y = pybamm.SpatialVariable(
+            "y", domain=["negative electrode", "separator"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z", domain=["negative electrode", "separator"], coord_sys="cartesian"
+        )
+
+        left = gen(
+            {
+                x_n: {"min": 0, "max": 1},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_n": 2, "y": 2, "z": 2},
+        )
+        right = gen(
+            {
+                x_s: {"min": 1, "max": 2},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_s": 2, "y": 2, "z": 2},
+        )
+
+        result = compute_interface_data(left, right)
+
+        assert len(result["left_cells"]) > 0
+        assert len(result["left_cells"]) == len(result["right_cells"])
+        assert np.all(result["cell_distances"] > 0)
+        assert np.all(result["face_areas"] > 0)
+
+    def test_interface_data_stored_on_submesh(self):
+        gen = UnstructuredMeshGenerator()
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator"],
+            coord_sys="cartesian",
+        )
+
+        left = gen(
+            {x_n: {"min": 0, "max": 1}, z: {"min": 0, "max": 1}},
+            {"x_n": 2, "z_2d": 2},
+        )
+        right = gen(
+            {x_s: {"min": 1, "max": 2}, z: {"min": 0, "max": 1}},
+            {"x_s": 2, "z_2d": 2},
+        )
+
+        compute_interface_data(
+            left, right, left_name="negative electrode", right_name="separator"
+        )
+
+        assert "separator" in left.interface_data
+        assert "negative electrode" in right.interface_data
+
+        left_to_right = left.interface_data["separator"]
+        right_to_left = right.interface_data["negative electrode"]
+
+        np.testing.assert_array_equal(
+            left_to_right["left_cells"], right_to_left["right_cells"]
+        )
+        np.testing.assert_array_equal(
+            left_to_right["right_cells"], right_to_left["left_cells"]
+        )
+
+
+# ======================================================================
+# TestMeshIntegration
+# ======================================================================
+
+
+class TestMeshIntegration:
+    def test_ghost_mesh_excluded(self):
+        x = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode"],
+            coord_sys="cartesian",
+        )
+        geometry = {
+            "negative electrode": {
+                x: {"min": 0.0, "max": 1.0},
+                z: {"min": 0.0, "max": 1.0},
+            }
+        }
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen},
+            {x: 3, z: 3},
+        )
+
+        ghost_keys = [k for k in mesh if "ghost" in str(k)]
+        assert len(ghost_keys) == 0
+
+    def test_combine_submeshes(self):
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        x_p = pybamm.SpatialVariable(
+            "x_p", domain=["positive electrode"], coord_sys="cartesian"
+        )
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator", "positive electrode"],
+            coord_sys="cartesian",
+        )
+
+        geometry = {
+            "negative electrode": {x_n: {"min": 0, "max": 1}, z: {"min": 0, "max": 1}},
+            "separator": {x_s: {"min": 1, "max": 1.5}, z: {"min": 0, "max": 1}},
+            "positive electrode": {
+                x_p: {"min": 1.5, "max": 2.5},
+                z: {"min": 0, "max": 1},
+            },
+        }
+
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {
+                "negative electrode": gen,
+                "separator": gen,
+                "positive electrode": gen,
+            },
+            {x_n: 3, x_s: 2, x_p: 3, z: 4},
+        )
+
+        n_neg = mesh["negative electrode"].npts
+        n_sep = mesh["separator"].npts
+        n_pos = mesh["positive electrode"].npts
+
+        combined = mesh[("negative electrode", "separator", "positive electrode")]
+        assert combined.npts == n_neg + n_sep + n_pos
+
+    def test_interface_data_computed_automatically(self):
+        """Mesh.__init__ should compute interface data between adjacent domains."""
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        z = pybamm.SpatialVariable(
+            "z_2d",
+            domain=["negative electrode", "separator"],
+            coord_sys="cartesian",
+        )
+
+        geometry = {
+            "negative electrode": {x_n: {"min": 0, "max": 1}, z: {"min": 0, "max": 1}},
+            "separator": {x_s: {"min": 1, "max": 2}, z: {"min": 0, "max": 1}},
+        }
+
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen, "separator": gen},
+            {x_n: 3, x_s: 3, z: 4},
+        )
+
+        neg_mesh = mesh["negative electrode"]
+        sep_mesh = mesh["separator"]
+
+        assert "separator" in neg_mesh.interface_data
+        assert "negative electrode" in sep_mesh.interface_data
+        assert len(neg_mesh.interface_data["separator"]["left_cells"]) > 0
+
+
+class TestBandwidthOptimization:
+    """Tests for _hex_grid loop ordering and optimize_ordering (RCM)."""
+
+    @staticmethod
+    def _bandwidth(submesh):
+        n_int = submesh._boundary_face_start
+        owners = submesh.face_owner[:n_int]
+        neighbors = submesh.face_neighbor
+        return int(np.max(np.abs(owners.astype(int) - neighbors.astype(int))))
+
+    def test_hex_grid_optimal_loop_order(self):
+        """_hex_grid should order cells so bandwidth = product of two smallest dims."""
+        for nx, ny, nz in [(3, 10, 5), (2, 4, 20), (7, 3, 3), (5, 5, 5)]:
+            nodes, elems = _hex_grid(
+                np.linspace(0, 1, nx + 1),
+                np.linspace(0, 1, ny + 1),
+                np.linspace(0, 1, nz + 1),
+            )
+            mesh = UnstructuredSubMesh(nodes, elems, coord_sys="cartesian")
+            bw = self._bandwidth(mesh)
+            dims = sorted([nx, ny, nz])
+            expected = dims[0] * dims[1]
+            assert bw == expected, (
+                f"nx={nx} ny={ny} nz={nz}: bw={bw}, expected={expected}"
+            )
+
+    def test_optimize_ordering_reduces_bandwidth(self):
+        """optimize_ordering (RCM) should not increase bandwidth."""
+        nodes, elems = _hex_grid(
+            np.linspace(0, 1, 4),
+            np.linspace(0, 1, 11),
+            np.linspace(0, 1, 6),
+        )
+        mesh = UnstructuredSubMesh(nodes, elems, coord_sys="cartesian")
+        bw_before = self._bandwidth(mesh)
+        mesh.optimize_ordering()
+        bw_after = self._bandwidth(mesh)
+        assert bw_after <= bw_before
+
+    def test_optimize_ordering_preserves_geometry(self):
+        """Cell volumes and centroids must be the same set after reordering."""
+        nodes, elems = _hex_grid(
+            np.linspace(0, 1, 4),
+            np.linspace(0, 1, 6),
+            np.linspace(0, 1, 4),
+        )
+        mesh = UnstructuredSubMesh(nodes, elems, coord_sys="cartesian")
+        vols_before = np.sort(mesh.cell_volumes)
+        cents_before = mesh.cell_centroids[np.lexsort(mesh.cell_centroids.T)]
+
+        mesh.optimize_ordering()
+
+        vols_after = np.sort(mesh.cell_volumes)
+        cents_after = mesh.cell_centroids[np.lexsort(mesh.cell_centroids.T)]
+        np.testing.assert_allclose(vols_before, vols_after)
+        np.testing.assert_allclose(cents_before, cents_after)
+
+    def test_optimize_ordering_preserves_interface_data(self):
+        """Interface cell centroids should point to the same physical cells."""
+        ye = np.linspace(0, 1, 6)
+        ze = np.linspace(0, 1, 4)
+        nodes_l, elems_l = _hex_grid(np.linspace(0, 1, 4), ye, ze)
+        mesh_l = UnstructuredSubMesh(nodes_l, elems_l, coord_sys="cartesian")
+        nodes_r, elems_r = _hex_grid(np.linspace(1, 2, 4), ye, ze)
+        mesh_r = UnstructuredSubMesh(nodes_r, elems_r, coord_sys="cartesian")
+        compute_interface_data(mesh_l, mesh_r, "left", "right")
+
+        iface = mesh_l.interface_data["right"]
+        centroids_pre = mesh_l.cell_centroids[iface["left_cells"]].copy()
+
+        mesh_l.optimize_ordering()
+
+        iface = mesh_l.interface_data["right"]
+        centroids_post = mesh_l.cell_centroids[iface["left_cells"]]
+        np.testing.assert_allclose(centroids_pre, centroids_post)

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -745,6 +745,59 @@ class TestFileGenerators:
         with pytest.raises(pybamm.GeometryError, match="cell data tag"):
             gen_bad({"x_n": {"min": 0.0, "max": 1.0}}, {})
 
+    def test_user_supplied_boundary_mapping_tags_faces(self):
+        """boundary_mapping maps tagged facet groups to boundary face names."""
+        import pytest
+
+        meshio = pytest.importorskip("meshio")
+        points = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=float)
+        tris = np.array([[0, 1, 2], [0, 2, 3]])
+        lines = np.array([[0, 1], [1, 2], [2, 3], [3, 0]])
+        gen = UserSuppliedUnstructuredMesh(
+            "unused.vtu", boundary_mapping={"seal": 1, "vent": 2}
+        )
+        gen._cached_mesh = meshio.Mesh(
+            points,
+            [("triangle", tris), ("line", lines)],
+            cell_data={"gmsh:physical": [np.array([0, 0]), np.array([1, 1, 2, 2])]},
+        )
+        sub = gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+        assert set(sub.boundary_faces) == {"seal", "vent"}
+        seal = sub.face_centroids[sub.boundary_faces["seal"]]
+        vent = sub.face_centroids[sub.boundary_faces["vent"]]
+        # seal = bottom + right edges, vent = top + left edges
+        np.testing.assert_allclose(sorted(map(tuple, seal)), [(0.5, 0.0), (1.0, 0.5)])
+        np.testing.assert_allclose(sorted(map(tuple, vent)), [(0.0, 0.5), (0.5, 1.0)])
+
+    def test_tagged_generator_boundary_mapping(self):
+        """TaggedSubMeshGenerator resolves surface physical groups to tags."""
+        import pytest
+
+        meshio = pytest.importorskip("meshio")
+        nodes, elements = _unit_cube_five_tets()
+        # Bottom cube face as the two triangles the 5-tet split puts there
+        base_tris = np.array([[0, 1, 2], [0, 2, 3]])
+        mesh = meshio.Mesh(
+            nodes,
+            [("tetra", elements), ("triangle", base_tris)],
+            cell_data={"gmsh:physical": [np.full(5, 1), np.full(2, 10)]},
+            field_data={"anode": np.array([1, 3]), "base": np.array([10, 2])},
+        )
+        fake_path = "fake_tagged_boundaries.msh"
+        TaggedSubMeshGenerator._mesh_cache[fake_path] = mesh
+        try:
+            gen = TaggedSubMeshGenerator(
+                "anode", fake_path, boundary_mapping={"bottom_seal": "base"}
+            )
+            sub = gen({}, {})
+            assert set(sub.boundary_faces) == {"bottom_seal"}
+            centroids = sub.face_centroids[sub.boundary_faces["bottom_seal"]]
+            np.testing.assert_allclose(centroids[:, 2], 0.0, atol=1e-14)
+            assert len(centroids) == 2
+        finally:
+            TaggedSubMeshGenerator._mesh_cache.pop(fake_path, None)
+
     def test_user_supplied_no_supported_cells_raises(self):
         """A mesh with only unsupported cell types raises."""
         import pytest

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -205,7 +205,17 @@ class TestUnstructuredSubMesh:
         elements = np.array([[0, 1, 2, 3, 4]], dtype=int)
         import pytest
 
-        with pytest.raises(ValueError, match="Unsupported"):
+        with pytest.raises(pybamm.GeometryError, match="Unsupported"):
+            UnstructuredSubMesh(nodes, elements)
+
+    def test_nonmanifold_face_raises(self):
+        """A face shared by more than two cells must raise, not vanish."""
+        import pytest
+
+        # Three triangles all sharing the edge (0, 1): a non-manifold fan.
+        nodes = np.array([[0, 0], [1, 0], [0.5, 1], [0.5, -1], [1.5, 0.5]], dtype=float)
+        elements = np.array([[0, 1, 2], [0, 1, 3], [0, 1, 4]], dtype=int)
+        with pytest.raises(pybamm.GeometryError, match="non-manifold"):
             UnstructuredSubMesh(nodes, elements)
 
     def test_2d_quad_mesh_basic(self):
@@ -322,7 +332,7 @@ class TestUnstructuredSubMesh:
         gen = UnstructuredMeshGenerator()
         x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
         lims = {x: {"min": 0.0, "max": 1.0}}
-        with pytest.raises(ValueError, match="supports 2D and 3D"):
+        with pytest.raises(pybamm.GeometryError, match="supports 2D and 3D"):
             gen(lims, {"x_n": 3})
 
     def test_generator_unknown_element_type_raises(self):
@@ -337,8 +347,44 @@ class TestUnstructuredSubMesh:
             direction="tb",
         )
         lims = {x: {"min": 0.0, "max": 1.0}, z: {"min": 0.0, "max": 1.0}}
-        with pytest.raises(ValueError, match="Unsupported 2D element_type"):
+        with pytest.raises(pybamm.GeometryError, match="Unsupported 2D element_type"):
             gen(lims, {"x_n": 2, "z_2d": 2})
+
+    def test_generator_tetrahedron_element_type(self):
+        """3D generator honours element_type='tetrahedron' (not just hexahedron)."""
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        y = pybamm.SpatialVariable("y", domain=["negative electrode"])
+        z = pybamm.SpatialVariable("z", domain=["negative electrode"])
+        lims = {
+            x: {"min": 0.0, "max": 1.0},
+            y: {"min": 0.0, "max": 1.0},
+            z: {"min": 0.0, "max": 1.0},
+        }
+        npts = {"x_n": 2, "y": 2, "z": 2}
+
+        hex_mesh = UnstructuredMeshGenerator()(lims, npts)
+        assert hex_mesh.element_type == "hexahedron"  # 3D default
+
+        tet_mesh = UnstructuredMeshGenerator(element_type="tetrahedron")(lims, npts)
+        assert tet_mesh.element_type == "tetrahedron"
+        assert tet_mesh.npts == 8 * 5  # 5 tets per hex
+        np.testing.assert_allclose(tet_mesh.cell_volumes.sum(), 1.0, atol=1e-14)
+
+    def test_generator_unknown_3d_element_type_raises(self):
+        """3D generator rejects a bogus element_type."""
+        import pytest
+
+        gen = UnstructuredMeshGenerator(element_type="dodecahedron")
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        y = pybamm.SpatialVariable("y", domain=["negative electrode"])
+        z = pybamm.SpatialVariable("z", domain=["negative electrode"])
+        lims = {
+            x: {"min": 0.0, "max": 1.0},
+            y: {"min": 0.0, "max": 1.0},
+            z: {"min": 0.0, "max": 1.0},
+        }
+        with pytest.raises(pybamm.GeometryError, match="Unsupported 3D element_type"):
+            gen(lims, {"x_n": 2, "y": 2, "z": 2})
 
     def test_generator_quad_element_type(self):
         """Generator with element_type='quad' produces quad submesh."""
@@ -746,6 +792,38 @@ class TestMeshIntegration:
         n_int = combined._boundary_face_start
         on_seam = np.abs(combined.face_centroids[:n_int, 0] - 1.0) < 1e-12
         assert on_seam.sum() > 0
+
+    def test_combine_tetrahedron_domains_conforming(self):
+        """Tet domains from the generator combine into one connected mesh.
+
+        Exercises the cumulative-offset regeneration in ``combine`` that keeps
+        the alternating tet triangulation conforming across the interface.
+        """
+        x_n = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"])
+        y = pybamm.SpatialVariable("y", domain=["negative electrode", "separator"])
+        z = pybamm.SpatialVariable("z", domain=["negative electrode", "separator"])
+        gen = UnstructuredMeshGenerator(element_type="tetrahedron")
+        left = gen(
+            {
+                x_n: {"min": 0, "max": 1},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_n": 2, "y": 2, "z": 2},
+        )
+        right = gen(
+            {
+                x_s: {"min": 1, "max": 2},
+                y: {"min": 0, "max": 1},
+                z: {"min": 0, "max": 1},
+            },
+            {"x_s": 2, "y": 2, "z": 2},
+        )
+        # Must not raise: interface tets triangulate identically on both sides.
+        combined = UnstructuredSubMesh.combine([left, right])
+        assert combined.element_type == "tetrahedron"
+        assert combined.npts == left.npts + right.npts
 
     def test_combine_disconnected_domains_raises(self):
         """A non-conforming interface must raise, not solve silently to garbage."""

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -1287,6 +1287,32 @@ class TestMeshIntegration:
         assert "No interface coupling between 'negative electrode'" in caplog.text
         assert "separator" in caplog.text
 
+    def test_combine_battery_scale_with_interface_jitter(self):
+        """Welding tolerances scale with the mesh, not with 1 metre.
+
+        Two 100 um domains whose shared interface is offset by 3 nm — the
+        precision loss a reduced-precision mesh file or a unit conversion
+        produces. The weld must absorb it (it is ~1e-4 of an edge), and
+        custom boundary tags must survive it.
+        """
+        um = 1e-6
+        ye = np.linspace(0, 100 * um, 3)
+        ze = np.linspace(0, 100 * um, 3)
+        left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 100 * um, 6), ye, ze))
+        right = UnstructuredSubMesh(
+            *_hex_grid(np.linspace(100 * um + 3e-9, 200 * um, 6), ye, ze)
+        )
+        left.detect_box_boundaries()
+        right.detect_box_boundaries()
+        left.boundary_faces["tab_top"] = left.boundary_faces.pop("top")
+
+        combined = UnstructuredSubMesh.combine([left, right])
+
+        assert combined.npts == left.npts + right.npts
+        assert "tab_top" in combined.boundary_faces
+        tab = combined.face_centroids[combined.boundary_faces["tab_top"]]
+        np.testing.assert_allclose(tab[:, 2], 100 * um, rtol=1e-6)
+
     def test_combine_mixed_element_types_raises(self):
         """Combining domains of different element types names both types."""
         import pytest

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -837,3 +837,38 @@ class TestBandwidthOptimization:
         iface = mesh_l.interface_data["right"]
         centroids_post = mesh_l.cell_centroids[iface["left_cells"]]
         np.testing.assert_allclose(centroids_pre, centroids_post)
+
+    def test_optimize_ordering_preserves_interface_pairing(self):
+        """``right_cells`` must keep indexing the neighbour after reordering."""
+        ye = np.linspace(0, 1, 4)
+        ze = np.linspace(0, 1, 3)
+        # Different x resolutions, so permuting the neighbour's indices by this
+        # mesh's permutation would run off the end of the neighbour.
+        nodes_l, elems_l = _hex_grid(np.linspace(0, 1, 4), ye, ze)
+        mesh_l = UnstructuredSubMesh(nodes_l, elems_l, coord_sys="cartesian")
+        nodes_r, elems_r = _hex_grid(np.linspace(1, 2, 3), ye, ze)
+        mesh_r = UnstructuredSubMesh(nodes_r, elems_r, coord_sys="cartesian")
+        assert mesh_l.npts > mesh_r.npts
+        compute_interface_data(mesh_l, mesh_r, "left", "right")
+
+        iface = mesh_l.interface_data["right"]
+        self_pre = mesh_l.cell_centroids[iface["left_cells"]].copy()
+        other_pre = mesh_r.cell_centroids[iface["right_cells"]].copy()
+
+        mesh_l.optimize_ordering()
+
+        iface = mesh_l.interface_data["right"]
+        assert iface["right_cells"].max() < mesh_r.npts
+        np.testing.assert_allclose(self_pre, mesh_l.cell_centroids[iface["left_cells"]])
+        np.testing.assert_allclose(
+            other_pre, mesh_r.cell_centroids[iface["right_cells"]]
+        )
+
+        # The neighbour's mirrored view of this mesh must follow the permutation
+        mirror = mesh_r.interface_data["left"]
+        np.testing.assert_allclose(
+            self_pre, mesh_l.cell_centroids[mirror["right_cells"]]
+        )
+        np.testing.assert_allclose(
+            other_pre, mesh_r.cell_centroids[mirror["left_cells"]]
+        )

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -2,8 +2,10 @@ import numpy as np
 
 import pybamm
 from pybamm.meshes.unstructured_submesh import (
+    TaggedSubMeshGenerator,
     UnstructuredMeshGenerator,
     UnstructuredSubMesh,
+    UserSuppliedUnstructuredMesh,
     _hex_grid,
     _hex_to_tet,
     _quad_to_tri,
@@ -594,6 +596,148 @@ class TestUnstructuredMeshGenerator:
 
 
 # ======================================================================
+# TestFileGenerators
+# ======================================================================
+
+
+class TestFileGenerators:
+    @staticmethod
+    def _write_two_triangle_vtu(path, tags=None):
+        """Unit square as 2 triangles, z=0, optional per-cell integer tags."""
+        import meshio
+
+        points = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=float)
+        cells = [("triangle", np.array([[0, 1, 2], [0, 2, 3]]))]
+        cell_data = {"tag": [np.asarray(tags)]} if tags is not None else {}
+        meshio.write(str(path), meshio.Mesh(points, cells, cell_data=cell_data))
+
+    def test_user_supplied_loads_whole_mesh(self, tmp_path):
+        """Full file load: z=0 points are trimmed to a 2D mesh."""
+        import pytest
+
+        pytest.importorskip("meshio")
+        path = tmp_path / "square.vtu"
+        self._write_two_triangle_vtu(path)
+
+        gen = UserSuppliedUnstructuredMesh(str(path))
+        sub = gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+        assert isinstance(sub, UnstructuredSubMesh)
+        assert sub.dimension == 2
+        assert sub.npts == 2
+        np.testing.assert_allclose(sub.cell_volumes.sum(), 1.0)
+        assert "square.vtu" in repr(gen)
+
+    def test_user_supplied_subdomain_filtering(self, tmp_path):
+        """subdomain_mapping selects only the cells with the matching tag."""
+        import pytest
+
+        pytest.importorskip("meshio")
+        path = tmp_path / "tagged.vtu"
+        self._write_two_triangle_vtu(path, tags=[1, 2])
+
+        gen = UserSuppliedUnstructuredMesh(
+            str(path), subdomain_mapping={"negative electrode": 1}
+        )
+        sub = gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+        assert sub.npts == 1
+
+        # A mesh with no cell data at all cannot satisfy a subdomain_mapping
+        import meshio
+
+        gen_bad = UserSuppliedUnstructuredMesh(
+            str(path), subdomain_mapping={"negative electrode": 1}
+        )
+        gen_bad._cached_mesh = meshio.Mesh(
+            np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=float),
+            [("triangle", np.array([[0, 1, 2]]))],
+        )
+        with pytest.raises(pybamm.GeometryError, match="cell data tag"):
+            gen_bad({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+    def test_user_supplied_no_supported_cells_raises(self):
+        """A mesh with only unsupported cell types raises."""
+        import pytest
+
+        meshio = pytest.importorskip("meshio")
+        gen = UserSuppliedUnstructuredMesh("unused.vtu")
+        gen._cached_mesh = meshio.Mesh(
+            np.array([[0, 0, 0], [1, 0, 0]], dtype=float),
+            [("line", np.array([[0, 1]]))],
+        )
+        with pytest.raises(pybamm.GeometryError, match="No supported cells"):
+            gen({"x_n": {"min": 0.0, "max": 1.0}}, {})
+
+    def test_domain_name_from_lims(self):
+        """String and SpatialVariable keys map to electrode domains; 'tabs' skipped."""
+        f = UserSuppliedUnstructuredMesh._domain_name_from_lims
+        assert f({"x_n": {}}) == "negative electrode"
+        assert f({"x_s": {}}) == "separator"
+        assert f({"tabs": {}, "x_p": {}}) == "positive electrode"
+        assert f({"r_n": {}}) is None
+        x = pybamm.SpatialVariable("x_n", domain=["negative electrode"])
+        assert f({x: {}}) == "negative electrode"
+
+    @staticmethod
+    def _tagged_gmsh_mesh():
+        """Synthetic meshio mesh: 5 tets of the unit cube, two physical groups."""
+        import meshio
+
+        nodes, elements = _unit_cube_five_tets()
+        return meshio.Mesh(
+            nodes,
+            [("tetra", elements)],
+            cell_data={"gmsh:physical": [np.array([1, 1, 1, 2, 2])]},
+            field_data={"anode": np.array([1, 3]), "cathode": np.array([2, 3])},
+        )
+
+    def test_tagged_generator_extracts_region(self):
+        import pytest
+
+        pytest.importorskip("meshio")
+        fake_path = "fake_tagged_mesh.msh"
+        TaggedSubMeshGenerator._mesh_cache[fake_path] = self._tagged_gmsh_mesh()
+        try:
+            gen = TaggedSubMeshGenerator("anode", fake_path, scale=2.0)
+            sub = gen({}, {})
+            assert isinstance(sub, UnstructuredSubMesh)
+            assert sub.npts == 3  # cells tagged 1
+            # scale multiplies coordinates: unit cube -> side 2
+            np.testing.assert_allclose(sub.nodes.max(axis=0), [2.0, 2.0, 2.0])
+        finally:
+            TaggedSubMeshGenerator._mesh_cache.pop(fake_path, None)
+
+    def test_tagged_generator_missing_region_raises(self):
+        import pytest
+
+        pytest.importorskip("meshio")
+        fake_path = "fake_tagged_mesh_2.msh"
+        TaggedSubMeshGenerator._mesh_cache[fake_path] = self._tagged_gmsh_mesh()
+        try:
+            gen = TaggedSubMeshGenerator("does-not-exist", fake_path)
+            with pytest.raises(pybamm.GeometryError, match="not in mesh field_data"):
+                gen({}, {})
+        finally:
+            TaggedSubMeshGenerator._mesh_cache.pop(fake_path, None)
+
+    def test_tagged_generator_region_without_tets_raises(self):
+        import pytest
+
+        pytest.importorskip("meshio")
+        fake_path = "fake_tagged_mesh_3.msh"
+        mesh = self._tagged_gmsh_mesh()
+        # Physical group 9 exists in field_data but tags no tet cells
+        mesh.field_data["empty"] = np.array([9, 3])
+        TaggedSubMeshGenerator._mesh_cache[fake_path] = mesh
+        try:
+            gen = TaggedSubMeshGenerator("empty", fake_path)
+            with pytest.raises(pybamm.GeometryError, match="no tets"):
+                gen({}, {})
+        finally:
+            TaggedSubMeshGenerator._mesh_cache.pop(fake_path, None)
+
+
+# ======================================================================
 # TestComputeInterfaceData
 # ======================================================================
 
@@ -702,6 +846,36 @@ class TestComputeInterfaceData:
         np.testing.assert_array_equal(
             left_to_right["right_cells"], right_to_left["left_cells"]
         )
+
+    def test_no_matching_boundary_faces_raises(self):
+        """A mesh without the required boundary bucket cannot be paired."""
+        import pytest
+
+        ye = np.linspace(0, 1, 3)
+        ze = np.linspace(0, 1, 3)
+        left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 1, 3), ye, ze))
+        nodes_r, elems_r = _hex_grid(np.linspace(1, 2, 3), ye, ze)
+        # Empty boundary_faces: no "left" bucket to match against
+        right = UnstructuredSubMesh(nodes_r, elems_r, boundary_faces={})
+
+        with pytest.raises(pybamm.GeometryError, match="matching boundary faces"):
+            compute_interface_data(left, right)
+
+    def test_transverse_mismatch_raises(self):
+        """Interface faces at different transverse positions cannot be paired."""
+        import pytest
+
+        ze = np.linspace(0, 1, 3)
+        left = UnstructuredSubMesh(
+            *_hex_grid(np.linspace(0, 1, 3), np.linspace(0, 1, 3), ze)
+        )
+        # y grid shifted by 0.37: same face count, wrong transverse positions
+        right = UnstructuredSubMesh(
+            *_hex_grid(np.linspace(1, 2, 3), np.linspace(0.37, 1.37, 3), ze)
+        )
+
+        with pytest.raises(pybamm.GeometryError, match="do not match"):
+            compute_interface_data(left, right)
 
 
 # ======================================================================
@@ -824,6 +998,53 @@ class TestMeshIntegration:
         combined = UnstructuredSubMesh.combine([left, right])
         assert combined.element_type == "tetrahedron"
         assert combined.npts == left.npts + right.npts
+
+    def test_combine_propagates_custom_boundary_tags(self):
+        """Non-standard boundary tags survive combining via centroid matching."""
+        ye = np.linspace(0, 1, 3)
+        ze = np.linspace(0, 1, 3)
+        left = UnstructuredSubMesh(*_hex_grid(np.linspace(0, 1, 3), ye, ze))
+        right = UnstructuredSubMesh(*_hex_grid(np.linspace(1, 2, 3), ye, ze))
+        left.boundary_faces["tab_top"] = left.boundary_faces.pop("top")
+
+        combined = UnstructuredSubMesh.combine([left, right])
+
+        assert "tab_top" in combined.boundary_faces
+        # The recovered faces sit on the z=1 plane of the left half only
+        tab_centroids = combined.face_centroids[combined.boundary_faces["tab_top"]]
+        np.testing.assert_allclose(tab_centroids[:, 2], 1.0)
+        assert tab_centroids[:, 0].max() <= 1.0
+
+    def test_mesh_skips_interface_for_mismatched_grids(self):
+        """Mesh.__init__ leaves interface_data empty when pairing fails."""
+        x_n = pybamm.SpatialVariable(
+            "x_n", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        x_s = pybamm.SpatialVariable("x_s", domain=["separator"], coord_sys="cartesian")
+        z_a = pybamm.SpatialVariable(
+            "z_2d", domain=["negative electrode"], coord_sys="cartesian"
+        )
+        z_b = pybamm.SpatialVariable(
+            "z_2d", domain=["separator"], coord_sys="cartesian"
+        )
+
+        # Transverse extents disagree (z: 0-1 vs 0-2), so pairing cannot match
+        geometry = {
+            "negative electrode": {
+                x_n: {"min": 0, "max": 1},
+                z_a: {"min": 0, "max": 1},
+            },
+            "separator": {x_s: {"min": 1, "max": 2}, z_b: {"min": 0, "max": 2}},
+        }
+        gen = UnstructuredMeshGenerator()
+        mesh = pybamm.Mesh(
+            geometry,
+            {"negative electrode": gen, "separator": gen},
+            {x_n: 3, x_s: 3, z_a: 4, z_b: 4},
+        )
+
+        assert mesh["negative electrode"].interface_data == {}
+        assert mesh["separator"].interface_data == {}
 
     def test_combine_disconnected_domains_raises(self):
         """A non-conforming interface must raise, not solve silently to garbage."""

--- a/packages/pybamm/tests/unit/test_serialisation/test_base_strategy_coverage.py
+++ b/packages/pybamm/tests/unit/test_serialisation/test_base_strategy_coverage.py
@@ -44,6 +44,7 @@ _SUBMESH_EXEMPT: set[type] = {
     pybamm.Uniform2DSubMesh,  # cannot serialise (no _from_json)
     pybamm.UserSupplied1DSubMesh,  # cannot serialise (no _from_json)
     pybamm.UserSupplied2DSubMesh,  # cannot serialise (no _from_json)
+    pybamm.UnstructuredSubMesh,  # cannot serialise (no _from_json)
 }
 
 


### PR DESCRIPTION
## Summary
- Add `UnstructuredSubMesh`, generators (`UnstructuredMeshGenerator`, `UserSuppliedUnstructuredMesh`, `TaggedSubMeshGenerator`), and `Mesh` interface coupling.
- Independent of the VectorField PR; both land before the spatial-method PR.

## Stack
1. #5686 — VectorField N-comp
2. **This PR** (#5687) — Meshing
3. #5688 — Spatial method + ProcessedVariable
4. #5689 — VTK plotting
5. #5690 — Unstructured DFN models

Full pre-split branch preserved on #5397 / `backup/unstructured-finite-volume-full`.

## Test plan
- [x] `tests/unit/test_meshes/test_unstructured_submesh.py` (41 tests)
- [ ] CI unit suite

Also in this stack: #5691 deprecates `pybamm.Magnitude`.