### PR TITLE
fix: rebuild all VectorField components in _from_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- `VectorField._from_json` now rebuilds all N components instead of only the first two, so a field with three or more components survives serialisation instead of silently losing its extra components (which later triggered an `IndexError` on `Component`). ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
-- `VectorField._from_json` now rebuilds all N components instead of only the first two, so a field with three or more components survives serialisation instead of silently losing its extra components (which later triggered an `IndexError` on `Component`). ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+- `VectorField._from_json` now rebuilds all N components instead of only the first two, so a field with three or more components survives serialisation instead of silently losing its extra components (which later triggered an `IndexError` on `Component`). ([#5703](https://github.com/pybamm-team/PyBaMM/pull/5703))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/packages/pybamm/src/pybamm/expression_tree/vector_field.py
+++ b/packages/pybamm/src/pybamm/expression_tree/vector_field.py
@@ -44,8 +44,8 @@ class VectorField(TensorField):
 
     @classmethod
     def _from_json(cls, snippet):
-        # Two positional args, not a single list -- override TensorField._from_json.
-        return cls(snippet["children"][0], snippet["children"][1])
+        # N positional args, not a single list -- override TensorField._from_json.
+        return cls(*snippet["children"])
 
     @property
     def n_components(self):

--- a/packages/pybamm/tests/unit/test_expression_tree/test_vector_field_and_magnitude.py
+++ b/packages/pybamm/tests/unit/test_expression_tree/test_vector_field_and_magnitude.py
@@ -98,6 +98,16 @@ class TestVectorFieldAndMagnitude:
         ):
             disc.process_symbol(vf2 + vf3)
 
+    def test_json_round_trip_preserves_all_components(self):
+        # A 3-component field must survive serialisation; a two-component
+        # _from_json would silently drop the third and later IndexError.
+        from pybamm.expression_tree.operations.serialise_kernel import decode, encode
+
+        vf = pybamm.VectorField(pybamm.Scalar(1), pybamm.Scalar(2), pybamm.Scalar(3))
+        rebuilt = decode(encode(vf))
+        assert rebuilt.n_components == 3
+        assert rebuilt == vf
+
     def test_disc_state_vector_propagation(self, mesh_2d):
         # binary and unary operators on a discretised VectorField must carry
         # the _disc_state_vector attribute over to the result


### PR DESCRIPTION
## Bug

`VectorField._from_json` in `packages/pybamm/src/pybamm/expression_tree/vector_field.py` hardcoded exactly two components:

```python
return cls(snippet["children"][0], snippet["children"][1])
```

`VectorField` supports N components (`>= 2`) and `to_json` emits all N children, but `_from_json` read only the first two. So a field with three or more components round-tripped through serialisation as a **two-component** field — the extra components were **silently dropped**. A later `Component(vf, i)` for `i >= 2` on the rebuilt field then raised `IndexError`.

## Fix

Pass all children through:

```python
return cls(*snippet["children"])
```

Two-component fields are unaffected (`cls(*children)` is equivalent for N=2), so existing serialisation round-trip tests still hold.

## Test

Added `test_json_round_trip_preserves_all_components` next to the existing `VectorField` tests. It builds a 3-component `pybamm.VectorField(Scalar(1), Scalar(2), Scalar(3))`, round-trips it through the serialise kernel (`decode(encode(vf))`), and asserts `rebuilt.n_components == 3` and `rebuilt == vf`.

- Before the source fix: **fails** with `assert 2 == 3` (rebuilt field has two components).
- After the fix: **passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)