### PR TITLE
Ensure step and cycle lengths match

### DIFF
--- a/packages/pybamm/src/pybamm/solvers/solution.py
+++ b/packages/pybamm/src/pybamm/solvers/solution.py
@@ -979,6 +979,9 @@ class Solution(SolutionBase):
                     data_short_names["Step"] = np.concatenate(
                         [data_short_names["Step"], j * np.ones_like(step.t)]
                     )
+                data_short_names["Step"] = data_short_names["Step"][
+                    : len(data_short_names["Cycle"])
+                ]
 
         return data_short_names
 


### PR DESCRIPTION
# Description

A one-line fix to ensure that the step length is not longer than the cycle length.

## Type of change

Add an entry under `# [Unreleased]` in [CHANGELOG.md](https://github.com/pybamm-team/PyBaMM/blob/main/CHANGELOG.md), in one of `## Breaking changes`, `## Deprecated`, `## Features`, or `## Bug fixes` (include PR number; breaking and deprecation entries need a one-line migration note). Internal-only PRs — refactor, docs, CI, tests — can skip this. See [RELEASE.md](https://github.com/pybamm-team/PyBaMM/blob/main/RELEASE.md) for the full policy.

# Important checks:

Please confirm the following before marking the PR as ready for review:
- No style issues: `nox -s pre-commit`
- All tests pass: `nox -s tests`
- The documentation builds: `nox -s doctests`
- Code is commented for hard-to-understand areas
- Tests added that prove fix is effective or that feature works
