### PR TITLE
Keep on-boundary 3D points inside the domain (fix corner/edge/face NaN masking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
-- 3D unstructured-mesh point-in-domain tests no longer misclassify points lying exactly on a domain face, edge, or corner as outside, so interpolating or plotting a field at the domain boundary no longer blanks it to NaN. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+- 3D unstructured-mesh point-in-domain tests no longer misclassify points lying exactly on a domain face, edge, or corner as outside, so interpolating or plotting a field at the domain boundary no longer blanks it to NaN. ([#5704](https://github.com/pybamm-team/PyBaMM/pull/5704))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- 3D unstructured-mesh point-in-domain tests no longer misclassify points lying exactly on a domain face, edge, or corner as outside, so interpolating or plotting a field at the domain boundary no longer blanks it to NaN. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
+++ b/packages/pybamm/src/pybamm/meshes/unstructured_submesh.py
@@ -681,7 +681,11 @@ class UnstructuredSubMesh(SubMesh):
 
             winding[i] = 2.0 * np.arctan2(num, den).sum()
 
-        return winding > 2.0 * np.pi
+        # Interior points have winding 4*pi and exterior 0; a point lying on a
+        # face/edge/corner has a partial value (2*pi / pi / pi-over-2). Use a
+        # small positive threshold so boundary points count as inside rather
+        # than being masked to NaN, while true exterior (winding ~ 0) stays out.
+        return winding > 0.1
 
 
 # ======================================================================

--- a/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
+++ b/packages/pybamm/tests/unit/test_meshes/test_unstructured_submesh.py
@@ -406,6 +406,25 @@ class TestUnstructuredSubMesh:
         assert mesh.contains_points_3d(np.array([[0.5, 0.5, 0.5]]))[0]
         assert not mesh.contains_points_3d(np.array([[2.0, 2.0, 2.0]]))[0]
 
+    def test_contains_points_3d_boundary_points_are_inside(self):
+        """Points lying exactly on a face, edge, or corner of the domain must
+        count as inside, not be masked out (their winding number is a partial
+        2*pi / pi / pi-over-2 rather than the full 4*pi)."""
+        mesh = UnstructuredSubMesh(*_hex_grid(*[np.linspace(0, 1, 3)] * 3))
+        mesh.detect_box_boundaries()
+
+        on_or_inside = np.array(
+            [
+                [0.0, 0.0, 0.0],  # corner
+                [0.5, 0.0, 0.0],  # edge midpoint
+                [0.5, 0.5, 0.0],  # face centre
+                [0.5, 0.5, 0.5],  # interior
+            ]
+        )
+        outside = np.array([[2.0, 2.0, 2.0]])
+        assert mesh.contains_points_3d(on_or_inside).all()
+        assert not mesh.contains_points_3d(outside)[0]
+
     def test_optimize_ordering_single_cell_noop(self):
         """optimize_ordering with 1 cell returns without permuting."""
         nodes = np.array([[0, 0], [1, 0], [0, 1]], dtype=float)


### PR DESCRIPTION
## Description

`UnstructuredSubMesh.contains_points_3d` decides whether 3D query points lie inside the mesh domain, using the generalized winding number (sum of signed solid angles over the boundary triangles), and returns `winding > 2 * np.pi`.

A point sitting **exactly on** the boundary surface gets a *partial* solid angle that lands at or below the halfway threshold, so it is misclassified as outside:

| point location | winding | `> 2π`? |
|---|---|---|
| interior | 4π | ✅ inside |
| flat face | 2π | ❌ (not strictly >) → outside |
| edge | π | ❌ → outside |
| corner | π/2 | ❌ → outside |
| exterior | 0 | ❌ outside |

`contains_points_3d` is called (via `ProcessedVariable._get_boundary_mask` → `_interpolate_spatial`, and via `get_3d_slices`) to blank out-of-domain points to NaN when **interpolating or plotting** a 3D unstructured field. So any query point that lands exactly on a domain face/edge/corner — which happens routinely when a regular plotting/sampling grid touches the domain boundary — is masked to NaN. The solution itself is unaffected; this is post-processing/plotting only.

Verified empirically on a unit cube: winding is exactly π/2 at a corner, π on an edge, 2π on a face, 4π in the interior, and 0 outside — matching the geometry.

## Fix

Lower the threshold below the smallest on-surface value (π/2 at a corner), so interior **and** on-boundary points count as inside while true exterior (winding ≈ 0) stays outside:

```python
return winding > 0.1
```

## Testing

- New test `test_contains_points_3d_boundary_points_are_inside` asserts a corner, edge midpoint, face centre, and interior point are all inside, and an exterior point is not. It **fails before** the change (corner/edge/face classified outside) and passes after — verified by reverting the source line alone.
- `uv run --group dev pytest packages/pybamm/tests/unit/test_meshes` — 163 passed.
- `uv run pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)