### PR TITLE
Fix max concentration in negative electrode (Ai2020)

### DIFF
--- a/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Ai2020.py
+++ b/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Ai2020.py
@@ -578,7 +578,7 @@ def get_parameter_values():
         "Contact resistance [Ohm]": 0,
         # negative electrode
         "Negative electrode conductivity [S.m-1]": 100.0,
-        "Maximum concentration in negative electrode [mol.m-3]": 28700.0,
+        "Maximum concentration in negative electrode [mol.m-3]": 29700.0,
         "Negative particle diffusivity [m2.s-1]": graphite_diffusivity_Dualfoil1998,
         "Negative electrode OCP [V]": graphite_ocp_Enertech_Ai2020,
         "Negative electrode porosity": 0.33,

--- a/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Ai2020.py
+++ b/packages/pybamm/src/pybamm/input/parameters/lithium_ion/Ai2020.py
@@ -390,7 +390,7 @@ def lico2_cracking_rate_Ai2020(T_dim):
     return k_cr * arrhenius
 
 
-def dlnf_dlnc_Ai2020(c_e, T, T_ref=298.3, t_plus=0.38):
+def dlnf_dlnc_Ai2020(c_e, T):
     """
     Activity dependence of LiPF6 in EC:DMC as a function of ion concentration.
 


### PR DESCRIPTION
# Description

Correcting the max concentration in negative electrode parameter for the Enertech LCO-G SPB655060 pouch cell, as found in Ai2020: https://doi.org/10.1149/2.0122001JES. Unless, of course, we believe it's the publication that's wrong? I can see we use the current value for another cell as well but, in that case, it matches the publication, Kim2011: https://doi.org/10.1149/1.3597614.
