### PR TITLE
Omit absent optional BPX parameters instead of emitting None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes
 
+- `ParameterValues.create_from_bpx` no longer writes `None` into the parameter set for thermal material properties (density and specific heat capacity) that a BPX file omits. Absent optional BPX fields are now dropped entirely, so building an isothermal model from a thermal-less BPX still works, and building a thermal model raises PyBaMM's usual named "parameter not found" error instead of a cryptic type error deep in the expression tree. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Bug fixes
 
-- `ParameterValues.create_from_bpx` no longer writes `None` into the parameter set for thermal material properties (density and specific heat capacity) that a BPX file omits. Absent optional BPX fields are now dropped entirely, so building an isothermal model from a thermal-less BPX still works, and building a thermal model raises PyBaMM's usual named "parameter not found" error instead of a cryptic type error deep in the expression tree. ([#XXXX](https://github.com/pybamm-team/PyBaMM/pull/XXXX))
+- `ParameterValues.create_from_bpx` no longer writes `None` into the parameter set for thermal material properties (density and specific heat capacity) that a BPX file omits. Absent optional BPX fields are now dropped entirely, so building an isothermal model from a thermal-less BPX still works, and building a thermal model raises PyBaMM's usual named "parameter not found" error instead of a cryptic type error deep in the expression tree. ([#5708](https://github.com/pybamm-team/PyBaMM/pull/5708))
 - `ElectrodeSOHSolver` now passes model options through, so hysteresis OCP branches are used. ([#5701](https://github.com/pybamm-team/PyBaMM/pull/5701))
 - Fixed a memory leak in `ElectrodeSOHSolver.theoretical_energy_integral`, which cached a new expression tree per call. ([#5695](https://github.com/pybamm-team/PyBaMM/pull/5695))
 - `BatchStudy.solve` no longer ignores its `solver` argument: previously the loop over study inputs shadowed it, so a caller-supplied solver was silently dropped. A solver from `BatchStudy(solvers=...)` still takes precedence. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))

--- a/packages/pybamm/src/pybamm/parameters/bpx.py
+++ b/packages/pybamm/src/pybamm/parameters/bpx.py
@@ -539,12 +539,21 @@ _BPX_OCP_HYSTERESIS_RENAMES = {
     "OCP (lithiation) [V]": "lithiation OCP [V]",
     "OCP (delithiation) [V]": "delithiation OCP [V]",
 }
-_OPTIONAL_HYSTERESIS_FIELDS = {"ocp_lith", "ocp_delith", "gamma_hys"}
 
 
 def _bpx_to_domain_param_dict(instance: BPX, pybamm_dict: dict, domain: Domain) -> dict:
     """
-    Turns a BPX instance in to a dictionary of parameters for PyBaMM for a given domain
+    Turns a BPX instance in to a dictionary of parameters for PyBaMM for a given domain.
+
+    Fields the BPX schema marks optional (e.g. the cell density and specific heat
+    capacity, or the electrode hysteresis branches) surface as ``None`` when absent,
+    because pydantic only guarantees *required* fields are populated. Such ``None``s
+    are omitted rather than written into ``pybamm_dict``: injecting ``None`` would
+    leave a broken parameter in ``ParameterValues`` that fails with a cryptic type
+    error deep in the expression tree if a model later needs it. Omitting them keeps
+    the isothermal path working when a BPX ships no thermal data, and lets PyBaMM's
+    usual "parameter not found" error name the missing parameter if a thermal model
+    does need it.
     """
     # Loop over fields in BPX instance and add to pybamm dictionary
     for name, field in instance.model_fields.items():
@@ -562,7 +571,7 @@ def _bpx_to_domain_param_dict(instance: BPX, pybamm_dict: dict, domain: Domain) 
                 # Loop over fields in phase instance and add to pybamm dictionary
                 for name_to_add, field_to_add in phase_instance.model_fields.items():
                     value = getattr(phase_instance, name_to_add)
-                    if value is None and name_to_add in _OPTIONAL_HYSTERESIS_FIELDS:
+                    if value is None:  # absent optional field: omit, don't emit None
                         continue
                     pybamm_names = _get_pybamm_name(field_to_add.alias, domain)
                     value = process_float_function_table(value, name_to_add)
@@ -570,7 +579,7 @@ def _bpx_to_domain_param_dict(instance: BPX, pybamm_dict: dict, domain: Domain) 
                         pybamm_dict[PHASE_NAMES[i] + pybamm_name] = value
         # Handle other fields, which correspond directly to parameters
         else:
-            if value is None and name in _OPTIONAL_HYSTERESIS_FIELDS:
+            if value is None:  # absent optional field: omit, don't emit None
                 continue
             pybamm_names = _get_pybamm_name(field.alias, domain)
             value = process_float_function_table(value, name)

--- a/packages/pybamm/tests/unit/test_parameters/test_bpx.py
+++ b/packages/pybamm/tests/unit/test_parameters/test_bpx.py
@@ -965,3 +965,43 @@ class TestBPX:
         ]
         param = pybamm.ParameterValues.create_from_bpx_obj(bpx_obj)
         assert param["Total heat transfer coefficient [W.m-2.K-1]"] == 0
+
+    # Optional thermal material properties (bpx>=1.1.1). BPX makes the cell
+    # density and specific heat capacity optional; many vendor files ship none.
+    # When they are absent PyBaMM must omit them rather than inject ``None``,
+    # so the isothermal path keeps working and the thermal path fails with the
+    # usual, named "parameter not found" error instead of a cryptic type error.
+    def _thermal_less_bpx_obj(self):
+        bpx_obj = copy.deepcopy(self.base)
+        del bpx_obj["Parameterisation"]["Cell"]["Specific heat capacity [J.K-1.kg-1]"]
+        del bpx_obj["Parameterisation"]["Cell"]["Density [kg.m-3]"]
+        return bpx_obj
+
+    def test_bpx_absent_thermal_properties_are_omitted_not_none(self):
+        param = pybamm.ParameterValues.create_from_bpx_obj(self._thermal_less_bpx_obj())
+        # No absent optional property may leak into ParameterValues as ``None``.
+        none_keys = [k for k, v in param.items() if v is None]
+        assert none_keys == [], f"BPX emitted None-valued parameters: {none_keys}"
+        # The specific thermal keys are absent entirely (not present-but-None).
+        for key in (
+            "Density [kg.m-3]",
+            "Specific heat capacity [J.K-1.kg-1]",
+            "Negative electrode density [kg.m-3]",
+            "Positive electrode specific heat capacity [J.kg-1.K-1]",
+            "Separator density [kg.m-3]",
+            "Negative current collector specific heat capacity [J.kg-1.K-1]",
+        ):
+            assert key not in param
+
+    def test_bpx_isothermal_model_builds_without_thermal_data(self):
+        param = pybamm.ParameterValues.create_from_bpx_obj(self._thermal_less_bpx_obj())
+        model = pybamm.lithium_ion.SPMe()  # isothermal: never reads thermal props
+        pybamm.Simulation(model, parameter_values=param).build()
+
+    def test_bpx_thermal_model_without_thermal_data_raises_named_error(self):
+        param = pybamm.ParameterValues.create_from_bpx_obj(self._thermal_less_bpx_obj())
+        model = pybamm.lithium_ion.SPMe({"thermal": "lumped"})
+        with pytest.raises(KeyError, match="not found") as excinfo:
+            pybamm.Simulation(model, parameter_values=param).build()
+        # the error names a specific missing thermal parameter, not a cryptic type error
+        assert "density [kg.m-3]" in str(excinfo.value).lower()


### PR DESCRIPTION
## Description

`pybamm.ParameterValues.create_from_bpx()` silently writes literal `None` into the parameter set for optional thermal material properties — the cell **density** and **specific heat capacity** — when a BPX file omits them. BPX (>=1.1.1) makes these optional, and many vendor files ship no thermal section at all.

An **isothermal** model never reads these keys, so it builds and solves fine. But building a **thermal** model (`{"thermal": "lumped"}`, `"x-full"`, …) lets a `None` reach the expression tree and fails with a cryptic, cause-less error:

```
TypeError: Parameter provided for 'Negative current collector density [kg.m-3]'
is of the wrong type (should either be scalar-like or callable)
```

A user parameterising a thermal model from a thermal-less BPX hits this with no indication that the real problem is missing BPX thermal data.

Concretely, a BPX with no density / specific-heat leaves **12** parameters set to `None`:

- `Density [kg.m-3]`, `Specific heat capacity [J.K-1.kg-1]`
- `{Negative,Positive} electrode density [kg.m-3]`, `Separator density [kg.m-3]`
- `{Negative,Positive} current collector density [kg.m-3]`
- `{Negative,Positive} electrode specific heat capacity [J.kg-1.K-1]`, `Separator specific heat capacity [J.kg-1.K-1]`
- `{Negative,Positive} current collector specific heat capacity [J.kg-1.K-1]`

(the domain-specific keys are propagated from the `None` cell-level values by the lumped-parameter loop in `bpx_to_param_dict`).

## Fix

In `_bpx_to_domain_param_dict`, drop any field whose value is `None` rather than writing it into the parameter dict. A `None` from `getattr` on a BPX pydantic instance only ever means an **absent optional field** (pydantic guarantees *required* fields are populated), so "value is `None`" is exactly "absent optional BPX field → omit it".

This generalises the previous hysteresis-only `None` skip (`_OPTIONAL_HYSTERESIS_FIELDS`), which is now redundant and removed.

Result:

- **Isothermal** build from a thermal-less BPX still works (unchanged).
- **Thermal** build now raises PyBaMM's usual, named missing-parameter error, e.g.
  `KeyError: "Parameter 'Negative current collector density [kg.m-3]' not found. ..."` — actionable, and points straight at the BPX thermal gap.
- No BPX field is ever written into `ParameterValues` as `None`.

This achieves the "fail clearly at thermal-model build" behaviour via PyBaMM's existing missing-parameter machinery, without coupling the thermal model build to BPX. (An alternative — intercepting at thermal-model build to raise a bespoke BPX-specific message — is more invasive; happy to take that direction instead if maintainers prefer.)

## Testing

Adds three regression tests in `tests/unit/test_parameters/test_bpx.py`, driven off the existing base fixture with the cell thermal properties removed:

- `test_bpx_absent_thermal_properties_are_omitted_not_none` — no parameter lands in `ParameterValues` as `None`, and the thermal keys are absent (not present-but-`None`).
- `test_bpx_isothermal_model_builds_without_thermal_data` — isothermal `SPMe` builds.
- `test_bpx_thermal_model_without_thermal_data_raises_named_error` — lumped-thermal `SPMe` raises a `KeyError` naming the specific missing thermal parameter.

Full `tests/unit/test_parameters/` and `tests/unit/test_serialisation/` suites pass locally; `pre-commit run` is clean.

Found while parameterising a vendor full-cell BPX that ships no thermal data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)