### PR TITLE
Process every boundary-condition side, not a fixed list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- Boundary conditions are no longer silently dropped when their side is not one of a fixed list of names: `"front"`/`"back"` and user-defined boundary regions (e.g. Gmsh physical groups) are now processed like any other side. ([#5702](https://github.com/pybamm-team/PyBaMM/pull/5702))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/packages/pybamm/src/pybamm/parameters/parameter_substitutor.py
+++ b/packages/pybamm/src/pybamm/parameters/parameter_substitutor.py
@@ -579,48 +579,26 @@ class ParameterSubstitutor:
         Process boundary conditions for a model.
 
         Boundary conditions are dictionaries {"left": left bc, "right": right bc}
-        in general, but may be imposed on the tabs (or *not* on the tab) for a
-        small number of variables.
+        in general, but may be imposed on the tabs (or *not* on the tab), or on
+        any named boundary region of the mesh (e.g. a Gmsh physical group).
+
+        Every side present in the model is processed: iterating a fixed list of
+        side names would silently discard conditions on any other tag.
         """
         new_boundary_conditions: dict[
             pybamm.Symbol, dict[str, tuple[pybamm.Symbol, str]]
         ] = {}
-        sides = [
-            "left",
-            "right",
-            "negative tab",
-            "positive tab",
-            "no tab",
-            "top",
-            "bottom",
-            "x_min",
-            "x_max",
-            "y_min",
-            "y_max",
-            "z_min",
-            "z_max",
-            "r_min",
-            "r_max",
-        ]
         for variable, bcs in model.boundary_conditions.items():
             processed_variable = self.process_symbol(variable)
             new_boundary_conditions[processed_variable] = {}
-            for side in sides:
-                try:
-                    bc, typ = bcs[side]
-                    pybamm.logger.verbose(
-                        f"Processing parameters for {variable!r} ({side} bc)"
-                    )
-                    processed_bc = (self.process_symbol(bc), typ)
-                    new_boundary_conditions[processed_variable][side] = processed_bc
-                except KeyError as err:
-                    # don't raise error if the key error comes from the side not being
-                    # found
-                    if err.args[0] in side:
-                        pass
-                    # do raise error otherwise (e.g. can't process symbol)
-                    else:
-                        raise
+            for side, (bc, typ) in bcs.items():
+                pybamm.logger.verbose(
+                    f"Processing parameters for {variable!r} ({side} bc)"
+                )
+                new_boundary_conditions[processed_variable][side] = (
+                    self.process_symbol(bc),
+                    typ,
+                )
 
         return new_boundary_conditions
 

--- a/packages/pybamm/tests/unit/test_parameters/test_parameter_values.py
+++ b/packages/pybamm/tests/unit/test_parameters/test_parameter_values.py
@@ -1081,6 +1081,39 @@ class TestParameterValues:
         with pytest.raises(KeyError):
             parameter_values.process_model(model)
 
+    def test_process_model_keeps_all_boundary_condition_sides(self):
+        # sides may be any named boundary region (3D faces, Gmsh physical
+        # groups, tabs), not only "left"/"right"
+        model = pybamm.BaseModel()
+        var = pybamm.Variable("var", domain="test")
+        model.rhs = {var: pybamm.Scalar(0)}
+        model.initial_conditions = {var: pybamm.Scalar(0)}
+        sides = {
+            "left": "a",
+            "right": "b",
+            "top": "c",
+            "bottom": "d",
+            "front": "e",
+            "back": "f",
+            "tab_top": "g",
+            "my region": "h",
+        }
+        model.boundary_conditions = {
+            var: {
+                side: (pybamm.Parameter(name), "Dirichlet")
+                for side, name in sides.items()
+            }
+        }
+
+        values = {name: index for index, name in enumerate(sides.values())}
+        pybamm.ParameterValues(values).process_model(model)
+
+        processed = next(iter(model.boundary_conditions.values()))
+        assert sorted(processed) == sorted(sides)
+        for side, name in sides.items():
+            assert processed[side][0].value == values[name]
+            assert processed[side][1] == "Dirichlet"
+
     def test_process_geometry(self):
         var = pybamm.Variable("var")
         geometry = {"negative electrode": {"x": {"min": 0, "max": var}}}


### PR DESCRIPTION
## Description

`ParameterSubstitutor.process_boundary_conditions` iterated a hardcoded list of side names:

```python
sides = ["left", "right", "negative tab", "positive tab", "no tab", "top", "bottom",
         "x_min", "x_max", "y_min", "y_max", "z_min", "z_max", "r_min", "r_max"]
```

and looked each one up in the model's boundary-condition dict, swallowing `KeyError` for absent sides. Two problems follow:

1. **Boundary conditions on any other side are silently discarded.** That includes `"front"` and `"back"` — needed for 3D finite-volume models — and every user-defined boundary name, for example a Gmsh physical group such as `"tab_top"` on an unstructured mesh. No warning is emitted; the condition simply never reaches discretisation.
2. **The `except KeyError` handler tests `if err.args[0] in side`**, a substring check. A genuine `KeyError` raised while processing a boundary-condition expression (e.g. a missing parameter) is swallowed whenever the missing key happens to be a substring of the side name currently being processed.

## Why it matters

On a 3D pouch-cell model that sets 11 sides on a concatenated solid-potential variable (`left, right, top, bottom, front, back, tab_top, tab_front, tab_back, tab_left, tab_right`), only four survive parameter processing: `bottom, left, right, top`.

The discarded `tab_top` entry was the only Dirichlet condition in the entire potential system — it pins the potential reference. Without it the potentials are determined only up to an additive constant, so the algebraic block acquires a uniform null mode (the smallest singular direction is constant across `phi_s_n`, `phi_s_p` and `phi_e`). Measured conditioning of the square algebraic Jacobian at the initial conditions:

| | smallest &#124;diag U&#124; | largest &#124;diag U&#124; | ratio |
|---|---|---|---|
| before | 1.43e-05 | 4.53e+09 | 3.2e-15 |
| after | 6.44e-02 | 4.53e+09 | 1.4e-11 |

3e-15 is machine precision, so the factorisation is effectively singular and the solve cannot initialise. With the fix the same model solves normally.

## Changes

- Iterate `bcs.items()` — the sides actually present in the model — instead of a fixed list.
- Drop the `try`/`except KeyError` so errors from `process_symbol` propagate.
- Update the docstring: sides may be any named boundary region.
- Regression test asserting that `front`, `back`, a tab tag and an arbitrary region name all survive `process_model` with their value and type intact. It fails on the previous code and passes here.

## Testing

- New test fails before the change, passes after (verified by reverting the source file alone).
- `uv run --group dev pytest packages/pybamm/tests/unit/test_parameters` — 293 passed.
- Full unit suite — 4167 passed; the only failures are three pre-existing environmental ones on this machine (two `test_create_gif` and `test_quick_plot::test_spm_simulation`, from a missing `libx265` codec), which fail identically on `main`.
- `uv run pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)