### PR TITLE
Pass model options through to the electrode SOH model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used.
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
 - `pybamm.citations.register` now names the citation the caller passed in when a BibTeX string fails to parse, instead of whichever entry the parser had reached. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
-- `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used.
+- `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
 - `pybamm.citations.register` now names the citation the caller passed in when a BibTeX string fails to parse, instead of whichever entry the parser had reached. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/packages/pybamm/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
+++ b/packages/pybamm/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh.py
@@ -239,11 +239,14 @@ class _ElectrodeSOHMSMR(_BaseElectrodeSOH):
         param=None,
         solve_for=None,
         known_value="cyclable lithium capacity",
+        options=None,
     ):
         pybamm.citations.register("Baker2018")
         super().__init__()
 
-        param = param or pybamm.LithiumIonParameters({"open-circuit potential": "MSMR"})
+        param = param or pybamm.LithiumIonParameters(
+            options or {"open-circuit potential": "MSMR"}
+        )
         solve_for = solve_for or ["Un_0", "Un_100"]
 
         if known_value == "cell capacity" and solve_for != ["Un_0", "Un_100"]:
@@ -431,11 +434,17 @@ class ElectrodeSOHSolver:
     def __get_electrode_soh_sims_full(self, direction):
         if self.options["open-circuit potential"] == "MSMR":
             full_model = _ElectrodeSOHMSMR(
-                direction, param=self.param, known_value=self.known_value
+                direction,
+                param=self.param,
+                known_value=self.known_value,
+                options=self.options,
             )
         else:
             full_model = _ElectrodeSOH(
-                direction, param=self.param, known_value=self.known_value
+                direction,
+                param=self.param,
+                known_value=self.known_value,
+                options=self.options,
             )
         return pybamm.Simulation(full_model, parameter_values=self.parameter_values)
 
@@ -446,12 +455,14 @@ class ElectrodeSOHSolver:
                 param=self.param,
                 solve_for=["Un_100"],
                 known_value=self.known_value,
+                options=self.options,
             )
             x0_model = _ElectrodeSOHMSMR(
                 direction,
                 param=self.param,
                 solve_for=["Un_0"],
                 known_value=self.known_value,
+                options=self.options,
             )
         else:
             x100_model = _ElectrodeSOH(
@@ -459,12 +470,14 @@ class ElectrodeSOHSolver:
                 param=self.param,
                 solve_for=["x_100"],
                 known_value=self.known_value,
+                options=self.options,
             )
             x0_model = _ElectrodeSOH(
                 direction,
                 param=self.param,
                 solve_for=["x_0"],
                 known_value=self.known_value,
+                options=self.options,
             )
         x100_sim = pybamm.Simulation(x100_model, parameter_values=self.parameter_values)
         x0_sim = pybamm.Simulation(x0_model, parameter_values=self.parameter_values)

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -202,6 +202,89 @@ class TestElectrodeSOH:
             esoh_solver.solve(inputs)
 
 
+class TestElectrodeSOHHysteresis:
+    """The eSOH model must equilibrate 100% SOC on the charge branch and 0% SOC on
+    the discharge branch, which requires the model options to reach `_ElectrodeSOH`."""
+
+    options = pybamm.BatteryModelOptions(
+        {"open-circuit potential": ("current sigmoid", "current sigmoid")}
+    )
+
+    @staticmethod
+    def _hysteresis_parameter_values():
+        """Chen2020 with OCP branches offset by +/- 50 mV from equilibrium."""
+        parameter_values = pybamm.ParameterValues("Chen2020")
+        updates = {}
+        for electrode in ["Negative", "Positive"]:
+            U_eq = parameter_values[f"{electrode} electrode OCP [V]"]
+            updates[f"{electrode} electrode lithiation OCP [V]"] = (
+                lambda sto, U_eq=U_eq: U_eq(sto) - 0.05
+            )
+            updates[f"{electrode} electrode delithiation OCP [V]"] = (
+                lambda sto, U_eq=U_eq: U_eq(sto) + 0.05
+            )
+        parameter_values.update(updates, check_already_exists=False)
+        return parameter_values
+
+    def test_ocp_branches_in_model(self):
+        esoh_solver = pybamm.lithium_ion.ElectrodeSOHSolver(
+            self._hysteresis_parameter_values(), options=self.options
+        )
+        model = esoh_solver._get_electrode_soh_sims_full(None).model
+        branches = {
+            var.name: sorted(
+                {node.name for node in eqn.pre_order() if node.name.endswith("OCP [V]")}
+            )
+            for var, eqn in model.algebraic.items()
+        }
+        assert branches == {
+            "x_100": [
+                "Negative electrode lithiation OCP [V]",
+                "Positive electrode delithiation OCP [V]",
+            ],
+            "x_0": [
+                "Negative electrode delithiation OCP [V]",
+                "Positive electrode lithiation OCP [V]",
+            ],
+        }
+
+    def test_solution_lies_on_hysteresis_branches(self):
+        parameter_values = self._hysteresis_parameter_values()
+        param = pybamm.LithiumIonParameters(self.options)
+        esoh_solver = pybamm.lithium_ion.ElectrodeSOHSolver(
+            parameter_values, param=param, options=self.options
+        )
+        sol = esoh_solver.solve(
+            {
+                "Q_n": parameter_values.evaluate(param.n.Q_init),
+                "Q_p": parameter_values.evaluate(param.p.Q_init),
+                "Q_Li": parameter_values.evaluate(param.Q_Li_particles_init),
+            }
+        )
+
+        T_ref = parameter_values["Reference temperature [K]"]
+
+        def ocv(x, y, negative_branch, positive_branch):
+            return parameter_values.evaluate(
+                param.p.prim.U(y, T_ref, positive_branch)
+                - param.n.prim.U(x, T_ref, negative_branch)
+            )
+
+        V_max = parameter_values["Open-circuit voltage at 100% SOC [V]"]
+        V_min = parameter_values["Open-circuit voltage at 0% SOC [V]"]
+        x_100, y_100, x_0, y_0 = sol["x_100"], sol["y_100"], sol["x_0"], sol["y_0"]
+
+        assert ocv(x_100, y_100, "lithiation", "delithiation") == pytest.approx(
+            V_max, abs=1e-6
+        )
+        assert ocv(x_0, y_0, "delithiation", "lithiation") == pytest.approx(
+            V_min, abs=1e-6
+        )
+        # the equilibrium branch is 100 mV away, so it cannot also satisfy the limits
+        assert ocv(x_100, y_100, None, None) == pytest.approx(V_max - 0.1, abs=1e-6)
+        assert ocv(x_0, y_0, None, None) == pytest.approx(V_min + 0.1, abs=1e-6)
+
+
 class TestElectrodeSOHComposite:
     @staticmethod
     def _check_phases_equal(results, xy, soc):


