### PR TITLE
fix: rename composite ESOH phase-capacity inputs off the MSMR name pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 - The `integration` nox session no longer installs the `pydiffsol` extra on macOS Intel CI runners, where it has no working build. ([#5726](https://github.com/pybamm-team/PyBaMM/pull/5726))
-- The composite electrode-SOH model's phase-capacity inputs are named `Q_n_prim` / `Q_n_sec` (and the positive equivalents) instead of `Q_n_1` / `Q_n_2`. The numbered form matched the deprecated-MSMR name pattern, so every composite solve emitted a `DeprecationWarning` naming an internal input the caller never set and cannot change. ([#5738](https://github.com/pybamm-team/PyBaMM/pull/5738))
+- The composite electrode-SOH model's phase-capacity inputs are renamed `Q_n_1` -> `Q_n_prim`, `Q_n_2` -> `Q_n_sec`, `Q_p_1` -> `Q_p_prim`, `Q_p_2` -> `Q_p_sec`. The numbered form matched the deprecated-MSMR name pattern, so every composite solve emitted a `DeprecationWarning` naming an input the caller never set and cannot change. No documented API takes these names, but they are visible in `all_inputs` on the ESOH sub-simulation's solution, so code introspecting those keys must use the new spellings. ([#5738](https://github.com/pybamm-team/PyBaMM/pull/5738))
 
 # [v26.8.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.8.0.0) - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - The `integration` nox session no longer installs the `pydiffsol` extra on macOS Intel CI runners, where it has no working build. ([#5726](https://github.com/pybamm-team/PyBaMM/pull/5726))
+- The composite electrode-SOH model's phase-capacity inputs are named `Q_n_prim` / `Q_n_sec` (and the positive equivalents) instead of `Q_n_1` / `Q_n_2`. The numbered form matched the deprecated-MSMR name pattern, so every composite solve emitted a `DeprecationWarning` about an internal input the caller never set, and injected an unused `... host site occupancy capacity (N) [A.h]` key into the solver inputs. ([#5738](https://github.com/pybamm-team/PyBaMM/pull/5738))
 
 # [v26.8.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.8.0.0) - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 - The `integration` nox session no longer installs the `pydiffsol` extra on macOS Intel CI runners, where it has no working build. ([#5726](https://github.com/pybamm-team/PyBaMM/pull/5726))
-- The composite electrode-SOH model's phase-capacity inputs are named `Q_n_prim` / `Q_n_sec` (and the positive equivalents) instead of `Q_n_1` / `Q_n_2`. The numbered form matched the deprecated-MSMR name pattern, so every composite solve emitted a `DeprecationWarning` about an internal input the caller never set, and injected an unused `... host site occupancy capacity (N) [A.h]` key into the solver inputs. ([#5738](https://github.com/pybamm-team/PyBaMM/pull/5738))
+- The composite electrode-SOH model's phase-capacity inputs are named `Q_n_prim` / `Q_n_sec` (and the positive equivalents) instead of `Q_n_1` / `Q_n_2`. The numbered form matched the deprecated-MSMR name pattern, so every composite solve emitted a `DeprecationWarning` naming an internal input the caller never set and cannot change. ([#5738](https://github.com/pybamm-team/PyBaMM/pull/5738))
 
 # [v26.8.0.0](https://github.com/pybamm-team/PyBaMM/tree/pybamm-v26.8.0.0) - 2026-08-13
 

--- a/packages/pybamm/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh_composite.py
+++ b/packages/pybamm/src/pybamm/models/full_battery_models/lithium_ion/electrode_soh_composite.py
@@ -144,14 +144,14 @@ def _get_electrode_capacity_equation(options, electrode):
     i_am_composite = check_if_composite(options, electrode)
     stoich_variables = _get_stoich_variables(options)
     direction = _get_direction(electrode)
-    Q_1 = pybamm.InputParameter(f"Q_{e}_1")
+    Q_1 = pybamm.InputParameter(f"Q_{e}_prim")
     Q = (
         direction
         * (stoich_variables[f"{prefix}_100_1"] - stoich_variables[f"{prefix}_0_1"])
         * Q_1
     )
     if i_am_composite:
-        Q_2 = pybamm.InputParameter(f"Q_{e}_2")
+        Q_2 = pybamm.InputParameter(f"Q_{e}_sec")
         Q += (
             direction
             * (stoich_variables[f"{prefix}_100_2"] - stoich_variables[f"{prefix}_0_2"])
@@ -168,20 +168,20 @@ def _get_cyclable_lithium_equation(options, soc="100"):
     """
     x_soc_1 = pybamm.Variable(f"x_{soc}_1", bounds=(0, 1))
     y_soc_1 = pybamm.Variable(f"y_{soc}_1", bounds=(0, 1))
-    Q_n_1 = pybamm.InputParameter("Q_n_1")
-    Q_p_1 = pybamm.InputParameter("Q_p_1")
-    lithium_primary_phases = Q_n_1 * x_soc_1 + Q_p_1 * y_soc_1
+    Q_n_prim = pybamm.InputParameter("Q_n_prim")
+    Q_p_prim = pybamm.InputParameter("Q_p_prim")
+    lithium_primary_phases = Q_n_prim * x_soc_1 + Q_p_prim * y_soc_1
     lithium_secondary_phases = 0.0
     is_positive_composite = check_if_composite(options, "positive")
     is_negative_composite = check_if_composite(options, "negative")
     if is_positive_composite:
-        Q_p_2 = pybamm.InputParameter("Q_p_2")
+        Q_p_sec = pybamm.InputParameter("Q_p_sec")
         y_soc_2 = pybamm.Variable(f"y_{soc}_2", bounds=(0, 1))
-        lithium_secondary_phases += Q_p_2 * y_soc_2
+        lithium_secondary_phases += Q_p_sec * y_soc_2
     if is_negative_composite:
-        Q_n_2 = pybamm.InputParameter("Q_n_2")
+        Q_n_sec = pybamm.InputParameter("Q_n_sec")
         x_soc_2 = pybamm.Variable(f"x_{soc}_2", bounds=(0, 1))
-        lithium_secondary_phases += Q_n_2 * x_soc_2
+        lithium_secondary_phases += Q_n_sec * x_soc_2
     return lithium_primary_phases + lithium_secondary_phases
 
 
@@ -470,18 +470,18 @@ class ElectrodeSOHComposite(pybamm.BaseModel):
             )
         elif initialization_method == "SOC":
             soc_init = pybamm.InputParameter("SOC_init")
-            negative_soc = x_init_1 * pybamm.InputParameter("Q_n_1")
+            negative_soc = x_init_1 * pybamm.InputParameter("Q_n_prim")
             if is_negative_composite:
                 x_init_2 = variables["x_init_2"]
-                negative_soc += x_init_2 * pybamm.InputParameter("Q_n_2")
+                negative_soc += x_init_2 * pybamm.InputParameter("Q_n_sec")
 
-            negative_0_soc = x_0_1 * pybamm.InputParameter("Q_n_1")
+            negative_0_soc = x_0_1 * pybamm.InputParameter("Q_n_prim")
             if is_negative_composite:
-                negative_0_soc += x_0_2 * pybamm.InputParameter("Q_n_2")
+                negative_0_soc += x_0_2 * pybamm.InputParameter("Q_n_sec")
 
-            negative_100_soc = x_100_1 * pybamm.InputParameter("Q_n_1")
+            negative_100_soc = x_100_1 * pybamm.InputParameter("Q_n_prim")
             if is_negative_composite:
-                negative_100_soc += x_100_2 * pybamm.InputParameter("Q_n_2")
+                negative_100_soc += x_100_2 * pybamm.InputParameter("Q_n_sec")
             self.algebraic[x_init_1] = (
                 (negative_soc - negative_0_soc) / (negative_100_soc - negative_0_soc)
             ) - soc_init
@@ -584,15 +584,15 @@ class ElectrodeSOHComposite(pybamm.BaseModel):
         is_positive_composite = check_if_composite(options, "positive")
         is_negative_composite = check_if_composite(options, "negative")
 
-        Q_n_1 = parameter_values.evaluate(param.n.prim.Q_init, inputs=inputs)
-        Q_p_1 = parameter_values.evaluate(param.p.prim.Q_init, inputs=inputs)
-        Qs = {"Q_n_1": Q_n_1, "Q_p_1": Q_p_1}
+        Q_n_prim = parameter_values.evaluate(param.n.prim.Q_init, inputs=inputs)
+        Q_p_prim = parameter_values.evaluate(param.p.prim.Q_init, inputs=inputs)
+        Qs = {"Q_n_prim": Q_n_prim, "Q_p_prim": Q_p_prim}
         if is_positive_composite:
-            Q_p_2 = parameter_values.evaluate(param.p.sec.Q_init, inputs=inputs)
-            Qs["Q_p_2"] = Q_p_2
+            Q_p_sec = parameter_values.evaluate(param.p.sec.Q_init, inputs=inputs)
+            Qs["Q_p_sec"] = Q_p_sec
         if is_negative_composite:
-            Q_n_2 = parameter_values.evaluate(param.n.sec.Q_init, inputs=inputs)
-            Qs["Q_n_2"] = Q_n_2
+            Q_n_sec = parameter_values.evaluate(param.n.sec.Q_init, inputs=inputs)
+            Qs["Q_n_sec"] = Q_n_sec
 
         Q_Li = parameter_values.evaluate(param.Q_Li_particles_init, inputs=inputs)
 
@@ -621,8 +621,8 @@ class ElectrodeSOHComposite(pybamm.BaseModel):
                 f"{initial_value!r} of type {type(initial_value).__name__}"
             )
 
-        Q_n_total = Q_n_1 + (Qs.get("Q_n_2", 0))
-        Q_p_total = Q_p_1 + (Qs.get("Q_p_2", 0))
+        Q_n_total = Q_n_prim + (Qs.get("Q_n_sec", 0))
+        Q_p_total = Q_p_prim + (Qs.get("Q_p_sec", 0))
 
         primary_options = _get_primary_only_options(options)
         # _ElectrodeSOH uses get_equilibrium_direction internally for the equilibrium
@@ -819,15 +819,15 @@ class ElectrodeSOHComposite(pybamm.BaseModel):
         is_positive_composite = check_if_composite(options, "positive")
         is_negative_composite = check_if_composite(options, "negative")
 
-        Q_n_1 = parameter_values.evaluate(param.n.prim.Q_init, inputs=inputs)
-        Q_p_1 = parameter_values.evaluate(param.p.prim.Q_init, inputs=inputs)
-        Qs = {"Q_n_1": Q_n_1, "Q_p_1": Q_p_1}
+        Q_n_prim = parameter_values.evaluate(param.n.prim.Q_init, inputs=inputs)
+        Q_p_prim = parameter_values.evaluate(param.p.prim.Q_init, inputs=inputs)
+        Qs = {"Q_n_prim": Q_n_prim, "Q_p_prim": Q_p_prim}
         if is_positive_composite:
-            Q_p_2 = parameter_values.evaluate(param.p.sec.Q_init, inputs=inputs)
-            Qs["Q_p_2"] = Q_p_2
+            Q_p_sec = parameter_values.evaluate(param.p.sec.Q_init, inputs=inputs)
+            Qs["Q_p_sec"] = Q_p_sec
         if is_negative_composite:
-            Q_n_2 = parameter_values.evaluate(param.n.sec.Q_init, inputs=inputs)
-            Qs["Q_n_2"] = Q_n_2
+            Q_n_sec = parameter_values.evaluate(param.n.sec.Q_init, inputs=inputs)
+            Qs["Q_n_sec"] = Q_n_sec
 
         Q_Li = parameter_values.evaluate(param.Q_Li_particles_init, inputs=inputs)
 

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -567,7 +567,9 @@ class TestElectrodeSOHComposite:
                 0.5, pvals, options=options
             )
 
-        renamed = [w for w in caught if "has been renamed to" in str(w.message)]
+        renamed = [
+            w for w in caught if "host site occupancy capacity" in str(w.message)
+        ]
         assert renamed == []
 
 

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -3,6 +3,7 @@
 #
 
 import contextlib
+import warnings
 
 import pytest
 
@@ -551,6 +552,22 @@ class TestElectrodeSOHComposite:
                     assert 0 <= results[key] <= 1, (
                         f"Stoichiometry {key} out of bounds: {results[key]}"
                     )
+
+    def test_phase_capacity_inputs_are_not_deprecated_msmr_names(self):
+        # The phase capacities are named "Q_n_prim"/"Q_n_sec" rather than
+        # "Q_n_1"/"Q_n_2" because the numbered form matches the deprecated-MSMR
+        # name pattern, so check_parameter_values would report every composite
+        # solve as using a renamed parameter the caller never set.
+        pvals = pybamm.ParameterValues("Chen2020_composite")
+        options = {"particle phases": ("2", "1")}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pybamm.lithium_ion.get_initial_stoichiometries_composite(
+                0.5, pvals, options=options
+            )
+
+        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
 
 
 class TestElectrodeSOHMSMR:

--- a/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
+++ b/packages/pybamm/tests/unit/test_models/test_full_battery_models/test_lithium_ion/test_electrode_soh.py
@@ -567,7 +567,8 @@ class TestElectrodeSOHComposite:
                 0.5, pvals, options=options
             )
 
-        assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
+        renamed = [w for w in caught if "has been renamed to" in str(w.message)]
+        assert renamed == []
 
 
 class TestElectrodeSOHMSMR:


### PR DESCRIPTION
Fixes #5737.

## Description

`electrode_soh_composite` named its phase-capacity `InputParameter`s `Q_n_1` / `Q_p_1` / `Q_n_2` / `Q_p_2`. Those match the deprecated-MSMR name pattern in `msmr.py`:

```
^(X|Q|w|U0|a|j0_ref)_(n|p)(_[ld])?_[0-9]+$
```

so when the inputs reach `ParameterValues.check_parameter_values` via `BaseSolver._set_up_model_inputs`, the deprecation branch fires. Two effects, on every composite / multi-phase initial-state solve:

1. A `DeprecationWarning` telling the user to rename a parameter they never set and cannot change — it names PyBaMM's own internal input.
2. A phantom key added to the returned dict: `values[new_param] = values.get(param)` adds e.g. `Negative electrode host site occupancy capacity (1) [A.h]` alongside `Q_n_1`. On this path it goes no further — `_set_up_model_inputs` keeps only the names the model declares, so the phantom entry is discarded before the solver sees it. The warning is the whole user-visible symptom; I overstated this in the issue and have corrected it there.

The collision is accidental: the composite `Q_n_1` is a **phase** capacity (primary/secondary particle), the MSMR `Q_n_1` is a **host site** capacity.

## Fix

Rename to `Q_n_prim` / `Q_n_sec` / `Q_p_prim` / `Q_p_sec`, which matches the `prim`/`sec` vocabulary already used for the phases (`param.n.prim`, `param.n.sec`) and the existing symbol-suffix convention elsewhere (`R_n_prim` in `standard_spatial_vars`, the `var_pts` keys).

**On whether this is breaking.** No documented API takes these names: `solve_split`, `solve_full`, and `get_initial_stoichiometries_composite` all build them internally from `parameter_values`, their `inputs` kwarg is a different namespace (it is forwarded to `parameter_values.evaluate`), and the returned dicts hold only stoichiometries. They do not appear in `summary_variables` (all 102 use display names) or in the user model's `solution.all_inputs` (`[{}]`).

They *are* visible in one place, so I would not call them unreachable: the ESOH sub-simulation's solution, which a caller can hold via the public `esoh_sim` kwarg on `solve_full` —

```python
ElectrodeSOHComposite.solve_full(0.5, pvals, options=options, esoh_sim=esoh_sim)
esoh_sim.solution.all_inputs
# [{'Q_Li': [...], 'Q_n_1': [...], 'Q_n_2': [...], 'Q_p_1': [...], 'SOC_init': [...]}]
```

Reading those keys is introspection rather than a documented contract, and code that does it fails with a loud `KeyError` rather than silently wrong numbers, so I have treated this as non-breaking and spelled the old -> new mapping out in the CHANGELOG instead. Happy to be overruled.

I also considered aligning with the `"Primary: Negative electrode capacity [A.h]"` convention and did not: `PHASE_NAMES = ["Primary: ", "Secondary: "]` (`parameters/bpx.py:95`) builds *`ParameterValues` keys*, whereas these are `InputParameter` names sitting in `all_inputs` next to `Q_Li`, `V_init`, `SOC_init`, and `z_1`. A long display-style string there would be the only one of its kind and would read as a parameter-set key.

Note the names are also built dynamically at `_get_electrode_capacity_equation` (`f"Q_{e}_1"` / `f"Q_{e}_2"`), which a grep for the literal strings misses; both forms are updated.

Narrowing `_VALID_NAME_RE` instead would be wrong: `Q_n_1` genuinely *is* a legacy MSMR name, so the check is correct on the name it is handed. The problem was that the composite path chose that name for something else.

## Verification

Before, on `main`:

```python
import warnings, pybamm

model = pybamm.lithium_ion.SPMe({"particle phases": ("2", "1")})
sim = pybamm.Simulation(model, parameter_values=pybamm.ParameterValues("Chen2020_composite"))
with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    sim.solve([0, 10], initial_soc="2.8 V")
print(len([w for w in caught if issubclass(w.category, DeprecationWarning)]))
# 3   ->   0 with this branch
```

Added `TestElectrodeSOHComposite::test_phase_capacity_inputs_are_not_deprecated_msmr_names`, which fails on `main` and passes here.

Local runs (`tests/unit/test_models`, `test_parameters`, `test_simulation.py`, `test_base_simulation.py`, `test_experiments`, `test_serialisation`, `test_batch_study.py`): 2770 passed, 13 skipped. `test_solvers/test_idaklu_jax.py` fails identically on unmodified `main` in my environment, so it is untouched by this change and left to CI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] No style issues: `nox -s pre-commit`
- [x] All tests pass: `nox -s tests` (see note above on the environmental `idaklu_jax` failures)
- [ ] The documentation builds: `nox -s doctests` — not run; no docs touched
- [x] Code is commented for hard-to-understand areas
- [x] Tests added that prove the fix is effective

