### PR TITLE
docs: update grid to 1-2-2-2 for better mobile layout

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Broadly, PyBaMM consists of
 Together, these enable flexible model definitions and fast battery simulations, allowing users to
 explore the effect of different battery designs and modeling assumptions under a variety of operating scenarios.
 
-.. grid:: 2
+.. grid:: 1 2 2 2
 
    .. grid-item-card::
       :img-top: _static/index-images/getting_started.svg


### PR DESCRIPTION
# Description

Changed the documentation homepage grid to `1 2 2 2` for better mobile readability.

Fixes #5706

## Type of change

Internal-only PRs — refactor, docs, CI, tests — can skip this.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
