### PR TITLE
Release v26.8.0.0 and pybammsolvers v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased](https://github.com/pybamm-team/PyBaMM/)
 
+# [v26.8.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.8.0.0) - 2026-08-13
+
 ## Features
 
 - Added unstructured mesh support (`UnstructuredSubMesh`, generators, and interface coupling) for arbitrary 2D/3D domains. Hexahedra must have planar faces (warped hexes raise a `GeometryError`), and `UserSuppliedUnstructuredMesh` accepts tetrahedral, triangular, and quadrilateral cells only. ([#5687](https://github.com/pybamm-team/PyBaMM/pull/5687))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `pybamm.citations.register` now names the citation the caller passed in when a BibTeX string fails to parse, instead of whichever entry the parser had reached. ([#5677](https://github.com/pybamm-team/PyBaMM/pull/5677))
 - Deserialising a parameter set whose interpolant specification is invalid now logs a warning naming the offending parameter, instead of printing the bare exception to stdout with no indication of which parameter fell back to zero. ([#5679](https://github.com/pybamm-team/PyBaMM/pull/5679))
 - A user-specified boundary tag that is absent from a mesh file now raises `GeometryError` instead of degrading to a warning and a mesh with no boundary groups. ([#5679](https://github.com/pybamm-team/PyBaMM/pull/5679))
+- Fixed the `pybammsolvers` CMake build under conda (`CONDA_BUILD=1`), where SUNDIALS, SuiteSparse, and CasADi are host dependencies rather than vendored: the `.idaklu` root defaults and the from-source bootstrap are skipped, the system CasADi is used instead of a pip one, and the libstdc++ ABI probe (which has no wheel to inspect and would wrongly force the legacy ABI) is now limited to the PyPI-CasADi path. Released as `pybammsolvers` v0.9.1. ([#5668](https://github.com/pybamm-team/PyBaMM/pull/5668))
 
 ## Optimizations
 

--- a/packages/pybamm/CITATION.cff
+++ b/packages/pybamm/CITATION.cff
@@ -24,6 +24,6 @@ keywords:
   - "expression tree"
   - "python"
   - "symbolic differentiation"
-version: "26.7.1.0"
+version: "26.8.0.0"
 repository-code: "https://github.com/pybamm-team/PyBaMM"
 title: "Python Battery Mathematical Modelling (PyBaMM)"

--- a/packages/pybammsolvers/pyproject.toml
+++ b/packages/pybammsolvers/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.10,<3.15"
 license-files = ["LICENSE"]
 readme = "README.md"
 # version.py stays the source of truth; a pre-commit hook mirrors it here.
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
     "casadi==3.7.2",
     "numpy>=2.0.0",

--- a/packages/pybammsolvers/src/pybammsolvers/version.py
+++ b/packages/pybammsolvers/src/pybammsolvers/version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the pybammsolvers version. Bump this at release;
 # a pre-commit hook mirrors it into pyproject.toml (see .pre-commit-config.yaml).
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/packages/pybammsolvers/vcpkg.json
+++ b/packages/pybammsolvers/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "pybammsolvers",
-  "version-string": "0.9.0",
+  "version-string": "0.9.1",
   "dependencies": [
     "casadi",
     {

--- a/uv.lock
+++ b/uv.lock
@@ -3098,7 +3098,7 @@ docs = [
 
 [[package]]
 name = "pybammsolvers"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/pybammsolvers" }
 dependencies = [
     { name = "casadi" },


### PR DESCRIPTION
Release prep per `RELEASE.md`. Two independent releases, one PR.

## PyBaMM v26.8.0.0

First feature release of August 2026 (`YY.MM.N.P`, `N=0`, `P=0`). No breaking changes or deprecations.

- `CHANGELOG.md`: dated `v26.8.0.0` heading prepended over the `# [Unreleased]` block
- `packages/pybamm/CITATION.cff`: `version` bumped to `26.8.0.0`

Contents verified against `git log pybamm-v26.7.1.0..HEAD` — 3 features (#5687, #5686, #5699) and 9 bug fixes. Everything else since 26.7.1.0 is CI, lint, and dependency work.

## pybammsolvers v0.9.1

Picks up #5668 (conda CMake guards), which has been on `main` since the 0.9.0 release.

- `version.py` bumped to `0.9.1`; the `sync-pybammsolvers-version` hook mirrored it into `pyproject.toml` and `vcpkg.json`
- Changelog bullet added under `v26.8.0.0` → Bug fixes, matching how previous solver changes were logged

## After merge

Two separate GitHub releases off the merge commit:

```
pybamm-v26.8.0.0        # triggers publish_pypi.yml
pybammsolvers-v0.9.1    # triggers release_solvers.yml
```

Copy the matching `CHANGELOG.md` block into each release description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)