### PR DESCRIPTION
## Description

`ElectrodeSOHSolver.__get_electrode_soh_sims_full` and `__get_electrode_soh_sims_split` constructed `_ElectrodeSOH`/`_ElectrodeSOHMSMR` without forwarding `options`, so the model always saw `options=None`. Every `get_equilibrium_direction(...)`/`get_lithiation_delithiation(...)` call inside then returned `None`, and the model used the plain `"Negative/Positive electrode OCP [V]"` parameters.

That contradicts the `_ElectrodeSOH` docstring:

> In the presence of a hysteresis model, equilibration in the charging direction is assumed for 100% SOC (charging OCP branch), and equilibration in the discharging direction is assumed for 0% SOC (discharging OCP branch).

`_get_lims_ocp` and `_check_esoh_feasible` in the same class *do* use `self.options`, so the feasibility check and the model could disagree about which OCP branch was in play.

Before:

```python
opts = {"open-circuit potential": ("current sigmoid", "single")}
model = pybamm.lithium_ion.SPM(opts)
s = pybamm.lithium_ion.ElectrodeSOHSolver(model.default_parameter_values, options=model.options)
m = s._get_electrode_soh_sims_full(None).model
x100 = list(m.algebraic)[0]
sorted({n.name for n in m.algebraic[x100].pre_order() if "OCP" in n.name})
# ['Negative electrode OCP [V]', 'Positive electrode OCP [V]']
```

After: `['Negative electrode lithiation OCP [V]', 'Positive electrode OCP [V]']`.

With hysteresis on both electrodes the branches now come out as `x_100` → negative lithiation + positive delithiation, `x_0` → negative delithiation + positive lithiation.

### No new parameter requirements

No shipped single-phase parameter set defines the lithiation/delithiation OCP parameters (only `Chen2020_composite`, for its secondary phase). But this change does not make anything newly unusable: `Chen2020` + `"current sigmoid"` already fails to build the *main* model with `KeyError: 'Negative electrode delithiation OCP [V]'`, because `base_hysteresis_ocp` calls the same `U(sto, T, "lithiation")`. Users supply these via BPX or `ParameterValues.update`.

### `_ElectrodeSOHMSMR`

Gains an `options` kwarg for symmetry, feeding its `param` default. MSMR is never in the hysteresis list so there is no behaviour change, but it does fix an unrelated latent breakage: the `param=None` fallback `LithiumIonParameters({"open-circuit potential": "MSMR"})` raises `OptionError` on `main` (`particle` and `intercalation kinetics` must also be MSMR), so `_ElectrodeSOHMSMR(direction)` never constructed. It now works when `options` is supplied.

## Tests

New `TestElectrodeSOHHysteresis` in `test_electrode_soh.py`:

- `test_ocp_branches_in_model` — asserts the exact OCP parameter names in each algebraic equation.
- `test_solution_lies_on_hysteresis_branches` — solves with OCP branches offset ±50 mV and checks the solution sits on the charge/discharge branches, and is 100 mV off the equilibrium branch.

Both fail on the unpatched tree and pass with the fix.

Wider run (`test_lithium_ion` + `test_simulation.py` + `test_experiments` + `test_parameters`): 46 failures before, the same 46 after — all pre-existing environment gaps, 41 of them `ModuleNotFoundError: bpx`.

## Not fixed here

- `_get_lims_ocp` reads stoichiometry limits off the *equilibrium* OCP data even when the model runs on hysteresis branches, and `_check_esoh_feasible` uses the cell-level `direction` rather than the per-SOC equilibrium direction — so the feasibility bound and the model can still disagree for data-driven hysteresis OCPs.
- A mixed `("MSMR", "current sigmoid")` OCP option routes to `_ElectrodeSOH` (the equality check is against the exact string), so a half-MSMR cell gets classical `U(sto)` on its MSMR electrode. Pre-existing, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)